### PR TITLE
feat(control-plane): add S3_UNSIGNED toggle for authless backends

### DIFF
--- a/.changeset/s3-unsigned-toggle.md
+++ b/.changeset/s3-unsigned-toggle.md
@@ -1,0 +1,6 @@
+---
+"llama-agents-control-plane": minor
+"llama-agents": patch
+---
+
+Add `controlPlane.objectStorage.s3.unsigned` (Helm) / `S3_UNSIGNED` (env) toggle to send S3 requests unsigned, enabling authless S3-compatible backends (s3proxy, LocalStack, public-read buckets) without placeholder credentials. When enabled, applies to all S3 uses — builds, backups, and code-repo storage.

--- a/.changeset/s3-unsigned-toggle.md
+++ b/.changeset/s3-unsigned-toggle.md
@@ -1,6 +1,5 @@
 ---
-"llama-agents-control-plane": minor
-"llama-agents": patch
+"llama-agents-control-plane": patch
 ---
 
 Add `controlPlane.objectStorage.s3.unsigned` (Helm) / `S3_UNSIGNED` (env) toggle to send S3 requests unsigned, enabling authless S3-compatible backends (s3proxy, LocalStack, public-read buckets) without placeholder credentials. When enabled, applies to all S3 uses — builds, backups, and code-repo storage.

--- a/charts/llama-agents/README.md
+++ b/charts/llama-agents/README.md
@@ -113,6 +113,7 @@ helm upgrade llama-agents oci://docker.io/llamaindex/llama-agents
 | controlPlane.objectStorage.s3.endpointUrl | string | `""` | S3 endpoint URL (leave empty for AWS) |
 | controlPlane.objectStorage.s3.bucket | string | `""` | S3 bucket name (**required**) |
 | controlPlane.objectStorage.s3.region | string | `""` | S3 region |
+| controlPlane.objectStorage.s3.unsigned | bool | `false` | Send S3 requests unsigned (no Authorization header). Enable for authless backends like s3proxy/LocalStack or public-read buckets. Leave `false` for real AWS, MinIO, or any auth-requiring backend. |
 | controlPlane.objectStorage.secretRef | string | `""` | K8s Secret name containing `S3_ACCESS_KEY` and `S3_SECRET_KEY` |
 | controlPlane.objectStorage.buildKeyPrefix | string | `"builds"` | Key prefix for build artifacts in the bucket |
 | controlPlane.objectStorage.backupKeyPrefix | string | `"backups"` | Key prefix for backup archives in the bucket |

--- a/charts/llama-agents/templates/deployment.yaml
+++ b/charts/llama-agents/templates/deployment.yaml
@@ -56,6 +56,8 @@ spec:
           value: {{ required "controlPlane.objectStorage.s3.bucket is required" .Values.controlPlane.objectStorage.s3.bucket | quote }}
         - name: S3_REGION
           value: {{ .Values.controlPlane.objectStorage.s3.region | quote }}
+        - name: S3_UNSIGNED
+          value: {{ .Values.controlPlane.objectStorage.s3.unsigned | default false | quote }}
         - name: BUILD_S3_KEY_PREFIX
           value: {{ .Values.controlPlane.objectStorage.buildKeyPrefix | quote }}
         - name: BACKUP_S3_KEY_PREFIX

--- a/charts/llama-agents/tests/object_storage_test.yaml
+++ b/charts/llama-agents/tests/object_storage_test.yaml
@@ -34,6 +34,11 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
+            name: S3_UNSIGNED
+            value: "false"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
             name: BACKUP_S3_KEY_PREFIX
             value: "backups"
       - contains:
@@ -41,6 +46,20 @@ tests:
           content:
             name: CODE_REPO_S3_KEY_PREFIX
             value: "git"
+
+  - it: sets S3_UNSIGNED to true when unsigned is enabled
+    set:
+      controlPlane:
+        objectStorage:
+          s3:
+            bucket: "my-bucket"
+            unsigned: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: S3_UNSIGNED
+            value: "true"
 
   - it: sets envFrom with objectStorage secretRef
     set:

--- a/charts/llama-agents/values.yaml
+++ b/charts/llama-agents/values.yaml
@@ -123,6 +123,9 @@ controlPlane:
       # -- S3 region
       # @section -- Object Storage
       region: ""
+      # -- Send S3 requests unsigned (no Authorization header). Enable for authless backends like s3proxy/LocalStack or public-read buckets. Leave `false` for real AWS, MinIO, or any auth-requiring backend.
+      # @section -- Object Storage
+      unsigned: false
     # -- K8s Secret name containing `S3_ACCESS_KEY` and `S3_SECRET_KEY`
     # @section -- Object Storage
     secretRef: ""

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/backup/storage.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/backup/storage.py
@@ -32,6 +32,7 @@ class S3BackupStorage(S3ObjectStorage):
         access_key: str | None = None,
         secret_key: str | None = None,
         key_prefix: str = "backups",
+        unsigned: bool = False,
     ) -> None:
         super().__init__(
             bucket=bucket,
@@ -40,6 +41,7 @@ class S3BackupStorage(S3ObjectStorage):
             access_key=access_key,
             secret_key=secret_key,
             key_prefix=key_prefix,
+            unsigned=unsigned,
         )
 
     def _key(self, backup_id: str) -> str:

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_service.py
@@ -18,6 +18,7 @@ def create_build_artifact_storage() -> BuildArtifactStorage | None:
         access_key=settings.s3_access_key,
         secret_key=settings.s3_secret_key,
         key_prefix=settings.build_s3_key_prefix,
+        unsigned=settings.s3_unsigned,
     )
 
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_storage.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/build_api/build_storage.py
@@ -38,6 +38,7 @@ class BuildArtifactStorage(S3ObjectStorage):
         access_key: str | None = None,
         secret_key: str | None = None,
         key_prefix: str = "builds",
+        unsigned: bool = False,
     ) -> None:
         super().__init__(
             bucket=bucket,
@@ -46,6 +47,7 @@ class BuildArtifactStorage(S3ObjectStorage):
             access_key=access_key,
             secret_key=secret_key,
             key_prefix=key_prefix,
+            unsigned=unsigned,
         )
 
     def _key(self, deployment_name: str, build_id: str) -> str:

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/code_repo/service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/code_repo/service.py
@@ -18,6 +18,7 @@ def create_code_repo_storage() -> CodeRepoStorage | None:
         access_key=settings.s3_access_key,
         secret_key=settings.s3_secret_key,
         key_prefix=settings.code_repo_s3_key_prefix,
+        unsigned=settings.s3_unsigned,
     )
 
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/backup_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/backup_service.py
@@ -288,6 +288,7 @@ def create_backup_service() -> BackupService | None:
         access_key=settings.s3_access_key,
         secret_key=settings.s3_secret_key,
         key_prefix=settings.backup_s3_key_prefix,
+        unsigned=settings.s3_unsigned,
     )
     return BackupService(storage)
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/settings.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/settings.py
@@ -84,6 +84,15 @@ class ControlPlaneSettings(BaseSettings):
         description="S3 secret key",
         alias="S3_SECRET_KEY",
     )
+    s3_unsigned: bool = Field(
+        default=False,
+        description=(
+            "Send S3 requests unsigned (no Authorization header). "
+            "Enable for authless S3-compatible backends (s3proxy, LocalStack, "
+            "public buckets). Overrides any configured credentials."
+        ),
+        alias="S3_UNSIGNED",
+    )
 
     # Backup-specific settings
     backup_s3_key_prefix: str = Field(

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/storage.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/storage.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import logging
 from contextlib import asynccontextmanager
-from typing import TYPE_CHECKING, AsyncIterator, TypedDict
+from typing import TYPE_CHECKING, Any, AsyncIterator, TypedDict
 
 import aioboto3
+from botocore import UNSIGNED
+from botocore.client import Config
 
 if TYPE_CHECKING:
     from types_aiobotocore_s3 import S3Client
@@ -19,6 +21,7 @@ class _S3ClientKwargs(TypedDict, total=False):
     region_name: str
     aws_access_key_id: str
     aws_secret_access_key: str
+    config: Any
 
 
 class S3ObjectStorage:
@@ -36,6 +39,7 @@ class S3ObjectStorage:
         access_key: str | None = None,
         secret_key: str | None = None,
         key_prefix: str = "",
+        unsigned: bool = False,
     ) -> None:
         self._bucket = bucket
         self._key_prefix = key_prefix.strip("/")
@@ -45,7 +49,12 @@ class S3ObjectStorage:
             self._client_kwargs["endpoint_url"] = endpoint_url
         if region:
             self._client_kwargs["region_name"] = region
-        if access_key and secret_key:
+        if unsigned:
+            # UNSIGNED bypasses boto's credential chain entirely — any creds
+            # set via env/IRSA/etc. are ignored. Intended for authless
+            # S3-compatible backends (s3proxy, LocalStack, public buckets).
+            self._client_kwargs["config"] = Config(signature_version=UNSIGNED)
+        elif access_key and secret_key:
             self._client_kwargs["aws_access_key_id"] = access_key
             self._client_kwargs["aws_secret_access_key"] = secret_key
 

--- a/packages/llama-agents-control-plane/tests/test_storage.py
+++ b/packages/llama-agents-control-plane/tests/test_storage.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Unit tests for the S3ObjectStorage client-construction path."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from botocore import UNSIGNED
+from botocore.client import Config
+from llama_agents.control_plane.storage import S3ObjectStorage
+
+
+def _make_async_cm() -> AsyncMock:
+    cm = AsyncMock()
+    cm.__aenter__.return_value = MagicMock()
+    cm.__aexit__.return_value = None
+    return cm
+
+
+@pytest.mark.asyncio
+async def test_client_uses_unsigned_config_when_unsigned_is_true() -> None:
+    storage = S3ObjectStorage(
+        bucket="b",
+        endpoint_url="https://s3proxy.example",
+        region="us-east-1",
+        access_key="leaked",
+        secret_key="leaked",
+        unsigned=True,
+    )
+    with patch.object(
+        storage._session, "client", return_value=_make_async_cm()
+    ) as mock_client:
+        async with storage._client():
+            pass
+
+    _, kwargs = mock_client.call_args
+    cfg = kwargs.get("config")
+    assert isinstance(cfg, Config)
+    assert getattr(cfg, "signature_version") is UNSIGNED
+    assert "aws_access_key_id" not in kwargs
+    assert "aws_secret_access_key" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_client_omits_config_and_passes_creds_when_unsigned_is_false() -> None:
+    storage = S3ObjectStorage(
+        bucket="b",
+        endpoint_url="https://s3.example",
+        region="us-east-1",
+        access_key="ak",
+        secret_key="sk",
+        unsigned=False,
+    )
+    with patch.object(
+        storage._session, "client", return_value=_make_async_cm()
+    ) as mock_client:
+        async with storage._client():
+            pass
+
+    _, kwargs = mock_client.call_args
+    assert "config" not in kwargs
+    assert kwargs.get("aws_access_key_id") == "ak"
+    assert kwargs.get("aws_secret_access_key") == "sk"


### PR DESCRIPTION
## Summary

- Add `controlPlane.objectStorage.s3.unsigned` (Helm) / `S3_UNSIGNED` (env) toggle so operators can point at authless S3-compatible backends (s3proxy, LocalStack, public-read buckets) without provisioning placeholder credentials.
- When enabled, `S3ObjectStorage` builds its boto client with `Config(signature_version=UNSIGNED)` and omits the access/secret kwargs — any leaked env creds are ignored. Default stays `false`, preserving the existing credential chain (explicit keys, IRSA, instance profiles, etc.).
- Applies to all S3 uses in the control plane: build artifacts, backups, and code-repo storage.
- Added unit tests covering both signed and unsigned client construction, and helm-unittest cases for the new env var in both states.