### PR TITLE
fix: build GC grace window + operator stale-job cleanup + auth retry

### DIFF
--- a/.changeset/build-gc-grace-and-retry-audit.md
+++ b/.changeset/build-gc-grace-and-retry-audit.md
@@ -1,0 +1,6 @@
+---
+"llama-agents-control-plane": patch
+"llamactl": patch
+---
+
+Add a grace window to build artifact GC (configurable via `BUILD_ARTIFACT_GC_GRACE_SECONDS`, default 75m) and stop auto-retrying `llamactl auth`'s non-idempotent key-creation POST.

--- a/.changeset/build-gc-grace-and-retry-audit.md
+++ b/.changeset/build-gc-grace-and-retry-audit.md
@@ -3,4 +3,4 @@
 "llamactl": patch
 ---
 
-Add a grace window to build artifact GC (configurable via `BUILD_ARTIFACT_GC_GRACE_SECONDS`, default 75m) and stop auto-retrying `llamactl auth`'s non-idempotent key-creation POST.
+Add a grace window to build artifact GC (configurable via `BUILD_ARTIFACT_GC_GRACE_SECONDS`, default 75m) and parallelize its delete loop with bounded concurrency. `llamactl auth`'s non-idempotent key-creation POST now only retries on connect-phase errors (`ConnectError`, `ConnectTimeout`, `PoolTimeout`) so initial-connectivity blips are absorbed without risking duplicate keys from a read-timeout retry.

--- a/operator/internal/controller/resources.go
+++ b/operator/internal/controller/resources.go
@@ -69,6 +69,10 @@ const (
 	// Default rollout timeout in seconds (30 minutes)
 	DefaultRolloutTimeoutSeconds int32 = 1800
 
+	// Build artifact GC walks ReplicaSets up to this limit to discover
+	// referenced buildIds, so pin it rather than relying on the apps/v1 default.
+	DeploymentRevisionHistoryLimit int32 = 10
+
 	// Environment variable for rollout timeout configuration
 	EnvRolloutTimeoutSeconds = "LLAMA_DEPLOY_ROLLOUT_TIMEOUT_SECONDS"
 
@@ -386,6 +390,43 @@ func (r *LlamaDeploymentReconciler) reconcileBuild(ctx context.Context, llamaDep
 	if llamaDeploy.Status.BuildId == buildId && llamaDeploy.Status.BuildStatus == BuildStatusSucceeded {
 		logger.V(1).Info("Build artifact already exists", "buildId", buildId)
 		return buildId, nil, nil
+	}
+
+	// If the spec advanced mid-build, cancel the stale in-flight Job so it
+	// doesn't race the new one uploading. Succeeded stale Jobs are preserved
+	// for the A → B → A rollback-by-cache-hit path.
+	if llamaDeploy.Status.BuildId != "" && llamaDeploy.Status.BuildId != buildId &&
+		(llamaDeploy.Status.BuildStatus == BuildStatusPending || llamaDeploy.Status.BuildStatus == BuildStatusRunning) {
+		staleBuildId := llamaDeploy.Status.BuildId
+		staleJobName := fmt.Sprintf("%s-build-%s", llamaDeploy.Name, staleBuildId)
+		if len(staleJobName) > 63 {
+			staleJobName = staleJobName[:63]
+		}
+		staleJob := &batchv1.Job{}
+		getErr := r.Get(ctx, client.ObjectKey{Name: staleJobName, Namespace: llamaDeploy.Namespace}, staleJob)
+		switch {
+		case errors.IsNotFound(getErr):
+			// Already gone (TTL reaped it, or a prior reconcile deleted it).
+		case getErr != nil:
+			return "", nil, fmt.Errorf("failed to check stale build job: %w", getErr)
+		case staleJob.Status.Succeeded > 0:
+			logger.V(1).Info("Prior build succeeded; leaving Job in place",
+				"staleBuildId", staleBuildId, "jobName", staleJobName)
+		default:
+			logger.Info("Superseding in-flight build Job for previous buildId",
+				"staleBuildId", staleBuildId,
+				"newBuildId", buildId,
+				"jobName", staleJobName)
+			if err := r.Delete(ctx, staleJob,
+				client.PropagationPolicy(metav1.DeletePropagationBackground),
+			); err != nil && !errors.IsNotFound(err) {
+				return "", nil, fmt.Errorf("failed to delete superseded build job: %w", err)
+			}
+			if r.Recorder != nil {
+				r.Recorder.Event(llamaDeploy, corev1.EventTypeNormal, PhaseBuilding,
+					fmt.Sprintf("Superseded stale build Job: %s", staleJobName))
+			}
+		}
 	}
 
 	// Check if a build Job already exists for this buildId
@@ -1044,6 +1085,7 @@ func (r *LlamaDeploymentReconciler) createDeploymentForLlama(llamaDeploy *llamad
 		Spec: appsv1.DeploymentSpec{
 			Replicas:                &replicas,
 			ProgressDeadlineSeconds: getRolloutTimeoutSeconds(),
+			RevisionHistoryLimit:    ptr(DeploymentRevisionHistoryLimit),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{"app": llamaDeploy.Name},
 			},

--- a/operator/internal/controller/resources.go
+++ b/operator/internal/controller/resources.go
@@ -81,6 +81,16 @@ const (
 	appserverTagPrefix = "appserver-"
 )
 
+// buildJobName computes the Job name for a given deployment/buildId combo,
+// truncated to Kubernetes' 63-character name limit.
+func buildJobName(deploymentName, buildId string) string {
+	name := fmt.Sprintf("%s-build-%s", deploymentName, buildId)
+	if len(name) > 63 {
+		name = name[:63]
+	}
+	return name
+}
+
 // looksLikeFilePath provides a lightweight heuristic to determine if a
 // deployment file path refers to a file rather than a directory. It avoids
 // filesystem access and relies on common file extensions and presence of an extension.
@@ -398,10 +408,7 @@ func (r *LlamaDeploymentReconciler) reconcileBuild(ctx context.Context, llamaDep
 	if llamaDeploy.Status.BuildId != "" && llamaDeploy.Status.BuildId != buildId &&
 		(llamaDeploy.Status.BuildStatus == BuildStatusPending || llamaDeploy.Status.BuildStatus == BuildStatusRunning) {
 		staleBuildId := llamaDeploy.Status.BuildId
-		staleJobName := fmt.Sprintf("%s-build-%s", llamaDeploy.Name, staleBuildId)
-		if len(staleJobName) > 63 {
-			staleJobName = staleJobName[:63]
-		}
+		staleJobName := buildJobName(llamaDeploy.Name, staleBuildId)
 		staleJob := &batchv1.Job{}
 		getErr := r.Get(ctx, client.ObjectKey{Name: staleJobName, Namespace: llamaDeploy.Namespace}, staleJob)
 		switch {
@@ -430,10 +437,7 @@ func (r *LlamaDeploymentReconciler) reconcileBuild(ctx context.Context, llamaDep
 	}
 
 	// Check if a build Job already exists for this buildId
-	jobName := fmt.Sprintf("%s-build-%s", llamaDeploy.Name, buildId)
-	if len(jobName) > 63 {
-		jobName = jobName[:63]
-	}
+	jobName := buildJobName(llamaDeploy.Name, buildId)
 
 	existingJob := &batchv1.Job{}
 	err := r.Get(ctx, client.ObjectKey{Name: jobName, Namespace: llamaDeploy.Namespace}, existingJob)
@@ -573,12 +577,7 @@ func (r *LlamaDeploymentReconciler) createBuildJob(llamaDeploy *llamadeployv1.Ll
 
 	envFrom := r.commonEnvFrom(llamaDeploy)
 
-	// Use a short suffix of the buildId for the Job name to avoid collisions
-	// Job names must be <= 63 chars
-	jobName := fmt.Sprintf("%s-build-%s", llamaDeploy.Name, buildId)
-	if len(jobName) > 63 {
-		jobName = jobName[:63]
-	}
+	jobName := buildJobName(llamaDeploy.Name, buildId)
 
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/internal/controller/resources.go
+++ b/operator/internal/controller/resources.go
@@ -372,6 +372,55 @@ func computeBuildId(llamaDeploy *llamadeployv1.LlamaDeployment) string {
 	return hash[:16]
 }
 
+// supersedeStaleBuildJob cancels any in-flight build Job whose buildId has
+// been superseded by a new spec. Succeeded stale Jobs are preserved for the
+// A → B → A rollback-by-cache-hit path. A missing Job is a no-op (TTL may
+// have reaped it, or a prior reconcile deleted it).
+func (r *LlamaDeploymentReconciler) supersedeStaleBuildJob(
+	ctx context.Context,
+	llamaDeploy *llamadeployv1.LlamaDeployment,
+	newBuildId string,
+) error {
+	if llamaDeploy.Status.BuildId == "" || llamaDeploy.Status.BuildId == newBuildId {
+		return nil
+	}
+	if llamaDeploy.Status.BuildStatus != BuildStatusPending &&
+		llamaDeploy.Status.BuildStatus != BuildStatusRunning {
+		return nil
+	}
+
+	logger := log.FromContext(ctx)
+	staleBuildId := llamaDeploy.Status.BuildId
+	staleJobName := buildJobName(llamaDeploy.Name, staleBuildId)
+	staleJob := &batchv1.Job{}
+	getErr := r.Get(ctx, client.ObjectKey{Name: staleJobName, Namespace: llamaDeploy.Namespace}, staleJob)
+	switch {
+	case errors.IsNotFound(getErr):
+		return nil
+	case getErr != nil:
+		return fmt.Errorf("failed to check stale build job: %w", getErr)
+	case staleJob.Status.Succeeded > 0:
+		logger.V(1).Info("Prior build succeeded; leaving Job in place",
+			"staleBuildId", staleBuildId, "jobName", staleJobName)
+		return nil
+	}
+
+	logger.Info("Superseding in-flight build Job for previous buildId",
+		"staleBuildId", staleBuildId,
+		"newBuildId", newBuildId,
+		"jobName", staleJobName)
+	if err := r.Delete(ctx, staleJob,
+		client.PropagationPolicy(metav1.DeletePropagationBackground),
+	); err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("failed to delete superseded build job: %w", err)
+	}
+	if r.Recorder != nil {
+		r.Recorder.Event(llamaDeploy, corev1.EventTypeNormal, PhaseBuilding,
+			fmt.Sprintf("Superseded stale build Job: %s", staleJobName))
+	}
+	return nil
+}
+
 // reconcileBuild ensures a build artifact exists for the current deployment inputs.
 // Returns the buildId if a build is ready, or ("", result, nil) if a build is in progress
 // and the caller should requeue.
@@ -403,37 +452,9 @@ func (r *LlamaDeploymentReconciler) reconcileBuild(ctx context.Context, llamaDep
 	}
 
 	// If the spec advanced mid-build, cancel the stale in-flight Job so it
-	// doesn't race the new one uploading. Succeeded stale Jobs are preserved
-	// for the A → B → A rollback-by-cache-hit path.
-	if llamaDeploy.Status.BuildId != "" && llamaDeploy.Status.BuildId != buildId &&
-		(llamaDeploy.Status.BuildStatus == BuildStatusPending || llamaDeploy.Status.BuildStatus == BuildStatusRunning) {
-		staleBuildId := llamaDeploy.Status.BuildId
-		staleJobName := buildJobName(llamaDeploy.Name, staleBuildId)
-		staleJob := &batchv1.Job{}
-		getErr := r.Get(ctx, client.ObjectKey{Name: staleJobName, Namespace: llamaDeploy.Namespace}, staleJob)
-		switch {
-		case errors.IsNotFound(getErr):
-			// Already gone (TTL reaped it, or a prior reconcile deleted it).
-		case getErr != nil:
-			return "", nil, fmt.Errorf("failed to check stale build job: %w", getErr)
-		case staleJob.Status.Succeeded > 0:
-			logger.V(1).Info("Prior build succeeded; leaving Job in place",
-				"staleBuildId", staleBuildId, "jobName", staleJobName)
-		default:
-			logger.Info("Superseding in-flight build Job for previous buildId",
-				"staleBuildId", staleBuildId,
-				"newBuildId", buildId,
-				"jobName", staleJobName)
-			if err := r.Delete(ctx, staleJob,
-				client.PropagationPolicy(metav1.DeletePropagationBackground),
-			); err != nil && !errors.IsNotFound(err) {
-				return "", nil, fmt.Errorf("failed to delete superseded build job: %w", err)
-			}
-			if r.Recorder != nil {
-				r.Recorder.Event(llamaDeploy, corev1.EventTypeNormal, PhaseBuilding,
-					fmt.Sprintf("Superseded stale build Job: %s", staleJobName))
-			}
-		}
+	// doesn't race the new one uploading.
+	if err := r.supersedeStaleBuildJob(ctx, llamaDeploy, buildId); err != nil {
+		return "", nil, err
 	}
 
 	// Check if a build Job already exists for this buildId

--- a/operator/internal/controller/resources_build_unit_test.go
+++ b/operator/internal/controller/resources_build_unit_test.go
@@ -872,6 +872,205 @@ func TestReconcileBuild_SkipsWhenRepoUrlEmpty(t *testing.T) {
 	}
 }
 
+// When the spec advances mid-build, the in-flight Job for the old buildId
+// must be deleted so it doesn't race the new one to upload.
+func TestReconcileBuild_SupersedesInFlightJob_OnBuildIdChange(t *testing.T) {
+	scheme := newTestScheme()
+
+	staleBuildId := "stalebuild1234"
+	staleJobName := fmt.Sprintf("%s-build-%s", "my-app", staleBuildId)
+	if len(staleJobName) > 63 {
+		staleJobName = staleJobName[:63]
+	}
+
+	llamaDeploy := &llamadeployv1.LlamaDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "my-app",
+			Namespace:  "default",
+			Generation: 2,
+		},
+		Spec: llamadeployv1.LlamaDeploymentSpec{
+			ProjectId: "proj-123",
+			RepoUrl:   "https://github.com/example/repo",
+			GitRef:    "main",
+			GitSha:    "abc123", // new git_sha → new computeBuildId
+		},
+		Status: llamadeployv1.LlamaDeploymentStatus{
+			BuildId:     staleBuildId,
+			BuildStatus: BuildStatusRunning,
+			Phase:       PhaseBuilding,
+		},
+	}
+
+	// In-flight Job for the stale buildId: no Succeeded, no Failed.
+	staleJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      staleJobName,
+			Namespace: "default",
+			Labels: map[string]string{
+				"deploy.llamaindex.ai/deployment": "my-app",
+				"deploy.llamaindex.ai/build-id":   staleBuildId,
+			},
+		},
+		Status: batchv1.JobStatus{}, // still running
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(llamaDeploy, staleJob).
+		WithStatusSubresource(llamaDeploy).
+		Build()
+
+	r := &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}
+	ctx := context.Background()
+
+	_, result, err := r.reconcileBuild(ctx, llamaDeploy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result after creating new build job")
+	}
+
+	// The stale Job should have been deleted.
+	var fetchedStale batchv1.Job
+	err = fakeClient.Get(ctx, types.NamespacedName{Name: staleJobName, Namespace: "default"}, &fetchedStale)
+	if err == nil {
+		t.Error("expected stale Job to be deleted, but it still exists")
+	}
+
+	// The new build Job should exist.
+	newBuildId := computeBuildId(llamaDeploy)
+	if newBuildId == staleBuildId {
+		t.Fatalf("test invariant broken: stale and new buildId are both %q", newBuildId)
+	}
+	newJobName := fmt.Sprintf("%s-build-%s", "my-app", newBuildId)
+	if len(newJobName) > 63 {
+		newJobName = newJobName[:63]
+	}
+	var newJob batchv1.Job
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: "default"}, &newJob); err != nil {
+		t.Errorf("expected new build Job %q to be created: %v", newJobName, err)
+	}
+}
+
+// Succeeded stale Jobs must be left alone so their artifacts remain available
+// for A → B → A rollback-by-cache-hit.
+func TestReconcileBuild_DoesNotDeleteSucceededSupersededJob(t *testing.T) {
+	scheme := newTestScheme()
+
+	staleBuildId := "succeededstale1"
+	staleJobName := fmt.Sprintf("%s-build-%s", "my-app", staleBuildId)
+	if len(staleJobName) > 63 {
+		staleJobName = staleJobName[:63]
+	}
+
+	llamaDeploy := &llamadeployv1.LlamaDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "my-app",
+			Namespace:  "default",
+			Generation: 2,
+		},
+		Spec: llamadeployv1.LlamaDeploymentSpec{
+			ProjectId: "proj-123",
+			RepoUrl:   "https://github.com/example/repo",
+			GitRef:    "main",
+			GitSha:    "new-sha",
+		},
+		Status: llamadeployv1.LlamaDeploymentStatus{
+			// BuildStatus is Running (stale) but the Job itself has Succeeded —
+			// the operator should inspect the Job and leave it alone.
+			BuildId:     staleBuildId,
+			BuildStatus: BuildStatusRunning,
+			Phase:       PhaseBuilding,
+		},
+	}
+
+	staleJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      staleJobName,
+			Namespace: "default",
+			Labels: map[string]string{
+				"deploy.llamaindex.ai/deployment": "my-app",
+				"deploy.llamaindex.ai/build-id":   staleBuildId,
+			},
+		},
+		Status: batchv1.JobStatus{Succeeded: 1},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(llamaDeploy, staleJob).
+		WithStatusSubresource(llamaDeploy).
+		Build()
+
+	r := &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}
+	ctx := context.Background()
+
+	if _, _, err := r.reconcileBuild(ctx, llamaDeploy); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The succeeded stale Job must still exist.
+	var fetchedStale batchv1.Job
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: staleJobName, Namespace: "default"}, &fetchedStale); err != nil {
+		t.Errorf("expected succeeded stale Job to be preserved, got err: %v", err)
+	}
+}
+
+// A stale Job that's already been reaped by TTL should not error — we just
+// proceed to create the new Job.
+func TestReconcileBuild_SupersedesJob_WhenStaleJobAlreadyGone(t *testing.T) {
+	scheme := newTestScheme()
+
+	llamaDeploy := &llamadeployv1.LlamaDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "my-app",
+			Namespace:  "default",
+			Generation: 2,
+		},
+		Spec: llamadeployv1.LlamaDeploymentSpec{
+			ProjectId: "proj-123",
+			RepoUrl:   "https://github.com/example/repo",
+			GitRef:    "main",
+			GitSha:    "abc123",
+		},
+		Status: llamadeployv1.LlamaDeploymentStatus{
+			BuildId:     "reapedstale12",
+			BuildStatus: BuildStatusRunning,
+			Phase:       PhaseBuilding,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(llamaDeploy).
+		WithStatusSubresource(llamaDeploy).
+		Build()
+
+	r := &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}
+	ctx := context.Background()
+
+	_, result, err := r.reconcileBuild(ctx, llamaDeploy)
+	if err != nil {
+		t.Fatalf("unexpected error when stale Job is absent: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result when creating new build job")
+	}
+
+	// New build Job should be created.
+	newBuildId := computeBuildId(llamaDeploy)
+	newJobName := fmt.Sprintf("%s-build-%s", "my-app", newBuildId)
+	if len(newJobName) > 63 {
+		newJobName = newJobName[:63]
+	}
+	var newJob batchv1.Job
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: "default"}, &newJob); err != nil {
+		t.Errorf("expected new build Job %q to be created: %v", newJobName, err)
+	}
+}
+
 func TestReconcileBuild_ProceedsWhenRepoUrlSetButGitShaEmpty(t *testing.T) {
 	scheme := newTestScheme()
 

--- a/operator/internal/controller/resources_build_unit_test.go
+++ b/operator/internal/controller/resources_build_unit_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	llamadeployv1 "llama-agents-operator/api/v1"
@@ -209,6 +210,69 @@ func newTestScheme() *runtime.Scheme {
 	_ = batchv1.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
 	return scheme
+}
+
+// buildSupersedeFixture describes a "stale build vs new spec" scenario. If
+// staleJobStatus is nil the stale Job is omitted from the fake client (models
+// the case where the Job was already TTL-reaped).
+type buildSupersedeFixture struct {
+	deploymentName string
+	staleBuildId   string
+	newGitSha      string
+	staleJobStatus *batchv1.JobStatus
+}
+
+// newBuildSupersedeFixture wires up an LlamaDeployment whose Status points at
+// staleBuildId/Running and whose Spec forces a new buildId via newGitSha,
+// optionally with a stale Job already in the cluster.
+func newBuildSupersedeFixture(
+	t *testing.T,
+	f buildSupersedeFixture,
+) (*LlamaDeploymentReconciler, *llamadeployv1.LlamaDeployment, client.Client) {
+	t.Helper()
+	scheme := newTestScheme()
+
+	llamaDeploy := &llamadeployv1.LlamaDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       f.deploymentName,
+			Namespace:  "default",
+			Generation: 2,
+		},
+		Spec: llamadeployv1.LlamaDeploymentSpec{
+			ProjectId: "proj-123",
+			RepoUrl:   "https://github.com/example/repo",
+			GitRef:    "main",
+			GitSha:    f.newGitSha,
+		},
+		Status: llamadeployv1.LlamaDeploymentStatus{
+			BuildId:     f.staleBuildId,
+			BuildStatus: BuildStatusRunning,
+			Phase:       PhaseBuilding,
+		},
+	}
+
+	objs := []client.Object{llamaDeploy}
+	if f.staleJobStatus != nil {
+		objs = append(objs, &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      buildJobName(f.deploymentName, f.staleBuildId),
+				Namespace: "default",
+				Labels: map[string]string{
+					"deploy.llamaindex.ai/deployment": f.deploymentName,
+					"deploy.llamaindex.ai/build-id":   f.staleBuildId,
+				},
+			},
+			Status: *f.staleJobStatus,
+		})
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		WithStatusSubresource(llamaDeploy).
+		Build()
+
+	return &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}, llamaDeploy, fakeClient
 }
 
 // ---------------------------------------------------------------------------
@@ -875,56 +939,15 @@ func TestReconcileBuild_SkipsWhenRepoUrlEmpty(t *testing.T) {
 // When the spec advances mid-build, the in-flight Job for the old buildId
 // must be deleted so it doesn't race the new one to upload.
 func TestReconcileBuild_SupersedesInFlightJob_OnBuildIdChange(t *testing.T) {
-	scheme := newTestScheme()
-
-	staleBuildId := "stalebuild1234"
-	staleJobName := fmt.Sprintf("%s-build-%s", "my-app", staleBuildId)
-	if len(staleJobName) > 63 {
-		staleJobName = staleJobName[:63]
-	}
-
-	llamaDeploy := &llamadeployv1.LlamaDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "my-app",
-			Namespace:  "default",
-			Generation: 2,
-		},
-		Spec: llamadeployv1.LlamaDeploymentSpec{
-			ProjectId: "proj-123",
-			RepoUrl:   "https://github.com/example/repo",
-			GitRef:    "main",
-			GitSha:    "abc123", // new git_sha → new computeBuildId
-		},
-		Status: llamadeployv1.LlamaDeploymentStatus{
-			BuildId:     staleBuildId,
-			BuildStatus: BuildStatusRunning,
-			Phase:       PhaseBuilding,
-		},
-	}
-
-	// In-flight Job for the stale buildId: no Succeeded, no Failed.
-	staleJob := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      staleJobName,
-			Namespace: "default",
-			Labels: map[string]string{
-				"deploy.llamaindex.ai/deployment": "my-app",
-				"deploy.llamaindex.ai/build-id":   staleBuildId,
-			},
-		},
-		Status: batchv1.JobStatus{}, // still running
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(llamaDeploy, staleJob).
-		WithStatusSubresource(llamaDeploy).
-		Build()
-
-	r := &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}
+	r, ld, c := newBuildSupersedeFixture(t, buildSupersedeFixture{
+		deploymentName: "my-app",
+		staleBuildId:   "stalebuild1234",
+		newGitSha:      "abc123",
+		staleJobStatus: &batchv1.JobStatus{}, // in-flight: no Succeeded, no Failed
+	})
 	ctx := context.Background()
 
-	_, result, err := r.reconcileBuild(ctx, llamaDeploy)
+	_, result, err := r.reconcileBuild(ctx, ld)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -933,23 +956,20 @@ func TestReconcileBuild_SupersedesInFlightJob_OnBuildIdChange(t *testing.T) {
 	}
 
 	// The stale Job should have been deleted.
+	staleJobName := buildJobName(ld.Name, "stalebuild1234")
 	var fetchedStale batchv1.Job
-	err = fakeClient.Get(ctx, types.NamespacedName{Name: staleJobName, Namespace: "default"}, &fetchedStale)
-	if err == nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: staleJobName, Namespace: "default"}, &fetchedStale); err == nil {
 		t.Error("expected stale Job to be deleted, but it still exists")
 	}
 
 	// The new build Job should exist.
-	newBuildId := computeBuildId(llamaDeploy)
-	if newBuildId == staleBuildId {
+	newBuildId := computeBuildId(ld)
+	if newBuildId == "stalebuild1234" {
 		t.Fatalf("test invariant broken: stale and new buildId are both %q", newBuildId)
 	}
-	newJobName := fmt.Sprintf("%s-build-%s", "my-app", newBuildId)
-	if len(newJobName) > 63 {
-		newJobName = newJobName[:63]
-	}
+	newJobName := buildJobName(ld.Name, newBuildId)
 	var newJob batchv1.Job
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: "default"}, &newJob); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: "default"}, &newJob); err != nil {
 		t.Errorf("expected new build Job %q to be created: %v", newJobName, err)
 	}
 }
@@ -957,63 +977,23 @@ func TestReconcileBuild_SupersedesInFlightJob_OnBuildIdChange(t *testing.T) {
 // Succeeded stale Jobs must be left alone so their artifacts remain available
 // for A → B → A rollback-by-cache-hit.
 func TestReconcileBuild_DoesNotDeleteSucceededSupersededJob(t *testing.T) {
-	scheme := newTestScheme()
-
-	staleBuildId := "succeededstale1"
-	staleJobName := fmt.Sprintf("%s-build-%s", "my-app", staleBuildId)
-	if len(staleJobName) > 63 {
-		staleJobName = staleJobName[:63]
-	}
-
-	llamaDeploy := &llamadeployv1.LlamaDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "my-app",
-			Namespace:  "default",
-			Generation: 2,
-		},
-		Spec: llamadeployv1.LlamaDeploymentSpec{
-			ProjectId: "proj-123",
-			RepoUrl:   "https://github.com/example/repo",
-			GitRef:    "main",
-			GitSha:    "new-sha",
-		},
-		Status: llamadeployv1.LlamaDeploymentStatus{
-			// BuildStatus is Running (stale) but the Job itself has Succeeded —
-			// the operator should inspect the Job and leave it alone.
-			BuildId:     staleBuildId,
-			BuildStatus: BuildStatusRunning,
-			Phase:       PhaseBuilding,
-		},
-	}
-
-	staleJob := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      staleJobName,
-			Namespace: "default",
-			Labels: map[string]string{
-				"deploy.llamaindex.ai/deployment": "my-app",
-				"deploy.llamaindex.ai/build-id":   staleBuildId,
-			},
-		},
-		Status: batchv1.JobStatus{Succeeded: 1},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(llamaDeploy, staleJob).
-		WithStatusSubresource(llamaDeploy).
-		Build()
-
-	r := &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}
+	r, ld, c := newBuildSupersedeFixture(t, buildSupersedeFixture{
+		deploymentName: "my-app",
+		staleBuildId:   "succeededstale1",
+		newGitSha:      "new-sha",
+		// BuildStatus is Running (stale) but the Job itself has Succeeded —
+		// the operator should inspect the Job and leave it alone.
+		staleJobStatus: &batchv1.JobStatus{Succeeded: 1},
+	})
 	ctx := context.Background()
 
-	if _, _, err := r.reconcileBuild(ctx, llamaDeploy); err != nil {
+	if _, _, err := r.reconcileBuild(ctx, ld); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// The succeeded stale Job must still exist.
+	staleJobName := buildJobName(ld.Name, "succeededstale1")
 	var fetchedStale batchv1.Job
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: staleJobName, Namespace: "default"}, &fetchedStale); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: staleJobName, Namespace: "default"}, &fetchedStale); err != nil {
 		t.Errorf("expected succeeded stale Job to be preserved, got err: %v", err)
 	}
 }
@@ -1021,37 +1001,15 @@ func TestReconcileBuild_DoesNotDeleteSucceededSupersededJob(t *testing.T) {
 // A stale Job that's already been reaped by TTL should not error — we just
 // proceed to create the new Job.
 func TestReconcileBuild_SupersedesJob_WhenStaleJobAlreadyGone(t *testing.T) {
-	scheme := newTestScheme()
-
-	llamaDeploy := &llamadeployv1.LlamaDeployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:       "my-app",
-			Namespace:  "default",
-			Generation: 2,
-		},
-		Spec: llamadeployv1.LlamaDeploymentSpec{
-			ProjectId: "proj-123",
-			RepoUrl:   "https://github.com/example/repo",
-			GitRef:    "main",
-			GitSha:    "abc123",
-		},
-		Status: llamadeployv1.LlamaDeploymentStatus{
-			BuildId:     "reapedstale12",
-			BuildStatus: BuildStatusRunning,
-			Phase:       PhaseBuilding,
-		},
-	}
-
-	fakeClient := fake.NewClientBuilder().
-		WithScheme(scheme).
-		WithObjects(llamaDeploy).
-		WithStatusSubresource(llamaDeploy).
-		Build()
-
-	r := &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}
+	r, ld, c := newBuildSupersedeFixture(t, buildSupersedeFixture{
+		deploymentName: "my-app",
+		staleBuildId:   "reapedstale12",
+		newGitSha:      "abc123",
+		staleJobStatus: nil, // no stale Job in the cluster
+	})
 	ctx := context.Background()
 
-	_, result, err := r.reconcileBuild(ctx, llamaDeploy)
+	_, result, err := r.reconcileBuild(ctx, ld)
 	if err != nil {
 		t.Fatalf("unexpected error when stale Job is absent: %v", err)
 	}
@@ -1059,14 +1017,9 @@ func TestReconcileBuild_SupersedesJob_WhenStaleJobAlreadyGone(t *testing.T) {
 		t.Fatal("expected non-nil result when creating new build job")
 	}
 
-	// New build Job should be created.
-	newBuildId := computeBuildId(llamaDeploy)
-	newJobName := fmt.Sprintf("%s-build-%s", "my-app", newBuildId)
-	if len(newJobName) > 63 {
-		newJobName = newJobName[:63]
-	}
+	newJobName := buildJobName(ld.Name, computeBuildId(ld))
 	var newJob batchv1.Job
-	if err := fakeClient.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: "default"}, &newJob); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: newJobName, Namespace: "default"}, &newJob); err != nil {
 		t.Errorf("expected new build Job %q to be created: %v", newJobName, err)
 	}
 }

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_gc.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_gc.py
@@ -8,6 +8,7 @@ the grace window must exceed the Job TTL.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta, timezone
 
@@ -16,6 +17,10 @@ from llama_agents.control_plane.build_api.build_service import build_artifact_st
 from llama_agents.control_plane.settings import settings
 
 logger = logging.getLogger(__name__)
+
+# Bounds concurrency when deleting aged-out build artifacts so a large
+# catch-up cohort can't saturate the storage client pool.
+_GC_DELETE_CONCURRENCY = 10
 
 
 async def _get_referenced_build_ids_from_replicasets(
@@ -55,7 +60,8 @@ async def gc_build_artifacts(
 
     Returns the number of artifacts deleted.
     """
-    if build_artifact_storage is None:
+    storage = build_artifact_storage
+    if storage is None:
         return 0
 
     referenced_build_ids = await _get_referenced_build_ids_from_replicasets(
@@ -63,14 +69,14 @@ async def gc_build_artifacts(
     )
     if keep_build_ids:
         referenced_build_ids |= keep_build_ids
-    artifacts = await build_artifact_storage.list_artifacts(deployment_id)
+    artifacts = await storage.list_artifacts(deployment_id)
 
     current_time = now if now is not None else datetime.now(timezone.utc)
     grace_cutoff = current_time - timedelta(
         seconds=settings.build_artifact_gc_grace_seconds
     )
 
-    deleted = 0
+    to_delete: list[str] = []
     retained_by_grace = 0
     for artifact in artifacts:
         if artifact.build_id in referenced_build_ids:
@@ -85,13 +91,35 @@ async def gc_build_artifacts(
             retained_by_grace += 1
             continue
 
-        logger.info(
-            "Deleting unreferenced build artifact: deployment=%s build_id=%s",
-            deployment_id,
-            artifact.build_id,
+        to_delete.append(artifact.build_id)
+
+    deleted = 0
+    if to_delete:
+        sem = asyncio.Semaphore(_GC_DELETE_CONCURRENCY)
+
+        async def _delete(build_id: str) -> None:
+            async with sem:
+                logger.info(
+                    "Deleting unreferenced build artifact: deployment=%s build_id=%s",
+                    deployment_id,
+                    build_id,
+                )
+                await storage.delete_artifact(deployment_id, build_id)
+
+        results = await asyncio.gather(
+            *(_delete(bid) for bid in to_delete),
+            return_exceptions=True,
         )
-        await build_artifact_storage.delete_artifact(deployment_id, artifact.build_id)
-        deleted += 1
+        for build_id, result in zip(to_delete, results):
+            if isinstance(result, BaseException):
+                logger.warning(
+                    "Failed to delete build artifact: deployment=%s build_id=%s error=%s",
+                    deployment_id,
+                    build_id,
+                    result,
+                )
+            else:
+                deleted += 1
 
     if deleted > 0 or retained_by_grace > 0:
         logger.info(

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_gc.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_gc.py
@@ -1,22 +1,27 @@
 """Build artifact garbage collection.
 
-Removes build artifacts from S3 that are no longer referenced by any live
-ReplicaSet. Artifacts are retained as long as any RS has a pod template
-with a matching LLAMA_DEPLOY_BUILD_ID env var.
+The grace window preserves the invariant: a build Job surviving within its
+TTLSecondsAfterFinished window with Status.Succeeded > 0 must still have its
+artifact in S3. The operator short-circuits new builds on that assumption, so
+the grace window must exceed the Job TTL.
 """
 
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta, timezone
 
 from llama_agents.control_plane import k8s_client
 from llama_agents.control_plane.build_api.build_service import build_artifact_storage
+from llama_agents.control_plane.settings import settings
 
 logger = logging.getLogger(__name__)
 
 
-async def _get_active_build_ids_for_deployment(deployment_id: str) -> set[str]:
-    """Return the set of build IDs referenced by live ReplicaSets for a deployment."""
+async def _get_referenced_build_ids_from_replicasets(
+    deployment_id: str,
+) -> set[str]:
+    """Return build IDs referenced by ReplicaSets in the deployment's revision history."""
     build_ids: set[str] = set()
 
     try:
@@ -41,45 +46,60 @@ async def _get_active_build_ids_for_deployment(deployment_id: str) -> set[str]:
 
 
 async def gc_build_artifacts(
-    deployment_id: str, keep_build_ids: set[str] | None = None
+    deployment_id: str,
+    keep_build_ids: set[str] | None = None,
+    *,
+    now: datetime | None = None,
 ) -> int:
-    """Remove unreferenced build artifacts for a deployment.
-
-    Args:
-        deployment_id: The deployment to GC artifacts for.
-        keep_build_ids: Additional build IDs to retain regardless of whether
-            they appear in a live ReplicaSet. This prevents a race where a
-            just-uploaded artifact is GC'd before its ReplicaSet is created.
+    """Delete artifacts that are both unreferenced and older than the grace window.
 
     Returns the number of artifacts deleted.
     """
     if build_artifact_storage is None:
         return 0
 
-    active_build_ids = await _get_active_build_ids_for_deployment(deployment_id)
+    referenced_build_ids = await _get_referenced_build_ids_from_replicasets(
+        deployment_id
+    )
     if keep_build_ids:
-        active_build_ids |= keep_build_ids
+        referenced_build_ids |= keep_build_ids
     artifacts = await build_artifact_storage.list_artifacts(deployment_id)
 
-    deleted = 0
-    for artifact in artifacts:
-        if artifact.build_id not in active_build_ids:
-            logger.info(
-                "Deleting unreferenced build artifact: deployment=%s build_id=%s",
-                deployment_id,
-                artifact.build_id,
-            )
-            await build_artifact_storage.delete_artifact(
-                deployment_id, artifact.build_id
-            )
-            deleted += 1
+    current_time = now if now is not None else datetime.now(timezone.utc)
+    grace_cutoff = current_time - timedelta(
+        seconds=settings.build_artifact_gc_grace_seconds
+    )
 
-    if deleted > 0:
+    deleted = 0
+    retained_by_grace = 0
+    for artifact in artifacts:
+        if artifact.build_id in referenced_build_ids:
+            continue
+
+        # S3 LastModified may come back naive in some backends; normalize to UTC.
+        artifact_ts = artifact.timestamp
+        if artifact_ts.tzinfo is None:
+            artifact_ts = artifact_ts.replace(tzinfo=timezone.utc)
+
+        if artifact_ts > grace_cutoff:
+            retained_by_grace += 1
+            continue
+
         logger.info(
-            "GC complete: deployment=%s deleted=%d retained=%d",
+            "Deleting unreferenced build artifact: deployment=%s build_id=%s",
+            deployment_id,
+            artifact.build_id,
+        )
+        await build_artifact_storage.delete_artifact(deployment_id, artifact.build_id)
+        deleted += 1
+
+    if deleted > 0 or retained_by_grace > 0:
+        logger.info(
+            "GC complete: deployment=%s deleted=%d retained_by_grace=%d total=%d",
             deployment_id,
             deleted,
-            len(artifacts) - deleted,
+            retained_by_grace,
+            len(artifacts),
         )
     return deleted
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/settings.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/settings.py
@@ -104,6 +104,14 @@ class ControlPlaneSettings(BaseSettings):
         alias="BUILD_S3_KEY_PREFIX",
     )
 
+    # Must exceed the operator's build Job TTLSecondsAfterFinished (3600s) so
+    # an artifact whose Job is still within its TTL is guaranteed to exist.
+    build_artifact_gc_grace_seconds: int = Field(
+        default=4500,
+        description="Grace window (seconds) before an unreferenced build artifact is eligible for GC.",
+        alias="BUILD_ARTIFACT_GC_GRACE_SECONDS",
+    )
+
     # Code repo settings
     code_repo_s3_key_prefix: str = Field(
         default="git",

--- a/packages/llama-agents-control-plane/tests/test_build_gc.py
+++ b/packages/llama-agents-control-plane/tests/test_build_gc.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for build artifact garbage collection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from llama_agents.control_plane.build_api import build_gc
+from llama_agents.control_plane.build_api.build_storage import ArtifactInfo
+
+
+@dataclass
+class FakeStorage:
+    """Minimal fake of BuildArtifactStorage for GC tests.
+
+    Tracks list/delete calls; no real S3.
+    """
+
+    artifacts: list[ArtifactInfo]
+    deleted: list[tuple[str, str]]
+
+    async def list_artifacts(self, deployment_name: str) -> list[ArtifactInfo]:
+        return [a for a in self.artifacts if a.deployment_name == deployment_name]
+
+    async def delete_artifact(self, deployment_name: str, build_id: str) -> None:
+        self.deleted.append((deployment_name, build_id))
+        self.artifacts = [
+            a
+            for a in self.artifacts
+            if not (a.deployment_name == deployment_name and a.build_id == build_id)
+        ]
+
+    async def delete_all_artifacts(self, deployment_name: str) -> int:
+        to_delete = [a for a in self.artifacts if a.deployment_name == deployment_name]
+        for a in to_delete:
+            self.deleted.append((a.deployment_name, a.build_id))
+        self.artifacts = [
+            a for a in self.artifacts if a.deployment_name != deployment_name
+        ]
+        return len(to_delete)
+
+
+def _artifact(
+    deployment: str, build_id: str, *, age_seconds: int, now: datetime
+) -> ArtifactInfo:
+    return ArtifactInfo(
+        deployment_name=deployment,
+        build_id=build_id,
+        timestamp=now - timedelta(seconds=age_seconds),
+        size_bytes=1024,
+    )
+
+
+@pytest.fixture
+def now() -> datetime:
+    return datetime(2026, 4, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def fake_storage() -> FakeStorage:
+    return FakeStorage(artifacts=[], deleted=[])
+
+
+@pytest.fixture
+def patched_gc(fake_storage: FakeStorage):
+    """Patch module-level deps of gc_build_artifacts: storage + k8s client."""
+    with (
+        patch.object(build_gc, "build_artifact_storage", fake_storage),
+        patch.object(
+            build_gc.k8s_client,
+            "list_replicasets_for_deployment",
+            AsyncMock(return_value=[]),
+        ) as mock_list,
+    ):
+        yield fake_storage, mock_list
+
+
+@pytest.mark.asyncio
+async def test_retains_two_recent_artifacts_for_same_deployment(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """Back-to-back uploads for different buildIds must both survive GC even
+    when no ReplicaSet references either yet."""
+    storage, _ = patched_gc
+    storage.artifacts = [
+        _artifact("doc-extract", "build-a", age_seconds=0, now=now),
+        _artifact("doc-extract", "build-b", age_seconds=1, now=now),
+    ]
+
+    deleted = await build_gc.gc_build_artifacts("doc-extract", now=now)
+
+    assert deleted == 0
+    assert storage.deleted == []
+    assert len(storage.artifacts) == 2
+
+
+@pytest.mark.asyncio
+async def test_retains_artifact_within_grace_window(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """Artifact older than a few minutes but within the grace window is kept."""
+    storage, _ = patched_gc
+    # 30 minutes old — well within default 4500s (75min) window
+    storage.artifacts = [
+        _artifact("app", "build-30m", age_seconds=30 * 60, now=now),
+    ]
+
+    deleted = await build_gc.gc_build_artifacts("app", now=now)
+
+    assert deleted == 0
+    assert storage.artifacts == [
+        _artifact("app", "build-30m", age_seconds=30 * 60, now=now),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_deletes_unreferenced_artifact_past_grace_window(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """Artifact older than the grace window AND unreferenced by any RS is deleted."""
+    storage, _ = patched_gc
+    # 2 hours old — well past the default 75min grace window
+    storage.artifacts = [
+        _artifact("app", "build-old", age_seconds=2 * 60 * 60, now=now),
+    ]
+
+    deleted = await build_gc.gc_build_artifacts("app", now=now)
+
+    assert deleted == 1
+    assert storage.deleted == [("app", "build-old")]
+
+
+@pytest.mark.asyncio
+async def test_retains_referenced_artifact_regardless_of_age(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """An artifact referenced by a live ReplicaSet must never be deleted, even if
+    it's arbitrarily old.
+    """
+    storage, mock_list = patched_gc
+    storage.artifacts = [
+        _artifact("app", "build-ancient", age_seconds=10 * 24 * 3600, now=now),
+    ]
+
+    # Build a fake ReplicaSet object shape that matches what the GC walks:
+    # rs.spec.template.spec.containers[].env[].{name,value}
+    class _Env:
+        def __init__(self, name: str, value: str) -> None:
+            self.name = name
+            self.value = value
+
+    class _Container:
+        def __init__(self, env: list[_Env]) -> None:
+            self.env = env
+
+    class _PodSpec:
+        def __init__(self, containers: list[_Container]) -> None:
+            self.containers = containers
+            self.init_containers: list[_Container] = []
+
+    class _Template:
+        def __init__(self, spec: _PodSpec) -> None:
+            self.spec = spec
+
+    class _RSSpec:
+        def __init__(self, template: _Template) -> None:
+            self.template = template
+
+    class _RS:
+        def __init__(self, spec: _RSSpec) -> None:
+            self.spec = spec
+
+    mock_list.return_value = [
+        _RS(
+            _RSSpec(
+                _Template(
+                    _PodSpec(
+                        [_Container([_Env("LLAMA_DEPLOY_BUILD_ID", "build-ancient")])]
+                    )
+                )
+            )
+        )
+    ]
+
+    deleted = await build_gc.gc_build_artifacts("app", now=now)
+
+    assert deleted == 0
+    assert storage.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_keep_build_ids_forces_retention(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """keep_build_ids is belt-and-suspenders: even for an aged-out artifact,
+    an explicit keep_build_ids entry prevents deletion."""
+    storage, _ = patched_gc
+    storage.artifacts = [
+        _artifact("app", "build-old", age_seconds=2 * 60 * 60, now=now),
+    ]
+
+    deleted = await build_gc.gc_build_artifacts(
+        "app", keep_build_ids={"build-old"}, now=now
+    )
+
+    assert deleted == 0
+    assert storage.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_mixed_cohort_only_aged_out_deleted(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """Given a mix of recent and aged-out artifacts, only the aged-out ones
+    that are also unreferenced get deleted."""
+    storage, _ = patched_gc
+    storage.artifacts = [
+        _artifact("app", "build-recent", age_seconds=60, now=now),
+        _artifact(
+            "app", "build-middle", age_seconds=60 * 60, now=now
+        ),  # 60m, within grace
+        _artifact("app", "build-old", age_seconds=3 * 60 * 60, now=now),  # 3h
+        _artifact("app", "build-ancient", age_seconds=10 * 3600, now=now),  # 10h
+    ]
+
+    deleted = await build_gc.gc_build_artifacts("app", now=now)
+
+    assert deleted == 2
+    deleted_ids = {bid for _, bid in storage.deleted}
+    assert deleted_ids == {"build-old", "build-ancient"}
+
+
+@pytest.mark.asyncio
+async def test_handles_naive_datetime_from_storage(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """Some S3 backends return naive datetimes; the GC must normalize before
+    comparison rather than raising a 'can't compare offset-naive to offset-aware'
+    TypeError."""
+    storage, _ = patched_gc
+    naive_now = now.replace(tzinfo=None)
+    storage.artifacts = [
+        ArtifactInfo(
+            deployment_name="app",
+            build_id="build-naive",
+            timestamp=naive_now - timedelta(hours=3),  # aged out
+            size_bytes=100,
+        ),
+    ]
+
+    deleted = await build_gc.gc_build_artifacts("app", now=now)
+
+    assert deleted == 1
+    assert storage.deleted == [("app", "build-naive")]
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_storage_disabled(now: datetime) -> None:
+    with patch.object(build_gc, "build_artifact_storage", None):
+        deleted = await build_gc.gc_build_artifacts("app", now=now)
+    assert deleted == 0
+
+
+@pytest.mark.asyncio
+async def test_delete_all_artifacts_for_deployment(
+    patched_gc: tuple[FakeStorage, AsyncMock], now: datetime
+) -> None:
+    """Deployment deletion path deletes everything regardless of age."""
+    storage, _ = patched_gc
+    storage.artifacts = [
+        _artifact("app", "build-a", age_seconds=1, now=now),
+        _artifact("app", "build-b", age_seconds=100, now=now),
+    ]
+
+    count = await build_gc.delete_all_artifacts_for_deployment("app")
+
+    assert count == 2
+    assert len(storage.deleted) == 2
+    assert storage.artifacts == []

--- a/packages/llama-agents-control-plane/tests/test_build_gc.py
+++ b/packages/llama-agents-control-plane/tests/test_build_gc.py
@@ -9,6 +9,16 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from kubernetes.client import (
+    V1Container,
+    V1EnvVar,
+    V1LabelSelector,
+    V1PodSpec,
+    V1PodTemplateSpec,
+    V1ReplicaSet,
+    V1ReplicaSetSpec,
+)
+from llama_agents.control_plane import k8s_client
 from llama_agents.control_plane.build_api import build_gc
 from llama_agents.control_plane.build_api.build_storage import ArtifactInfo
 
@@ -55,6 +65,28 @@ def _artifact(
     )
 
 
+def _replicaset_with_build_id(build_id: str) -> V1ReplicaSet:
+    """Build a V1ReplicaSet whose pod template references the given build_id
+    via the LLAMA_DEPLOY_BUILD_ID env var — matching what the GC walks."""
+    return V1ReplicaSet(
+        spec=V1ReplicaSetSpec(
+            selector=V1LabelSelector(match_labels={}),
+            template=V1PodTemplateSpec(
+                spec=V1PodSpec(
+                    containers=[
+                        V1Container(
+                            name="app",
+                            env=[
+                                V1EnvVar(name="LLAMA_DEPLOY_BUILD_ID", value=build_id)
+                            ],
+                        )
+                    ],
+                ),
+            ),
+        ),
+    )
+
+
 @pytest.fixture
 def now() -> datetime:
     return datetime(2026, 4, 8, 12, 0, 0, tzinfo=timezone.utc)
@@ -71,7 +103,7 @@ def patched_gc(fake_storage: FakeStorage):
     with (
         patch.object(build_gc, "build_artifact_storage", fake_storage),
         patch.object(
-            build_gc.k8s_client,
+            k8s_client,
             "list_replicasets_for_deployment",
             AsyncMock(return_value=[]),
         ) as mock_list,
@@ -146,45 +178,7 @@ async def test_retains_referenced_artifact_regardless_of_age(
         _artifact("app", "build-ancient", age_seconds=10 * 24 * 3600, now=now),
     ]
 
-    # Build a fake ReplicaSet object shape that matches what the GC walks:
-    # rs.spec.template.spec.containers[].env[].{name,value}
-    class _Env:
-        def __init__(self, name: str, value: str) -> None:
-            self.name = name
-            self.value = value
-
-    class _Container:
-        def __init__(self, env: list[_Env]) -> None:
-            self.env = env
-
-    class _PodSpec:
-        def __init__(self, containers: list[_Container]) -> None:
-            self.containers = containers
-            self.init_containers: list[_Container] = []
-
-    class _Template:
-        def __init__(self, spec: _PodSpec) -> None:
-            self.spec = spec
-
-    class _RSSpec:
-        def __init__(self, template: _Template) -> None:
-            self.template = template
-
-    class _RS:
-        def __init__(self, spec: _RSSpec) -> None:
-            self.spec = spec
-
-    mock_list.return_value = [
-        _RS(
-            _RSSpec(
-                _Template(
-                    _PodSpec(
-                        [_Container([_Env("LLAMA_DEPLOY_BUILD_ID", "build-ancient")])]
-                    )
-                )
-            )
-        )
-    ]
+    mock_list.return_value = [_replicaset_with_build_id("build-ancient")]
 
     deleted = await build_gc.gc_build_artifacts("app", now=now)
 
@@ -281,3 +275,37 @@ async def test_delete_all_artifacts_for_deployment(
     assert count == 2
     assert len(storage.deleted) == 2
     assert storage.artifacts == []
+
+
+@pytest.mark.asyncio
+async def test_partial_delete_failure_does_not_abort_remaining(now: datetime) -> None:
+    """One failing delete in a concurrent batch must not prevent the others
+    from running; the returned count should reflect only successful deletes."""
+    artifacts = [
+        _artifact("app", "build-good-1", age_seconds=3 * 3600, now=now),
+        _artifact("app", "build-bad", age_seconds=3 * 3600, now=now),
+        _artifact("app", "build-good-2", age_seconds=3 * 3600, now=now),
+    ]
+    deleted: list[tuple[str, str]] = []
+
+    async def delete_artifact(deployment_name: str, build_id: str) -> None:
+        if build_id == "build-bad":
+            raise RuntimeError("simulated S3 failure")
+        deleted.append((deployment_name, build_id))
+
+    fake = AsyncMock()
+    fake.list_artifacts = AsyncMock(return_value=artifacts)
+    fake.delete_artifact = AsyncMock(side_effect=delete_artifact)
+
+    with (
+        patch.object(build_gc, "build_artifact_storage", fake),
+        patch.object(
+            k8s_client,
+            "list_replicasets_for_deployment",
+            AsyncMock(return_value=[]),
+        ),
+    ):
+        count = await build_gc.gc_build_artifacts("app", now=now)
+
+    assert count == 2
+    assert sorted(bid for _, bid in deleted) == ["build-good-1", "build-good-2"]

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -421,7 +421,6 @@ async def _create_or_update_agent_api_key(auth_svc: AuthService, profile: Auth) 
     """
     import httpx
     from llama_agents.cli.auth.client import PlatformAuthClient
-    from llama_agents.cli.utils.retry import run_with_network_retries
 
     if profile.api_key is not None:
         async with PlatformAuthClient(profile.api_url, profile.api_key) as client:
@@ -438,10 +437,10 @@ async def _create_or_update_agent_api_key(auth_svc: AuthService, profile: Auth) 
         async with auth_svc.profile_client(profile) as client:
             name = f"{profile.name} llamactl on {profile.device_oidc.device_name if profile.device_oidc else 'unknown'}"
 
+            # Do not wrap in run_with_network_retries — this POST is
+            # non-idempotent and a retry on timeout creates duplicate keys.
             try:
-                api_key = await run_with_network_retries(
-                    lambda: client.create_agent_api_key(name)
-                )
+                api_key = await client.create_agent_api_key(name)
             except httpx.HTTPStatusError:
                 # Do not treat HTTP errors as transient; re-raise for normal handling.
                 raise

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -421,6 +421,7 @@ async def _create_or_update_agent_api_key(auth_svc: AuthService, profile: Auth) 
     """
     import httpx
     from llama_agents.cli.auth.client import PlatformAuthClient
+    from llama_agents.cli.utils.retry import run_with_network_retries
 
     if profile.api_key is not None:
         async with PlatformAuthClient(profile.api_url, profile.api_key) as client:
@@ -437,10 +438,14 @@ async def _create_or_update_agent_api_key(auth_svc: AuthService, profile: Auth) 
         async with auth_svc.profile_client(profile) as client:
             name = f"{profile.name} llamactl on {profile.device_oidc.device_name if profile.device_oidc else 'unknown'}"
 
-            # Do not wrap in run_with_network_retries — this POST is
-            # non-idempotent and a retry on timeout creates duplicate keys.
+            # Non-idempotent POST: only retry connect-phase errors so we
+            # absorb initial-connectivity blips without risking duplicate
+            # keys from a read-timeout retry.
             try:
-                api_key = await client.create_agent_api_key(name)
+                api_key = await run_with_network_retries(
+                    lambda: client.create_agent_api_key(name),
+                    idempotent=False,
+                )
             except httpx.HTTPStatusError:
                 # Do not treat HTTP errors as transient; re-raise for normal handling.
                 raise

--- a/packages/llamactl/src/llama_agents/cli/textual/git_validation.py
+++ b/packages/llamactl/src/llama_agents/cli/textual/git_validation.py
@@ -329,6 +329,7 @@ class GitValidationWidget(Widget):
             client = get_client()
 
             try:
+                # validate_repository is a read-only POST, so retries are safe.
                 self.validation_response = await run_with_network_retries(
                     lambda: client.validate_repository(
                         repo_url=self.repo_url,

--- a/packages/llamactl/src/llama_agents/cli/utils/retry.py
+++ b/packages/llamactl/src/llama_agents/cli/utils/retry.py
@@ -15,7 +15,8 @@ _T = TypeVar("_T")
 
 
 def _is_transient_httpx_error(exc: BaseException) -> bool:
-    """Return True for network-level httpx errors that are safe to retry.
+    """Return True for network-level httpx errors that are safe to retry
+    for idempotent operations.
 
     - Retries on httpx.RequestError (connection errors, timeouts, etc.)
     - Never retries httpx.HTTPStatusError (4xx/5xx responses from the server)
@@ -25,21 +26,41 @@ def _is_transient_httpx_error(exc: BaseException) -> bool:
     )
 
 
+def _is_connect_phase_error(exc: BaseException) -> bool:
+    """Return True for httpx errors that are guaranteed to have occurred
+    before the request reached the server — safe to retry even for
+    non-idempotent operations.
+
+    Excludes read/write errors and RemoteProtocolError, any of which may
+    have happened after the server accepted (and possibly processed) the
+    request.
+    """
+    return isinstance(
+        exc,
+        (httpx.ConnectError, httpx.ConnectTimeout, httpx.PoolTimeout),
+    )
+
+
 async def run_with_network_retries(
     operation: Callable[[], Awaitable[_T]],
     *,
     max_attempts: int = 3,
+    idempotent: bool = True,
 ) -> _T:
     """Run an async operation with standard network retry semantics.
 
     Retries transient httpx network errors with exponential backoff, but does not retry
     HTTP status errors. After the final attempt, the last exception is re-raised.
 
-    Only wrap idempotent / read-only operations — retrying a non-idempotent
-    POST/PATCH/DELETE on a timeout can cause duplicate server-side mutations.
+    When ``idempotent`` is False, retries are restricted to connect-phase
+    errors (ConnectError, ConnectTimeout, PoolTimeout) — i.e. failures where
+    the request is guaranteed to have never reached the server. This lets
+    callers stay resilient to initial-connectivity blips without risking
+    duplicate server-side effects from a read-timeout retry.
     """
+    classifier = _is_transient_httpx_error if idempotent else _is_connect_phase_error
     async for attempt in AsyncRetrying(
-        retry=retry_if_exception(_is_transient_httpx_error),
+        retry=retry_if_exception(classifier),
         stop=stop_after_attempt(max_attempts),
         wait=wait_exponential(multiplier=1, min=1),
         reraise=True,

--- a/packages/llamactl/src/llama_agents/cli/utils/retry.py
+++ b/packages/llamactl/src/llama_agents/cli/utils/retry.py
@@ -34,6 +34,9 @@ async def run_with_network_retries(
 
     Retries transient httpx network errors with exponential backoff, but does not retry
     HTTP status errors. After the final attempt, the last exception is re-raised.
+
+    Only wrap idempotent / read-only operations — retrying a non-idempotent
+    POST/PATCH/DELETE on a timeout can cause duplicate server-side mutations.
     """
     async for attempt in AsyncRetrying(
         retry=retry_if_exception(_is_transient_httpx_error),

--- a/packages/llamactl/tests/test_auth_cli.py
+++ b/packages/llamactl/tests/test_auth_cli.py
@@ -1,5 +1,4 @@
 from types import SimpleNamespace
-from typing import Awaitable, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -142,10 +141,16 @@ def test_auth_project_interactive_sets_selected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_or_update_agent_api_key_retries_and_raises_on_network_error() -> (
+async def test_create_or_update_agent_api_key_raises_on_network_error_without_retry() -> (
     None
 ):
-    """Network errors while provisioning API tokens should be retried with a clear message."""
+    """Network errors while provisioning API tokens should surface immediately
+    with a clear message, without auto-retrying.
+
+    create_agent_api_key is a non-idempotent POST. Auto-retrying on a transient
+    network error can produce duplicate API keys per llamactl login. See the
+    2026-04-08 document-extraction rollout plan Phase 3 client retry audit.
+    """
     profile = Auth(
         id="id-1",
         name="test",
@@ -164,28 +169,11 @@ async def test_create_or_update_agent_api_key_retries_and_raises_on_network_erro
 
     mock_client.create_agent_api_key = AsyncMock(side_effect=httpx.RequestError("boom"))
 
-    async def fake_run_with_network_retries(
-        operation: Callable[[], Awaitable[object]],
-        *,
-        max_attempts: int = 3,
-    ) -> object:
-        attempts = 0
-        while True:
-            try:
-                attempts += 1
-                return await operation()
-            except httpx.RequestError:
-                if attempts >= max_attempts:
-                    raise
-
-    with patch(
-        "llama_agents.cli.utils.retry.run_with_network_retries",
-        side_effect=fake_run_with_network_retries,
-    ):
-        with pytest.raises(Exception) as exc_info:
-            await _create_or_update_agent_api_key(mock_auth_svc, profile)
+    with pytest.raises(Exception) as exc_info:
+        await _create_or_update_agent_api_key(mock_auth_svc, profile)
 
     msg = str(exc_info.value)
     assert "Network error while provisioning an API token" in msg
-    # Should have retried multiple times
-    assert mock_client.create_agent_api_key.await_count == 3
+    # Should have tried exactly once — no silent retry amplification on
+    # non-idempotent POST.
+    assert mock_client.create_agent_api_key.await_count == 1

--- a/packages/llamactl/tests/test_auth_cli.py
+++ b/packages/llamactl/tests/test_auth_cli.py
@@ -141,15 +141,12 @@ def test_auth_project_interactive_sets_selected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_or_update_agent_api_key_raises_on_network_error_without_retry() -> (
-    None
-):
-    """Network errors while provisioning API tokens should surface immediately
-    with a clear message, without auto-retrying.
+async def test_create_or_update_agent_api_key_does_not_retry_read_timeout() -> None:
+    """Read-phase errors must not trigger retries.
 
-    create_agent_api_key is a non-idempotent POST. Auto-retrying on a transient
-    network error can produce duplicate API keys per llamactl login. See the
-    2026-04-08 document-extraction rollout plan Phase 3 client retry audit.
+    create_agent_api_key is a non-idempotent POST: a ReadTimeout after the
+    request left the client could mean the server already created a key, so
+    retrying would duplicate it.
     """
     profile = Auth(
         id="id-1",
@@ -167,13 +164,48 @@ async def test_create_or_update_agent_api_key_raises_on_network_error_without_re
     mock_client_cm.__aenter__.return_value = mock_client
     mock_auth_svc.profile_client.return_value = mock_client_cm
 
-    mock_client.create_agent_api_key = AsyncMock(side_effect=httpx.RequestError("boom"))
+    mock_client.create_agent_api_key = AsyncMock(
+        side_effect=httpx.ReadTimeout("server took too long")
+    )
 
     with pytest.raises(Exception) as exc_info:
         await _create_or_update_agent_api_key(mock_auth_svc, profile)
 
-    msg = str(exc_info.value)
-    assert "Network error while provisioning an API token" in msg
-    # Should have tried exactly once — no silent retry amplification on
-    # non-idempotent POST.
+    assert "Network error while provisioning an API token" in str(exc_info.value)
     assert mock_client.create_agent_api_key.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_agent_api_key_retries_connect_error() -> None:
+    """Connect-phase errors (DNS, connection refused, connect timeout) happen
+    before the request is sent, so retrying is safe even for a non-idempotent
+    POST. The CLI should absorb a brief connectivity blip.
+    """
+    profile = Auth(
+        id="id-1",
+        name="test",
+        api_url="https://example.com",
+        project_id="proj",
+        api_key=None,
+        api_key_id=None,
+        device_oidc=None,
+    )
+
+    mock_auth_svc = MagicMock()
+    mock_client_cm = AsyncMock()
+    mock_client = MagicMock()
+    mock_client_cm.__aenter__.return_value = mock_client
+    mock_auth_svc.profile_client.return_value = mock_client_cm
+
+    mock_client.create_agent_api_key = AsyncMock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    # Patch tenacity's sleep so the test doesn't pay real back-off.
+    with patch("tenacity.nap.time.sleep"), patch("asyncio.sleep", AsyncMock()):
+        with pytest.raises(Exception) as exc_info:
+            await _create_or_update_agent_api_key(mock_auth_svc, profile)
+
+    assert "Network error while provisioning an API token" in str(exc_info.value)
+    # Default max_attempts=3 — every attempt should have run the operation.
+    assert mock_client.create_agent_api_key.await_count == 3

--- a/packages/llamactl/tests/test_retry.py
+++ b/packages/llamactl/tests/test_retry.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for run_with_network_retries classifier behavior."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+from llama_agents.cli.utils.retry import run_with_network_retries
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    """Skip real back-off sleeps so these tests stay fast."""
+    with patch("tenacity.nap.time.sleep"), patch("asyncio.sleep", AsyncMock()):
+        yield
+
+
+async def _raising(exc: BaseException, counter: list[int]):
+    counter.append(1)
+    raise exc
+
+
+@pytest.mark.asyncio
+async def test_idempotent_true_retries_read_timeout() -> None:
+    counter: list[int] = []
+    with pytest.raises(httpx.ReadTimeout):
+        await run_with_network_retries(
+            lambda: _raising(httpx.ReadTimeout("slow"), counter),
+            max_attempts=3,
+        )
+    assert len(counter) == 3
+
+
+@pytest.mark.asyncio
+async def test_idempotent_true_retries_connect_error() -> None:
+    counter: list[int] = []
+    with pytest.raises(httpx.ConnectError):
+        await run_with_network_retries(
+            lambda: _raising(httpx.ConnectError("refused"), counter),
+            max_attempts=3,
+        )
+    assert len(counter) == 3
+
+
+@pytest.mark.asyncio
+async def test_idempotent_false_does_not_retry_read_timeout() -> None:
+    """Read-phase error — request may have reached the server. No retry."""
+    counter: list[int] = []
+    with pytest.raises(httpx.ReadTimeout):
+        await run_with_network_retries(
+            lambda: _raising(httpx.ReadTimeout("slow"), counter),
+            max_attempts=3,
+            idempotent=False,
+        )
+    assert len(counter) == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_false_does_not_retry_remote_protocol_error() -> None:
+    """RemoteProtocolError may have happened after the server accepted the
+    request — no retry for non-idempotent callers."""
+    counter: list[int] = []
+    with pytest.raises(httpx.RemoteProtocolError):
+        await run_with_network_retries(
+            lambda: _raising(httpx.RemoteProtocolError("eof"), counter),
+            max_attempts=3,
+            idempotent=False,
+        )
+    assert len(counter) == 1
+
+
+@pytest.mark.asyncio
+async def test_idempotent_false_retries_connect_error() -> None:
+    counter: list[int] = []
+    with pytest.raises(httpx.ConnectError):
+        await run_with_network_retries(
+            lambda: _raising(httpx.ConnectError("refused"), counter),
+            max_attempts=3,
+            idempotent=False,
+        )
+    assert len(counter) == 3
+
+
+@pytest.mark.asyncio
+async def test_idempotent_false_retries_connect_timeout() -> None:
+    counter: list[int] = []
+    with pytest.raises(httpx.ConnectTimeout):
+        await run_with_network_retries(
+            lambda: _raising(httpx.ConnectTimeout("no syn-ack"), counter),
+            max_attempts=3,
+            idempotent=False,
+        )
+    assert len(counter) == 3
+
+
+@pytest.mark.asyncio
+async def test_idempotent_false_retries_pool_timeout() -> None:
+    counter: list[int] = []
+    with pytest.raises(httpx.PoolTimeout):
+        await run_with_network_retries(
+            lambda: _raising(httpx.PoolTimeout("saturated"), counter),
+            max_attempts=3,
+            idempotent=False,
+        )
+    assert len(counter) == 3
+
+
+@pytest.mark.asyncio
+async def test_never_retries_http_status_error() -> None:
+    """HTTPStatusError is a server response, not a transient failure."""
+    counter: list[int] = []
+    resp = httpx.Response(500, request=httpx.Request("POST", "https://x"))
+    err = httpx.HTTPStatusError("500", request=resp.request, response=resp)
+    with pytest.raises(httpx.HTTPStatusError):
+        await run_with_network_retries(
+            lambda: _raising(err, counter),
+            max_attempts=3,
+        )
+    assert len(counter) == 1
+
+
+@pytest.mark.asyncio
+async def test_succeeds_on_second_attempt() -> None:
+    counter: list[int] = []
+
+    async def op() -> str:
+        counter.append(1)
+        if len(counter) < 2:
+            raise httpx.ConnectError("first try")
+        return "ok"
+
+    result = await run_with_network_retries(op, max_attempts=3, idempotent=False)
+    assert result == "ok"
+    assert len(counter) == 2


### PR DESCRIPTION
- control-plane: retain build artifacts within a configurable grace window (`BUILD_ARTIFACT_GC_GRACE_SECONDS`, default 75m) so GC doesn't race recent uploads.
- operator: cancel in-flight build Jobs when the computed buildId advances mid-build; preserve Succeeded stale Jobs so rollback-by-cache-hit still works. Pin `RevisionHistoryLimit` on the apps/v1 Deployment.
- llamactl: don't retry `create_agent_api_key` on non-connect network errors — it's a non-idempotent POST.