### PR TITLE
fix: replay current pause segment on implicit 'now' SSE cursor

### DIFF
--- a/packages/llama-agents-server/src/llama_agents/server/_api.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_api.py
@@ -644,10 +644,25 @@ class _WorkflowAPI:
         if run_id is None:
             raise HTTPException(detail="Handler has no associated run", status_code=404)
 
-        # Resolve "now" cursor to current max sequence
+        # An implicit "now" cursor on an idle handler must rewind to the
+        # current pause segment, otherwise a late subscriber drops the HITL
+        # events that triggered the pause and hangs.
+        #
+        # `idle_since` alone is not sufficient: DBOSIdleReleaseDecorator
+        # defers that column until its idle_timeout expires, so the event log
+        # tail is used as a second signal.
         if after_sequence is None:
             all_current = await store.query_events(run_id)
-            after_sequence = all_current[-1].sequence if all_current else -1
+            is_idle = persistent.idle_since is not None or (
+                bool(all_current)
+                and AbstractWorkflowStore._is_idle_event(all_current[-1])
+            )
+            if is_idle:
+                after_sequence = AbstractWorkflowStore._rewind_to_current_pause(
+                    all_current
+                )
+            else:
+                after_sequence = all_current[-1].sequence if all_current else -1
 
         # Check if already fully consumed
         remaining_events = await store.query_events(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -22,7 +22,7 @@ from pydantic import (
 from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
 from workflows.context.state_store import StateStore
-from workflows.events import StopEvent
+from workflows.events import StopEvent, WorkflowIdleEvent
 from workflows.runtime.types.ticks import WorkflowTick, WorkflowTickAdapter
 
 logger = logging.getLogger(__name__)
@@ -205,6 +205,29 @@ class AbstractWorkflowStore(ABC):
 
         types = (event.event.types or []) + [event.event.type]
         return StopEvent.__name__ in types
+
+    @staticmethod
+    def _is_idle_event(event: StoredEvent) -> bool:
+        types = (event.event.types or []) + [event.event.type]
+        return WorkflowIdleEvent.__name__ in types
+
+    @staticmethod
+    def _rewind_to_current_pause(events: list[StoredEvent]) -> int:
+        """Exclusive cursor positioned just before the current idle segment.
+
+        Returned sequence is used as ``after_sequence`` to replay the events
+        between the previous ``WorkflowIdleEvent`` and the current one (so
+        late SSE subscribers receive the HITL events that triggered the
+        pause). Returns -1 when the current pause is the first one, or when
+        ``events`` contains no ``WorkflowIdleEvent``.
+        """
+        latest_idle = prev_idle = None
+        for i, stored in enumerate(events):
+            if AbstractWorkflowStore._is_idle_event(stored):
+                prev_idle, latest_idle = latest_idle, i
+        if latest_idle is None or prev_idle is None:
+            return -1
+        return events[prev_idle].sequence
 
     async def subscribe_events(
         self, run_id: str, after_sequence: int = -1

--- a/packages/llama-agents-server/tests/server/test_sse_idle_replay.py
+++ b/packages/llama-agents-server/tests/server/test_sse_idle_replay.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Regression tests for the SSE cursor race on idle/HITL workflows.
+
+An implicit "now" cursor on a handler that has already emitted a HITL event
+and gone idle must rewind to the pause segment, otherwise the fresh subscriber
+misses the prompt and hangs.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import httpx
+import pytest
+from llama_agents.client.client import WorkflowClient
+from llama_agents.server import MemoryWorkflowStore, WorkflowServer
+from llama_agents.server._store.abstract_workflow_store import HandlerQuery
+from server_test_fixtures import (  # type: ignore[import]
+    live_server,
+    wait_for_passing,
+)
+from workflows import Context, Workflow, step
+from workflows.events import (
+    Event,
+    HumanResponseEvent,
+    InputRequiredEvent,
+    StartEvent,
+    StopEvent,
+    WorkflowIdleEvent,
+)
+
+
+class PromptEvent(InputRequiredEvent):
+    prompt: str
+
+
+class AnswerEvent(HumanResponseEvent):
+    answer: str
+
+
+class PausingWorkflow(Workflow):
+    """Emits a HITL event, then waits for the human response."""
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> PromptEvent:
+        return PromptEvent(prompt="what is your name?")
+
+    @step
+    async def finish(self, ctx: Context, ev: AnswerEvent) -> StopEvent:
+        return StopEvent(result=f"hello, {ev.answer}")
+
+
+def _make_server() -> WorkflowServer:
+    server = WorkflowServer(workflow_store=MemoryWorkflowStore())
+    server.add_workflow(
+        "pausing",
+        PausingWorkflow(),
+        additional_events=[PromptEvent, AnswerEvent],
+    )
+    return server
+
+
+async def _drive_until_idle(client: WorkflowClient, handler_id: str) -> None:
+    """Drain events until WorkflowIdleEvent is persisted."""
+
+    async def consume() -> None:
+        async for env in client.get_workflow_events(
+            handler_id,
+            include_internal_events=True,
+            after_sequence=-1,
+        ):
+            if env.type == WorkflowIdleEvent.__name__:
+                return
+        raise AssertionError("stream ended before WorkflowIdleEvent")
+
+    await asyncio.wait_for(consume(), timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_late_sse_client_receives_hitl_event_and_workflow_completes() -> None:
+    """End-to-end invariant: late subscriber receives the prompt, answers, run completes.
+
+    With the default runtime both idle signals (``idle_since`` and the
+    ``WorkflowIdleEvent`` tail) are true after idling; this test pins the
+    user-visible happy path. Branch-isolation for the DBOS-deferred
+    ``idle_since=None`` case is covered by the next test.
+    """
+    async with live_server(_make_server) as (base_url, _server):
+        client = WorkflowClient(base_url=base_url)
+        started = await client.run_workflow_nowait("pausing")
+        handler_id = started.handler_id
+
+        await _drive_until_idle(client, handler_id)
+
+        received: list[str] = []
+
+        async def read_until_prompt() -> None:
+            stream = client.get_workflow_events(
+                handler_id,
+                include_internal_events=False,
+                after_sequence="now",
+            )
+            async for env in stream:
+                received.append(env.type)
+                if env.type == PromptEvent.__name__:
+                    return
+            raise AssertionError(
+                f"stream ended without yielding PromptEvent (saw: {received})"
+            )
+
+        await asyncio.wait_for(read_until_prompt(), timeout=3.0)
+
+        # Unblock the workflow and confirm it completes end-to-end.
+        send = await client.send_event(handler_id, AnswerEvent(answer="world"))
+        assert send.status == "sent"
+
+        async def handler_completed() -> None:
+            data = await client.get_handler(handler_id)
+            assert data.status == "completed"
+            assert data.result is not None
+            assert data.result.value.get("result") == "hello, world"
+
+        await wait_for_passing(handler_completed, max_duration=5.0, interval=0.05)
+
+
+@pytest.mark.asyncio
+async def test_fresh_sse_client_replays_when_idle_since_is_unset() -> None:
+    """Rewind must fire on the event-log tail signal alone.
+
+    Pins the DBOS scenario: ``DBOSIdleReleaseDecorator`` defers the handler's
+    ``idle_since`` column until its idle_timeout expires, so the row looks
+    "running" while the workflow is in fact blocked on a human response.
+    """
+    async with live_server(_make_server) as (base_url, server):
+        client = WorkflowClient(base_url=base_url)
+        started = await client.run_workflow_nowait("pausing")
+        handler_id = started.handler_id
+
+        await _drive_until_idle(client, handler_id)
+
+        store = server._workflow_store
+        found = await store.query(HandlerQuery(handler_id_in=[handler_id]))
+        assert found, "handler must exist before clearing idle_since"
+        persistent = found[0]
+        assert persistent.run_id is not None
+        await store.update_handler_status(persistent.run_id, idle_since=None)
+
+        received: list[str] = []
+
+        async def read_until_prompt() -> None:
+            stream = client.get_workflow_events(
+                handler_id,
+                include_internal_events=False,
+                after_sequence="now",
+            )
+            async for env in stream:
+                received.append(env.type)
+                if env.type == PromptEvent.__name__:
+                    return
+            raise AssertionError(
+                f"stream ended without yielding PromptEvent (saw: {received})"
+            )
+
+        await asyncio.wait_for(read_until_prompt(), timeout=3.0)
+
+
+@pytest.mark.asyncio
+async def test_fresh_sse_client_not_rewound_when_not_idle() -> None:
+    """Non-idle handlers must keep the unchanged "now = only new events" semantic."""
+
+    class SlowStreamingEvent(Event):
+        value: int
+
+    class SlowStreamingWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            for i in range(3):
+                ctx.write_event_to_stream(SlowStreamingEvent(value=i))
+                await asyncio.sleep(0.05)
+            return StopEvent(result="done")
+
+    def make_server() -> WorkflowServer:
+        server = WorkflowServer(workflow_store=MemoryWorkflowStore())
+        server.add_workflow(
+            "slow",
+            SlowStreamingWorkflow(),
+            additional_events=[SlowStreamingEvent],
+        )
+        return server
+
+    async with live_server(make_server) as (base_url, _server):
+        client = WorkflowClient(base_url=base_url)
+        started = await client.run_workflow_nowait("slow")
+        handler_id = started.handler_id
+
+        async def completed() -> None:
+            data = await client.get_handler(handler_id)
+            assert data.status == "completed"
+
+        await wait_for_passing(completed, max_duration=3.0, interval=0.05)
+
+        async with httpx.AsyncClient(base_url=base_url, timeout=3.0) as http:
+            resp = await http.get(
+                f"/events/{handler_id}",
+                params={
+                    "sse": "true",
+                    "include_internal": "false",
+                    "after_sequence": "now",
+                },
+            )
+            assert resp.status_code == 204, (
+                f"expected 204 (no new events) for completed non-idle run, "
+                f"got {resp.status_code}: {resp.text[:200]}"
+            )


### PR DESCRIPTION
## Summary

The SSE endpoint's `after_sequence=now` default resolved to the current max sequence at connect time, so any event persisted before the GET landed was skipped. For a handler that had already emitted a HITL event and gone idle, the fresh subscriber missed the prompt and the workflow sat parked until DBOS `recv_async` timed out (~1 min later by default).

Fix is in `_resolve_event_stream`: when the handler is idle at connect time, rewind to the start of the current pause segment so the HITL events that triggered the pause get replayed. The rewind helper lives on `AbstractWorkflowStore` next to `_is_terminal_event`.

## Why two idle signals

The `is_idle` check ORs:

- `persistent.idle_since is not None`
- last persisted event is a `WorkflowIdleEvent`

Both are needed. `DBOSIdleReleaseDecorator._DBOSIdleReleaseInternalRunAdapter.write_to_event_stream` (in `llama_agents/dbos/idle_release.py`) does not set `idle_since` when it observes `WorkflowIdleEvent` — it only schedules a deferred release that fires after `idle_timeout` (default 60s). Until that fires, the handler row is `idle_since=NULL` while the workflow is in fact blocked on human input. Relying on `idle_since` alone would leave every DBOS-backed HITL subscriber hanging on the same race.

## Repro

A workflow emits `InputRequiredEvent` then `ctx.wait_for_event(HumanResponseEvent)`. Client posts `/run-nowait`, workflow persists events 0..N including `WorkflowIdleEvent`, then the client opens `GET /events/{id}?sse=true` with the default cursor. Pre-patch, the cursor resolves to N; the client listens for seq > N; the workflow is parked so nothing new arrives.

Reproducible any time the gap between POST return and SSE GET arrival exceeds the time to reach the first HITL event — ingress, TLS handshake, service mesh, client event-loop pressure.

## Tests

`packages/llama-agents-server/tests/server/test_sse_idle_replay.py`:

| Test | Covers |
|---|---|
| `test_late_sse_client_receives_hitl_event_and_workflow_completes` | End-to-end happy path: late subscriber receives prompt, answers, workflow completes. With the default runtime both idle signals are true after idling. |
| `test_fresh_sse_client_replays_when_idle_since_is_unset` | DBOS-deferred case, isolated: manually clears `idle_since` so only the event-log-tail signal can trigger the rewind. |
| `test_fresh_sse_client_not_rewound_when_not_idle` | Non-idle guard: `now` on a terminal run still returns 204, no accidental replay. |

Also verified end-to-end on a 3-client concurrent HITL workload that was deadlocking pre-patch: 3/3 complete in 7.6 min post-patch, 0 HTTP errors, every prompt delivered.