### PR TITLE
Generate workflow server reference docs

### DIFF
--- a/docs/src/content/docs/workflows-api-reference/index.md
+++ b/docs/src/content/docs/workflows-api-reference/index.md
@@ -1,0 +1,1017 @@
+---
+title: Workflows API Reference
+---
+
+<!-- THIS FILE IS GENERATED. DO NOT EDIT MANUALLY. -->
+
+**Version**: `2.8.3`
+
+This reference is generated from the server's OpenAPI schema. It lists all endpoints, their parameters, request bodies, and responses.
+
+
+### /events/{handler_id}
+
+#### GET
+
+**Summary**: Stream workflow events
+
+
+Streams events produced by a workflow execution. Events are emitted as
+newline-delimited JSON by default, or as Server-Sent Events when `sse=true`.
+Event data is returned as an envelope that preserves backward-compatible fields
+and adds metadata for type-safety on the client:
+{
+  "value": &lt;pydantic serialized value&gt;,
+  "types": [&lt;class names from MRO excluding the event class and base Event&gt;],
+  "type": &lt;class name&gt;,
+  "qualified_name": &lt;python module path + class name&gt;,
+}
+
+Event queue is mutable. Elements are added to the queue by the workflow handler, and removed by any consumer of the queue.
+The queue is protected by a lock that is acquired by the consumer, so only one consumer of the queue at a time is allowed.
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| handler_id | path | yes | string | Identifier returned from the no-wait run endpoint. |
+| sse | query | no | boolean | If false, as NDJSON instead of Server-Sent Events. |
+| include_internal | query | no | boolean | If true, include internal workflow events (e.g., step state changes). |
+| acquire_timeout | query | no | number | Timeout for acquiring the lock to iterate over the events. |
+| include_qualified_name | query | no | boolean | If true, include the qualified name of the event in the response body. |
+
+
+**Responses**
+
+
+#### 200
+Streaming started
+
+- Content type: `text/event-stream`
+```json
+{
+  "type": "object",
+  "description": "Server-Sent Events stream of event data.",
+  "properties": {
+    "value": {
+      "type": "object",
+      "description": "The event value."
+    },
+    "type": {
+      "type": "string",
+      "description": "The class name of the event."
+    },
+    "types": {
+      "type": "array",
+      "description": "Superclass names from MRO (excluding the event class and base Event).",
+      "items": {
+        "type": "string"
+      }
+    },
+    "qualified_name": {
+      "type": "string",
+      "description": "The qualified name of the event."
+    }
+  },
+  "required": [
+    "value",
+    "type"
+  ]
+}
+```
+
+#### 404
+Handler not found
+
+
+
+#### POST
+
+**Summary**: Send event to workflow
+
+
+Sends an event to a running workflow's context.
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| handler_id | path | yes | string | Workflow handler identifier. |
+
+
+**Request Body**
+
+
+- Required: yes
+
+- Content type: `application/json`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "event": {
+      "description": "Serialized event. Accepts object or JSON-encoded string for backward compatibility.",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "JSON string of the event envelope or value.",
+          "examples": [
+            "{\"type\": \"ExternalEvent\", \"value\": {\"response\": \"hi\"}}"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "The class name of the event."
+            },
+            "value": {
+              "type": "object",
+              "description": "The event value object (preferred over data)."
+            }
+          },
+          "additionalProperties": true
+        }
+      ]
+    },
+    "step": {
+      "type": "string",
+      "description": "Optional target step name. If not provided, event is sent to all steps."
+    }
+  },
+  "required": [
+    "event"
+  ]
+}
+```
+
+
+**Responses**
+
+
+#### 200
+Event sent successfully
+
+- Content type: `application/json`
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "sent"
+      ]
+    }
+  },
+  "required": [
+    "status"
+  ]
+}
+```
+
+#### 400
+Invalid event data
+
+
+#### 404
+Handler not found
+
+
+#### 409
+Workflow already completed
+
+
+
+
+
+### /handlers
+
+#### GET
+
+**Summary**: Get handlers
+
+
+Returns all workflow handlers.
+
+
+**Responses**
+
+
+#### 200
+List of handlers
+
+- Content type: `application/json`
+  - Schema: `HandlersList`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "handlers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/Handler"
+      }
+    }
+  },
+  "required": [
+    "handlers"
+  ]
+}
+```
+
+
+
+
+### /handlers/{handler_id}/cancel
+
+#### POST
+
+**Summary**: Stop and delete handler
+
+
+Stops a running workflow handler by cancelling its tasks. Optionally removes the
+handler from the persistence store if purge=true.
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| handler_id | path | yes | string | Workflow handler identifier. |
+| purge | query | no | boolean | If true, also deletes the handler from the store, otherwise updates the status to cancelled. |
+
+
+**Responses**
+
+
+#### 200
+Handler cancelled and deleted or cancelled only
+
+- Content type: `application/json`
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "deleted",
+        "cancelled"
+      ]
+    }
+  },
+  "required": [
+    "status"
+  ]
+}
+```
+
+#### 404
+Handler not found
+
+
+
+
+
+### /health
+
+#### GET
+
+**Summary**: Health check
+
+
+Returns the server health status.
+
+
+**Responses**
+
+
+#### 200
+Successful health check
+
+- Content type: `application/json`
+```json
+{
+  "type": "object",
+  "properties": {
+    "status": {
+      "type": "string",
+      "example": "healthy"
+    }
+  },
+  "required": [
+    "status"
+  ]
+}
+```
+
+
+
+
+### /results/{handler_id}
+
+#### GET
+
+**Summary**: Get workflow result
+
+
+Returns the final result of an asynchronously started workflow, if available
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| handler_id | path | yes | string | Workflow run identifier returned from the no-wait run endpoint. |
+
+
+**Responses**
+
+
+#### 200
+Result is available
+
+- Content type: `application/json`
+  - Schema: `Handler`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "handler_id": {
+      "type": "string"
+    },
+    "workflow_name": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string",
+      "nullable": true
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "error": {
+      "type": "string",
+      "nullable": true
+    },
+    "result": {
+      "description": "Workflow result value"
+    }
+  },
+  "required": [
+    "handler_id",
+    "workflow_name",
+    "status",
+    "started_at"
+  ]
+}
+```
+
+#### 202
+Result not ready yet
+
+- Content type: `application/json`
+  - Schema: `Handler`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "handler_id": {
+      "type": "string"
+    },
+    "workflow_name": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string",
+      "nullable": true
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "error": {
+      "type": "string",
+      "nullable": true
+    },
+    "result": {
+      "description": "Workflow result value"
+    }
+  },
+  "required": [
+    "handler_id",
+    "workflow_name",
+    "status",
+    "started_at"
+  ]
+}
+```
+
+#### 404
+Handler not found
+
+
+#### 500
+Error computing result
+
+- Content type: `text/plain`
+```json
+{
+  "type": "string"
+}
+```
+
+
+
+
+### /workflows
+
+#### GET
+
+**Summary**: List workflows
+
+
+Returns the list of registered workflow names.
+
+
+**Responses**
+
+
+#### 200
+List of workflows
+
+- Content type: `application/json`
+```json
+{
+  "type": "object",
+  "properties": {
+    "workflows": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "required": [
+    "workflows"
+  ]
+}
+```
+
+
+
+
+### /workflows/{name}/events
+
+#### GET
+
+**Summary**: List workflow events
+
+
+Returns the list of registered workflow event schemas.
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| name | path | yes | string | Registered workflow name. |
+
+
+**Responses**
+
+
+#### 200
+List of workflow event schemas
+
+- Content type: `application/json`
+```json
+{
+  "type": "object",
+  "properties": {
+    "events": {
+      "type": "array",
+      "description": "List of workflow event JSON schemas",
+      "items": {
+        "type": "object"
+      }
+    }
+  },
+  "required": [
+    "events"
+  ]
+}
+```
+
+
+
+
+### /workflows/{name}/representation
+
+#### GET
+
+**Summary**: Get the representation of the workflow
+
+
+Get the representation of the workflow as a directed graph in JSON format
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| name | path | yes | string | Registered workflow name. |
+
+
+**Request Body**
+
+
+- Required: no
+
+
+**Responses**
+
+
+#### 200
+JSON representation successfully retrieved
+
+- Content type: `application/json`
+```json
+{
+  "type": "object",
+  "properties": {
+    "graph": {
+      "description": "the elements of the JSON representation of the workflow"
+    }
+  },
+  "required": [
+    "graph"
+  ]
+}
+```
+
+#### 404
+Workflow not found
+
+
+#### 500
+Error while getting JSON workflow representation
+
+
+
+
+
+### /workflows/{name}/run
+
+#### POST
+
+**Summary**: Run workflow (wait)
+
+
+Runs the specified workflow synchronously and returns the final result.
+The request body may include an optional serialized start event, an optional
+context object, and optional keyword arguments passed to the workflow run.
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| name | path | yes | string | Registered workflow name. |
+
+
+**Request Body**
+
+
+- Required: no
+
+- Content type: `application/json`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "start_event": {
+      "type": "object",
+      "description": "Plain JSON object representing the start event (e.g., {\"message\": \"...\"})."
+    },
+    "context": {
+      "type": "object",
+      "description": "Serialized workflow Context."
+    },
+    "handler_id": {
+      "type": "string",
+      "description": "Workflow handler identifier to continue from a previous completed run."
+    },
+    "kwargs": {
+      "type": "object",
+      "description": "Additional keyword arguments for the workflow."
+    }
+  }
+}
+```
+
+
+**Responses**
+
+
+#### 200
+Workflow completed successfully
+
+- Content type: `application/json`
+  - Schema: `Handler`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "handler_id": {
+      "type": "string"
+    },
+    "workflow_name": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string",
+      "nullable": true
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "error": {
+      "type": "string",
+      "nullable": true
+    },
+    "result": {
+      "description": "Workflow result value"
+    }
+  },
+  "required": [
+    "handler_id",
+    "workflow_name",
+    "status",
+    "started_at"
+  ]
+}
+```
+
+#### 400
+Invalid start_event payload
+
+
+#### 404
+Workflow or handler identifier not found
+
+
+#### 500
+Error running workflow or invalid request body
+
+
+
+
+
+### /workflows/{name}/run-nowait
+
+#### POST
+
+**Summary**: Run workflow (no-wait)
+
+
+Starts the specified workflow asynchronously and returns a handler identifier
+which can be used to query results or stream events.
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| name | path | yes | string | Registered workflow name. |
+
+
+**Request Body**
+
+
+- Required: no
+
+- Content type: `application/json`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "start_event": {
+      "type": "object",
+      "description": "Plain JSON object representing the start event (e.g., {\"message\": \"...\"})."
+    },
+    "context": {
+      "type": "object",
+      "description": "Serialized workflow Context."
+    },
+    "handler_id": {
+      "type": "string",
+      "description": "Workflow handler identifier to continue from a previous completed run."
+    },
+    "kwargs": {
+      "type": "object",
+      "description": "Additional keyword arguments for the workflow."
+    }
+  }
+}
+```
+
+
+**Responses**
+
+
+#### 200
+Workflow started
+
+- Content type: `application/json`
+  - Schema: `Handler`
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "handler_id": {
+      "type": "string"
+    },
+    "workflow_name": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string",
+      "nullable": true
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "error": {
+      "type": "string",
+      "nullable": true
+    },
+    "result": {
+      "description": "Workflow result value"
+    }
+  },
+  "required": [
+    "handler_id",
+    "workflow_name",
+    "status",
+    "started_at"
+  ]
+}
+```
+
+#### 400
+Invalid start_event payload
+
+
+#### 404
+Workflow or handler identifier not found
+
+
+
+
+
+### /workflows/{name}/schema
+
+#### GET
+
+**Summary**: Get JSON schema for start event
+
+
+Gets the JSON schema of the start and stop events from the specified workflow and returns it under "start" (start event) and "stop" (stop event)
+
+
+**Parameters**
+
+
+| Name | In | Required | Type | Description |
+| --- | --- | :---: | --- | --- |
+| name | path | yes | string | Registered workflow name. |
+
+
+**Request Body**
+
+
+- Required: no
+
+
+**Responses**
+
+
+#### 200
+JSON schema successfully retrieved for start event
+
+- Content type: `application/json`
+```json
+{
+  "type": "object",
+  "properties": {
+    "start": {
+      "description": "JSON schema for the start event"
+    },
+    "stop": {
+      "description": "JSON schema for the stop event"
+    }
+  },
+  "required": [
+    "start",
+    "stop"
+  ]
+}
+```
+
+#### 404
+Workflow not found
+
+
+#### 500
+Error while getting the JSON schema for the start or stop event
+
+
+
+
+
+### Components
+
+
+These are the component schemas referenced above.
+
+
+#### Handler
+
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "handler_id": {
+      "type": "string"
+    },
+    "workflow_name": {
+      "type": "string"
+    },
+    "run_id": {
+      "type": "string",
+      "nullable": true
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "running",
+        "completed",
+        "failed",
+        "cancelled"
+      ]
+    },
+    "started_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "completed_at": {
+      "type": "string",
+      "format": "date-time",
+      "nullable": true
+    },
+    "error": {
+      "type": "string",
+      "nullable": true
+    },
+    "result": {
+      "description": "Workflow result value"
+    }
+  },
+  "required": [
+    "handler_id",
+    "workflow_name",
+    "status",
+    "started_at"
+  ]
+}
+```
+
+
+
+#### HandlersList
+
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "handlers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/components/schemas/Handler"
+      }
+    }
+  },
+  "required": [
+    "handlers"
+  ]
+}
+```
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,8 @@ dependencies = ["pyyaml>=6.0.2"]
 
 [tool.hatch.envs.server.scripts]
 openapi = "python -m workflows.server.server --output openapi.json"
+reference = "python scripts/generate_server_reference_docs.py --openapi openapi.json --out docs/src/content/docs/workflows-api-reference"
+reference-all = "python -m workflows.server.server --output openapi.json && python scripts/generate_server_reference_docs.py --openapi openapi.json --out docs/src/content/docs/workflows-api-reference"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"

--- a/scripts/generate_server_reference_docs.py
+++ b/scripts/generate_server_reference_docs.py
@@ -1,0 +1,272 @@
+# SPDX-License-Identifier: MIT
+"""
+Generate Markdown reference docs for the Workflows Server API from an OpenAPI JSON.
+
+Usage:
+  uv run python scripts/generate_server_reference_docs.py \
+    --openapi openapi.json \
+    --out docs/src/content/docs/workflows-api-reference
+
+If --openapi is not provided or the file is missing, this script attempts
+to import and call WorkflowServer().openapi_schema() to obtain the schema
+without spinning up a server.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Tuple, Union
+
+
+Json = Union[dict, list, str, int, float, bool, None]
+
+
+@dataclass
+class Config:
+    openapi_path: Optional[Path]
+    out_dir: Path
+
+
+def load_openapi(config: Config) -> Dict[str, Any]:
+    if config.openapi_path is not None and config.openapi_path.exists():
+        with config.openapi_path.open("r", encoding="utf-8") as f:
+            return json.load(f)
+    # Fallback: generate via in-process import
+    try:
+        from workflows.server.server import WorkflowServer  # type: ignore
+
+        schema = WorkflowServer().openapi_schema()
+        return schema
+    except Exception as e:  # pragma: no cover - fallback only
+        raise RuntimeError(
+            "Failed to load OpenAPI. Provide --openapi pointing to an existing JSON, "
+            f"or ensure server optional deps are installed. Error: {e}"
+        ) from e
+
+
+def ensure_out_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def md_escape(text: str) -> str:
+    # Minimal escaping for markdown tables and headings
+    return (
+        text.replace("|", "\\|")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace("`", "\u0060")
+    )
+
+
+def render_schema(schema: Json) -> str:
+    try:
+        return "```json\n" + json.dumps(schema, indent=2, ensure_ascii=False) + "\n```\n"
+    except Exception:
+        return "```json\n{}\n```\n"
+
+
+def resolve_ref(ref: str, components: Mapping[str, Any]) -> Tuple[str, Optional[Json]]:
+    # Specs like '#/components/schemas/Handler'
+    if not ref.startswith("#/"):
+        return ref, None
+    parts = ref.split("/")
+    if len(parts) < 4:
+        return ref, None
+    _, components_key, group, name = parts[0], parts[1], parts[2], "/".join(parts[3:])
+    if components_key != "components":
+        return ref, None
+    group_map = components.get(group, {}) if isinstance(components, Mapping) else {}
+    node = group_map.get(name)
+    return name, node
+
+
+def schema_title(schema: Mapping[str, Any]) -> Optional[str]:
+    title = schema.get("title")
+    if isinstance(title, str) and title.strip():
+        return title
+    return None
+
+
+def render_parameters_table(params: List[Mapping[str, Any]], components: Mapping[str, Any]) -> str:
+    if not params:
+        return ""
+    rows: List[str] = ["| Name | In | Required | Type | Description |", "| --- | --- | :---: | --- | --- |"]
+    for p in params:
+        name = md_escape(str(p.get("name", "")))
+        loc = md_escape(str(p.get("in", "")))
+        required = "yes" if p.get("required", False) else "no"
+        desc = md_escape(str(p.get("description", "")).strip())
+        typ = ""
+        schema = p.get("schema")
+        if isinstance(schema, Mapping):
+            if "$ref" in schema:
+                ref_name, ref_schema = resolve_ref(str(schema["$ref"]), components)
+                typ = ref_name
+            else:
+                typ = str(schema.get("type", ""))
+                if schema.get("enum"):
+                    try:
+                        enum_vals = ", ".join(map(str, schema["enum"]))
+                        typ = f"{typ} (enum: {enum_vals})"
+                    except Exception:
+                        pass
+        rows.append(f"| {name} | {loc} | {required} | {md_escape(typ)} | {desc} |")
+    return "\n".join(rows) + "\n\n"
+
+
+def render_request_body(rb: Mapping[str, Any], components: Mapping[str, Any]) -> str:
+    lines: List[str] = []
+    required = rb.get("required", False)
+    lines.append(f"- Required: {'yes' if required else 'no'}\n")
+    content = rb.get("content", {})
+    if not isinstance(content, Mapping):
+        return "\n".join(lines) + "\n"
+    for content_type, media in content.items():
+        lines.append(f"- Content type: `{content_type}`\n")
+        if not isinstance(media, Mapping):
+            continue
+        schema = media.get("schema")
+        if schema is None:
+            continue
+        # Resolve top-level $ref for readability
+        if isinstance(schema, Mapping) and "$ref" in schema:
+            ref_name, ref_schema = resolve_ref(str(schema["$ref"]), components)
+            lines.append(f"  - Schema: `{ref_name}`\n\n")
+            if ref_schema is not None:
+                lines.append(render_schema(ref_schema))
+        else:
+            lines.append(render_schema(schema))
+    return "\n".join(lines) + "\n"
+
+
+def render_responses(responses: Mapping[str, Any], components: Mapping[str, Any]) -> str:
+    out: List[str] = []
+    for status, spec in sorted(responses.items(), key=lambda kv: kv[0]):
+        out.append(f"#### {status}\n")
+        if not isinstance(spec, Mapping):
+            out.append("(no details)\n\n")
+            continue
+        desc = str(spec.get("description", "")).strip()
+        if desc:
+            out.append(desc + "\n\n")
+        content = spec.get("content", {})
+        if isinstance(content, Mapping):
+            for content_type, media in content.items():
+                out.append(f"- Content type: `{content_type}`\n")
+                if not isinstance(media, Mapping):
+                    continue
+                schema = media.get("schema")
+                if schema is None:
+                    continue
+                if isinstance(schema, Mapping) and "$ref" in schema:
+                    ref_name, ref_schema = resolve_ref(str(schema["$ref"]), components)
+                    out.append(f"  - Schema: `{ref_name}`\n\n")
+                    if ref_schema is not None:
+                        out.append(render_schema(ref_schema))
+                else:
+                    out.append(render_schema(schema))
+        out.append("\n")
+    return "".join(out)
+
+
+def build_index_md(openapi: Mapping[str, Any]) -> str:
+    info = openapi.get("info", {}) if isinstance(openapi, Mapping) else {}
+    title = str(info.get("title", "Workflows Server API")).strip() or "Workflows Server API"
+    version = str(info.get("version", "")).strip()
+    header = [
+        "---",
+        f"title: {title} Reference",
+        "---",
+        "",
+        "<!-- THIS FILE IS GENERATED. DO NOT EDIT MANUALLY. -->",
+        "",
+    ]
+    header.append(f"**Version**: `{version}`\n" if version else "")
+    header.append(
+        "This reference is generated from the server's OpenAPI schema. It lists all endpoints, their parameters, request bodies, and responses.\n\n"
+    )
+
+    # Paths
+    paths = openapi.get("paths", {}) if isinstance(openapi, Mapping) else {}
+    components = openapi.get("components", {}) if isinstance(openapi, Mapping) else {}
+
+    # Order paths lexicographically for stability
+    for path_str in sorted(paths.keys()):
+        header.append(f"### {path_str}\n")
+        methods = paths[path_str]
+        if not isinstance(methods, Mapping):
+            header.append("(no method definitions)\n\n")
+            continue
+        # Order methods by common HTTP verb order
+        verb_order = {"get": 0, "post": 1, "put": 2, "patch": 3, "delete": 4, "options": 5, "head": 6}
+        for method, op in sorted(methods.items(), key=lambda kv: (verb_order.get(kv[0].lower(), 99), kv[0])):
+            if not isinstance(op, Mapping):
+                continue
+            verb = method.upper()
+            op_id = op.get("operationId")
+            summary = str(op.get("summary", "")).strip()
+            description = str(op.get("description", "")).strip()
+            header.append(f"#### {verb}\n")
+            if summary:
+                header.append(f"**Summary**: {md_escape(summary)}\n\n")
+            if description:
+                header.append(md_escape(description) + "\n\n")
+
+            params = op.get("parameters", [])
+            if isinstance(params, list) and params:
+                header.append("**Parameters**\n\n")
+                header.append(render_parameters_table(params, components))
+
+            request_body = op.get("requestBody")
+            if isinstance(request_body, Mapping):
+                header.append("**Request Body**\n\n")
+                header.append(render_request_body(request_body, components))
+
+            responses = op.get("responses")
+            if isinstance(responses, Mapping) and responses:
+                header.append("**Responses**\n\n")
+                header.append(render_responses(responses, components))
+
+        header.append("\n")
+
+    # Components appendix (schemas only)
+    schemas = components.get("schemas", {}) if isinstance(components, Mapping) else {}
+    if isinstance(schemas, Mapping) and schemas:
+        header.append("### Components\n\n")
+        header.append("These are the component schemas referenced above.\n\n")
+        for name in sorted(schemas.keys()):
+            header.append(f"#### {name}\n\n")
+            header.append(render_schema(schemas[name]))
+            header.append("\n")
+
+    return "\n".join([line for line in header if line is not None])
+
+
+def write_index(dest_dir: Path, content: str) -> None:
+    ensure_out_dir(dest_dir)
+    out_path = dest_dir / "index.md"
+    out_path.write_text(content, encoding="utf-8")
+
+
+def parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Generate Markdown reference from OpenAPI JSON")
+    parser.add_argument("--openapi", type=str, default=None, help="Path to OpenAPI json file")
+    parser.add_argument("--out", type=str, required=True, help="Output directory for generated markdown")
+    args = parser.parse_args()
+
+    openapi_path = Path(args.openapi) if args.openapi is not None else None
+    out_dir = Path(args.out)
+    return Config(openapi_path=openapi_path, out_dir=out_dir)
+
+
+def main() -> None:
+    config = parse_args()
+    openapi = load_openapi(config)
+    content = build_index_md(openapi)
+    write_index(config.out_dir, content)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_server_reference_docs.py
+++ b/scripts/generate_server_reference_docs.py
@@ -261,6 +261,9 @@ def build_index_md(openapi: Mapping[str, Any]) -> str:
 def write_index(dest_dir: Path, content: str) -> None:
     ensure_out_dir(dest_dir)
     out_path = dest_dir / "index.md"
+    # Ensure trailing newline to satisfy end-of-file linters
+    if not content.endswith("\n"):
+        content = content + "\n"
     out_path.write_text(content, encoding="utf-8")
 
 


### PR DESCRIPTION
Add a script to generate Markdown reference docs for the workflows server API from its OpenAPI schema.

---
Linear Issue: [LI-3952](https://linear.app/llamaindex/issue/LI-3952/add-reference-docs-for-workflows-server)

<a href="https://cursor.com/background-agent?bcId=bc-8230f382-ae7f-4966-9f1a-eca484c3c0da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8230f382-ae7f-4966-9f1a-eca484c3c0da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

