### PR TITLE
Fix memory leak from copied RunContext

### DIFF
--- a/.changeset/clear-runcontext-on-consume.md
+++ b/.changeset/clear-runcontext-on-consume.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+fix: drop RunContext strong refs when the control loop consumes them, so asyncio TimerHandle Context snapshots (e.g. aiohttp's periodic `_cleanup_closed`) cannot pin the workflow graph

--- a/.changeset/clear-runcontext-on-consume.md
+++ b/.changeset/clear-runcontext-on-consume.md
@@ -2,4 +2,4 @@
 "llama-index-workflows": patch
 ---
 
-fix: drop RunContext strong refs when the control loop consumes them, so asyncio TimerHandle Context snapshots (e.g. aiohttp's periodic `_cleanup_closed`) cannot pin the workflow graph
+fix: memory leak where asyncio timers could capture a Workflow reference via RunContext

--- a/.changeset/clear-runcontext-on-consume.md
+++ b/.changeset/clear-runcontext-on-consume.md
@@ -2,4 +2,4 @@
 "llama-index-workflows": patch
 ---
 
-fix: memory leak where asyncio timers could capture a Workflow reference via RunContext
+fix memory leak where asyncio timers could capture a Workflow reference via RunContext

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -60,7 +60,7 @@ from workflows.runtime.types.named_task import (
 from workflows.runtime.types.plugin import (
     InternalRunAdapter,
     WaitResultTick,
-    get_current_run,
+    consume_current_run,
 )
 from workflows.runtime.types.results import (
     AddCollectedEvent,
@@ -530,11 +530,12 @@ async def control_loop(
     """
     The main async control loop for a workflow run.
     """
-    current = get_current_run()
-    state = init_state or BrokerState.from_workflow(current.workflow)
-    runner = _ControlLoopRunner(
-        current.workflow, current.run_adapter, current.context, current.steps, state
-    )
+    # Consume the RunContext payload immediately so its strong references to
+    # the workflow graph are dropped before any step gets a chance to schedule
+    # an asyncio handle whose Context snapshot would otherwise pin them.
+    workflow, run_adapter, context, steps = consume_current_run()
+    state = init_state or BrokerState.from_workflow(workflow)
+    runner = _ControlLoopRunner(workflow, run_adapter, context, steps, state)
     return await runner.run(start_event=start_event)
 
 

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -530,12 +530,14 @@ async def control_loop(
     """
     The main async control loop for a workflow run.
     """
-    # Consume the RunContext payload immediately so its strong references to
-    # the workflow graph are dropped before any step gets a chance to schedule
-    # an asyncio handle whose Context snapshot would otherwise pin them.
-    workflow, run_adapter, context, steps = consume_current_run()
-    state = init_state or BrokerState.from_workflow(workflow)
-    runner = _ControlLoopRunner(workflow, run_adapter, context, steps, state)
+    # Consume the RunContext immediately so the container's strong reference
+    # to the workflow graph is dropped before any step gets a chance to schedule
+    # an asyncio handle whose Context snapshot would otherwise pin it.
+    run = consume_current_run()
+    state = init_state or BrokerState.from_workflow(run.workflow)
+    runner = _ControlLoopRunner(
+        run.workflow, run.run_adapter, run.context, run.steps, state
+    )
     return await runner.run(start_event=start_event)
 
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
@@ -346,64 +346,64 @@ class ExternalRunAdapter(ABC):
 
 @dataclass
 class RunContext:
-    """One-shot payload used to hand a workflow run from `create_workflow_run_function`
-    to the control loop across the narrow `ControlLoopFunction` boundary.
-
-    Consumed exactly once via `consume_current_run()` at the top of the control
-    loop. Fields are cleared on consumption so any `asyncio` `TimerHandle` that
-    snapshots the current `Context` cannot keep the workflow object graph alive
-    through this dataclass.
+    """Payload handed from `create_workflow_run_function` to the control loop
+    across the narrow `ControlLoopFunction` boundary.
     """
 
-    workflow: Workflow | None
-    run_adapter: InternalRunAdapter | None
-    context: Context | None
-    steps: dict[str, StepWorkerFunction] | None
+    workflow: Workflow
+    run_adapter: InternalRunAdapter
+    context: Context
+    steps: dict[str, StepWorkerFunction]
 
-    def consume(
-        self,
-    ) -> tuple[Workflow, InternalRunAdapter, Context, dict[str, StepWorkerFunction]]:
-        wf, adapter, ctx, steps = (
-            self.workflow,
-            self.run_adapter,
-            self.context,
-            self.steps,
-        )
-        if wf is None or adapter is None or ctx is None or steps is None:
+
+@dataclass
+class RunContextContainer:
+    """Mutable one-shot holder for a `RunContext`.
+
+    The control loop calls `consume()` at entry, which drops the container's
+    reference to the payload. Because `asyncio` snapshots the current `Context`
+    when scheduling handles (e.g. `loop.call_later` for periodic timers like
+    aiohttp's `TCPConnector._cleanup_closed`), any such snapshot would otherwise
+    keep the workflow object graph alive via this container until the timer
+    fires. Clearing the single shared instance breaks that reference chain.
+    """
+
+    payload: RunContext | None
+
+    def consume(self) -> RunContext:
+        payload, self.payload = self.payload, None
+        if payload is None:
             raise RuntimeError("RunContext has already been consumed")
-        self.workflow = None
-        self.run_adapter = None
-        self.context = None
-        self.steps = None
-        return wf, adapter, ctx, steps
+        return payload
 
 
-_current_run: ContextVar[RunContext | None] = ContextVar("current_run", default=None)
+_current_run: ContextVar[RunContextContainer | None] = ContextVar(
+    "current_run", default=None
+)
 
 
 @contextmanager
-def run_context(ctx: RunContext) -> Generator[RunContext, None, None]:
+def run_context(ctx: RunContext) -> Generator[RunContextContainer, None, None]:
     """Set the current run context for the duration of a workflow run."""
-    token = _current_run.set(ctx)
+    container = RunContextContainer(payload=ctx)
+    token = _current_run.set(container)
     try:
-        yield ctx
+        yield container
     finally:
         _current_run.reset(token)
 
 
-def consume_current_run() -> tuple[
-    Workflow, InternalRunAdapter, Context, dict[str, StepWorkerFunction]
-]:
+def consume_current_run() -> RunContext:
     """Consume the current `RunContext` payload exactly once.
 
-    Drops the strong references the `RunContext` dataclass holds so that any
-    `Context` snapshot taken by `asyncio` (e.g. via `loop.call_later`) cannot
-    pin the workflow graph through it.
+    Drops the container's strong reference to the payload so that any `Context`
+    snapshot taken by `asyncio` (e.g. via `loop.call_later`) cannot pin the
+    workflow graph through it.
     """
-    ctx = _current_run.get()
-    if ctx is None:
+    container = _current_run.get()
+    if container is None:
         raise RuntimeError("Not in a workflow run context")
-    return ctx.consume()
+    return container.consume()
 
 
 class WorkflowSet:

--- a/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
@@ -351,8 +351,7 @@ class RunContext:
 
     Consumed exactly once via `consume_current_run()` at the top of the control
     loop. Fields are cleared on consumption so any `asyncio` `TimerHandle` that
-    snapshots the current `Context` (e.g. periodic timers like aiohttp's
-    `TCPConnector._cleanup_closed`) cannot keep the workflow object graph alive
+    snapshots the current `Context` cannot keep the workflow object graph alive
     through this dataclass.
     """
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
@@ -346,12 +346,37 @@ class ExternalRunAdapter(ABC):
 
 @dataclass
 class RunContext:
-    """Context for an active workflow run, available via get_current_run()."""
+    """One-shot payload used to hand a workflow run from `create_workflow_run_function`
+    to the control loop across the narrow `ControlLoopFunction` boundary.
 
-    workflow: Workflow
-    run_adapter: InternalRunAdapter
-    context: Context
-    steps: dict[str, StepWorkerFunction]
+    Consumed exactly once via `consume_current_run()` at the top of the control
+    loop. Fields are cleared on consumption so any `asyncio` `TimerHandle` that
+    snapshots the current `Context` (e.g. periodic timers like aiohttp's
+    `TCPConnector._cleanup_closed`) cannot keep the workflow object graph alive
+    through this dataclass.
+    """
+
+    workflow: Workflow | None
+    run_adapter: InternalRunAdapter | None
+    context: Context | None
+    steps: dict[str, StepWorkerFunction] | None
+
+    def consume(
+        self,
+    ) -> tuple[Workflow, InternalRunAdapter, Context, dict[str, StepWorkerFunction]]:
+        wf, adapter, ctx, steps = (
+            self.workflow,
+            self.run_adapter,
+            self.context,
+            self.steps,
+        )
+        if wf is None or adapter is None or ctx is None or steps is None:
+            raise RuntimeError("RunContext has already been consumed")
+        self.workflow = None
+        self.run_adapter = None
+        self.context = None
+        self.steps = None
+        return wf, adapter, ctx, steps
 
 
 _current_run: ContextVar[RunContext | None] = ContextVar("current_run", default=None)
@@ -367,12 +392,19 @@ def run_context(ctx: RunContext) -> Generator[RunContext, None, None]:
         _current_run.reset(token)
 
 
-def get_current_run() -> RunContext:
-    """Get the current run context. Raises if not in a workflow run."""
+def consume_current_run() -> tuple[
+    Workflow, InternalRunAdapter, Context, dict[str, StepWorkerFunction]
+]:
+    """Consume the current `RunContext` payload exactly once.
+
+    Drops the strong references the `RunContext` dataclass holds so that any
+    `Context` snapshot taken by `asyncio` (e.g. via `loop.call_later`) cannot
+    pin the workflow graph through it.
+    """
     ctx = _current_run.get()
     if ctx is None:
         raise RuntimeError("Not in a workflow run context")
-    return ctx
+    return ctx.consume()
 
 
 class WorkflowSet:

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -659,49 +659,34 @@ async def test_workflow_instances_garbage_collected_after_completion() -> None:
 
 
 @pytest.mark.asyncio
-async def test_workflow_not_pinned_by_periodic_timer_context() -> None:
-    # Regression test: a periodic asyncio timer started during workflow
-    # execution must not permanently pin the Workflow via the ContextVar
-    # snapshot in TimerHandle._context. See bug report on ContextVar +
-    # periodic timer context propagation leak.
+async def test_workflow_not_pinned_by_timer_handle_context() -> None:
+    # Regression: TimerHandle._context snapshots the ContextVar holding
+    # RunContext -> Workflow, pinning the workflow until the handle runs
+    # (or forever if it re-registers itself, like aiohttp's _cleanup_closed).
+    handles: list[asyncio.TimerHandle] = []
+
     class TinyWorkflow(Workflow):
         @step
         async def only(self, ev: StartEvent) -> StopEvent:
-            loop = asyncio.get_running_loop()
-
-            def _periodic() -> None:
-                # Re-register self, mimicking aiohttp TCPConnector._cleanup_closed.
-                h = loop.call_later(0.05, _periodic)
-                periodic_handles.append(h)
-
-            h = loop.call_later(0.05, _periodic)
-            periodic_handles.append(h)
+            handles.append(asyncio.get_running_loop().call_later(3600, lambda: None))
             return StopEvent(result="done")
 
-    periodic_handles: list[asyncio.TimerHandle] = []
     refs: list[weakref.ReferenceType[Workflow]] = []
-
     try:
         for _ in range(5):
             wf = TinyWorkflow()
-            refs.append(
-                cast(weakref.ReferenceType[Workflow], weakref.ref(wf))
-            )
+            refs.append(cast(weakref.ReferenceType[Workflow], weakref.ref(wf)))
             await WorkflowTestRunner(wf).run()
             del wf
 
-        # Let the periodic timer fire and re-register several times.
-        await asyncio.sleep(0.5)
-
         for _ in range(3):
             gc.collect()
-            await asyncio.sleep(0)
 
         assert all(r() is None for r in refs), (
-            f"{sum(r() is not None for r in refs)} workflows pinned by periodic timer Context"
+            f"{sum(r() is not None for r in refs)} workflows pinned by TimerHandle context"
         )
     finally:
-        for h in periodic_handles:
+        for h in handles:
             h.cancel()
 
 

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -658,6 +658,53 @@ async def test_workflow_instances_garbage_collected_after_completion() -> None:
     assert all([r() is None for r in refs])
 
 
+@pytest.mark.asyncio
+async def test_workflow_not_pinned_by_periodic_timer_context() -> None:
+    # Regression test: a periodic asyncio timer started during workflow
+    # execution must not permanently pin the Workflow via the ContextVar
+    # snapshot in TimerHandle._context. See bug report on ContextVar +
+    # periodic timer context propagation leak.
+    class TinyWorkflow(Workflow):
+        @step
+        async def only(self, ev: StartEvent) -> StopEvent:
+            loop = asyncio.get_running_loop()
+
+            def _periodic() -> None:
+                # Re-register self, mimicking aiohttp TCPConnector._cleanup_closed.
+                h = loop.call_later(0.05, _periodic)
+                periodic_handles.append(h)
+
+            h = loop.call_later(0.05, _periodic)
+            periodic_handles.append(h)
+            return StopEvent(result="done")
+
+    periodic_handles: list[asyncio.TimerHandle] = []
+    refs: list[weakref.ReferenceType[Workflow]] = []
+
+    try:
+        for _ in range(5):
+            wf = TinyWorkflow()
+            refs.append(
+                cast(weakref.ReferenceType[Workflow], weakref.ref(wf))
+            )
+            await WorkflowTestRunner(wf).run()
+            del wf
+
+        # Let the periodic timer fire and re-register several times.
+        await asyncio.sleep(0.5)
+
+        for _ in range(3):
+            gc.collect()
+            await asyncio.sleep(0)
+
+        assert all(r() is None for r in refs), (
+            f"{sum(r() is not None for r in refs)} workflows pinned by periodic timer Context"
+        )
+    finally:
+        for h in periodic_handles:
+            h.cancel()
+
+
 def test_workflow_error_no_steps_configured_message() -> None:
     class Dummy(Workflow):
         @step

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -662,7 +662,7 @@ async def test_workflow_instances_garbage_collected_after_completion() -> None:
 async def test_workflow_not_pinned_by_timer_handle_context() -> None:
     # Regression: TimerHandle._context snapshots the ContextVar holding
     # RunContext -> Workflow, pinning the workflow until the handle runs
-    # (or forever if it re-registers itself, like aiohttp's _cleanup_closed).
+    # (or forever if the handle re-registers itself).
     handles: list[asyncio.TimerHandle] = []
 
     class TinyWorkflow(Workflow):


### PR DESCRIPTION
Fixes #485.

asyncio `TimerHandle`s capture the current `Context` at schedule time, which pinned the workflow's `RunContext` ContextVar until the timer fired. Long-lived periodic timers (e.g. aiohttp's `TCPConnector` cleanup) kept workflows alive indefinitely.

Fix: clear the `RunContext` ContextVar once the control loop is done consuming, breaking the reference chain from timer handles back to the workflow.