### PR TITLE
Add Context.get_step_context() to access step context without parameter

### DIFF
--- a/.changeset/add-context-get-current.md
+++ b/.changeset/add-context-get-current.md
@@ -2,4 +2,4 @@
 "llama-index-workflows": minor
 ---
 
-Add `Context.get_current()` static method to retrieve the step context without a `ctx` parameter in the step signature
+Add `Context.get_step_context()` static method to retrieve the step context without a `ctx` parameter in the step signature

--- a/.changeset/add-context-get-current.md
+++ b/.changeset/add-context-get-current.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": minor
+---
+
+Add `Context.get_current()` static method to retrieve the step context without a `ctx` parameter in the step signature

--- a/packages/llama-index-workflows/src/workflows/context/context.py
+++ b/packages/llama-index-workflows/src/workflows/context/context.py
@@ -26,6 +26,7 @@ from workflows.context.pre_context import PreContext
 from workflows.errors import (
     ContextSerdeError,
     ContextStateError,
+    WorkflowRuntimeError,
 )
 from workflows.events import (
     Event,
@@ -141,6 +142,39 @@ class Context(Generic[MODEL_T]):
         new_ctx = cast(Context[MODEL_T], object.__new__(cls))
         new_ctx._face = face
         return new_ctx
+
+    @staticmethod
+    def get_current() -> Context:
+        """Return the `Context` for the currently executing step.
+
+        This is useful for middleware, decorators, or wrappers that need
+        access to the step context without requiring the user-defined step
+        function to declare a ``ctx: Context`` parameter.
+
+        Returns:
+            Context: The context instance (in internal-face state) for the
+            running step.
+
+        Raises:
+            WorkflowRuntimeError: If called outside of a step function.
+
+        Examples:
+            ```python
+            from workflows import Context
+
+            async def my_middleware():
+                ctx = Context.get_current()
+                await ctx.wait_for_event(SomeEvent)
+            ```
+        """
+        from workflows.runtime.types.results import InternalContextVar
+
+        try:
+            return InternalContextVar.get()
+        except LookupError:
+            raise WorkflowRuntimeError(
+                "Context.get_current() may only be called from within a step function"
+            )
 
     @property
     def is_running(self) -> bool:

--- a/packages/llama-index-workflows/src/workflows/context/context.py
+++ b/packages/llama-index-workflows/src/workflows/context/context.py
@@ -38,6 +38,7 @@ from workflows.runtime.types.internal_state import BrokerState
 from workflows.runtime.types.plugin import (
     ExternalRunAdapter,
 )
+from workflows.runtime.types.results import InternalContextVar
 from workflows.types import RunResultT
 from workflows.utils import _nanoid as nanoid
 
@@ -167,14 +168,18 @@ class Context(Generic[MODEL_T]):
                 await ctx.wait_for_event(SomeEvent)
             ```
         """
-        from workflows.runtime.types.results import InternalContextVar
-
         try:
-            return InternalContextVar.get()
+            ref = InternalContextVar.get()
         except LookupError:
             raise WorkflowRuntimeError(
                 "Context.get_current() may only be called from within a step function"
             )
+        ctx = ref()
+        if ctx is None:
+            raise WorkflowRuntimeError(
+                "Context.get_current() may only be called from within a step function"
+            )
+        return ctx
 
     @property
     def is_running(self) -> bool:

--- a/packages/llama-index-workflows/src/workflows/context/context.py
+++ b/packages/llama-index-workflows/src/workflows/context/context.py
@@ -145,12 +145,12 @@ class Context(Generic[MODEL_T]):
         return new_ctx
 
     @staticmethod
-    def get_current() -> Context:
+    def get_step_context() -> Context:
         """Return the `Context` for the currently executing step.
 
-        This is useful for middleware, decorators, or wrappers that need
-        access to the step context without requiring the user-defined step
-        function to declare a ``ctx: Context`` parameter.
+        This is useful for decorators or wrappers around step functions that
+        need access to the step context without requiring the user-defined
+        step to declare a ``ctx: Context`` parameter.
 
         Returns:
             Context: The context instance (in internal-face state) for the
@@ -163,21 +163,21 @@ class Context(Generic[MODEL_T]):
             ```python
             from workflows import Context
 
-            async def my_middleware():
-                ctx = Context.get_current()
-                await ctx.wait_for_event(SomeEvent)
+            # Inside a decorator that wraps a step function
+            ctx = Context.get_step_context()
+            ctx.send_event(ProgressEvent(msg="step starting"))
             ```
         """
         try:
             ref = InternalContextVar.get()
         except LookupError:
             raise WorkflowRuntimeError(
-                "Context.get_current() may only be called from within a step function"
+                "Context.get_step_context() may only be called from within a step function"
             )
         ctx = ref()
         if ctx is None:
             raise WorkflowRuntimeError(
-                "Context.get_current() may only be called from within a step function"
+                "Context.get_step_context() may only be called from within a step function"
             )
         return ctx
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -107,6 +107,10 @@ class WaitingForEvent(Exception, Generic[EventType]):
 
 StepWorkerStateContextVar = ContextVar[StepWorkerContext]("step_worker")
 
+# Holds the Context (in internal-face state) for the currently executing step.
+# Set alongside StepWorkerStateContextVar in as_step_worker_function().
+InternalContextVar: ContextVar[Any] = ContextVar("internal_context")
+
 
 ###################################
 # Data returned by step functions #

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import dataclasses
+import weakref
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import (
@@ -107,9 +108,12 @@ class WaitingForEvent(Exception, Generic[EventType]):
 
 StepWorkerStateContextVar = ContextVar[StepWorkerContext]("step_worker")
 
-# Holds the Context (in internal-face state) for the currently executing step.
-# Set alongside StepWorkerStateContextVar in as_step_worker_function().
-InternalContextVar: ContextVar[Any] = ContextVar("internal_context")
+# Holds a weakref to the Context (in internal-face state) for the currently
+# executing step.  A weakref is used so that asyncio timer-handle context
+# snapshots do not pin the Workflow in memory (see RunContextContainer for
+# the analogous fix at the run level).  The strong reference lives as a local
+# variable in as_step_worker_function(); the weakref here is only a lookup handle.
+InternalContextVar: ContextVar[weakref.ref[Any]] = ContextVar("internal_context")
 
 
 ###################################

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -36,6 +36,7 @@ from workflows.runtime.types.plugin import (
     run_context,
 )
 from workflows.runtime.types.results import (
+    InternalContextVar,
     Returns,
     StepFunctionResult,
     StepWorkerContext,
@@ -169,6 +170,7 @@ def as_step_worker_function(
         token = StepWorkerStateContextVar.set(
             StepWorkerContext(state=state, returns=returns)
         )
+        ctx_token = InternalContextVar.set(internal_context)
 
         try:
             config = workflow._get_steps()[step_name]._step_config
@@ -276,6 +278,10 @@ def as_step_worker_function(
             await internal_context._finalize_step()
             return returns.return_values
         finally:
+            try:
+                InternalContextVar.reset(ctx_token)
+            except Exception:
+                pass
             try:
                 StepWorkerStateContextVar.reset(token)
             except Exception:

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -8,6 +8,7 @@ import functools
 import inspect
 import time
 import uuid
+import weakref
 from contextvars import copy_context
 from typing import TYPE_CHECKING, Any, Awaitable, Callable, Protocol, TypeVar
 
@@ -170,7 +171,7 @@ def as_step_worker_function(
         token = StepWorkerStateContextVar.set(
             StepWorkerContext(state=state, returns=returns)
         )
-        ctx_token = InternalContextVar.set(internal_context)
+        ctx_token = InternalContextVar.set(weakref.ref(internal_context))
 
         try:
             config = workflow._get_steps()[step_name]._step_config

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -845,7 +845,7 @@ async def test_get_step_context_supports_wait_for_event() -> None:
             ctx = Context.get_step_context()
             result = await ctx.wait_for_event(
                 ResumeEvent,
-                waiter_event=InputRequiredEvent(prefix="waiting"),  # type: ignore[call-arg]
+                waiter_event=InputRequiredEvent(),
             )
             return StopEvent(result=result.value)
 

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -16,6 +16,7 @@ from workflows.context.context import (
     _warn_is_running_in_step,
 )
 from workflows.context.external_context import ExternalContext
+from workflows.context.internal_context import InternalContext
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import (
     DictState,
@@ -775,6 +776,85 @@ def test_deserialize_state_from_dict_empty_dict_state() -> None:
 
     assert isinstance(result, DictState)
     assert len(list(result.items())) == 0
+
+
+# ============================================================================
+# Context.get_current() Tests
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_get_current_outside_step_raises() -> None:
+    """Calling Context.get_current() outside a step should raise WorkflowRuntimeError."""
+    with pytest.raises(WorkflowRuntimeError, match="may only be called from within"):
+        Context.get_current()
+
+
+@pytest.mark.asyncio
+async def test_get_current_inside_step() -> None:
+    """Context.get_current() should return the step's context inside a step."""
+    captured_ctx = None
+
+    class TestWorkflow(Workflow):
+        @step
+        async def my_step(self, ev: StartEvent) -> StopEvent:
+            nonlocal captured_ctx
+            captured_ctx = Context.get_current()
+            return StopEvent(result="done")
+
+    wf = TestWorkflow()
+    result = await wf.run()
+    assert result == "done"
+    assert captured_ctx is not None
+    # The returned context should be in internal face state
+    assert isinstance(captured_ctx._face, InternalContext)
+
+
+@pytest.mark.asyncio
+async def test_get_current_matches_ctx_parameter() -> None:
+    """Context.get_current() should return the same Context as the ctx parameter."""
+    ctx_from_param = None
+    ctx_from_get_current = None
+
+    class TestWorkflow(Workflow):
+        @step
+        async def my_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            nonlocal ctx_from_param, ctx_from_get_current
+            ctx_from_param = ctx
+            ctx_from_get_current = Context.get_current()
+            return StopEvent(result="done")
+
+    wf = TestWorkflow()
+    await wf.run()
+    assert ctx_from_param is ctx_from_get_current
+
+
+@pytest.mark.asyncio
+async def test_get_current_supports_wait_for_event() -> None:
+    """Context.get_current() should return a context that supports wait_for_event."""
+
+    class ResumeEvent(Event):
+        value: str = "resumed"
+
+    class TestWorkflow(Workflow):
+        @step
+        async def waiting_step(self, ev: StartEvent) -> StopEvent:
+            ctx = Context.get_current()
+            result = await ctx.wait_for_event(
+                ResumeEvent,
+                waiter_event=InputRequiredEvent(prefix="waiting"),  # type: ignore[call-arg]
+            )
+            return StopEvent(result=result.value)
+
+    wf = TestWorkflow()
+    handler = wf.run()
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            handler.ctx.send_event(ResumeEvent(value="hello"))
+
+    result = await handler
+    assert result == "hello"
 
 
 def test_deserialize_state_from_dict_defaults_to_dict_state() -> None:

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -4,7 +4,10 @@
 from __future__ import annotations
 
 import asyncio
+import gc
 import json
+import weakref
+from typing import cast
 
 import pytest
 from pydantic import BaseModel
@@ -779,27 +782,27 @@ def test_deserialize_state_from_dict_empty_dict_state() -> None:
 
 
 # ============================================================================
-# Context.get_current() Tests
+# Context.get_step_context() Tests
 # ============================================================================
 
 
 @pytest.mark.asyncio
-async def test_get_current_outside_step_raises() -> None:
-    """Calling Context.get_current() outside a step should raise WorkflowRuntimeError."""
+async def test_get_step_context_outside_step_raises() -> None:
+    """Calling Context.get_step_context() outside a step should raise WorkflowRuntimeError."""
     with pytest.raises(WorkflowRuntimeError, match="may only be called from within"):
-        Context.get_current()
+        Context.get_step_context()
 
 
 @pytest.mark.asyncio
-async def test_get_current_inside_step() -> None:
-    """Context.get_current() should return the step's context inside a step."""
+async def test_get_step_context_inside_step() -> None:
+    """Context.get_step_context() should return the step's context inside a step."""
     captured_ctx = None
 
     class TestWorkflow(Workflow):
         @step
         async def my_step(self, ev: StartEvent) -> StopEvent:
             nonlocal captured_ctx
-            captured_ctx = Context.get_current()
+            captured_ctx = Context.get_step_context()
             return StopEvent(result="done")
 
     wf = TestWorkflow()
@@ -811,27 +814,27 @@ async def test_get_current_inside_step() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_current_matches_ctx_parameter() -> None:
-    """Context.get_current() should return the same Context as the ctx parameter."""
+async def test_get_step_context_matches_ctx_parameter() -> None:
+    """Context.get_step_context() should return the same Context as the ctx parameter."""
     ctx_from_param = None
-    ctx_from_get_current = None
+    ctx_from_get_step_context = None
 
     class TestWorkflow(Workflow):
         @step
         async def my_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
-            nonlocal ctx_from_param, ctx_from_get_current
+            nonlocal ctx_from_param, ctx_from_get_step_context
             ctx_from_param = ctx
-            ctx_from_get_current = Context.get_current()
+            ctx_from_get_step_context = Context.get_step_context()
             return StopEvent(result="done")
 
     wf = TestWorkflow()
     await wf.run()
-    assert ctx_from_param is ctx_from_get_current
+    assert ctx_from_param is ctx_from_get_step_context
 
 
 @pytest.mark.asyncio
-async def test_get_current_supports_wait_for_event() -> None:
-    """Context.get_current() should return a context that supports wait_for_event."""
+async def test_get_step_context_supports_wait_for_event() -> None:
+    """Context.get_step_context() should return a context that supports wait_for_event."""
 
     class ResumeEvent(Event):
         value: str = "resumed"
@@ -839,7 +842,7 @@ async def test_get_current_supports_wait_for_event() -> None:
     class TestWorkflow(Workflow):
         @step
         async def waiting_step(self, ev: StartEvent) -> StopEvent:
-            ctx = Context.get_current()
+            ctx = Context.get_step_context()
             result = await ctx.wait_for_event(
                 ResumeEvent,
                 waiter_event=InputRequiredEvent(prefix="waiting"),  # type: ignore[call-arg]
@@ -855,6 +858,40 @@ async def test_get_current_supports_wait_for_event() -> None:
 
     result = await handler
     assert result == "hello"
+
+
+@pytest.mark.asyncio
+async def test_get_step_context_does_not_pin_workflow() -> None:
+    """InternalContextVar should not pin the Workflow via timer handle context snapshots."""
+    handles: list[asyncio.TimerHandle] = []
+
+    class TinyWorkflow(Workflow):
+        @step
+        async def only(self, ev: StartEvent) -> StopEvent:
+            ctx = Context.get_step_context()
+            assert ctx is not None
+            # Schedule a long-lived timer that snapshots the current ContextVars
+            handles.append(asyncio.get_running_loop().call_later(3600, lambda: None))
+            return StopEvent(result="done")
+
+    refs: list[weakref.ReferenceType[Workflow]] = []
+    try:
+        for _ in range(5):
+            wf = TinyWorkflow()
+            refs.append(cast(weakref.ReferenceType[Workflow], weakref.ref(wf)))
+            await WorkflowTestRunner(wf).run()
+            del wf
+
+        for _ in range(3):
+            gc.collect()
+
+        assert all(r() is None for r in refs), (
+            f"{sum(r() is not None for r in refs)} workflows pinned by "
+            "InternalContextVar in TimerHandle context"
+        )
+    finally:
+        for h in handles:
+            h.cancel()
 
 
 def test_deserialize_state_from_dict_defaults_to_dict_state() -> None:


### PR DESCRIPTION
Fix for #505 

expose a context based getter for step context (internal variety) while step is running