### PR TITLE
feat: add org abstraction layer for project scoping

### DIFF
--- a/.changeset/large-hats-cheer.md
+++ b/.changeset/large-hats-cheer.md
@@ -1,0 +1,7 @@
+---
+"llama-agents-control-plane": minor
+"llama-agents-core": minor
+"llamactl": minor
+---
+
+feat: add support for organizations

--- a/operator/dev.py
+++ b/operator/dev.py
@@ -257,7 +257,7 @@ def up(ctx: click.Context) -> None:
             "-f",
             str(PROJECT_ROOT / "operator" / "Tiltfile"),
             "--",
-            f"--target={target}",
+            target,
         ],
     )
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
@@ -245,7 +245,12 @@ async def find_deployment_id(name: str, force_suffix: bool = False) -> str:
 
 
 # in order to not conflict in URI routes
-reserved_deployment_ids = ["validate-repository", "list-projects", "version"]
+reserved_deployment_ids = [
+    "validate-repository",
+    "list-projects",
+    "list-orgs",
+    "version",
+]
 
 
 async def create_deployment(

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
@@ -248,7 +248,7 @@ async def find_deployment_id(name: str, force_suffix: bool = False) -> str:
 reserved_deployment_ids = [
     "validate-repository",
     "list-projects",
-    "list-orgs",
+    "organizations",
     "version",
 ]
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
@@ -42,10 +42,13 @@ from overrides import override
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_ORG = schema.OrgSummary(org_id="default", org_name="Default")
+
+
 class PublicDeploymentService(AbstractPublicDeploymentsService):
     @override
     async def get_version(self) -> schema.VersionResponse:
-        capabilities: list[schema.Capability] = []
+        capabilities: list[schema.Capability] = [schema.Capabilities.ORGS]
         if code_repo_storage is not None:
             capabilities.append(schema.Capabilities.CODE_PUSH)
         return schema.VersionResponse(
@@ -71,7 +74,13 @@ class DeploymentService(AbstractDeploymentsService):
         return deployment
 
     @override
-    async def get_projects(self) -> schema.ProjectsListResponse:
+    async def get_orgs(self) -> schema.OrgsListResponse:
+        return schema.OrgsListResponse(orgs=[DEFAULT_ORG])
+
+    @override
+    async def get_projects(
+        self, org_id: str | None = None
+    ) -> schema.ProjectsListResponse:
         return schema.ProjectsListResponse(
             projects=await k8s_client.get_projects_with_deployment_count()
         )

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
@@ -42,7 +42,7 @@ from overrides import override
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_ORG = schema.OrgSummary(org_id="default", org_name="Default")
+DEFAULT_ORG = schema.OrgSummary(org_id="default", org_name="Default", is_default=True)
 
 
 class PublicDeploymentService(AbstractPublicDeploymentsService):

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
@@ -48,7 +48,7 @@ DEFAULT_ORG = schema.OrgSummary(org_id="default", org_name="Default", is_default
 class PublicDeploymentService(AbstractPublicDeploymentsService):
     @override
     async def get_version(self) -> schema.VersionResponse:
-        capabilities: list[schema.Capability] = [schema.Capabilities.ORGS]
+        capabilities: list[schema.Capability] = [schema.Capabilities.ORGANIZATIONS]
         if code_repo_storage is not None:
             capabilities.append(schema.Capabilities.CODE_PUSH)
         return schema.VersionResponse(
@@ -74,8 +74,8 @@ class DeploymentService(AbstractDeploymentsService):
         return deployment
 
     @override
-    async def get_orgs(self) -> schema.OrgsListResponse:
-        return schema.OrgsListResponse(orgs=[DEFAULT_ORG])
+    async def get_organizations(self) -> schema.OrganizationsListResponse:
+        return schema.OrganizationsListResponse(organizations=[DEFAULT_ORG])
 
     @override
     async def get_projects(

--- a/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
+++ b/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
@@ -26,7 +26,7 @@ from llama_agents.core.schema.git_validation import (
     RepositoryValidationResponse,
 )
 from llama_agents.core.schema.projects import (
-    OrgsListResponse,
+    OrganizationsListResponse,
     OrgSummary,
     ProjectsListResponse,
     ProjectSummary,
@@ -120,11 +120,11 @@ class ControlPlaneClient(BaseClient):
         _raise_for_status(response)
         return RestoreResponse.model_validate(response.json())
 
-    async def list_orgs(self) -> List[OrgSummary]:
-        response = await self.client.get("/api/v1beta1/deployments/list-orgs")
+    async def list_organizations(self) -> List[OrgSummary]:
+        response = await self.client.get("/api/v1beta1/deployments/organizations")
         _raise_for_status(response)
-        orgs_response = OrgsListResponse.model_validate(response.json())
-        return list(orgs_response.orgs)
+        orgs_response = OrganizationsListResponse.model_validate(response.json())
+        return list(orgs_response.organizations)
 
     async def list_projects(self, org_id: str | None = None) -> List[ProjectSummary]:
         params = {}

--- a/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
+++ b/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
@@ -25,7 +25,12 @@ from llama_agents.core.schema.git_validation import (
     RepositoryValidationRequest,
     RepositoryValidationResponse,
 )
-from llama_agents.core.schema.projects import ProjectsListResponse, ProjectSummary
+from llama_agents.core.schema.projects import (
+    OrgsListResponse,
+    OrgSummary,
+    ProjectsListResponse,
+    ProjectSummary,
+)
 from llama_agents.core.schema.public import VersionResponse
 
 
@@ -115,11 +120,22 @@ class ControlPlaneClient(BaseClient):
         _raise_for_status(response)
         return RestoreResponse.model_validate(response.json())
 
-    async def list_projects(self) -> List[ProjectSummary]:
-        response = await self.client.get("/api/v1beta1/deployments/list-projects")
+    async def list_orgs(self) -> List[OrgSummary]:
+        response = await self.client.get("/api/v1beta1/deployments/list-orgs")
+        _raise_for_status(response)
+        orgs_response = OrgsListResponse.model_validate(response.json())
+        return list(orgs_response.orgs)
+
+    async def list_projects(self, org_id: str | None = None) -> List[ProjectSummary]:
+        params = {}
+        if org_id is not None:
+            params["org_id"] = org_id
+        response = await self.client.get(
+            "/api/v1beta1/deployments/list-projects", params=params
+        )
         _raise_for_status(response)
         projects_response = ProjectsListResponse.model_validate(response.json())
-        return [project for project in projects_response.projects]
+        return list(projects_response.projects)
 
 
 def _raise_for_status(response: httpx.Response) -> None:

--- a/packages/llama-agents-core/src/llama_agents/core/schema/__init__.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/__init__.py
@@ -19,7 +19,7 @@ from .deployments import (
     apply_deployment_update,
 )
 from .git_validation import RepositoryValidationRequest, RepositoryValidationResponse
-from .projects import ProjectsListResponse, ProjectSummary
+from .projects import OrgsListResponse, OrgSummary, ProjectsListResponse, ProjectSummary
 from .public import Capabilities, Capability, VersionResponse
 
 __all__ = [
@@ -41,6 +41,8 @@ __all__ = [
     "LlamaDeploymentPhase",
     "RepositoryValidationResponse",
     "RepositoryValidationRequest",
+    "OrgSummary",
+    "OrgsListResponse",
     "ProjectSummary",
     "ProjectsListResponse",
     "VersionResponse",

--- a/packages/llama-agents-core/src/llama_agents/core/schema/__init__.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/__init__.py
@@ -19,7 +19,12 @@ from .deployments import (
     apply_deployment_update,
 )
 from .git_validation import RepositoryValidationRequest, RepositoryValidationResponse
-from .projects import OrgsListResponse, OrgSummary, ProjectsListResponse, ProjectSummary
+from .projects import (
+    OrganizationsListResponse,
+    OrgSummary,
+    ProjectsListResponse,
+    ProjectSummary,
+)
 from .public import Capabilities, Capability, VersionResponse
 
 __all__ = [
@@ -42,7 +47,7 @@ __all__ = [
     "RepositoryValidationResponse",
     "RepositoryValidationRequest",
     "OrgSummary",
-    "OrgsListResponse",
+    "OrganizationsListResponse",
     "ProjectSummary",
     "ProjectsListResponse",
     "VersionResponse",

--- a/packages/llama-agents-core/src/llama_agents/core/schema/projects.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/projects.py
@@ -5,12 +5,26 @@ from pydantic import model_validator
 from .base import Base
 
 
+class OrgSummary(Base):
+    """Summary of an organization."""
+
+    org_id: str
+    org_name: str
+
+
+class OrgsListResponse(Base):
+    """Response model for listing organizations."""
+
+    orgs: list[OrgSummary]
+
+
 class ProjectSummary(Base):
     """Summary of a project with deployment count"""
 
     project_id: str
     project_name: str
     deployment_count: int
+    org_id: str = "default"
 
     @model_validator(mode="before")
     @classmethod

--- a/packages/llama-agents-core/src/llama_agents/core/schema/projects.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/projects.py
@@ -10,6 +10,7 @@ class OrgSummary(Base):
 
     org_id: str
     org_name: str
+    is_default: bool = False
 
 
 class OrgsListResponse(Base):

--- a/packages/llama-agents-core/src/llama_agents/core/schema/projects.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/projects.py
@@ -13,10 +13,10 @@ class OrgSummary(Base):
     is_default: bool = False
 
 
-class OrgsListResponse(Base):
+class OrganizationsListResponse(Base):
     """Response model for listing organizations."""
 
-    orgs: list[OrgSummary]
+    organizations: list[OrgSummary]
 
 
 class ProjectSummary(Base):

--- a/packages/llama-agents-core/src/llama_agents/core/schema/public.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/public.py
@@ -9,7 +9,7 @@ class Capabilities:
     """Known capability identifiers advertised by the server."""
 
     CODE_PUSH: Capability = "code_push"
-    ORGS: Capability = "orgs"
+    ORGANIZATIONS: Capability = "organizations"
 
 
 class VersionResponse(Base):

--- a/packages/llama-agents-core/src/llama_agents/core/schema/public.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/public.py
@@ -9,6 +9,7 @@ class Capabilities:
     """Known capability identifiers advertised by the server."""
 
     CODE_PUSH: Capability = "code_push"
+    ORGS: Capability = "orgs"
 
 
 class VersionResponse(Base):

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
@@ -22,9 +22,18 @@ class AbstractPublicDeploymentsService(ABC):
 
 class AbstractDeploymentsService(ABC):
     @abstractmethod
-    async def get_projects(self) -> schema.ProjectsListResponse:
+    async def get_orgs(self) -> schema.OrgsListResponse:
         """
-        Get a list of projects
+        Get a list of organizations.
+        """
+        ...
+
+    @abstractmethod
+    async def get_projects(
+        self, org_id: str | None = None
+    ) -> schema.ProjectsListResponse:
+        """
+        Get a list of projects, optionally filtered by org_id.
         """
         ...
 

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
@@ -22,7 +22,7 @@ class AbstractPublicDeploymentsService(ABC):
 
 class AbstractDeploymentsService(ABC):
     @abstractmethod
-    async def get_orgs(self) -> schema.OrgsListResponse:
+    async def get_organizations(self) -> schema.OrganizationsListResponse:
         """
         Get a list of organizations.
         """

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
@@ -54,10 +54,10 @@ def create_v1beta1_deployments_router(
     async def get_version() -> schema.VersionResponse:
         return await public_service.get_version()
 
-    @router.get("/list-orgs")
-    async def get_orgs() -> schema.OrgsListResponse:
+    @router.get("/organizations")
+    async def get_organizations() -> schema.OrganizationsListResponse:
         """Get all organizations"""
-        return await deployments_service.get_orgs()
+        return await deployments_service.get_organizations()
 
     @router.get("/list-projects")
     async def get_projects(

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
@@ -54,10 +54,17 @@ def create_v1beta1_deployments_router(
     async def get_version() -> schema.VersionResponse:
         return await public_service.get_version()
 
+    @router.get("/list-orgs")
+    async def get_orgs() -> schema.OrgsListResponse:
+        """Get all organizations"""
+        return await deployments_service.get_orgs()
+
     @router.get("/list-projects")
-    async def get_projects() -> schema.ProjectsListResponse:
+    async def get_projects(
+        org_id: Annotated[str | None, Query()] = None,
+    ) -> schema.ProjectsListResponse:
         """Get all unique projects with their deployment counts"""
-        return await deployments_service.get_projects()
+        return await deployments_service.get_projects(org_id=org_id)
 
     @router.post("/validate-repository")
     async def validate_repository(

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -18,7 +18,7 @@ from llama_agents.cli.styles import (
     PRIMARY_COL,
     WARNING,
 )
-from llama_agents.cli.utils.capabilities import probe_orgs_support
+from llama_agents.cli.utils.capabilities import probe_organizations_support
 from rich import print as rprint
 from rich.table import Table
 from rich.text import Text
@@ -97,10 +97,10 @@ def create_api_key_profile(
 
         # Interactive mode: prompt for token (masked) and validate
         token_value = api_key or _prompt_for_api_key()
-        org = _discover_org(auth_svc, api_key=token_value)
+        org = _discover_organization(auth_svc, api_key=token_value)
         org_id_for_projects = org.org_id if org is not None else None
         if org is not None:
-            rprint(f"Projects for [bold]{org.org_name}[/]")
+            rprint(f"Projects for organization [bold]{org.org_name}[/]")
         projects = _prompt_validate_api_key_and_list_projects(
             auth_svc, token_value, org_id=org_id_for_projects
         )
@@ -306,7 +306,7 @@ def change_project(
     # Discover org if not explicitly provided (profile exists, credentials available)
     org = None
     if org_id is None:
-        org = _discover_org(auth_svc)
+        org = _discover_organization(auth_svc)
         if org is not None:
             org_id = org.org_id
 
@@ -335,7 +335,7 @@ def change_project(
             return
 
         if org is not None:
-            rprint(f"Projects for [bold]{org.org_name}[/]")
+            rprint(f"Projects for organization [bold]{org.org_name}[/]")
 
         result = questionary.select(
             "Select a project",
@@ -497,7 +497,7 @@ def _create_device_profile() -> Auth:
     token = oidc_device.device_access_token
 
     # Discover org for project scoping (pass token — no profile exists yet)
-    org = _discover_org(auth_svc, api_key=token)
+    org = _discover_organization(auth_svc, api_key=token)
     org_id = org.org_id if org is not None else None
 
     # Obtain or prompt for project ID and create profile
@@ -509,7 +509,7 @@ def _create_device_profile() -> Auth:
         raise click.ClickException("No projects found for this account")
 
     if org is not None:
-        rprint(f"Projects for [bold]{org.org_name}[/]")
+        rprint(f"Projects for organization [bold]{org.org_name}[/]")
 
     selected_project_id = _select_or_enter_project(projects, True)
     if not selected_project_id:
@@ -731,7 +731,7 @@ def _list_projects(
     return asyncio.run(_run())
 
 
-def _list_orgs(
+def _list_organizations(
     auth_svc: AuthService,
     api_key: str | None = None,
 ) -> list[OrgSummary]:
@@ -744,25 +744,25 @@ def _list_orgs(
             api_key or (profile.api_key if profile else None),
             None if api_key is not None else auth_svc.auth_middleware(profile),
         ) as client:
-            return await client.list_orgs()
+            return await client.list_organizations()
 
     return asyncio.run(_run())
 
 
-def _discover_org(
+def _discover_organization(
     auth_svc: AuthService, api_key: str | None = None
 ) -> OrgSummary | None:
-    """Discover the default org from the server if it supports the orgs capability.
+    """Discover the default organization from the server.
 
     Returns the default OrgSummary (by is_default flag, falling back to first),
-    or None if the server doesn't support orgs.
+    or None if the server doesn't support organizations.
     """
-    if not probe_orgs_support():
+    if not probe_organizations_support():
         return None
-    orgs = _list_orgs(auth_svc, api_key=api_key)
-    if not orgs:
+    organizations = _list_organizations(auth_svc, api_key=api_key)
+    if not organizations:
         return None
-    return next((o for o in orgs if o.is_default), orgs[0])
+    return next((o for o in organizations if o.is_default), organizations[0])
 
 
 def _prompt_validate_api_key_and_list_projects(

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import click
-from llama_agents.cli.param_types import ProfileType, ProjectType
+from llama_agents.cli.param_types import OrgType, ProfileType, ProjectType
 from llama_agents.cli.styles import (
     ACTIVE_INDICATOR,
     HEADER_COLOR,
@@ -286,11 +286,52 @@ def me() -> None:
         raise click.Abort()
 
 
+# Organizations commands
+@auth.command("organizations")
+@global_options
+def list_organizations() -> None:
+    """List organizations available to the current profile"""
+    try:
+        auth_svc = _get_service().current_auth_service()
+        if not probe_organizations_support():
+            rprint(f"[{WARNING}]This server does not support organizations[/]")
+            return
+
+        organizations = _list_organizations(auth_svc)
+        if not organizations:
+            rprint(f"[{WARNING}]No organizations found[/]")
+            return
+
+        table = Table(show_edge=False, box=None, header_style=f"bold {HEADER_COLOR}")
+        table.add_column("  Org ID", style=PRIMARY_COL)
+        table.add_column("Name", style=MUTED_COL)
+        table.add_column("Default", style=MUTED_COL)
+
+        for org in organizations:
+            indicator = Text()
+            if org.is_default:
+                indicator.append("* ", style=ACTIVE_INDICATOR)
+            else:
+                indicator.append("  ")
+            indicator.append(org.org_id)
+            table.add_row(indicator, org.org_name, "yes" if org.is_default else "")
+
+        console.print(table)
+
+    except Exception as e:
+        rprint(f"[red]Error: {e}[/red]")
+        raise click.Abort()
+
+
 # Projects commands
 @auth.command("project")
 @click.argument("project_id", required=False, type=ProjectType())
 @click.option(
-    "--org", "org_id", default=None, help="Organization ID to scope projects to"
+    "--org",
+    "org_id",
+    default=None,
+    type=OrgType(),
+    help="Organization ID to scope projects to",
 )
 @interactive_option
 @global_options

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -7,7 +7,7 @@ import platform
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import click
 from llama_agents.cli.param_types import ProfileType, ProjectType
@@ -18,6 +18,7 @@ from llama_agents.cli.styles import (
     PRIMARY_COL,
     WARNING,
 )
+from llama_agents.cli.utils.capabilities import probe_orgs_support
 from rich import print as rprint
 from rich.table import Table
 from rich.text import Text
@@ -28,9 +29,13 @@ from ..options import global_options, interactive_option
 if TYPE_CHECKING:
     from llama_agents.cli.config.auth_service import AuthService
     from llama_agents.cli.config.env_service import EnvService
-    from llama_agents.core.schema.projects import ProjectSummary
+    from llama_agents.core.schema.projects import OrgSummary, ProjectSummary
 
     from ..config.schema import Auth, DeviceOIDC
+
+
+class NoProjectsFoundError(Exception):
+    """Raised when the authenticated user has no accessible projects on an org-less server."""
 
 
 _ClickPath = getattr(click, "Path")
@@ -92,7 +97,13 @@ def create_api_key_profile(
 
         # Interactive mode: prompt for token (masked) and validate
         token_value = api_key or _prompt_for_api_key()
-        projects = _prompt_validate_api_key_and_list_projects(auth_svc, token_value)
+        org = _discover_org(auth_svc, api_key=token_value)
+        org_id_for_projects = org.org_id if org is not None else None
+        if org is not None:
+            rprint(f"Projects for [bold]{org.org_name}[/]")
+        projects = _prompt_validate_api_key_and_list_projects(
+            auth_svc, token_value, org_id=org_id_for_projects
+        )
 
         # Select or enter project ID
         selected_project_id = project_id or _select_or_enter_project(
@@ -122,6 +133,14 @@ def device_login() -> None:
         rprint(
             f"[green]Created login profile '{created.name}' and set as current[/green]"
         )
+
+    except NoProjectsFoundError:
+        rprint(f"[{WARNING}]⚠️ No Existing Projects - Welcome to LlamaCloud![/]")
+        rprint(f"[{WARNING}]Looks like this may be your first time logging in.[/]")
+        rprint(
+            f"[{WARNING}]Before you can get started, log in to https://cloud.llamaindex.ai to complete your account setup.[/]"
+        )
+        return
 
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")
@@ -284,12 +303,13 @@ def change_project(
     auth_svc = _get_service().current_auth_service()
     profile = validate_authenticated_profile(interactive)
 
-    # Discover org if not explicitly provided
+    # Discover org if not explicitly provided (profile exists, credentials available)
     org = None
     if org_id is None:
         org = _discover_org(auth_svc)
         if org is not None:
             org_id = org.org_id
+
     if project_id and profile.project_id == project_id:
         return
     if project_id:
@@ -474,14 +494,18 @@ def _create_device_profile() -> Auth:
     base_url = auth_svc.env.api_url.rstrip("/")
 
     oidc_device = asyncio.run(_run_device_authentication(base_url))
+    token = oidc_device.device_access_token
 
-    # Discover org for project scoping
-    org = _discover_org(auth_svc)
+    # Discover org for project scoping (pass token — no profile exists yet)
+    org = _discover_org(auth_svc, api_key=token)
     org_id = org.org_id if org is not None else None
 
     # Obtain or prompt for project ID and create profile
-    projects = _list_projects(auth_svc, oidc_device.device_access_token, org_id=org_id)
+    projects = _list_projects(auth_svc, token, org_id=org_id)
     if not projects:
+        if org is None:
+            # Legacy org-less server — account not set up yet
+            raise NoProjectsFoundError()
         raise click.ClickException("No projects found for this account")
 
     if org is not None:
@@ -710,8 +734,8 @@ def _list_projects(
 def _list_orgs(
     auth_svc: AuthService,
     api_key: str | None = None,
-) -> list[Any]:
-    async def _run() -> list[Any]:
+) -> list[OrgSummary]:
+    async def _run() -> list[OrgSummary]:
         from llama_agents.core.client.manage_client import ControlPlaneClient
 
         profile = auth_svc.get_current_profile()
@@ -725,39 +749,39 @@ def _list_orgs(
     return asyncio.run(_run())
 
 
-def _discover_org(auth_svc: AuthService) -> Any | None:
-    """Discover the current org from the server if it supports the orgs capability.
+def _discover_org(
+    auth_svc: AuthService, api_key: str | None = None
+) -> OrgSummary | None:
+    """Discover the default org from the server if it supports the orgs capability.
 
-    Returns the first OrgSummary, or None if the server doesn't support orgs.
+    Returns the default OrgSummary (by is_default flag, falling back to first),
+    or None if the server doesn't support orgs.
     """
-    from llama_agents.cli.utils.capabilities import probe_orgs_support
-
     if not probe_orgs_support():
         return None
-    try:
-        orgs = _list_orgs(auth_svc)
-        return orgs[0] if orgs else None
-    except Exception:
+    orgs = _list_orgs(auth_svc, api_key=api_key)
+    if not orgs:
         return None
+    return next((o for o in orgs if o.is_default), orgs[0])
 
 
 def _prompt_validate_api_key_and_list_projects(
-    auth_svc: AuthService, api_key: str
+    auth_svc: AuthService, api_key: str, org_id: str | None = None
 ) -> list[ProjectSummary]:
     import httpx
 
     try:
-        return _list_projects(auth_svc, api_key)
+        return _list_projects(auth_svc, api_key, org_id=org_id)
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 401:
             rprint("[red]Invalid API key. Please try again.[/red]")
             return _prompt_validate_api_key_and_list_projects(
-                auth_svc, _prompt_for_api_key()
+                auth_svc, _prompt_for_api_key(), org_id=org_id
             )
         if e.response.status_code == 403:
             rprint("[red]This environment requires a valid API key.[/red]")
             return _prompt_validate_api_key_and_list_projects(
-                auth_svc, _prompt_for_api_key()
+                auth_svc, _prompt_for_api_key(), org_id=org_id
             )
         raise
     except Exception as e:
@@ -825,7 +849,7 @@ def _select_profile(
             rprint(f"[{WARNING}]No profiles found[/]")
             return None
 
-        choices: list[Any] = []
+        choices: list[questionary.Choice] = []
         current = auth_svc.get_current_profile()
 
         for profile in profiles:

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -47,11 +47,6 @@ def _get_service() -> EnvService:
     return service
 
 
-# Specific auth/login flow exceptions
-class NoProjectsFoundError(Exception):
-    """Raised when the authenticated user has no accessible projects."""
-
-
 # Create sub-applications for organizing commands
 @app.group(
     help="Login to llama cloud control plane to manage deployments",
@@ -127,15 +122,6 @@ def device_login() -> None:
         rprint(
             f"[green]Created login profile '{created.name}' and set as current[/green]"
         )
-
-    except NoProjectsFoundError:
-        # Friendly guidance for first-time users with no projects
-        rprint(f"[{WARNING}]⚠️ No Existing Projects - Welcome to LlamaCloud![/]")
-        rprint(f"[{WARNING}]Looks like this may be your first time logging in.[/]")
-        rprint(
-            f"[{WARNING}]Before you can get started, log in to https://cloud.llamaindex.ai to complete your account setup.[/]"
-        )
-        return
 
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")
@@ -284,19 +270,31 @@ def me() -> None:
 # Projects commands
 @auth.command("project")
 @click.argument("project_id", required=False, type=ProjectType())
+@click.option(
+    "--org", "org_id", default=None, help="Organization ID to scope projects to"
+)
 @interactive_option
 @global_options
-def change_project(project_id: str | None, interactive: bool) -> None:
+def change_project(
+    project_id: str | None, org_id: str | None, interactive: bool
+) -> None:
     """Change the active project for the current profile"""
     import questionary
 
     auth_svc = _get_service().current_auth_service()
     profile = validate_authenticated_profile(interactive)
+
+    # Discover org if not explicitly provided
+    org = None
+    if org_id is None:
+        org = _discover_org(auth_svc)
+        if org is not None:
+            org_id = org.org_id
     if project_id and profile.project_id == project_id:
         return
     if project_id:
         if auth_svc.env.requires_auth:
-            projects = _list_projects(auth_svc)
+            projects = _list_projects(auth_svc, org_id=org_id)
             if not next(
                 (project for project in projects if project.project_id == project_id),
                 None,
@@ -310,11 +308,15 @@ def change_project(project_id: str | None, interactive: bool) -> None:
             "No --project-id provided. Run `llamactl auth project --help` for more information."
         )
     try:
-        projects = _list_projects(auth_svc)
+        projects = _list_projects(auth_svc, org_id=org_id)
 
         if not projects:
             rprint(f"[{WARNING}]No projects found[/]")
             return
+
+        if org is not None:
+            rprint(f"Projects for [bold]{org.org_name}[/]")
+
         result = questionary.select(
             "Select a project",
             choices=[
@@ -473,11 +475,17 @@ def _create_device_profile() -> Auth:
 
     oidc_device = asyncio.run(_run_device_authentication(base_url))
 
+    # Discover org for project scoping
+    org = _discover_org(auth_svc)
+    org_id = org.org_id if org is not None else None
+
     # Obtain or prompt for project ID and create profile
-    projects = _list_projects(auth_svc, oidc_device.device_access_token)
+    projects = _list_projects(auth_svc, oidc_device.device_access_token, org_id=org_id)
     if not projects:
-        # No projects available for this user yet
-        raise NoProjectsFoundError()
+        raise click.ClickException("No projects found for this account")
+
+    if org is not None:
+        rprint(f"Projects for [bold]{org.org_name}[/]")
 
     selected_project_id = _select_or_enter_project(projects, True)
     if not selected_project_id:
@@ -683,6 +691,7 @@ def _prompt_for_api_key() -> str:
 def _list_projects(
     auth_svc: AuthService,
     api_key: str | None = None,
+    org_id: str | None = None,
 ) -> list[ProjectSummary]:
     async def _run() -> list[ProjectSummary]:
         from llama_agents.core.client.manage_client import ControlPlaneClient
@@ -693,9 +702,43 @@ def _list_projects(
             api_key or (profile.api_key if profile else None),
             None if api_key is not None else auth_svc.auth_middleware(profile),
         ) as client:
-            return await client.list_projects()
+            return await client.list_projects(org_id=org_id)
 
     return asyncio.run(_run())
+
+
+def _list_orgs(
+    auth_svc: AuthService,
+    api_key: str | None = None,
+) -> list[Any]:
+    async def _run() -> list[Any]:
+        from llama_agents.core.client.manage_client import ControlPlaneClient
+
+        profile = auth_svc.get_current_profile()
+        async with ControlPlaneClient.ctx(
+            auth_svc.env.api_url,
+            api_key or (profile.api_key if profile else None),
+            None if api_key is not None else auth_svc.auth_middleware(profile),
+        ) as client:
+            return await client.list_orgs()
+
+    return asyncio.run(_run())
+
+
+def _discover_org(auth_svc: AuthService) -> Any | None:
+    """Discover the current org from the server if it supports the orgs capability.
+
+    Returns the first OrgSummary, or None if the server doesn't support orgs.
+    """
+    from llama_agents.cli.utils.capabilities import probe_orgs_support
+
+    if not probe_orgs_support():
+        return None
+    try:
+        orgs = _list_orgs(auth_svc)
+        return orgs[0] if orgs else None
+    except Exception:
+        return None
 
 
 def _prompt_validate_api_key_and_list_projects(

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -14,20 +14,19 @@ from llama_agents.cli.options import (
     native_tls_option,
 )
 from llama_agents.cli.styles import WARNING
-from llama_agents.cli.utils.capabilities import probe_orgs_support
+from llama_agents.cli.utils.capabilities import probe_organizations_support
 from llama_agents.cli.utils.redact import redact_api_key
 from llama_agents.core.config import DEFAULT_DEPLOYMENT_FILE_PATH
 from llama_agents.core.deployment_config import (
     read_deployment_config_from_git_root_or_cwd,
 )
-from llama_agents.core.schema.projects import ProjectSummary
+from llama_agents.core.schema.projects import OrgSummary, ProjectSummary
 from rich import print as rprint
 
 from ..app import app
 
 if TYPE_CHECKING:
     from llama_agents.cli.config.schema import Auth
-    from llama_agents.core.schema.projects import OrgSummary
 
 logger = logging.getLogger(__name__)
 _ClickPath = getattr(click, "Path")
@@ -319,15 +318,16 @@ def _maybe_select_project_for_env_key() -> None:
     if not api_key:
         return
     try:
-        supports_orgs = probe_orgs_support()
+        supports_organizations = probe_organizations_support()
 
         async def _run() -> tuple[OrgSummary | None, list[ProjectSummary]]:
             async with ControlPlaneClient.ctx(base_url, api_key, None) as client:
                 org: OrgSummary | None = None
-                if supports_orgs:
-                    orgs = await client.list_orgs()
+                if supports_organizations:
+                    organizations = await client.list_organizations()
                     org = next(
-                        (o for o in orgs if o.is_default), orgs[0] if orgs else None
+                        (o for o in organizations if o.is_default),
+                        organizations[0] if organizations else None,
                     )
                 org_id = org.org_id if org is not None else None
                 projects = await client.list_projects(org_id=org_id)
@@ -341,7 +341,7 @@ def _maybe_select_project_for_env_key() -> None:
             return
 
         if org is not None:
-            rprint(f"Projects for [bold]{org.org_name}[/]")
+            rprint(f"Projects for organization [bold]{org.org_name}[/]")
 
         # Multiple: prompt selection
         choice = questionary.select(

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 
 import click
 from click.exceptions import Abort, Exit
@@ -318,16 +318,26 @@ def _maybe_select_project_for_env_key() -> None:
         return
     try:
 
-        async def _run() -> list[ProjectSummary]:
+        async def _run() -> tuple[list[Any], list[ProjectSummary]]:
             async with ControlPlaneClient.ctx(base_url, api_key, None) as client:
-                return await client.list_projects()
+                try:
+                    orgs = await client.list_orgs()
+                except Exception:
+                    orgs = []
+                org_id = orgs[0].org_id if orgs else None
+                projects = await client.list_projects(org_id=org_id)
+                return orgs, projects
 
-        projects = asyncio.run(_run())
+        orgs, projects = asyncio.run(_run())
         if not projects:
             return
         if len(projects) == 1:
             os.environ["LLAMA_DEPLOY_PROJECT_ID"] = projects[0].project_id
             return
+
+        if orgs:
+            rprint(f"Projects for [bold]{orgs[0].org_name}[/]")
+
         # Multiple: prompt selection
         choice = questionary.select(
             "Select a project",

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 import click
 from click.exceptions import Abort, Exit
@@ -14,6 +14,7 @@ from llama_agents.cli.options import (
     native_tls_option,
 )
 from llama_agents.cli.styles import WARNING
+from llama_agents.cli.utils.capabilities import probe_orgs_support
 from llama_agents.cli.utils.redact import redact_api_key
 from llama_agents.core.config import DEFAULT_DEPLOYMENT_FILE_PATH
 from llama_agents.core.deployment_config import (
@@ -26,6 +27,7 @@ from ..app import app
 
 if TYPE_CHECKING:
     from llama_agents.cli.config.schema import Auth
+    from llama_agents.core.schema.projects import OrgSummary
 
 logger = logging.getLogger(__name__)
 _ClickPath = getattr(click, "Path")
@@ -317,26 +319,29 @@ def _maybe_select_project_for_env_key() -> None:
     if not api_key:
         return
     try:
+        supports_orgs = probe_orgs_support()
 
-        async def _run() -> tuple[list[Any], list[ProjectSummary]]:
+        async def _run() -> tuple[OrgSummary | None, list[ProjectSummary]]:
             async with ControlPlaneClient.ctx(base_url, api_key, None) as client:
-                try:
+                org: OrgSummary | None = None
+                if supports_orgs:
                     orgs = await client.list_orgs()
-                except Exception:
-                    orgs = []
-                org_id = orgs[0].org_id if orgs else None
+                    org = next(
+                        (o for o in orgs if o.is_default), orgs[0] if orgs else None
+                    )
+                org_id = org.org_id if org is not None else None
                 projects = await client.list_projects(org_id=org_id)
-                return orgs, projects
+                return org, projects
 
-        orgs, projects = asyncio.run(_run())
+        org, projects = asyncio.run(_run())
         if not projects:
             return
         if len(projects) == 1:
             os.environ["LLAMA_DEPLOY_PROJECT_ID"] = projects[0].project_id
             return
 
-        if orgs:
-            rprint(f"Projects for [bold]{orgs[0].org_name}[/]")
+        if org is not None:
+            rprint(f"Projects for [bold]{org.org_name}[/]")
 
         # Multiple: prompt selection
         choice = questionary.select(

--- a/packages/llamactl/src/llama_agents/cli/param_types.py
+++ b/packages/llamactl/src/llama_agents/cli/param_types.py
@@ -45,6 +45,20 @@ def _fetch_projects() -> list[CompletionItem]:
     ]
 
 
+def _fetch_organizations() -> list[CompletionItem]:
+    from llama_agents.cli.client import get_control_plane_client
+
+    client = get_control_plane_client()
+    organizations = asyncio.run(client.list_organizations())
+    return [
+        CompletionItem(
+            o.org_id,
+            help=f"{o.org_name}{' (default)' if o.is_default else ''}",
+        )
+        for o in organizations
+    ]
+
+
 def _fetch_deployment_history(deployment_id: str) -> list[CompletionItem]:
     from llama_agents.cli.client import get_project_client
 
@@ -97,6 +111,15 @@ class ProjectType(click.ParamType):
         self, ctx: click.Context, param: click.Parameter, incomplete: str
     ) -> list[CompletionItem]:
         return _filter(_safe_fetch(_fetch_projects), incomplete)
+
+
+class OrgType(click.ParamType):
+    name = "org"
+
+    def shell_complete(
+        self, ctx: click.Context, param: click.Parameter, incomplete: str
+    ) -> list[CompletionItem]:
+        return _filter(_safe_fetch(_fetch_organizations), incomplete)
 
 
 class EnvironmentType(click.ParamType):

--- a/packages/llamactl/src/llama_agents/cli/utils/capabilities.py
+++ b/packages/llamactl/src/llama_agents/cli/utils/capabilities.py
@@ -34,9 +34,9 @@ def probe_code_push_support() -> bool | None:
     return _probe_capability(Capabilities.CODE_PUSH)
 
 
-def probe_orgs_support() -> bool | None:
-    """Probe the current environment's server for orgs capability.
+def probe_organizations_support() -> bool | None:
+    """Probe the current environment's server for organizations capability.
 
     Returns True/False if the probe succeeds, or None if it fails (fail open).
     """
-    return _probe_capability(Capabilities.ORGS)
+    return _probe_capability(Capabilities.ORGANIZATIONS)

--- a/packages/llamactl/src/llama_agents/cli/utils/capabilities.py
+++ b/packages/llamactl/src/llama_agents/cli/utils/capabilities.py
@@ -9,21 +9,34 @@ from llama_agents.core.schema.public import Capabilities
 logger = logging.getLogger(__name__)
 
 
-def probe_code_push_support() -> bool | None:
-    """Probe the current environment's server for code_push capability.
+def _probe_capability(capability: str) -> bool | None:
+    """Probe whether the current environment's server advertises a capability.
 
     Returns True/False if the probe succeeds, or None if it fails (fail open).
     """
-    # Local import: env_service transitively pulls in httpx/auth_service which
-    # are too heavy for CLI startup (guarded by test_cli_imports).
     from llama_agents.cli.config.env_service import service
 
     try:
         env = service.get_current_environment()
         if not env.capabilities:
-            # Capabilities not yet populated — try a fresh probe
             env = service.auto_update_env(env)
-        return Capabilities.CODE_PUSH in env.capabilities
+        return capability in env.capabilities
     except Exception:
         logger.debug("Failed to probe server capabilities", exc_info=True)
         return None
+
+
+def probe_code_push_support() -> bool | None:
+    """Probe the current environment's server for code_push capability.
+
+    Returns True/False if the probe succeeds, or None if it fails (fail open).
+    """
+    return _probe_capability(Capabilities.CODE_PUSH)
+
+
+def probe_orgs_support() -> bool | None:
+    """Probe the current environment's server for orgs capability.
+
+    Returns True/False if the probe succeeds, or None if it fails (fail open).
+    """
+    return _probe_capability(Capabilities.ORGS)

--- a/packages/llamactl/tests/test_auth_login.py
+++ b/packages/llamactl/tests/test_auth_login.py
@@ -47,7 +47,7 @@ def test_create_device_profile_cleans_up_on_api_key_failure() -> None:
             return_value=_make_fake_device_oidc(),
         ),
         patch(
-            "llama_agents.cli.commands.auth._discover_org",
+            "llama_agents.cli.commands.auth._discover_organization",
             return_value=None,
         ),
         patch(

--- a/packages/llamactl/tests/test_auth_login.py
+++ b/packages/llamactl/tests/test_auth_login.py
@@ -47,6 +47,10 @@ def test_create_device_profile_cleans_up_on_api_key_failure() -> None:
             return_value=_make_fake_device_oidc(),
         ),
         patch(
+            "llama_agents.cli.commands.auth._discover_org",
+            return_value=None,
+        ),
+        patch(
             "llama_agents.cli.commands.auth._list_projects",
             return_value=[SimpleNamespace(project_id="proj-1")],
         ),


### PR DESCRIPTION
## Summary

- Add a thin org abstraction (list-orgs endpoint, org_id on projects) to match the API shape expected by the cloud proxy
- CLI discovers orgs via capability check and threads org context through project selection flows