### PR TITLE
fix: properly serialize DictState in state manager

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dev = [
 
 [project]
 name = "llama-index-workflows"
-version = "1.0.0"
+version = "1.0.1"
 description = "An event-driven, async-first, step-based way to control the execution flow of AI applications like Agents."
 readme = "README.md"
 license = "MIT"

--- a/src/workflows/context/state_store.py
+++ b/src/workflows/context/state_store.py
@@ -109,12 +109,10 @@ class InMemoryStateStore(Generic[MODEL_T]):
         For DictState, uses the BaseSerializer for individual items since they can be arbitrary types.
         For other Pydantic models, leverages Pydantic's serialization but uses BaseSerializer for complex types.
         """
-        state_dict = self._state.model_dump()
-
         # Special handling for DictState - serialize each item in _data
         if isinstance(self._state, DictState):
             serialized_data = {}
-            for key, value in state_dict.get("_data", {}).items():
+            for key, value in self._state.items():
                 try:
                     serialized_data[key] = serializer.serialize(value)
                 except Exception as e:

--- a/uv.lock
+++ b/uv.lock
@@ -192,7 +192,7 @@ wheels = [
 
 [[package]]
 name = "llama-index-workflows"
-version = "0.2.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "eval-type-backport", marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
By calling `model_dump()` before serializing, we through away a lot of types for the serializer which actually breaks re-hydration.