### PR TITLE
perf(runtime): stream ticks during resume replay

### DIFF
--- a/.changeset/streaming-tick-replay.md
+++ b/.changeset/streaming-tick-replay.md
@@ -2,7 +2,6 @@
 "llama-index-workflows": patch
 "llama-agents-server": patch
 "llama-agents-dbos": patch
-"llama-agents-agentcore": patch
 ---
 
-Stream ticks during resume so peak memory is bounded by batch size rather than total tick history. Adds `rebuild_state_from_ticks_stream`, `AbstractWorkflowStore.query_ticks`/`stream_ticks`, and switches idle-release and persistence-runtime replay to the streaming path.
+Stream ticks during resume so peak memory is bounded by batch size rather than total tick history.

--- a/.changeset/streaming-tick-replay.md
+++ b/.changeset/streaming-tick-replay.md
@@ -1,0 +1,8 @@
+---
+"llama-index-workflows": patch
+"llama-agents-server": patch
+"llama-agents-dbos": patch
+"llama-agents-agentcore": patch
+---
+
+Stream ticks during resume so peak memory is bounded by batch size rather than total tick history. Adds `rebuild_state_from_ticks_stream`, `AbstractWorkflowStore.query_ticks`/`stream_ticks`, and switches idle-release and persistence-runtime replay to the streaming path.

--- a/packages/llama-agents-dbos/pyproject.toml
+++ b/packages/llama-agents-dbos/pyproject.toml
@@ -24,8 +24,8 @@ license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
   "dbos>=2.14.0",
-  "llama-agents-server[asyncpg]>=0.2.0",
-  "llama-index-workflows>=2.15.0,<3.0.0"
+  "llama-agents-server[asyncpg]>=0.4.6",
+  "llama-index-workflows>=2.19.1,<3.0.0"
 ]
 
 [tool.basedpyright]

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
+from collections.abc import Awaitable, Callable, Coroutine
 from datetime import datetime, timezone
 from typing import Any
 
@@ -20,6 +20,7 @@ from llama_agents.dbos.journal.lifecycle import RunLifecycleLock, RunLifecycleSt
 from llama_agents.server._store.abstract_workflow_store import (
     AbstractWorkflowStore,
     HandlerQuery,
+    stream_workflow_ticks,
 )
 from typing_extensions import override
 from workflows.context.serializers import JsonSerializer
@@ -44,7 +45,6 @@ from workflows.runtime.types.plugin import (
 from workflows.runtime.types.ticks import (
     TickIdleRelease,
     WorkflowTick,
-    WorkflowTickAdapter,
 )
 from workflows.workflow import Workflow
 
@@ -52,13 +52,6 @@ from dbos import DBOS
 
 logger = logging.getLogger(__name__)
 
-
-TICK_REPLAY_BATCH_SIZE = 100
-"""Max ticks held in memory at once during idle-release resume replay.
-
-Bounds peak memory when rebuilding state for a resumed workflow with a
-long tick history. Not a user-facing config knob.
-"""
 
 # How long to wait before declaring a "releasing" state as crashed
 CRASH_TIMEOUT_SECONDS = 120.0
@@ -265,20 +258,11 @@ class DBOSIdleReleaseDecorator(BaseRuntimeDecorator):
     async def _broker_state_from_ticks(
         self, workflow: Workflow, run_id: str
     ) -> BrokerState:
-        """Rebuild BrokerState from persisted ticks.
-
-        Streams ticks from the store so peak memory during replay is bounded
-        by ``TICK_REPLAY_BATCH_SIZE`` rather than by total tick history size.
-        """
+        """Rebuild BrokerState from persisted ticks."""
         init_state = BrokerState.from_workflow(workflow)
-
-        async def _stream() -> AsyncIterator[WorkflowTick]:
-            async for stored in self._store.stream_ticks(
-                run_id, batch_size=TICK_REPLAY_BATCH_SIZE
-            ):
-                yield WorkflowTickAdapter.validate_python(stored.tick_data)
-
-        return await rebuild_state_from_ticks_stream(init_state, _stream())
+        return await rebuild_state_from_ticks_stream(
+            init_state, stream_workflow_ticks(self._store, run_id)
+        )
 
     async def _do_resume(
         self,

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable, Coroutine
+from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
 from datetime import datetime, timezone
 from typing import Any
 
@@ -25,7 +25,10 @@ from typing_extensions import override
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import infer_state_type
 from workflows.events import Event, WorkflowIdleEvent
-from workflows.runtime.control_loop import rebuild_state_from_ticks
+from workflows.runtime.control_loop import (
+    rebuild_state_from_ticks,
+    rebuild_state_from_ticks_stream,
+)
 from workflows.runtime.runtime_decorators import (
     BaseExternalRunAdapterDecorator,
     BaseInternalRunAdapterDecorator,
@@ -48,6 +51,14 @@ from workflows.workflow import Workflow
 from dbos import DBOS
 
 logger = logging.getLogger(__name__)
+
+
+TICK_REPLAY_BATCH_SIZE = 25
+"""Max ticks held in memory at once during idle-release resume replay.
+
+Bounds peak memory when rebuilding state for a resumed workflow with a
+long tick history. Not a user-facing config knob.
+"""
 
 # How long to wait before declaring a "releasing" state as crashed
 CRASH_TIMEOUT_SECONDS = 120.0
@@ -254,17 +265,20 @@ class DBOSIdleReleaseDecorator(BaseRuntimeDecorator):
     async def _broker_state_from_ticks(
         self, workflow: Workflow, run_id: str
     ) -> BrokerState:
-        """Rebuild BrokerState from persisted ticks."""
-        stored_ticks = await self._store.get_ticks(run_id)
+        """Rebuild BrokerState from persisted ticks.
+
+        Streams ticks from the store so peak memory during replay is bounded
+        by ``TICK_REPLAY_BATCH_SIZE`` rather than by total tick history size.
+        """
         init_state = BrokerState.from_workflow(workflow)
 
-        if stored_ticks:
-            ticks = [
-                WorkflowTickAdapter.validate_python(st.tick_data) for st in stored_ticks
-            ]
-            init_state = rebuild_state_from_ticks(init_state, ticks)
+        async def _stream() -> AsyncIterator[WorkflowTick]:
+            async for stored in self._store.stream_ticks(
+                run_id, batch_size=TICK_REPLAY_BATCH_SIZE
+            ):
+                yield WorkflowTickAdapter.validate_python(stored.tick_data)
 
-        return init_state
+        return await rebuild_state_from_ticks_stream(init_state, _stream())
 
     async def _do_resume(
         self,

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -53,7 +53,7 @@ from dbos import DBOS
 logger = logging.getLogger(__name__)
 
 
-TICK_REPLAY_BATCH_SIZE = 25
+TICK_REPLAY_BATCH_SIZE = 100
 """Max ticks held in memory at once during idle-release resume replay.
 
 Bounds peak memory when rebuilding state for a resumed workflow with a

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -167,21 +167,8 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
     async def get_ticks(self, run_id: str) -> list[StoredTick]:
         return await self._resolve().get_ticks(run_id)
 
-    async def query_ticks(
-        self,
-        run_id: str,
-        *,
-        after_sequence: int | None = None,
-        limit: int | None = None,
-    ) -> list[StoredTick]:
-        return await self._resolve().query_ticks(
-            run_id, after_sequence=after_sequence, limit=limit
-        )
-
-    def stream_ticks(
-        self, run_id: str, *, batch_size: int = 100
-    ) -> AsyncIterator[StoredTick]:
-        return self._resolve().stream_ticks(run_id, batch_size=batch_size)
+    def stream_ticks(self, run_id: str) -> AsyncIterator[StoredTick]:
+        return self._resolve().stream_ticks(run_id)
 
 
 class ExecutorLeaseConfig(TypedDict, total=False):

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -14,7 +14,7 @@ import logging
 import sqlite3
 import threading
 import time
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, AsyncGenerator, TypedDict, cast
 
 import asyncpg
@@ -166,6 +166,22 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
 
     async def get_ticks(self, run_id: str) -> list[StoredTick]:
         return await self._resolve().get_ticks(run_id)
+
+    async def query_ticks(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> list[StoredTick]:
+        return await self._resolve().query_ticks(
+            run_id, after_sequence=after_sequence, limit=limit
+        )
+
+    def stream_ticks(
+        self, run_id: str, *, batch_size: int = 100
+    ) -> AsyncIterator[StoredTick]:
+        return self._resolve().stream_ticks(run_id, batch_size=batch_size)
 
 
 class ExecutorLeaseConfig(TypedDict, total=False):

--- a/packages/llama-agents-server/pyproject.toml
+++ b/packages/llama-agents-server/pyproject.toml
@@ -24,7 +24,7 @@ description = "HTTP server for deploying and serving LlamaIndex workflows as web
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "llama-index-workflows>=2.16.0,<3.0.0",
+  "llama-index-workflows>=2.19.1,<3.0.0",
   "llama-agents-client>=0.2.0",
   "starlette>=0.39.0",
   "uvicorn>=0.32.0",

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import sqlite3
-from collections.abc import Coroutine
+from collections.abc import AsyncIterator, Coroutine
 from datetime import datetime, timezone
 from typing import Any
 
@@ -22,7 +22,7 @@ from workflows import Context
 from workflows.context.context_types import SerializedContext
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.events import StartEvent
-from workflows.runtime.control_loop import rebuild_state_from_ticks
+from workflows.runtime.control_loop import rebuild_state_from_ticks_stream
 from workflows.runtime.runtime_decorators import (
     BaseInternalRunAdapterDecorator,
     BaseRuntimeDecorator,
@@ -49,6 +49,10 @@ from .._store.abstract_workflow_store import (
 from .._store.sqlite.sqlite_state_store import SqliteStateStore
 
 logger = logging.getLogger(__name__)
+
+
+TICK_REPLAY_BATCH_SIZE = 25
+"""Max ticks held in memory at once during persistence-runtime replay."""
 
 
 class _PersistenceInternalRunAdapter(BaseInternalRunAdapterDecorator):
@@ -148,13 +152,19 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
     async def context_from_ticks(
         self, workflow: Workflow, run_id: str
     ) -> Context | None:
-        """Rebuild a Context from persisted ticks (and legacy ctx if available)."""
-        stored_ticks = await self._store.get_ticks(run_id)
-        serializer = JsonSerializer()
+        """Rebuild a Context from persisted ticks (and legacy ctx if available).
 
+        Ticks are replayed via :meth:`stream_ticks` so peak memory is bounded
+        by ``TICK_REPLAY_BATCH_SIZE`` rather than the full tick history.
+        """
+        serializer = JsonSerializer()
         legacy_ctx = self._get_legacy_ctx(run_id)
 
-        if not stored_ticks and not legacy_ctx:
+        # Probe for tick existence without materializing everything.
+        first_page = await self._store.query_ticks(run_id, limit=1)
+        has_ticks = len(first_page) > 0
+
+        if not has_ticks and not legacy_ctx:
             return None
 
         if legacy_ctx:
@@ -164,11 +174,15 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         else:
             init_state = BrokerState.from_workflow(workflow)
 
-        if stored_ticks:
-            ticks = [
-                WorkflowTickAdapter.validate_python(st.tick_data) for st in stored_ticks
-            ]
-            init_state = rebuild_state_from_ticks(init_state, ticks)
+        if has_ticks:
+
+            async def _stream() -> AsyncIterator[WorkflowTick]:
+                async for stored in self._store.stream_ticks(
+                    run_id, batch_size=TICK_REPLAY_BATCH_SIZE
+                ):
+                    yield WorkflowTickAdapter.validate_python(stored.tick_data)
+
+            init_state = await rebuild_state_from_ticks_stream(init_state, _stream())
 
         serialized = init_state.to_serialized(serializer)
         return Context.from_dict(

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -51,7 +51,7 @@ from .._store.sqlite.sqlite_state_store import SqliteStateStore
 logger = logging.getLogger(__name__)
 
 
-TICK_REPLAY_BATCH_SIZE = 25
+TICK_REPLAY_BATCH_SIZE = 100
 """Max ticks held in memory at once during persistence-runtime replay."""
 
 

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -45,14 +45,11 @@ from .._store.abstract_workflow_store import (
     HandlerQuery,
     PersistentHandler,
     as_legacy_context_store,
+    stream_workflow_ticks,
 )
 from .._store.sqlite.sqlite_state_store import SqliteStateStore
 
 logger = logging.getLogger(__name__)
-
-
-TICK_REPLAY_BATCH_SIZE = 100
-"""Max ticks held in memory at once during persistence-runtime replay."""
 
 
 class _PersistenceInternalRunAdapter(BaseInternalRunAdapterDecorator):
@@ -152,19 +149,17 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
     async def context_from_ticks(
         self, workflow: Workflow, run_id: str
     ) -> Context | None:
-        """Rebuild a Context from persisted ticks (and legacy ctx if available).
-
-        Ticks are replayed via :meth:`stream_ticks` so peak memory is bounded
-        by ``TICK_REPLAY_BATCH_SIZE`` rather than the full tick history.
-        """
+        """Rebuild a Context from persisted ticks (and legacy ctx if available)."""
         serializer = JsonSerializer()
         legacy_ctx = self._get_legacy_ctx(run_id)
 
-        # Probe for tick existence without materializing everything.
-        first_page = await self._store.query_ticks(run_id, limit=1)
-        has_ticks = len(first_page) > 0
+        tick_stream = stream_workflow_ticks(self._store, run_id)
+        try:
+            first_tick = await tick_stream.__anext__()
+        except StopAsyncIteration:
+            first_tick = None
 
-        if not has_ticks and not legacy_ctx:
+        if first_tick is None and not legacy_ctx:
             return None
 
         if legacy_ctx:
@@ -174,15 +169,16 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         else:
             init_state = BrokerState.from_workflow(workflow)
 
-        if has_ticks:
+        if first_tick is not None:
 
-            async def _stream() -> AsyncIterator[WorkflowTick]:
-                async for stored in self._store.stream_ticks(
-                    run_id, batch_size=TICK_REPLAY_BATCH_SIZE
-                ):
-                    yield WorkflowTickAdapter.validate_python(stored.tick_data)
+            async def _with_first() -> AsyncIterator[WorkflowTick]:
+                yield first_tick
+                async for tick in tick_stream:
+                    yield tick
 
-            init_state = await rebuild_state_from_ticks_stream(init_state, _stream())
+            init_state = await rebuild_state_from_ticks_stream(
+                init_state, _with_first()
+            )
 
         serialized = init_state.to_serialized(serializer)
         return Context.from_dict(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -148,6 +148,55 @@ class AbstractWorkflowStore(ABC):
     @abstractmethod
     async def get_ticks(self, run_id: str) -> list[StoredTick]: ...
 
+    async def query_ticks(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> list[StoredTick]:
+        """Return a page of stored ticks for *run_id*.
+
+        Returns ticks with ``sequence > after_sequence`` (or from the
+        beginning if ``after_sequence`` is ``None``/``-1``), ordered by
+        sequence, up to ``limit`` rows.
+
+        The default implementation filters the output of :meth:`get_ticks`
+        in memory. Backends should override with a true paginated query so
+        that :meth:`stream_ticks` bounds peak memory at replay time.
+        """
+        all_ticks = await self.get_ticks(run_id)
+        if after_sequence is not None:
+            all_ticks = [t for t in all_ticks if t.sequence > after_sequence]
+        if limit is not None:
+            all_ticks = all_ticks[:limit]
+        return all_ticks
+
+    async def stream_ticks(
+        self, run_id: str, *, batch_size: int = 100
+    ) -> AsyncIterator[StoredTick]:
+        """Async-iterate stored ticks for *run_id* in sequence order.
+
+        Reads one page of ``batch_size`` ticks at a time via
+        :meth:`query_ticks`, yielding them individually. Peak in-memory tick
+        count for the consumer is bounded by ``batch_size``.
+
+        Iteration terminates when a page returns fewer than ``batch_size``
+        rows. Concurrent writers appending ticks while this runs are not
+        serialized with it; the stream sees at least the rows committed
+        before each page query.
+        """
+        cursor: int | None = None
+        while True:
+            batch = await self.query_ticks(
+                run_id, after_sequence=cursor, limit=batch_size
+            )
+            for tick in batch:
+                yield tick
+                cursor = tick.sequence
+            if len(batch) < batch_size:
+                return
+
     async def after_tick(self, run_id: str, tick_data: dict[str, Any]) -> None:
         """Called after a tick's commands have been processed.
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -31,8 +31,6 @@ Status = Literal["running", "completed", "failed", "cancelled"]
 
 TERMINAL_STATUSES: frozenset[Status] = frozenset(("completed", "failed", "cancelled"))
 
-TICK_REPLAY_BATCH_SIZE = 100
-
 
 def is_terminal_status(status: Status) -> bool:
     return status in TERMINAL_STATUSES
@@ -151,39 +149,14 @@ class AbstractWorkflowStore(ABC):
     @abstractmethod
     async def get_ticks(self, run_id: str) -> list[StoredTick]: ...
 
-    async def query_ticks(
-        self,
-        run_id: str,
-        *,
-        after_sequence: int | None = None,
-        limit: int | None = None,
-    ) -> list[StoredTick]:
-        """Return ticks with ``sequence > after_sequence``, ordered by sequence, up to ``limit``.
+    async def stream_ticks(self, run_id: str) -> AsyncIterator[StoredTick]:
+        """Async-iterate stored ticks in sequence order (ascending).
 
-        Backends should override with a paginated query; the default
-        materializes all ticks via :meth:`get_ticks`.
+        Default loads all ticks via :meth:`get_ticks`. Override for true
+        streaming (e.g. cursor-based pagination).
         """
-        all_ticks = await self.get_ticks(run_id)
-        if after_sequence is not None:
-            all_ticks = [t for t in all_ticks if t.sequence > after_sequence]
-        if limit is not None:
-            all_ticks = all_ticks[:limit]
-        return all_ticks
-
-    async def stream_ticks(
-        self, run_id: str, *, batch_size: int = TICK_REPLAY_BATCH_SIZE
-    ) -> AsyncIterator[StoredTick]:
-        """Async-iterate stored ticks for *run_id* in sequence order, ``batch_size`` per page."""
-        cursor: int | None = None
-        while True:
-            batch = await self.query_ticks(
-                run_id, after_sequence=cursor, limit=batch_size
-            )
-            for tick in batch:
-                yield tick
-                cursor = tick.sequence
-            if len(batch) < batch_size:
-                return
+        for tick in await self.get_ticks(run_id):
+            yield tick
 
     async def after_tick(self, run_id: str, tick_data: dict[str, Any]) -> None:
         """Called after a tick's commands have been processed.
@@ -277,9 +250,7 @@ def as_legacy_context_store(store: AbstractWorkflowStore) -> LegacyContextStore 
 async def stream_workflow_ticks(
     store: AbstractWorkflowStore,
     run_id: str,
-    *,
-    batch_size: int = TICK_REPLAY_BATCH_SIZE,
 ) -> AsyncIterator[WorkflowTick]:
     """Stream validated WorkflowTick objects for *run_id* from *store*."""
-    async for stored in store.stream_ticks(run_id, batch_size=batch_size):
+    async for stored in store.stream_ticks(run_id):
         yield WorkflowTickAdapter.validate_python(stored.tick_data)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -23,12 +23,15 @@ from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
 from workflows.context.state_store import StateStore
 from workflows.events import StopEvent
+from workflows.runtime.types.ticks import WorkflowTick, WorkflowTickAdapter
 
 logger = logging.getLogger(__name__)
 
 Status = Literal["running", "completed", "failed", "cancelled"]
 
 TERMINAL_STATUSES: frozenset[Status] = frozenset(("completed", "failed", "cancelled"))
+
+TICK_REPLAY_BATCH_SIZE = 100
 
 
 def is_terminal_status(status: Status) -> bool:
@@ -155,15 +158,10 @@ class AbstractWorkflowStore(ABC):
         after_sequence: int | None = None,
         limit: int | None = None,
     ) -> list[StoredTick]:
-        """Return a page of stored ticks for *run_id*.
+        """Return ticks with ``sequence > after_sequence``, ordered by sequence, up to ``limit``.
 
-        Returns ticks with ``sequence > after_sequence`` (or from the
-        beginning if ``after_sequence`` is ``None``/``-1``), ordered by
-        sequence, up to ``limit`` rows.
-
-        The default implementation filters the output of :meth:`get_ticks`
-        in memory. Backends should override with a true paginated query so
-        that :meth:`stream_ticks` bounds peak memory at replay time.
+        Backends should override with a paginated query; the default
+        materializes all ticks via :meth:`get_ticks`.
         """
         all_ticks = await self.get_ticks(run_id)
         if after_sequence is not None:
@@ -173,19 +171,9 @@ class AbstractWorkflowStore(ABC):
         return all_ticks
 
     async def stream_ticks(
-        self, run_id: str, *, batch_size: int = 100
+        self, run_id: str, *, batch_size: int = TICK_REPLAY_BATCH_SIZE
     ) -> AsyncIterator[StoredTick]:
-        """Async-iterate stored ticks for *run_id* in sequence order.
-
-        Reads one page of ``batch_size`` ticks at a time via
-        :meth:`query_ticks`, yielding them individually. Peak in-memory tick
-        count for the consumer is bounded by ``batch_size``.
-
-        Iteration terminates when a page returns fewer than ``batch_size``
-        rows. Concurrent writers appending ticks while this runs are not
-        serialized with it; the stream sees at least the rows committed
-        before each page query.
-        """
+        """Async-iterate stored ticks for *run_id* in sequence order, ``batch_size`` per page."""
         cursor: int | None = None
         while True:
             batch = await self.query_ticks(
@@ -284,3 +272,14 @@ def as_legacy_context_store(store: AbstractWorkflowStore) -> LegacyContextStore 
     if isinstance(store, LegacyContextStore):
         return store
     return None
+
+
+async def stream_workflow_ticks(
+    store: AbstractWorkflowStore,
+    run_id: str,
+    *,
+    batch_size: int = TICK_REPLAY_BATCH_SIZE,
+) -> AsyncIterator[WorkflowTick]:
+    """Stream validated WorkflowTick objects for *run_id* from *store*."""
+    async for stored in store.stream_ticks(run_id, batch_size=batch_size):
+        yield WorkflowTickAdapter.validate_python(stored.tick_data)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -420,20 +420,7 @@ class AgentDataStore(AbstractWorkflowStore):
         )
 
     async def get_ticks(self, run_id: str) -> list[StoredTick]:
-        page_size = 100
-        all_ticks: list[StoredTick] = []
-        last_sequence: int | None = None
-
-        while True:
-            page = await self.query_ticks(
-                run_id, after_sequence=last_sequence, limit=page_size
-            )
-            all_ticks.extend(page)
-            if len(page) < page_size:
-                break
-            last_sequence = page[-1].sequence
-
-        return all_ticks
+        return [t async for t in self.stream_ticks(run_id)]
 
     async def query_ticks(
         self,
@@ -443,16 +430,46 @@ class AgentDataStore(AbstractWorkflowStore):
         limit: int | None = None,
     ) -> list[StoredTick]:
         await self._regroup_ticks(run_id)
+        # When unbounded, page through results to avoid silently truncating at
+        # the API's default page cap.
+        if limit is None:
+            return [
+                t
+                async for t in self._iter_ticks(
+                    run_id, after_sequence=after_sequence, page_size=100
+                )
+            ]
+        return await self._fetch_ticks_page(
+            run_id, after_sequence=after_sequence, page_size=limit
+        )
+
+    async def _fetch_ticks_page(
+        self, run_id: str, *, after_sequence: int | None, page_size: int
+    ) -> list[StoredTick]:
         filters: dict[str, Any] = {"run_id": {"eq": run_id}}
         if after_sequence is not None:
             filters["sequence"] = {"gt": after_sequence}
         page = await self._client.search(
             self._ticks_collection,
             filters,
-            page_size=limit or 1000,
+            page_size=page_size,
             order_by="sequence",
         )
         return [StoredTick.model_validate(item["data"]) for item in page]
+
+    async def _iter_ticks(
+        self, run_id: str, *, after_sequence: int | None, page_size: int
+    ) -> AsyncIterator[StoredTick]:
+        cursor = after_sequence
+        while True:
+            page = await self._fetch_ticks_page(
+                run_id, after_sequence=cursor, page_size=page_size
+            )
+            for tick in page:
+                yield tick
+                cursor = tick.sequence
+            if len(page) < page_size:
+                return
 
     # ------------------------------------------------------------------
     # State store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -28,6 +28,8 @@ from .agent_data_state_store import AgentDataStateStore
 
 logger = logging.getLogger(__name__)
 
+_TICK_PAGE_SIZE = 100
+
 
 class AgentDataStore(AbstractWorkflowStore):
     """Workflow store backed by the LlamaCloud Agent Data API.
@@ -422,53 +424,24 @@ class AgentDataStore(AbstractWorkflowStore):
     async def get_ticks(self, run_id: str) -> list[StoredTick]:
         return [t async for t in self.stream_ticks(run_id)]
 
-    async def query_ticks(
-        self,
-        run_id: str,
-        *,
-        after_sequence: int | None = None,
-        limit: int | None = None,
-    ) -> list[StoredTick]:
+    async def stream_ticks(self, run_id: str) -> AsyncIterator[StoredTick]:
         await self._regroup_ticks(run_id)
-        # When unbounded, page through results to avoid silently truncating at
-        # the API's default page cap.
-        if limit is None:
-            return [
-                t
-                async for t in self._iter_ticks(
-                    run_id, after_sequence=after_sequence, page_size=100
-                )
-            ]
-        return await self._fetch_ticks_page(
-            run_id, after_sequence=after_sequence, page_size=limit
-        )
-
-    async def _fetch_ticks_page(
-        self, run_id: str, *, after_sequence: int | None, page_size: int
-    ) -> list[StoredTick]:
-        filters: dict[str, Any] = {"run_id": {"eq": run_id}}
-        if after_sequence is not None:
-            filters["sequence"] = {"gt": after_sequence}
-        page = await self._client.search(
-            self._ticks_collection,
-            filters,
-            page_size=page_size,
-            order_by="sequence",
-        )
-        return [StoredTick.model_validate(item["data"]) for item in page]
-
-    async def _iter_ticks(
-        self, run_id: str, *, after_sequence: int | None, page_size: int
-    ) -> AsyncIterator[StoredTick]:
-        cursor = after_sequence
+        cursor: int | None = None
         while True:
-            page = await self._fetch_ticks_page(
-                run_id, after_sequence=cursor, page_size=page_size
+            filters: dict[str, Any] = {"run_id": {"eq": run_id}}
+            if cursor is not None:
+                filters["sequence"] = {"gt": cursor}
+            page = await self._client.search(
+                self._ticks_collection,
+                filters,
+                page_size=_TICK_PAGE_SIZE,
+                order_by="sequence",
             )
-            for tick in page:
+            for item in page:
+                tick = StoredTick.model_validate(item["data"])
                 yield tick
                 cursor = tick.sequence
-            if len(page) < page_size:
+            if len(page) < _TICK_PAGE_SIZE:
                 return
 
     # ------------------------------------------------------------------

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -420,28 +420,39 @@ class AgentDataStore(AbstractWorkflowStore):
         )
 
     async def get_ticks(self, run_id: str) -> list[StoredTick]:
-        await self._regroup_ticks(run_id)
         page_size = 100
-        all_items: list[dict[str, Any]] = []
-        last_sequence = -1
+        all_ticks: list[StoredTick] = []
+        last_sequence: int | None = None
 
         while True:
-            filters: dict[str, Any] = {
-                "run_id": {"eq": run_id},
-                "sequence": {"gt": last_sequence},
-            }
-            page = await self._client.search(
-                self._ticks_collection,
-                filters,
-                page_size=page_size,
-                order_by="sequence",
+            page = await self.query_ticks(
+                run_id, after_sequence=last_sequence, limit=page_size
             )
-            all_items.extend(page)
+            all_ticks.extend(page)
             if len(page) < page_size:
                 break
-            last_sequence = page[-1]["data"]["sequence"]
+            last_sequence = page[-1].sequence
 
-        return [StoredTick.model_validate(item["data"]) for item in all_items]
+        return all_ticks
+
+    async def query_ticks(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> list[StoredTick]:
+        await self._regroup_ticks(run_id)
+        filters: dict[str, Any] = {"run_id": {"eq": run_id}}
+        if after_sequence is not None:
+            filters["sequence"] = {"gt": after_sequence}
+        page = await self._client.search(
+            self._ticks_collection,
+            filters,
+            page_size=limit or 1000,
+            order_by="sequence",
+        )
+        return [StoredTick.model_validate(item["data"]) for item in page]
 
     # ------------------------------------------------------------------
     # State store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
@@ -200,20 +200,6 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
     async def get_ticks(self, run_id: str) -> list[StoredTick]:
         return list(self.ticks.get(run_id, []))
 
-    async def query_ticks(
-        self,
-        run_id: str,
-        *,
-        after_sequence: int | None = None,
-        limit: int | None = None,
-    ) -> list[StoredTick]:
-        ticks = self.ticks.get(run_id, [])
-        if after_sequence is not None:
-            ticks = [t for t in ticks if t.sequence > after_sequence]
-        if limit is not None:
-            ticks = ticks[:limit]
-        return list(ticks)
-
     async def subscribe_events(
         self, run_id: str, after_sequence: int = -1
     ) -> AsyncIterator[StoredEvent]:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
@@ -200,6 +200,20 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
     async def get_ticks(self, run_id: str) -> list[StoredTick]:
         return list(self.ticks.get(run_id, []))
 
+    async def query_ticks(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> list[StoredTick]:
+        ticks = self.ticks.get(run_id, [])
+        if after_sequence is not None:
+            ticks = [t for t in ticks if t.sequence > after_sequence]
+        if limit is not None:
+            ticks = ticks[:limit]
+        return list(ticks)
+
     async def subscribe_events(
         self, run_id: str, after_sequence: int = -1
     ) -> AsyncIterator[StoredEvent]:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -29,6 +29,8 @@ from .postgres_state_store import PostgresStateStore
 
 logger = logging.getLogger(__name__)
 
+_TICK_PAGE_SIZE = 100
+
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -441,39 +443,39 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             for row in rows
         ]
 
-    async def query_ticks(
-        self,
-        run_id: str,
-        *,
-        after_sequence: int | None = None,
-        limit: int | None = None,
-    ) -> list[StoredTick]:
+    async def stream_ticks(self, run_id: str) -> AsyncIterator[StoredTick]:
         pool = await self._ensure_pool()
-        sql = (
-            f"SELECT run_id, sequence, timestamp, tick_data FROM {self._ticks_ref} "
-            "WHERE run_id = $1"
-        )
-        params: list[Any] = [run_id]
-        if after_sequence is not None:
-            sql += f" AND sequence > ${len(params) + 1}"
-            params.append(after_sequence)
-        sql += " ORDER BY sequence"
-        if limit is not None:
-            sql += f" LIMIT ${len(params) + 1}"
-            params.append(limit)
-        async with pool.acquire() as conn:
-            rows = await conn.fetch(sql, *params)
-        return [
-            StoredTick(
-                run_id=row["run_id"],
-                sequence=row["sequence"],
-                timestamp=row["timestamp"],
-                tick_data=json.loads(row["tick_data"])
-                if isinstance(row["tick_data"], str)
-                else row["tick_data"],
-            )
-            for row in rows
-        ]
+        cursor: int | None = None
+        while True:
+            if cursor is None:
+                sql = (
+                    f"SELECT run_id, sequence, timestamp, tick_data "
+                    f"FROM {self._ticks_ref} WHERE run_id = $1 "
+                    f"ORDER BY sequence LIMIT $2"
+                )
+                params: list[Any] = [run_id, _TICK_PAGE_SIZE]
+            else:
+                sql = (
+                    f"SELECT run_id, sequence, timestamp, tick_data "
+                    f"FROM {self._ticks_ref} WHERE run_id = $1 AND sequence > $2 "
+                    f"ORDER BY sequence LIMIT $3"
+                )
+                params = [run_id, cursor, _TICK_PAGE_SIZE]
+            async with pool.acquire() as conn:
+                rows = await conn.fetch(sql, *params)
+            for row in rows:
+                tick = StoredTick(
+                    run_id=row["run_id"],
+                    sequence=row["sequence"],
+                    timestamp=row["timestamp"],
+                    tick_data=json.loads(row["tick_data"])
+                    if isinstance(row["tick_data"], str)
+                    else row["tick_data"],
+                )
+                yield tick
+                cursor = tick.sequence
+            if len(rows) < _TICK_PAGE_SIZE:
+                return
 
     # ── Helpers ─────────────────────────────────────────────────────────
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -441,6 +441,40 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             for row in rows
         ]
 
+    async def query_ticks(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> list[StoredTick]:
+        pool = await self._ensure_pool()
+        sql = (
+            f"SELECT run_id, sequence, timestamp, tick_data FROM {self._ticks_ref} "
+            "WHERE run_id = $1"
+        )
+        params: list[Any] = [run_id]
+        if after_sequence is not None:
+            sql += f" AND sequence > ${len(params) + 1}"
+            params.append(after_sequence)
+        sql += " ORDER BY sequence"
+        if limit is not None:
+            sql += f" LIMIT ${len(params) + 1}"
+            params.append(limit)
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(sql, *params)
+        return [
+            StoredTick(
+                run_id=row["run_id"],
+                sequence=row["sequence"],
+                timestamp=row["timestamp"],
+                tick_data=json.loads(row["tick_data"])
+                if isinstance(row["tick_data"], str)
+                else row["tick_data"],
+            )
+            for row in rows
+        ]
+
     # ── Helpers ─────────────────────────────────────────────────────────
 
     def _build_filters(self, query: HandlerQuery) -> tuple[list[str], list[Any]] | None:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -26,6 +26,8 @@ from ..abstract_workflow_store import (
 from .migrate import run_migrations as _run_migrations
 from .sqlite_state_store import SqliteStateStore
 
+_TICK_PAGE_SIZE = 100
+
 
 class SqliteWorkflowStore(AbstractWorkflowStore):
     def __init__(
@@ -282,37 +284,36 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
             for row in rows
         ]
 
-    async def query_ticks(
-        self,
-        run_id: str,
-        *,
-        after_sequence: int | None = None,
-        limit: int | None = None,
-    ) -> list[StoredTick]:
-        sql = (
-            "SELECT run_id, sequence, timestamp, tick_data FROM ticks WHERE run_id = ?"
-        )
-        params: list[Any] = [run_id]
-        if after_sequence is not None:
-            sql += " AND sequence > ?"
-            params.append(after_sequence)
-        sql += " ORDER BY sequence"
-        if limit is not None:
-            sql += " LIMIT ?"
-            params.append(limit)
-        with self._connect() as conn:
-            cursor = conn.cursor()
-            cursor.execute(sql, params)
-            rows = cursor.fetchall()
-        return [
-            StoredTick(
-                run_id=row[0],
-                sequence=row[1],
-                timestamp=datetime.fromisoformat(row[2]),
-                tick_data=json.loads(row[3]),
-            )
-            for row in rows
-        ]
+    async def stream_ticks(self, run_id: str) -> AsyncIterator[StoredTick]:
+        seq_cursor: int | None = None
+        while True:
+            if seq_cursor is None:
+                sql = (
+                    "SELECT run_id, sequence, timestamp, tick_data FROM ticks "
+                    "WHERE run_id = ? ORDER BY sequence LIMIT ?"
+                )
+                params: list[Any] = [run_id, _TICK_PAGE_SIZE]
+            else:
+                sql = (
+                    "SELECT run_id, sequence, timestamp, tick_data FROM ticks "
+                    "WHERE run_id = ? AND sequence > ? ORDER BY sequence LIMIT ?"
+                )
+                params = [run_id, seq_cursor, _TICK_PAGE_SIZE]
+            with self._connect() as conn:
+                cursor = conn.cursor()
+                cursor.execute(sql, params)
+                rows = cursor.fetchall()
+            for row in rows:
+                tick = StoredTick(
+                    run_id=row[0],
+                    sequence=row[1],
+                    timestamp=datetime.fromisoformat(row[2]),
+                    tick_data=json.loads(row[3]),
+                )
+                yield tick
+                seq_cursor = tick.sequence
+            if len(rows) < _TICK_PAGE_SIZE:
+                return
 
     def get_legacy_ctx(self, run_id: str) -> dict[str, Any] | None:
         """Read the old ctx column for a run_id, if present."""

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -282,6 +282,38 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
             for row in rows
         ]
 
+    async def query_ticks(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> list[StoredTick]:
+        sql = (
+            "SELECT run_id, sequence, timestamp, tick_data FROM ticks WHERE run_id = ?"
+        )
+        params: list[Any] = [run_id]
+        if after_sequence is not None:
+            sql += " AND sequence > ?"
+            params.append(after_sequence)
+        sql += " ORDER BY sequence"
+        if limit is not None:
+            sql += " LIMIT ?"
+            params.append(limit)
+        with self._connect() as conn:
+            cursor = conn.cursor()
+            cursor.execute(sql, params)
+            rows = cursor.fetchall()
+        return [
+            StoredTick(
+                run_id=row[0],
+                sequence=row[1],
+                timestamp=datetime.fromisoformat(row[2]),
+                tick_data=json.loads(row[3]),
+            )
+            for row in rows
+        ]
+
     def get_legacy_ctx(self, run_id: str) -> dict[str, Any] | None:
         """Read the old ctx column for a run_id, if present."""
         with self._connect() as conn:

--- a/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
+++ b/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
@@ -25,34 +25,11 @@ class _FakeStreamingStore:
         self._count = count
         self._payload_size = payload_size
 
-    async def query_ticks(
-        self,
-        run_id: str,
-        *,
-        after_sequence: int | None = None,
-        limit: int | None = None,
-    ) -> list[StoredTick]:
-        start = 0 if after_sequence is None else after_sequence + 1
-        end = self._count if limit is None else min(self._count, start + limit)
-        return [self._make_stored_tick(i) for i in range(start, end)]
-
-    async def stream_ticks(
-        self, run_id: str, *, batch_size: int = 100
-    ) -> AsyncIterator[StoredTick]:
-        cursor: int | None = None
-        while True:
-            batch = await self.query_ticks(
-                run_id, after_sequence=cursor, limit=batch_size
-            )
-            for tick in batch:
-                yield tick
-                cursor = tick.sequence
-            if len(batch) < batch_size:
-                return
+    async def stream_ticks(self, run_id: str) -> AsyncIterator[StoredTick]:
+        for i in range(self._count):
+            yield self._make_stored_tick(i)
 
     def _make_stored_tick(self, seq: int) -> StoredTick:
-        # Unique per-tick payload defeats string interning so each tick
-        # contributes its own allocation.
         payload = f"{seq:08d}" + ("x" * (self._payload_size - 8))
         tick = TickPublishEvent(event=_BigEvent(payload=payload))
         return StoredTick(
@@ -70,20 +47,19 @@ def _empty_state() -> BrokerState:
 
 
 @pytest.mark.asyncio
-async def test_stream_replay_peak_memory_bounded_by_batch_size() -> None:
+async def test_stream_replay_peak_memory_bounded() -> None:
     payload_size = 200_000  # ~200 KB per tick
     total_ticks = 200
-    batch_size = 10
 
     store = _FakeStreamingStore(count=total_ticks, payload_size=payload_size)
 
     # Warm up caches (Pydantic TypeAdapter, class tables, etc.) before measuring.
-    async for stored in store.stream_ticks("r", batch_size=batch_size):
+    async for stored in store.stream_ticks("r"):
         WorkflowTickAdapter.validate_python(stored.tick_data)
         break
 
     async def _stream() -> AsyncIterator:
-        async for stored in store.stream_ticks("r", batch_size=batch_size):
+        async for stored in store.stream_ticks("r"):
             yield WorkflowTickAdapter.validate_python(stored.tick_data)
 
     tracemalloc.start()
@@ -93,28 +69,25 @@ async def test_stream_replay_peak_memory_bounded_by_batch_size() -> None:
     finally:
         tracemalloc.stop()
 
-    bound = batch_size * payload_size * 5
+    # Bound: a few ticks worth, not the full history.
+    bound = payload_size * 10
     assert peak < bound, (
         f"Peak memory {peak} bytes exceeded bound {bound} bytes "
-        f"(total_ticks={total_ticks}, batch_size={batch_size}, "
-        f"payload_size={payload_size})."
+        f"(total_ticks={total_ticks}, payload_size={payload_size})."
     )
 
 
 @pytest.mark.asyncio
 async def test_stream_replay_memory_bound_detects_full_materialization() -> None:
-    # Sanity: the bound in the positive test must actually fire on full
-    # materialization, otherwise the assertion is toothless.
     payload_size = 200_000
     total_ticks = 200
-    batch_size = 10
 
     store = _FakeStreamingStore(count=total_ticks, payload_size=payload_size)
 
     async def _all_then_stream() -> AsyncIterator:
         materialized = [
             WorkflowTickAdapter.validate_python(s.tick_data)
-            async for s in store.stream_ticks("r", batch_size=batch_size)
+            async for s in store.stream_ticks("r")
         ]
         for t in materialized:
             yield t
@@ -126,7 +99,7 @@ async def test_stream_replay_memory_bound_detects_full_materialization() -> None
     finally:
         tracemalloc.stop()
 
-    bound = batch_size * payload_size * 5
+    bound = payload_size * 10
     assert peak >= bound, (
         f"Expected full materialization to blow the bound ({peak} < {bound})."
     )

--- a/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
+++ b/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
@@ -1,14 +1,5 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
-"""Regression test: streaming tick replay must not materialize full history.
-
-If this test fails, the streaming replay path has regressed back to an O(N)
-allocation pattern, which would reintroduce the idle-release OOM this work
-targets. The bound is deliberately generous (a small multiple of
-batch_size * payload_size) so it triggers only on true O(N) regressions,
-not allocator noise.
-"""
-
 from __future__ import annotations
 
 import tracemalloc
@@ -30,14 +21,6 @@ class _BigEvent(Event):
 
 
 class _FakeStreamingStore:
-    """Minimal fake that generates synthetic ticks lazily.
-
-    Not a full AbstractWorkflowStore - only implements stream_ticks/query_ticks,
-    which is all the replay path needs. Generating ticks on demand instead of
-    holding them in a list lets the test isolate whether the *consumer* holds
-    the full history.
-    """
-
     def __init__(self, count: int, payload_size: int) -> None:
         self._count = count
         self._payload_size = payload_size
@@ -68,8 +51,8 @@ class _FakeStreamingStore:
                 return
 
     def _make_stored_tick(self, seq: int) -> StoredTick:
-        # Unique per-tick payload so Python string interning doesn't collapse
-        # memory cost across ticks — otherwise the test measures nothing.
+        # Unique per-tick payload defeats string interning so each tick
+        # contributes its own allocation.
         payload = f"{seq:08d}" + ("x" * (self._payload_size - 8))
         tick = TickPublishEvent(event=_BigEvent(payload=payload))
         return StoredTick(
@@ -88,14 +71,13 @@ def _empty_state() -> BrokerState:
 
 @pytest.mark.asyncio
 async def test_stream_replay_peak_memory_bounded_by_batch_size() -> None:
-    """Peak memory during replay must scale with batch_size, not tick count."""
     payload_size = 200_000  # ~200 KB per tick
     total_ticks = 200
     batch_size = 10
 
     store = _FakeStreamingStore(count=total_ticks, payload_size=payload_size)
 
-    # Warm up caches (Pydantic TypeAdapter, class tables, etc.)
+    # Warm up caches (Pydantic TypeAdapter, class tables, etc.) before measuring.
     async for stored in store.stream_ticks("r", batch_size=batch_size):
         WorkflowTickAdapter.validate_python(stored.tick_data)
         break
@@ -111,26 +93,18 @@ async def test_stream_replay_peak_memory_bounded_by_batch_size() -> None:
     finally:
         tracemalloc.stop()
 
-    # Generous bound: if we accidentally materialize all N ticks, peak will be
-    # total_ticks * payload_size (~40 MB). batch_size * payload_size * 5 is
-    # ~10 MB — a comfortable gap.
     bound = batch_size * payload_size * 5
     assert peak < bound, (
         f"Peak memory {peak} bytes exceeded bound {bound} bytes "
         f"(total_ticks={total_ticks}, batch_size={batch_size}, "
-        f"payload_size={payload_size}). Streaming replay appears to be "
-        f"materializing the full history."
+        f"payload_size={payload_size})."
     )
 
 
 @pytest.mark.asyncio
 async def test_stream_replay_memory_bound_detects_full_materialization() -> None:
-    """Sanity check: the bound would fail if ticks were materialized upfront.
-
-    This guards against a future refactor that silently converts the stream
-    into a list — the peak assertion in the positive test would lose its
-    teeth without this companion check.
-    """
+    # Sanity: the bound in the positive test must actually fire on full
+    # materialization, otherwise the assertion is toothless.
     payload_size = 200_000
     total_ticks = 200
     batch_size = 10
@@ -154,7 +128,5 @@ async def test_stream_replay_memory_bound_detects_full_materialization() -> None
 
     bound = batch_size * payload_size * 5
     assert peak >= bound, (
-        f"Expected full materialization to blow the bound ({peak} < {bound}). "
-        f"If this assertion fires, the memory bound is too loose — the "
-        f"streaming test is not actually exercising the bound."
+        f"Expected full materialization to blow the bound ({peak} < {bound})."
     )

--- a/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
+++ b/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Regression test: streaming tick replay must not materialize full history.
+
+If this test fails, the streaming replay path has regressed back to an O(N)
+allocation pattern, which would reintroduce the idle-release OOM this work
+targets. The bound is deliberately generous (a small multiple of
+batch_size * payload_size) so it triggers only on true O(N) regressions,
+not allocator noise.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+
+import pytest
+from llama_agents.server._store.abstract_workflow_store import (
+    AbstractWorkflowStore,
+    StoredTick,
+)
+from workflows.events import Event
+from workflows.runtime.control_loop import rebuild_state_from_ticks_stream
+from workflows.runtime.types.internal_state import BrokerConfig, BrokerState
+from workflows.runtime.types.ticks import TickPublishEvent, WorkflowTickAdapter
+
+
+class _BigEvent(Event):
+    payload: str
+
+
+class _FakeStreamingStore:
+    """Minimal fake that generates synthetic ticks lazily.
+
+    Not a full AbstractWorkflowStore - only implements stream_ticks/query_ticks,
+    which is all the replay path needs. Generating ticks on demand instead of
+    holding them in a list lets the test isolate whether the *consumer* holds
+    the full history.
+    """
+
+    def __init__(self, count: int, payload_size: int) -> None:
+        self._count = count
+        self._payload_size = payload_size
+
+    async def query_ticks(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int | None = None,
+        limit: int | None = None,
+    ) -> list[StoredTick]:
+        start = 0 if after_sequence is None else after_sequence + 1
+        end = self._count if limit is None else min(self._count, start + limit)
+        return [self._make_stored_tick(i) for i in range(start, end)]
+
+    async def stream_ticks(
+        self, run_id: str, *, batch_size: int = 100
+    ) -> AsyncIterator[StoredTick]:
+        cursor: int | None = None
+        while True:
+            batch = await self.query_ticks(
+                run_id, after_sequence=cursor, limit=batch_size
+            )
+            for tick in batch:
+                yield tick
+                cursor = tick.sequence
+            if len(batch) < batch_size:
+                return
+
+    def _make_stored_tick(self, seq: int) -> StoredTick:
+        # Unique per-tick payload so Python string interning doesn't collapse
+        # memory cost across ticks — otherwise the test measures nothing.
+        payload = f"{seq:08d}" + ("x" * (self._payload_size - 8))
+        tick = TickPublishEvent(event=_BigEvent(payload=payload))
+        return StoredTick(
+            run_id="r",
+            sequence=seq,
+            timestamp=datetime.now(timezone.utc),
+            tick_data=tick.model_dump(),
+        )
+
+
+def _empty_state() -> BrokerState:
+    return BrokerState(
+        is_running=True, config=BrokerConfig(steps={}, timeout=None), workers={}
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_replay_peak_memory_bounded_by_batch_size() -> None:
+    """Peak memory during replay must scale with batch_size, not tick count."""
+    payload_size = 200_000  # ~200 KB per tick
+    total_ticks = 200
+    batch_size = 10
+
+    store = _FakeStreamingStore(count=total_ticks, payload_size=payload_size)
+
+    # Warm up caches (Pydantic TypeAdapter, class tables, etc.)
+    async for stored in store.stream_ticks("r", batch_size=batch_size):
+        WorkflowTickAdapter.validate_python(stored.tick_data)
+        break
+
+    async def _stream() -> AsyncIterator:
+        async for stored in store.stream_ticks("r", batch_size=batch_size):
+            yield WorkflowTickAdapter.validate_python(stored.tick_data)
+
+    tracemalloc.start()
+    try:
+        await rebuild_state_from_ticks_stream(_empty_state(), _stream())
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    # Generous bound: if we accidentally materialize all N ticks, peak will be
+    # total_ticks * payload_size (~40 MB). batch_size * payload_size * 5 is
+    # ~10 MB — a comfortable gap.
+    bound = batch_size * payload_size * 5
+    assert peak < bound, (
+        f"Peak memory {peak} bytes exceeded bound {bound} bytes "
+        f"(total_ticks={total_ticks}, batch_size={batch_size}, "
+        f"payload_size={payload_size}). Streaming replay appears to be "
+        f"materializing the full history."
+    )
+
+
+@pytest.mark.asyncio
+async def test_stream_replay_memory_bound_detects_full_materialization() -> None:
+    """Sanity check: the bound would fail if ticks were materialized upfront.
+
+    This guards against a future refactor that silently converts the stream
+    into a list — the peak assertion in the positive test would lose its
+    teeth without this companion check.
+    """
+    payload_size = 200_000
+    total_ticks = 200
+    batch_size = 10
+
+    store = _FakeStreamingStore(count=total_ticks, payload_size=payload_size)
+
+    async def _all_then_stream() -> AsyncIterator:
+        materialized = [
+            WorkflowTickAdapter.validate_python(s.tick_data)
+            async for s in store.stream_ticks("r", batch_size=batch_size)
+        ]
+        for t in materialized:
+            yield t
+
+    tracemalloc.start()
+    try:
+        await rebuild_state_from_ticks_stream(_empty_state(), _all_then_stream())
+        _current, peak = tracemalloc.get_traced_memory()
+    finally:
+        tracemalloc.stop()
+
+    bound = batch_size * payload_size * 5
+    assert peak >= bound, (
+        f"Expected full materialization to blow the bound ({peak} < {bound}). "
+        f"If this assertion fires, the memory bound is too loose — the "
+        f"streaming test is not actually exercising the bound."
+    )
+

--- a/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
+++ b/packages/llama-agents-server/tests/server/test_streaming_replay_memory.py
@@ -17,7 +17,6 @@ from datetime import datetime, timezone
 
 import pytest
 from llama_agents.server._store.abstract_workflow_store import (
-    AbstractWorkflowStore,
     StoredTick,
 )
 from workflows.events import Event
@@ -159,4 +158,3 @@ async def test_stream_replay_memory_bound_detects_full_materialization() -> None
         f"If this assertion fires, the memory bound is too loose — the "
         f"streaming test is not actually exercising the bound."
     )
-

--- a/packages/llama-agents-server/tests/server/test_workflow_store_events.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_store_events.py
@@ -262,3 +262,80 @@ async def test_subscribe_events_already_terminated(
 
     assert len(collected) == 2
     assert collected[-1].event.type == "StopEvent"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tick query / stream
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "seed_count, after_sequence, limit, expected_sequences",
+    [
+        pytest.param(5, 2, None, [3, 4], id="after_sequence_only"),
+        pytest.param(5, None, 3, [0, 1, 2], id="limit_only"),
+        pytest.param(10, 3, 2, [4, 5], id="after_sequence_and_limit"),
+        pytest.param(5, None, None, [0, 1, 2, 3, 4], id="unbounded"),
+    ],
+)
+async def test_query_ticks_paginates(
+    store: AbstractWorkflowStore,
+    seed_count: int,
+    after_sequence: int | None,
+    limit: int | None,
+    expected_sequences: list[int],
+) -> None:
+    for i in range(seed_count):
+        await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
+
+    result = await store.query_ticks(
+        "run-1", after_sequence=after_sequence, limit=limit
+    )
+    assert [t.sequence for t in result] == expected_sequences
+
+
+@pytest.mark.asyncio
+async def test_stream_ticks_yields_all_rows_in_order(
+    store: AbstractWorkflowStore,
+) -> None:
+    for i in range(10):
+        await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
+
+    yielded: list[int] = []
+    async for tick in store.stream_ticks("run-1", batch_size=3):
+        yielded.append(tick.sequence)
+
+    assert yielded == list(range(10))
+
+
+@pytest.mark.asyncio
+async def test_stream_ticks_empty_history(
+    store: AbstractWorkflowStore,
+) -> None:
+    yielded: list[object] = []
+    async for tick in store.stream_ticks("empty-run", batch_size=10):
+        yielded.append(tick)
+    assert yielded == []
+
+
+@pytest.mark.asyncio
+async def test_stream_ticks_batch_size_larger_than_total(
+    store: AbstractWorkflowStore,
+) -> None:
+    for i in range(3):
+        await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
+
+    yielded = [t.sequence async for t in store.stream_ticks("run-1", batch_size=100)]
+    assert yielded == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_stream_ticks_batch_size_one(
+    store: AbstractWorkflowStore,
+) -> None:
+    for i in range(4):
+        await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
+
+    yielded = [t.sequence async for t in store.stream_ticks("run-1", batch_size=1)]
+    assert yielded == [0, 1, 2, 3]

--- a/packages/llama-agents-server/tests/server/test_workflow_store_events.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_store_events.py
@@ -265,43 +265,17 @@ async def test_subscribe_events_already_terminated(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "seed_count, after_sequence, limit, expected_sequences",
-    [
-        pytest.param(5, 2, None, [3, 4], id="after_sequence_only"),
-        pytest.param(5, None, 3, [0, 1, 2], id="limit_only"),
-        pytest.param(10, 3, 2, [4, 5], id="after_sequence_and_limit"),
-        pytest.param(5, None, None, [0, 1, 2, 3, 4], id="unbounded"),
-    ],
-)
-async def test_query_ticks_paginates(
-    store: AbstractWorkflowStore,
-    seed_count: int,
-    after_sequence: int | None,
-    limit: int | None,
-    expected_sequences: list[int],
-) -> None:
-    for i in range(seed_count):
-        await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
-
-    result = await store.query_ticks(
-        "run-1", after_sequence=after_sequence, limit=limit
-    )
-    assert [t.sequence for t in result] == expected_sequences
-
-
-@pytest.mark.asyncio
 async def test_stream_ticks_yields_all_rows_in_order(
     store: AbstractWorkflowStore,
 ) -> None:
-    for i in range(10):
+    for i in range(13):
         await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
 
     yielded: list[int] = []
-    async for tick in store.stream_ticks("run-1", batch_size=3):
+    async for tick in store.stream_ticks("run-1"):
         yielded.append(tick.sequence)
 
-    assert yielded == list(range(10))
+    assert yielded == list(range(13))
 
 
 @pytest.mark.asyncio
@@ -309,28 +283,6 @@ async def test_stream_ticks_empty_history(
     store: AbstractWorkflowStore,
 ) -> None:
     yielded: list[object] = []
-    async for tick in store.stream_ticks("empty-run", batch_size=10):
+    async for tick in store.stream_ticks("empty-run"):
         yielded.append(tick)
     assert yielded == []
-
-
-@pytest.mark.asyncio
-async def test_stream_ticks_batch_size_larger_than_total(
-    store: AbstractWorkflowStore,
-) -> None:
-    for i in range(3):
-        await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
-
-    yielded = [t.sequence async for t in store.stream_ticks("run-1", batch_size=100)]
-    assert yielded == [0, 1, 2]
-
-
-@pytest.mark.asyncio
-async def test_stream_ticks_batch_size_one(
-    store: AbstractWorkflowStore,
-) -> None:
-    for i in range(4):
-        await store.append_tick("run-1", {"type": "TickSendEvent", "i": i})
-
-    yielded = [t.sequence async for t in store.stream_ticks("run-1", batch_size=1)]
-    assert yielded == [0, 1, 2, 3]

--- a/packages/llama-agents-server/tests/server/test_workflow_store_events.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_store_events.py
@@ -264,11 +264,6 @@ async def test_subscribe_events_already_terminated(
     assert collected[-1].event.type == "StopEvent"
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Tick query / stream
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "seed_count, after_sequence, limit, expected_sequences",

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -574,18 +574,8 @@ async def rebuild_state_from_ticks_stream(
     state: BrokerState,
     ticks: AsyncIterable[WorkflowTick],
 ) -> BrokerState:
-    """Streaming variant of rebuild_state_from_ticks.
-
-    Consumes ticks from an async iterable so the full tick history does not
-    need to be materialized in memory. Peak memory during replay is bounded
-    by the caller's iterator, not by the total number of ticks on disk.
-
-    Semantics match rebuild_state_from_ticks: rewind_in_progress is applied
-    exactly once before any ticks are consumed, then _reduce_tick runs once
-    per yielded tick.
-    """
+    """Streaming variant of :func:`rebuild_state_from_ticks`."""
     state, _ = rewind_in_progress(state, time.time())
-
     async for tick in ticks:
         state, _ = _reduce_tick(tick, state, time.time())
     return state

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -10,6 +10,7 @@ import inspect
 import logging
 import time
 import traceback
+from collections.abc import AsyncIterable
 from dataclasses import replace
 from typing import TYPE_CHECKING
 
@@ -566,6 +567,27 @@ def rebuild_state_from_ticks(
         state, _ = _reduce_tick(
             tick, state, time.time()
         )  # somewhat broken kludge on the timestamps, need to move these to ticks
+    return state
+
+
+async def rebuild_state_from_ticks_stream(
+    state: BrokerState,
+    ticks: AsyncIterable[WorkflowTick],
+) -> BrokerState:
+    """Streaming variant of rebuild_state_from_ticks.
+
+    Consumes ticks from an async iterable so the full tick history does not
+    need to be materialized in memory. Peak memory during replay is bounded
+    by the caller's iterator, not by the total number of ticks on disk.
+
+    Semantics match rebuild_state_from_ticks: rewind_in_progress is applied
+    exactly once before any ticks are consumed, then _reduce_tick runs once
+    per yielded tick.
+    """
+    state, _ = rewind_in_progress(state, time.time())
+
+    async for tick in ticks:
+        state, _ = _reduce_tick(tick, state, time.time())
     return state
 
 

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
@@ -1095,11 +1095,6 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
     assert result.workers["test_step"].queue[0].event == event2
 
 
-# ─────────────────────────────────────────────────────────────────────────────
-# Tests for rebuild_state_from_ticks_stream
-# ─────────────────────────────────────────────────────────────────────────────
-
-
 async def _aiter(ticks: list[WorkflowTick]) -> AsyncIterator[WorkflowTick]:
     for t in ticks:
         yield t
@@ -1127,7 +1122,6 @@ def _simple_step_tick_sequence() -> list[WorkflowTick]:
 
 
 async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) -> None:
-    """Empty stream still applies rewind_in_progress like the list variant."""
     shared_state = StepWorkerState(
         step_name="test_step", collected_events={}, collected_waiters=[]
     )
@@ -1179,7 +1173,6 @@ async def test_rebuild_state_from_ticks_stream_multi_tick_equivalence(
 async def test_rebuild_state_from_ticks_stream_large_history_equivalence(
     base_state: BrokerState, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """500-tick replay parity: streaming and list paths must agree."""
     monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
     ticks: list[WorkflowTick] = [
         TickAddEvent(event=MyTestEvent(value=i)) for i in range(500)
@@ -1194,7 +1187,6 @@ async def test_rebuild_state_from_ticks_stream_large_history_equivalence(
 async def test_rebuild_state_from_ticks_stream_clears_in_progress(
     base_state: BrokerState,
 ) -> None:
-    """Mirror of test_rebuild_state_from_ticks_clears_in_progress via stream."""
     event1 = MyTestEvent(value=1)
     event2 = MyTestEvent(value=2)
     shared_state = StepWorkerState(

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
@@ -10,6 +10,7 @@ testing them in isolation without running the full async control loop.
 from __future__ import annotations
 
 import hashlib
+from collections.abc import AsyncIterator
 from typing import cast
 
 import pytest
@@ -40,6 +41,7 @@ from workflows.runtime.control_loop import (
     _process_timeout_tick,
     _reduce_tick,
     rebuild_state_from_ticks,
+    rebuild_state_from_ticks_stream,
     rewind_in_progress,
 )
 from workflows.runtime.types.commands import (
@@ -1091,3 +1093,147 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
     # Queue should have event2 (since num_workers=1, only 1 can be in_progress)
     assert len(result.workers["test_step"].queue) == 1
     assert result.workers["test_step"].queue[0].event == event2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests for rebuild_state_from_ticks_stream
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _aiter(ticks: list[WorkflowTick]) -> AsyncIterator[WorkflowTick]:
+    for t in ticks:
+        yield t
+
+
+def _simple_step_tick_sequence() -> list[WorkflowTick]:
+    event1 = MyTestEvent(value=1)
+    event2 = MyTestEvent(value=2)
+    return [
+        TickAddEvent(event=event1),
+        TickStepResult(
+            step_name="test_step",
+            worker_id=0,
+            event=event1,
+            result=[StepWorkerResult(result=OtherEvent(data="done1"))],
+        ),
+        TickAddEvent(event=event2),
+        TickStepResult(
+            step_name="test_step",
+            worker_id=0,
+            event=event2,
+            result=[StepWorkerResult(result=StopEvent(result="done2"))],
+        ),
+    ]
+
+
+async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) -> None:
+    """Empty stream still applies rewind_in_progress like the list variant."""
+    shared_state = StepWorkerState(
+        step_name="test_step", collected_events={}, collected_waiters=[]
+    )
+    event1 = MyTestEvent(value=1)
+    base_state.workers["test_step"].in_progress = [
+        InProgressState(
+            event=event1,
+            worker_id=0,
+            shared_state=shared_state,
+            attempts=1,
+            first_attempt_at=100.0,
+        ),
+    ]
+
+    streamed = await rebuild_state_from_ticks_stream(base_state, _aiter([]))
+
+    # rewind_in_progress re-assigns worker_id=0 starting fresh; in_progress preserved.
+    assert len(streamed.workers["test_step"].in_progress) == 1
+    assert streamed.workers["test_step"].in_progress[0].worker_id == 0
+    assert streamed.workers["test_step"].in_progress[0].event == event1
+
+
+async def test_rebuild_state_from_ticks_stream_single_tick(
+    base_state: BrokerState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Freeze time so timestamp kludges don't diverge between paths.
+    monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
+    ticks: list[WorkflowTick] = [TickAddEvent(event=MyTestEvent(value=42))]
+    streamed = await rebuild_state_from_ticks_stream(
+        base_state.deepcopy(), _aiter(ticks)
+    )
+    listed = rebuild_state_from_ticks(base_state.deepcopy(), ticks)
+    assert streamed == listed
+
+
+async def test_rebuild_state_from_ticks_stream_multi_tick_equivalence(
+    base_state: BrokerState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
+    ticks = _simple_step_tick_sequence()
+    streamed = await rebuild_state_from_ticks_stream(
+        base_state.deepcopy(), _aiter(list(ticks))
+    )
+    listed = rebuild_state_from_ticks(base_state.deepcopy(), list(ticks))
+    assert streamed == listed
+    assert streamed.is_running is False
+
+
+async def test_rebuild_state_from_ticks_stream_large_history_equivalence(
+    base_state: BrokerState, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """500-tick replay parity: streaming and list paths must agree."""
+    monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
+    ticks: list[WorkflowTick] = [
+        TickAddEvent(event=MyTestEvent(value=i)) for i in range(500)
+    ]
+    streamed = await rebuild_state_from_ticks_stream(
+        base_state.deepcopy(), _aiter(list(ticks))
+    )
+    listed = rebuild_state_from_ticks(base_state.deepcopy(), list(ticks))
+    assert streamed == listed
+
+
+async def test_rebuild_state_from_ticks_stream_clears_in_progress(
+    base_state: BrokerState,
+) -> None:
+    """Mirror of test_rebuild_state_from_ticks_clears_in_progress via stream."""
+    event1 = MyTestEvent(value=1)
+    event2 = MyTestEvent(value=2)
+    shared_state = StepWorkerState(
+        step_name="test_step", collected_events={}, collected_waiters=[]
+    )
+    base_state.workers["test_step"].in_progress = [
+        InProgressState(
+            event=event1,
+            worker_id=1,
+            shared_state=shared_state,
+            attempts=0,
+            first_attempt_at=100.0,
+        ),
+        InProgressState(
+            event=event2,
+            worker_id=2,
+            shared_state=shared_state,
+            attempts=0,
+            first_attempt_at=100.0,
+        ),
+    ]
+    ticks: list[WorkflowTick] = [
+        TickAddEvent(event=event1),
+        TickStepResult(
+            step_name="test_step",
+            worker_id=0,
+            event=event1,
+            result=[StepWorkerResult(result=OtherEvent(data="done1"))],
+        ),
+        TickAddEvent(event=event2),
+        TickStepResult(
+            step_name="test_step",
+            worker_id=0,
+            event=event2,
+            result=[StepWorkerResult(result=StopEvent(result="done2"))],
+        ),
+    ]
+
+    final_state = await rebuild_state_from_ticks_stream(base_state, _aiter(ticks))
+
+    assert final_state.is_running is False
+    assert len(final_state.workers["test_step"].in_progress) == 0


### PR DESCRIPTION
## Summary

- Idle-release and persistence-runtime rebuilds stream ticks batch-by-batch instead of materializing the full history. Peak memory during resume is now bounded by `batch_size × avg_tick_size`, not total tick count.
- Adds `rebuild_state_from_ticks_stream` and `AbstractWorkflowStore.query_ticks` / `stream_ticks`, with real paged implementations on memory, sqlite, postgres, agent_data, and agentcore backends (DBOS gets passthroughs).
- Includes list-vs-stream equivalence tests, a 500-tick parity test, and a tracemalloc regression test — plus a companion test that verifies the bound actually bites if someone reverts to full materialization.

Fixes the OOM pattern we've seen on long-running DBOS workflows with large event payloads. The complementary "don't put multi-MB blobs on Events" cleanup is out of scope here — this is the minimal cut that bounds resume memory without changing any user-facing API.