### PR TITLE
Clean up type ignore comments to use Pyright-specific codes

### DIFF
--- a/packages/llama-agents-agentcore/src/llama_agents/agentcore/entrypoint.py
+++ b/packages/llama-agents-agentcore/src/llama_agents/agentcore/entrypoint.py
@@ -317,7 +317,7 @@ async def _action_run(
         ).model_dump()
 
     workflow_name = str(parsed[0])
-    start_event: StartEvent = parsed[1]  # ty: ignore[invalid-assignment]  # type: ignore
+    start_event: StartEvent = parsed[1]  # type: ignore[reportAssignmentType]  # ty: ignore[invalid-assignment]
     handler_id = _resolve_handler_id(payload, session_id)
     service = get_agentcore_service()
 

--- a/packages/llama-agents-integration-tests/tests/test_runtime_matrix.py
+++ b/packages/llama-agents-integration-tests/tests/test_runtime_matrix.py
@@ -238,7 +238,7 @@ class SyncWorkflow(Workflow):
 class MultiRunWorkflow(Workflow):
     @step
     async def step(self, ev: StartEvent) -> StopEvent:
-        return StopEvent(result=ev.number * 2)  # type: ignore
+        return StopEvent(result=ev.number * 2)
 
 
 class ErrorWorkflow(Workflow):

--- a/packages/llama-agents-server/src/llama_agents/server/_api.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_api.py
@@ -1026,10 +1026,7 @@ class _WorkflowAPI:
         }
 
         status_in: list[Status] | None = (
-            cast(  # type: ignore[ty:invalid-argument-type]
-                list[Status],
-                list(set(allowed_status_values).intersection(status_values)),
-            )
+            list(set(allowed_status_values).intersection(status_values))
             if status_values is not None
             else None
         )

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -98,7 +98,7 @@ class AgentDataStateStore(Generic[MODEL_T]):
         if issubclass(self.state_type, DictState):
             data = json.loads(state_json)
             return deserialize_dict_state_data(data, self._serializer)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-        return self._serializer.deserialize(state_json)  # type: ignore[ty:invalid-return-type]
+        return self._serializer.deserialize(state_json)
 
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()

--- a/packages/llama-agents-server/src/llama_agents/server/_store/migration_utils.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/migration_utils.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 try:
-    from importlib.resources.abc import (  # type: ignore  # ty: ignore[unresolved-import]
+    from importlib.resources.abc import (  # type: ignore
         Traversable,
     )
 except ImportError:  # pre 3.11
-    from importlib.abc import (  # type: ignore  # ty: ignore[unresolved-import]
+    from importlib.abc import (
         Traversable,
     )
 import re
@@ -21,7 +21,7 @@ def iter_migration_files(source_pkg: str) -> list[Traversable]:
     pkg = import_module(source_pkg)
     root = resources.files(pkg)
     files = (p for p in root.iterdir() if p.name.endswith(".sql"))
-    return sorted(files, key=lambda p: p.name)  # type: ignore  # ty: ignore[invalid-return-type]
+    return sorted(files, key=lambda p: p.name)  # type: ignore[reportReturnType]
 
 
 def parse_target_version(sql_text: str) -> int | None:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -94,7 +94,7 @@ class PostgresStateStore(Generic[MODEL_T]):
         if issubclass(self.state_type, DictState):
             data = json.loads(state_json)
             return deserialize_dict_state_data(data, self._serializer)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-        return self._serializer.deserialize(state_json)  # type: ignore[ty:invalid-return-type]
+        return self._serializer.deserialize(state_json)
 
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -125,7 +125,7 @@ class SqliteStateStore(Generic[MODEL_T]):
         if issubclass(self.state_type, DictState):
             data = json.loads(state_json)
             return deserialize_dict_state_data(data, self._serializer)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-        return self._serializer.deserialize(state_json)  # type: ignore[ty:invalid-return-type]
+        return self._serializer.deserialize(state_json)
 
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -7,7 +7,7 @@ from typing_extensions import TypeVar
 
 from workflows.context.state_store import DictState
 
-MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore  # ty: ignore[invalid-return-type]
+MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)
 
 
 class SerializedContextV0(BaseModel):

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -342,7 +342,7 @@ class DictState(DictLikeModel):
 
 
 # Default state type is DictState for the generic type
-MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore  # ty: ignore[invalid-return-type]
+MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)
 
 
 @runtime_checkable
@@ -520,13 +520,13 @@ class InMemoryStateStore(Generic[MODEL_T]):
             ValueError: If the payload is not in_memory format.
         """
         if not serialized_state:
-            return cls(DictState())  # type: ignore[arg-type]  # ty: ignore[invalid-assignment]
+            return cls(DictState())  # type: ignore[arg-type]
 
         # Validate it's in_memory format (raises ValueError if not)
         parse_in_memory_state(serialized_state)
 
         state_instance = deserialize_state_from_dict(serialized_state, serializer)
-        return cls(state_instance)  # type: ignore[arg-type]  # ty: ignore[invalid-assignment]
+        return cls(state_instance)  # type: ignore[arg-type]
 
     @asynccontextmanager
     async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -819,7 +819,7 @@ def _process_step_result_tick(
             new_waiter = StepWorkerWaiter(
                 waiter_id=result.waiter_id,
                 event=this_execution.event,
-                waiting_for_event=result.event_type,  # type: ignore[ty:invalid-argument-type]
+                waiting_for_event=result.event_type,
                 requirements=result.requirements,
                 has_requirements=bool(len(result.requirements)),
                 resolved_event=None,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -251,7 +251,7 @@ def as_step_worker_function(
                             None,
                             lambda: copy.run(
                                 lambda: _run_with_tags(merged_tags, partial_func)
-                            ),  # type: ignore[ty:invalid-return-type]
+                            ),
                         )
                     )
                 else:

--- a/packages/llama-index-workflows/tests/test_decorator.py
+++ b/packages/llama-index-workflows/tests/test_decorator.py
@@ -16,7 +16,7 @@ def test_decorated_config() -> None:
         async def entry(self, ev: StartEvent) -> StopEvent:
             return StopEvent(result="done")
 
-    def f(self, ev: Event) -> Event:  # type: ignore  # noqa: ANN001
+    def f(self, ev: Event) -> Event:  # noqa: ANN001
         return Event()
 
     res = step(workflow=LocalWorkflow)(f)

--- a/packages/llama-index-workflows/tests/test_resources.py
+++ b/packages/llama-index-workflows/tests/test_resources.py
@@ -56,13 +56,13 @@ class ThirdEvent(Event):
 
 class ChatMessage(BaseModel):
     @classmethod
-    def from_str(cls, role, content):  # type: ignore  # noqa: ANN001
+    def from_str(cls, role, content):  # noqa: ANN001
         return mock.MagicMock(content=content)
 
 
 class Memory(mock.MagicMock):
     @classmethod
-    def from_defaults(cls, *args, **kwargs):  # type: ignore  # noqa: ANN002, ANN003
+    def from_defaults(cls, *args, **kwargs):  # noqa: ANN002, ANN003
         return mock.MagicMock()
 
 
@@ -227,7 +227,7 @@ def test_resource_config_path_selector_error(
 async def test_resource() -> None:
     m = Memory.from_defaults("user_id_123", token_limit=60000)
 
-    def get_memory(*args, **kwargs) -> Memory:  # type: ignore  # noqa: ANN002, ANN003
+    def get_memory(*args, **kwargs) -> Memory:  # noqa: ANN002, ANN003
         return m
 
     class TestWorkflow(Workflow):
@@ -252,7 +252,7 @@ async def test_resource() -> None:
 async def test_resource_async() -> None:
     m = Memory.from_defaults("user_id_123", token_limit=60000)
 
-    async def get_memory(*args, **kwargs) -> Memory:  # type: ignore  # noqa: ANN002, ANN003
+    async def get_memory(*args, **kwargs) -> Memory:  # noqa: ANN002, ANN003
         return m
 
     class TestWorkflow(Workflow):
@@ -348,19 +348,19 @@ async def test_caching_behavior() -> None:
         ) -> StopEvent:
             global cc
             counter_thing.incr()
-            cc = counter_thing.counter  # type: ignore
+            cc = counter_thing.counter
             return StopEvent()
 
     wf_1 = TestWorkflow(disable_validation=True)
     await wf_1.run()
     assert (
-        cc == 2  # type: ignore
+        cc == 2
     )  # this is expected to be 2, as it is a cached resource shared by test_step and test_step_2, which means at test_step counter_thing.counter goes from 0 to 1 and at test_step_2 goes from 1 to 2
 
     wf_2 = TestWorkflow(disable_validation=True)
     await wf_2.run()
     assert (
-        cc == 2  # type: ignore
+        cc == 2
     )  # the cache is workflow-specific, so since wf_2 is different from wf_1, we expect no interference between the two
 
 
@@ -438,7 +438,7 @@ async def test_non_caching_behavior() -> None:
         ) -> StepEvent:
             global cc1
             counter_thing.incr()
-            cc1 = counter_thing.counter  # type: ignore
+            cc1 = counter_thing.counter
             return StepEvent()
 
         @step
@@ -451,13 +451,13 @@ async def test_non_caching_behavior() -> None:
         ) -> StopEvent:
             global cc2
             counter_thing.incr()
-            cc2 = counter_thing.counter  # type: ignore
+            cc2 = counter_thing.counter
             return StopEvent()
 
     wf_1 = TestWorkflow(disable_validation=True)
     await wf_1.run()
-    assert cc1 == 1  # type: ignore
-    assert cc2 == 1  # type: ignore
+    assert cc1 == 1
+    assert cc2 == 1
 
 
 @pytest.mark.asyncio
@@ -568,10 +568,10 @@ async def test_circular_resource_dependency_detection() -> None:
     # Create the cycle by modifying __annotations__ after creating the resources
     # This allows us to create mutual dependencies
 
-    def cyclic_factory_a(b: Annotated[B, "placeholder"]) -> A:  # type: ignore
+    def cyclic_factory_a(b: Annotated[B, "placeholder"]) -> A:
         return A()
 
-    def cyclic_factory_b(a: Annotated[A, "placeholder"]) -> B:  # type: ignore
+    def cyclic_factory_b(a: Annotated[A, "placeholder"]) -> B:
         return B()
 
     # Create resources

--- a/packages/llama-index-workflows/tests/test_utils.py
+++ b/packages/llama-index-workflows/tests/test_utils.py
@@ -26,7 +26,7 @@ from .conftest import (  # type: ignore[import]
 
 
 def test_validate_step_signature_of_method() -> None:
-    def f(self, ev: OneTestEvent) -> OneTestEvent:  # type: ignore  # noqa: ANN001
+    def f(self, ev: OneTestEvent) -> OneTestEvent:  # noqa: ANN001
         return OneTestEvent()
 
     validate_step_signature(inspect_signature(f))
@@ -75,7 +75,7 @@ def test_validate_step_signature_no_params() -> None:
 
 
 def test_validate_step_signature_no_annotations() -> None:
-    def f(self, ev) -> None:  # type: ignore  # noqa: ANN001
+    def f(self, ev) -> None:  # noqa: ANN001
         pass
 
     with pytest.raises(
@@ -86,7 +86,7 @@ def test_validate_step_signature_no_annotations() -> None:
 
 
 def test_validate_step_signature_wrong_annotations() -> None:
-    def f(self, ev: str) -> None:  # type: ignore  # noqa: ANN001
+    def f(self, ev: str) -> None:  # noqa: ANN001
         pass
 
     with pytest.raises(
@@ -97,7 +97,7 @@ def test_validate_step_signature_wrong_annotations() -> None:
 
 
 def test_validate_step_signature_no_return_annotations() -> None:
-    def f(self, ev: OneTestEvent):  # type: ignore  # noqa: ANN001
+    def f(self, ev: OneTestEvent):  # noqa: ANN001
         pass
 
     with pytest.raises(
@@ -108,7 +108,7 @@ def test_validate_step_signature_no_return_annotations() -> None:
 
 
 def test_validate_step_signature_no_events() -> None:
-    def f(self, ctx: Context) -> None:  # type: ignore  # noqa: ANN001
+    def f(self, ctx: Context) -> None:  # noqa: ANN001
         pass
 
     with pytest.raises(
@@ -119,10 +119,10 @@ def test_validate_step_signature_no_events() -> None:
 
 
 def test_validate_step_signature_too_many_params() -> None:
-    def f1(self, ev: OneTestEvent, foo: OneTestEvent) -> None:  # type: ignore  # noqa: ANN001
+    def f1(self, ev: OneTestEvent, foo: OneTestEvent) -> None:  # noqa: ANN001
         pass
 
-    def f2(ev: OneTestEvent, foo: OneTestEvent) -> None:  # type: ignore  # noqa: ANN001
+    def f2(ev: OneTestEvent, foo: OneTestEvent) -> None:  # noqa: ANN001
         pass
 
     with pytest.raises(
@@ -172,7 +172,7 @@ def test_get_param_types() -> None:
 
 
 def test_get_param_types_no_annotations() -> None:
-    def f(foo) -> None:  # type: ignore  # noqa: ANN001
+    def f(foo) -> None:  # noqa: ANN001
         pass
 
     sig = inspect.signature(f)

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -186,7 +186,7 @@ def test_add_step_not_a_step() -> None:
         WorkflowValidationError,
         match="Step function another_step is missing the `@step` decorator.",
     ):
-        TestWorkflow.add_step(another_step)  # type: ignore
+        TestWorkflow.add_step(another_step)  # type: ignore[reportArgumentType]
 
 
 def test_workflow_disable_validation() -> None:
@@ -268,7 +268,7 @@ async def test_workflow_context_to_dict() -> None:
         ctx = handler.ctx
         await signal_ready.wait()
         # get the context dict
-        data = ctx.to_dict()  # type:ignore
+        data = ctx.to_dict()
 
         await handler.cancel_run()
 
@@ -288,7 +288,7 @@ class HumanInTheLoopWorkflow(Workflow):
     async def step1(self, ctx: Context, ev: StartEvent) -> InputRequiredEvent:
         cur_runs = await ctx.store.get("step1_runs", default=0)
         await ctx.store.set("step1_runs", cur_runs + 1)
-        return InputRequiredEvent(prefix="Enter a number: ")  # type:ignore
+        return InputRequiredEvent(prefix="Enter a number: ")  # type: ignore[reportCallIssue]
 
     @step
     async def step2(self, ctx: Context, ev: HumanResponseEvent) -> StopEvent:
@@ -314,8 +314,8 @@ async def test_human_in_the_loop_with_resume() -> None:
             break
 
     assert handler.exception()
-    new_handler = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))  # type:ignore
-    new_handler.ctx.send_event(HumanResponseEvent(response="42"))  # type:ignore
+    new_handler = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))  # type: ignore[reportArgumentType]
+    new_handler.ctx.send_event(HumanResponseEvent(response="42"))  # type: ignore[reportCallIssue]
 
     final_result = await new_handler
     assert final_result == "42"


### PR DESCRIPTION
## Summary
This PR standardizes type ignore comments across the codebase to use Pyright-specific error codes instead of generic `# type: ignore` comments. This improves type checking clarity and allows for more granular suppression of specific type errors and trims back a lot of ty warnings