### PR TITLE
Add comprehensive README documentation for examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,42 @@
+# LlamaAgents Examples
+
+A collection of runnable examples showing how to build, serve, and deploy agent workflows with `llama-index-workflows` and `llama-agents-*`.
+
+New to the project? Start at the top of the list and work down — each step builds on the previous.
+
+## Start here
+
+1. **[`feature_walkthrough.ipynb`](feature_walkthrough.ipynb)** — The single best place to begin. A guided tour of workflows, steps, events, context, branching, loops, and streaming, all in one notebook.
+2. **[`agent.ipynb`](agent.ipynb)** — Build a simple agent as a workflow. Covers tool calling and the agent loop pattern.
+3. **[`document_processing.ipynb`](document_processing.ipynb)** — A realistic document pipeline: parsing, extraction, and orchestration.
+
+## Serving workflows as an API
+
+4. **[`server/`](server/)** — Wrap a workflow as a REST API with `WorkflowServer`, standalone or mounted inside an existing FastAPI app.
+5. **[`client/`](client/)** — Call a running workflow server from Python with `WorkflowClient`, including streaming and human-in-the-loop.
+
+## Durability and scale
+
+6. **[`durable_workflows.ipynb`](durable_workflows.ipynb)** — Save and resume workflow runs using pluggable storage.
+7. **[`dbos/`](dbos/)** — Production-grade durability with DBOS: crash recovery, multi-replica servers, and idle release.
+
+## Deployment
+
+8. **[`docker/`](docker/)** — Containerize a workflow server with Docker.
+9. **[`k8s-otel/`](k8s-otel/)** — Deploy to Kubernetes with OpenTelemetry, Tilt, and a kind cluster.
+
+## Observability and evaluation
+
+10. **[`observability/`](observability/)** — Trace workflows with Arize Phoenix, Langfuse, and the built-in context logger.
+11. **[`eval_driven_prompt_refinement.ipynb`](eval_driven_prompt_refinement.ipynb)** — Iterate on prompts using evaluation-driven feedback loops.
+
+## Advanced patterns
+
+- **[`streaming_internal_events.ipynb`](streaming_internal_events.ipynb)** — Stream intermediate events from nested workflow steps.
+- **[`state_management_with_vector_databases.ipynb`](state_management_with_vector_databases.ipynb)** — Persist workflow state in a vector database.
+- **[`document_agents/`](document_agents/)** — A finance triage agent built with document workflows.
+- **[`visualization/`](visualization/)** — Visualize workflow graphs, including resource nodes.
+
+---
+
+For more on the library, see the [`llama-index-workflows` package README](../packages/llama-index-workflows/README.md) and the [project root README](../README.md).

--- a/examples/client/README.md
+++ b/examples/client/README.md
@@ -1,0 +1,24 @@
+# Client Examples
+
+Call a running `WorkflowServer` from Python with `llama_agents.client.WorkflowClient`. Each subfolder is a self-contained pair: a server script you run first, and a client script you run against it.
+
+## Examples
+
+| Folder | What it shows |
+| --- | --- |
+| [`base/`](base/) | The minimal client/server pair — submit a run, stream events, get the result. **Start here.** |
+| [`human_in_the_loop/`](human_in_the_loop/) | A workflow that pauses to wait for human input via `InputRequiredEvent` / `HumanResponseEvent`, and a client that responds to it. |
+
+## Running
+
+In one terminal, start the server:
+
+```bash
+uv run examples/client/base/workflow_server.py
+```
+
+In another, run the client:
+
+```bash
+uv run examples/client/base/workflow_client.py
+```

--- a/examples/dbos/README.md
+++ b/examples/dbos/README.md
@@ -1,0 +1,26 @@
+# DBOS Durability Examples
+
+Examples of running durable workflows backed by [DBOS](https://github.com/dbos-inc/dbos-transact-py). DBOS gives you crash recovery, resumable runs, and multi-replica coordination with either SQLite (zero setup) or Postgres.
+
+See [`packages/llama-agents-dbos/ARCHITECTURE.md`](../../packages/llama-agents-dbos/ARCHITECTURE.md) for the underlying model.
+
+## Examples
+
+| File | What it shows |
+| --- | --- |
+| [`server_quickstart.py`](server_quickstart.py) | The simplest durable `WorkflowServer` setup, using SQLite out of the box. **Start here.** |
+| [`durable_workflow.py`](durable_workflow.py) | A looping counter workflow you can interrupt with Ctrl+C and resume with `--resume`. Demonstrates checkpointing without a server. |
+| [`server_replicas.py`](server_replicas.py) | Two `WorkflowServer` replicas sharing a Postgres-backed event store. Start a run on replica A, stream events from replica B, interrupt, and resume. Requires Docker (uses [`docker-compose.yml`](docker-compose.yml)). |
+| [`idle_release_demo.py`](idle_release_demo.py) | Shows how long-idle workflows are released from memory and automatically resumed when a new event arrives. |
+| [`_replica.py`](_replica.py) | Single-replica server process used internally by `server_replicas.py`. |
+
+## Running
+
+```bash
+# Quickest path — no database required
+uv run examples/dbos/server_quickstart.py
+
+# Multi-replica (needs Docker for Postgres)
+docker compose -f examples/dbos/docker-compose.yml up -d
+uv run examples/dbos/server_replicas.py
+```

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,24 @@
+# Docker Example
+
+A minimal container image that serves a workflow with `WorkflowServer`.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| [`app.py`](app.py) | The workflow and `WorkflowServer` entrypoint. |
+| [`Dockerfile`](Dockerfile) | Builds a slim Python image with the app and its dependencies. |
+| [`requirements.txt`](requirements.txt) | Runtime dependencies installed into the image. |
+
+## Running
+
+```bash
+docker build -t workflows-example examples/docker
+docker run --rm -p 8000:8000 workflows-example
+```
+
+Then call it from the host:
+
+```bash
+curl -X POST http://localhost:8000/workflows/echo/run -d '{"start_event": {"message": "hi"}}'
+```

--- a/examples/observability/README.md
+++ b/examples/observability/README.md
@@ -1,0 +1,13 @@
+# Observability Examples
+
+Trace and inspect workflow runs using the built-in context logger and third-party observability platforms.
+
+## Examples
+
+| Notebook | What it shows |
+| --- | --- |
+| [`workflows_observability_pt1.ipynb`](workflows_observability_pt1.ipynb) | Part 1: the basics of instrumenting a workflow and reading its event stream. **Start here.** |
+| [`workflows_observability_pt2.ipynb`](workflows_observability_pt2.ipynb) | Part 2: deeper patterns — custom spans, nested workflows, and step-level timing. |
+| [`workflow_context_logging.ipynb`](workflow_context_logging.ipynb) | Use the built-in context logger to emit structured logs tied to a run. |
+| [`workflows_observablitiy_arize_phoenix.ipynb`](workflows_observablitiy_arize_phoenix.ipynb) | Export traces to [Arize Phoenix](https://phoenix.arize.com/) for visualization. |
+| [`workflows_observablitiy_langfuse.ipynb`](workflows_observablitiy_langfuse.ipynb) | Export traces to [Langfuse](https://langfuse.com/). |

--- a/examples/server/README.md
+++ b/examples/server/README.md
@@ -1,0 +1,22 @@
+# Server Examples
+
+Expose workflows as HTTP APIs with `llama_agents.server.WorkflowServer`. Run standalone or mount inside an existing FastAPI / Starlette app.
+
+## Examples
+
+| File | What it shows |
+| --- | --- |
+| [`server_example.py`](server_example.py) | The minimal standalone `WorkflowServer`. **Start here.** |
+| [`server_example.ipynb`](server_example.ipynb) | Same example as a walkthrough notebook, with explanations and a client call. |
+| [`server.py`](server.py) | Mount `WorkflowServer` inside an existing FastAPI app alongside your own routes. |
+| [`fastapi_server_example.ipynb`](fastapi_server_example.ipynb) | Notebook version of the FastAPI integration pattern. |
+
+## Running
+
+```bash
+uv run examples/server/server_example.py
+# then in another terminal
+curl -X POST http://localhost:8000/workflows/echo/run -d '{"start_event": {"message": "hi"}}'
+```
+
+See also the [`client/`](../client/) examples for calling a running server from Python.


### PR DESCRIPTION
## Summary
Added a complete set of README files documenting the examples directory structure and how to use each example. This provides clear guidance for users getting started with llama-agents workflows.

## Key Changes
- **`examples/README.md`** — Main entry point documenting all examples organized by learning path:
  - Start here section (feature walkthrough, agent building, document processing)
  - Serving workflows as APIs (server and client examples)
  - Durability and scale (durable workflows, DBOS)
  - Deployment (Docker, Kubernetes)
  - Observability and evaluation
  - Advanced patterns

- **`examples/server/README.md`** — Documents how to expose workflows as HTTP APIs with `WorkflowServer`, including standalone and FastAPI integration patterns

- **`examples/client/README.md`** — Explains how to call running `WorkflowServer` instances from Python, with examples for basic usage and human-in-the-loop patterns

- **`examples/dbos/README.md`** — Documents DBOS durability examples showing crash recovery, resumable runs, and multi-replica coordination with SQLite or Postgres

- **`examples/docker/README.md`** — Explains containerizing a workflow server with Docker

- **`examples/observability/README.md`** — Documents tracing and inspection of workflow runs using built-in logging and third-party platforms (Arize Phoenix, Langfuse)

## Notable Details
- READMEs follow a consistent structure with file descriptions and running instructions
- Main README provides a curated learning path from basics to advanced patterns
- Each example folder has a focused README explaining its specific use case
- Includes quick-start commands for users to get running immediately

https://claude.ai/code/session_01RZjRStRDFYAuWUzxoRkXao