### PR TITLE
chore: deprecate old workflow.send_event() method

### DIFF
--- a/src/workflows/workflow.py
+++ b/src/workflows/workflow.py
@@ -312,8 +312,7 @@ class Workflow(metaclass=WorkflowMeta):
         DEPRECATED: This method is deprecated and will be removed in a future version.
         """
         warnings.warn(
-            "send_event() is deprecated and will be removed in a future version. "
-            "There are no alternatives.",
+            "send_event() is deprecated and will be removed in a future version. Use ctx.send_event() instead.",
             DeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
Method has never been officially deprecated, but it's been spitting a warning since a long time, let's just make it official so we can schedule it for removal.