### PR TITLE
Add configurable Docker buildx cache mode for GHA

### DIFF
--- a/operator/package.json
+++ b/operator/package.json
@@ -8,6 +8,7 @@
     "platforms": [
       "linux/amd64",
       "linux/arm64"
-    ]
+    ],
+    "cacheMode": "min"
   }
 }

--- a/src/dev_cli/changesets.py
+++ b/src/dev_cli/changesets.py
@@ -107,6 +107,12 @@ class DockerConfig(BaseModel):
     imageName: str
     target: str | None = None
     platforms: list[Platform] = Field(default_factory=list)
+    # GHA buildx cache mode. ``max`` caches every intermediate stage
+    # (expensive to upload but best reuse); ``min`` only caches the
+    # final layers. Use ``min`` for small/static binary builds (e.g.
+    # the operator) where uploading the base image + builder layers
+    # to GHA cache costs more than a clean rebuild.
+    cacheMode: Literal["min", "max"] = "max"
 
 
 class HelmConfig(BaseModel):
@@ -477,6 +483,7 @@ class DockerBuildAction(BaseModel):
     version: str
     build_tag: str  # full registry/repo:version-<arch>
     cache_scope: str  # GHA buildx cache scope (per package + arch)
+    cache_mode: Literal["min", "max"] = "max"  # GHA buildx cache-to mode
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -599,6 +606,7 @@ def plan_docker(
                     version=version,
                     build_tag=build_tag,
                     cache_scope=f"{pkg.name}-{suffix}",
+                    cache_mode=image.cacheMode,
                 )
             )
         manifests.append(
@@ -721,13 +729,19 @@ def _execute_docker_build(action: DockerBuildAction, dry_run: bool) -> None:
         cmd.extend(["--target", action.target])
     # GHA buildx cache. Only emits cache directives under GitHub Actions
     # with the runtime token exposed (see ``crazy-max/ghaction-github-runtime``).
+    # ``compression=zstd`` shrinks the exported cache blobs, and
+    # ``ignore-error=true`` keeps a flaky cache push from failing the
+    # whole job (the image is already pushed to the registry by then).
     if os.environ.get("ACTIONS_RUNTIME_TOKEN") and os.environ.get("ACTIONS_CACHE_URL"):
         cmd.extend(
             [
                 "--cache-from",
                 f"type=gha,scope={action.cache_scope}",
                 "--cache-to",
-                f"type=gha,mode=max,scope={action.cache_scope}",
+                (
+                    f"type=gha,mode={action.cache_mode},scope={action.cache_scope}"
+                    ",compression=zstd,ignore-error=true"
+                ),
             ]
         )
     cmd.append(".")

--- a/tests/dev_cli/test_changesets.py
+++ b/tests/dev_cli/test_changesets.py
@@ -751,6 +751,70 @@ def test_execute_docker_build_action_invokes_buildx() -> None:
     assert "--tag" in cmd and "docker.io/llamaindex/test:1.0.0-amd64" in cmd
 
 
+def test_execute_docker_build_action_emits_gha_cache_flags(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ACTIONS_RUNTIME_TOKEN", "token")
+    monkeypatch.setenv("ACTIONS_CACHE_URL", "https://cache.example.com")
+    with patch("dev_cli.changesets.run_command") as mock_run:
+        execute_action(_docker_build_action(), dry_run=False)
+    cmd = mock_run.call_args[0][0]
+    assert "--cache-from" in cmd
+    cache_to = cmd[cmd.index("--cache-to") + 1]
+    # Default cache_mode is "max"; zstd + ignore-error are always set under GHA.
+    assert "mode=max" in cache_to
+    assert "scope=pkg-amd64" in cache_to
+    assert "compression=zstd" in cache_to
+    assert "ignore-error=true" in cache_to
+
+
+def test_execute_docker_build_action_respects_cache_mode_min(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ACTIONS_RUNTIME_TOKEN", "token")
+    monkeypatch.setenv("ACTIONS_CACHE_URL", "https://cache.example.com")
+    action = _docker_build_action().model_copy(update={"cache_mode": "min"})
+    with patch("dev_cli.changesets.run_command") as mock_run:
+        execute_action(action, dry_run=False)
+    cmd = mock_run.call_args[0][0]
+    cache_to = cmd[cmd.index("--cache-to") + 1]
+    assert "mode=min" in cache_to
+    assert "mode=max" not in cache_to
+
+
+def test_plan_docker_propagates_cache_mode() -> None:
+    packages = [
+        PackageJson(
+            name="pkg-min",
+            path=Path("/tmp/pkg-min"),
+            version="1.0.0",
+            private=False,
+            docker=DockerConfig(
+                dockerfile="docker/Dockerfile",
+                imageName="llamaindex/pkg-min",
+                platforms=["linux/amd64"],
+                cacheMode="min",
+            ),
+        ),
+        PackageJson(
+            name="pkg-default",
+            path=Path("/tmp/pkg-default"),
+            version="1.0.0",
+            private=False,
+            docker=DockerConfig(
+                dockerfile="docker/Dockerfile",
+                imageName="llamaindex/pkg-default",
+                platforms=["linux/amd64"],
+            ),
+        ),
+    ]
+    with patch("dev_cli.changesets.is_docker_image_published", return_value=False):
+        builds, _ = plan_docker(packages)
+    by_pkg = {b.package: b for b in builds}
+    assert by_pkg["pkg-min"].cache_mode == "min"
+    assert by_pkg["pkg-default"].cache_mode == "max"
+
+
 def test_execute_docker_manifest_action_combines_source_tags() -> None:
     action = DockerManifestAction(
         package="pkg",


### PR DESCRIPTION
## Summary
This PR adds support for configurable Docker buildx cache modes in GitHub Actions, allowing packages to optimize cache behavior based on their build characteristics. It introduces a `cacheMode` field to control whether all intermediate stages or only final layers are cached.

## Key Changes
- Added `cacheMode` field to `DockerConfig` with "min" and "max" options (defaults to "max")
- Added `cache_mode` field to `DockerBuildAction` to propagate the configuration through the build pipeline
- Updated `_execute_docker_build()` to use the configurable cache mode instead of hardcoded "max"
- Enhanced GHA cache directives with `compression=zstd` and `ignore-error=true` flags for better cache efficiency and reliability
- Updated `plan_docker()` to pass `cacheMode` from package configuration to build actions
- Set operator package to use `cacheMode: "min"` for optimized builds of small/static binaries

## Implementation Details
- The `cacheMode` field supports two modes:
  - `"max"`: Caches every intermediate stage (expensive to upload but best reuse)
  - `"min"`: Only caches final layers (better for small/static builds where cache upload costs exceed rebuild time)
- Cache compression with zstd reduces exported cache blob sizes
- `ignore-error=true` prevents flaky cache pushes from failing the entire job (image is already pushed to registry)
- Comprehensive test coverage added for cache mode configuration and propagation

https://claude.ai/code/session_011wyVkncgp2JSQ8z3TqwPY5