### PR TITLE
Export workflow instrumentation event types from public API

### DIFF
--- a/packages/llama-index-workflows/src/workflows/__init__.py
+++ b/packages/llama-index-workflows/src/workflows/__init__.py
@@ -5,6 +5,11 @@ from pkgutil import extend_path
 
 from .context import Context
 from .decorators import step
+from .runtime.types.step_function import (
+    SpanCancelledEvent,
+    WorkflowRunOutputEvent,
+    WorkflowStepOutputEvent,
+)
 from .workflow import Workflow
 
 __path__ = extend_path(__path__, __name__)
@@ -12,6 +17,9 @@ __path__ = extend_path(__path__, __name__)
 
 __all__ = [
     "Context",
+    "SpanCancelledEvent",
     "Workflow",
+    "WorkflowRunOutputEvent",
+    "WorkflowStepOutputEvent",
     "step",
 ]


### PR DESCRIPTION
WorkflowStepOutputEvent, WorkflowRunOutputEvent, and SpanCancelledEvent are emitted through the LlamaIndex instrumentation dispatcher during workflow execution. Observability integrations such as openinference-instrumentation-llama-index use singledispatch to handle known event types and log a warning for any type they don't recognise:
- WARNING - Unhandled event of type WorkflowStepOutputEvent
- WARNING - Unhandled event of type WorkflowRunOutputEvent

The [root fix belongs in the openinference package](https://github.com/Arize-ai/openinference/pull/2908) (add no-op or meaningful handlers for these types). Exporting the classes from `workflows.__init__` gives the openinference maintainers a stable public import path:
- from workflows import WorkflowStepOutputEvent, WorkflowRunOutputEvent, SpanCancelledEvent

so they can register singledispatch handlers without importing from internal implementation modules.