### PR TITLE
fix(ci): publish operator image and push release tags explicitly

### DIFF
--- a/.changeset/large-poems-guess.md
+++ b/.changeset/large-poems-guess.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-operator": patch
+---
+
+Publish llama-agents-operator docker image from the release pipeline.

--- a/.changeset/large-poems-guess.md
+++ b/.changeset/large-poems-guess.md
@@ -1,5 +1,0 @@
----
-"llama-agents-operator": patch
----
-
-Publish llama-agents-operator docker image from the release pipeline.

--- a/.github/workflows/publish_changesets.yml
+++ b/.github/workflows/publish_changesets.yml
@@ -254,8 +254,26 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
+          set -euo pipefail
+          echo "Existing tags at HEAD before changeset tag:"
+          git tag --points-at HEAD | sort || true
+
           pnpm exec changeset tag
-          git push --tags
+
+          echo "Tags at HEAD after changeset tag:"
+          NEW_TAGS=$(git tag --points-at HEAD | sort)
+          echo "$NEW_TAGS"
+
+          if [ -z "$NEW_TAGS" ]; then
+            echo "No tags to push."
+            exit 0
+          fi
+
+          # Push each tag explicitly so failures surface instead of being
+          # hidden behind ``git push --tags`` silently reporting
+          # "Everything up-to-date" when the default push refspec drops
+          # tags that aren't reachable from tracked branches.
+          echo "$NEW_TAGS" | xargs -r git push --verbose origin
 
       - name: Extract published llama-agents-server version
         if: github.ref == 'refs/heads/main'

--- a/operator/package.json
+++ b/operator/package.json
@@ -1,6 +1,7 @@
 {
   "name": "llama-agents-operator",
   "version": "0.11.0",
+  "private": false,
   "docker": {
     "dockerfile": "docker/operator.Dockerfile",
     "imageName": "llamaindex/llama-agents-operator",


### PR DESCRIPTION
## Summary

- Mark `llama-agents-operator` as non-private so the release pipeline builds and pushes its Docker image. The package defaulted to `private: true` via `src/dev_cli/changesets.py`, so the image was never in the publish plan even as the chart bumped the image tag reference.
- Replace `git push --tags` in the `Finalize release` step with an explicit, verbose push of the tags `changeset tag` just created at HEAD. The previous form was reporting "Everything up-to-date" and leaving the new tags on the local runner — which is why only `llama-agents-server@v*` tags (created separately by the OpenAPI publish release action) have been landing on the remote for a while.

Missing historical tags will need to be created separately, pointing at the version-bump commits that introduced each version.