### PR TITLE
fix: reset working tree after changesets/action before planning

### DIFF
--- a/.github/workflows/publish_changesets.yml
+++ b/.github/workflows/publish_changesets.yml
@@ -88,6 +88,18 @@ jobs:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
 
+      # When there are pending changesets, the step above runs ``pnpm -w
+      # run version`` to build the release PR. With ``commitMode:
+      # github-api`` those edits are committed through the API and left
+      # uncommitted in the local working tree. If we don't reset, the
+      # plan step below scans the mutated tree, emits actions for the
+      # *next* versions, and the downstream publish jobs (which do a
+      # fresh checkout of the branch) then build artifacts for the
+      # previous versions and fail to match the plan. Reset so the plan
+      # reflects what is actually committed on the branch.
+      - name: Reset working tree after changesets action
+        run: git reset --hard HEAD
+
       - name: Compute publish plan
         id: plan
         run: uv run dev changeset-plan --output publish-plan.json

--- a/src/dev_cli/changesets.py
+++ b/src/dev_cli/changesets.py
@@ -677,6 +677,19 @@ def _execute_pypi(action: PypiAction, dry_run: bool) -> None:
     if dry_run:
         click.echo("  dry run, skipping uv build / uv publish")
         return
+    # Guard against stale plans: the plan is generated in a different job
+    # from a potentially different working tree than this one, so confirm
+    # the checked-out package still matches the version we intend to
+    # publish before invoking uv build (which silently builds whatever
+    # version is on disk).
+    pyproject = Path.cwd() / action.path / "pyproject.toml"
+    _, on_disk = current_version(pyproject)
+    if on_disk != action.version:
+        raise RuntimeError(
+            f"Plan expects {action.package}@{action.version} but "
+            f"{pyproject} is at {on_disk}. The plan was generated from a "
+            f"different workspace state than the current checkout."
+        )
     run_command(["uv", "build", "--package", action.package])
     dist_prefix = action.package.replace("-", "_")
     pattern = f"dist/{dist_prefix}-{action.version}*"

--- a/tests/dev_cli/test_changesets.py
+++ b/tests/dev_cli/test_changesets.py
@@ -16,6 +16,7 @@ from dev_cli.changesets import (
     HelmAction,
     HelmConfig,
     PackageJson,
+    PypiAction,
     PyProjectContainer,
     _resolve_template,
     _write_toml_values,
@@ -771,6 +772,47 @@ def test_execute_docker_manifest_action_combines_source_tags() -> None:
     assert cmd.count("--tag") == 2
     assert "docker.io/llamaindex/test:1.0.0-amd64" in cmd
     assert "docker.io/llamaindex/test:1.0.0-arm64" in cmd
+
+
+# -- _execute_pypi tests --
+
+
+def _write_pyproject(path: Path, name: str, version: str) -> None:
+    path.write_text(
+        f'[project]\nname = "{name}"\nversion = "{version}"\ndependencies = []\n'
+    )
+
+
+def test_execute_pypi_dry_run_skips_run_command(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pkg_dir = tmp_path / "packages" / "pkg"
+    pkg_dir.mkdir(parents=True)
+    _write_pyproject(pkg_dir / "pyproject.toml", "pkg", "1.2.3")
+    monkeypatch.chdir(tmp_path)
+    action = PypiAction(package="pkg", version="1.2.3", path="packages/pkg")
+    with patch("dev_cli.changesets.run_command") as mock_run:
+        execute_action(action, dry_run=True)
+    mock_run.assert_not_called()
+
+
+def test_execute_pypi_raises_when_plan_version_mismatches_on_disk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Reproduces the publish_changesets.yml bug: the plan was computed
+    # from a tree where ``pnpm -w run version`` had bumped pyproject.toml
+    # to 0.8.10, but the publish job checks out the branch fresh and
+    # sees the still-committed 0.8.9. Without this guard, uv build would
+    # silently produce 0.8.9 artifacts that don't match the plan glob.
+    pkg_dir = tmp_path / "packages" / "pkg"
+    pkg_dir.mkdir(parents=True)
+    _write_pyproject(pkg_dir / "pyproject.toml", "pkg", "0.8.9")
+    monkeypatch.chdir(tmp_path)
+    action = PypiAction(package="pkg", version="0.8.10", path="packages/pkg")
+    with patch("dev_cli.changesets.run_command") as mock_run:
+        with pytest.raises(RuntimeError, match="Plan expects pkg@0.8.10"):
+            execute_action(action, dry_run=False)
+    mock_run.assert_not_called()
 
 
 # -- plan_helm / execute_helm_action tests --


### PR DESCRIPTION
When a regular push-to-main contains a pending changeset file, the
changesets/action step runs ``pnpm -w run version`` locally to build
the release PR. With ``commitMode: github-api`` those edits are
committed through the API and left uncommitted in the local working
tree. The ``changeset-plan`` step then scanned the mutated tree and
emitted actions for the *next* versions; the downstream publish jobs
checked out the branch fresh, built artifacts for the still-committed
previous versions, and failed when the publish glob didn't match. Reset
the tree before planning so the plan reflects what is actually on the
branch, and add an explicit version-mismatch guard in ``_execute_pypi``
so a future regression fails fast with a clear message.