### PR TITLE
fix(appserver): target the venv uv resolves, not <template>/.venv

### DIFF
--- a/.changeset/workspace-aware-appserver-install.md
+++ b/.changeset/workspace-aware-appserver-install.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-appserver": patch
+---
+
+Fix appserver install when the target template is a uv workspace member. Install now targets whichever venv `uv run` resolves to, instead of a hard-coded `<template>/.venv`, so `llamactl dev validate` and `llamactl serve` work in workspace layouts.

--- a/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
+++ b/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
@@ -254,7 +254,6 @@ def _get_appserver_workflows_requirement() -> SpecifierSet | None:
 def _ensure_compatible_workflows(
     source_root: Path,
     path: Path,
-    venv_path: Path,
 ) -> None:
     """Check if the user's llama-index-workflows version is compatible with the appserver.
 
@@ -289,7 +288,6 @@ def _ensure_compatible_workflows(
             path,
             "add",
             [f"llama-index-workflows{req_str}"],
-            extra_env={"UV_PROJECT_ENVIRONMENT": str(venv_path)},
         )
     except subprocess.CalledProcessError:
         raise RuntimeError(
@@ -321,11 +319,27 @@ def run_uv(
     )
 
 
-def ensure_venv(source_root: Path, path: Path, force: bool = False) -> Path:
-    venv_path = source_root / path / ".venv"
-    if force or not venv_path.exists():
-        run_uv(source_root, path, "venv", [str(venv_path)])
-    return venv_path
+def _resolve_project_venv(source_root: Path, path: Path) -> Path:
+    """
+    Return the venv path uv would use for this project.
+
+    Must be called after ``uv sync`` so the venv is guaranteed to exist. Asks uv
+    itself (via ``uv run``) rather than reimplementing uv's workspace / project
+    resolution. This keeps the install side aligned with ``start_*_in_target_venv``,
+    which also uses bare ``uv run`` and so targets the same venv uv picks here.
+    """
+    result = subprocess.check_output(
+        [
+            "uv",
+            "run",
+            "--no-progress",
+            "python",
+            "-c",
+            "import sys; print(sys.prefix)",
+        ],
+        cwd=source_root / path,
+    )
+    return Path(result.decode("utf-8").strip())
 
 
 def _install_and_add_appserver_if_missing(
@@ -337,7 +351,9 @@ def _install_and_add_appserver_if_missing(
     auto_upgrade: bool = True,
 ) -> None:
     """
-    Ensure venv, install project deps, and add the appserver to the venv if it's missing or outdated
+    Sync project deps (letting uv pick the venv location, so we agree with uv run
+    in workspace and non-workspace layouts) and install the appserver if missing
+    or outdated.
     """
 
     if not (source_root / path / "pyproject.toml").exists():
@@ -347,17 +363,16 @@ def _install_and_add_appserver_if_missing(
         return
 
     editable = are_we_editable_mode()
-    venv_path = ensure_venv(source_root, path, force=editable)
     run_uv(
         source_root,
         path,
         "sync",
         ["--no-dev", "--inexact"],
-        extra_env={"UV_PROJECT_ENVIRONMENT": str(venv_path)},
     )
+    venv_path = _resolve_project_venv(source_root, path)
 
     if auto_upgrade:
-        _ensure_compatible_workflows(source_root, path, venv_path)
+        _ensure_compatible_workflows(source_root, path)
 
     if sdists:
         run_uv(
@@ -368,14 +383,20 @@ def _install_and_add_appserver_if_missing(
             + [str(s.absolute()) for s in sdists]
             + ["--prefix", str(venv_path)],
         )
-    elif are_we_editable_mode():
+    elif editable:
         same_python_version = _same_python_version(venv_path)
         if not same_python_version.is_same:
             logger.error(
-                f"Python version mismatch. Current: {same_python_version.current_version} != Project: {same_python_version.target_version}. During development, the target environment must be running the same Python version, otherwise the appserver cannot be installed."
+                f"Python version mismatch at {venv_path}: runtime "
+                f"{same_python_version.current_version} != venv "
+                f"{same_python_version.target_version}. In editable-appserver mode the "
+                f"target venv must run the same Python as the appserver process, "
+                f"otherwise the appserver cannot be installed."
             )
             raise RuntimeError(
-                f"Python version mismatch. Current: {same_python_version.current_version} != Project: {same_python_version.target_version}"
+                f"Python version mismatch at {venv_path}: runtime "
+                f"{same_python_version.current_version} != venv "
+                f"{same_python_version.target_version}"
             )
         pyproject = _find_development_pyproject()
         if pyproject is None:

--- a/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
+++ b/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
@@ -193,31 +193,40 @@ def inject_appserver_into_target(
     )
 
 
+def _uv_run_python(cwd: Path, snippet: str, *, stderr: int | None = None) -> str:
+    """
+    Run a python snippet via ``uv run`` inside the project venv uv resolves for
+    ``cwd``. Returns stripped stdout. Use this anywhere we need to probe the
+    target venv (installed version, ``sys.prefix``, etc.) so all probes agree
+    with what the start-time runners see.
+    """
+    result = subprocess.check_output(
+        ["uv", "run", "--no-progress", "python", "-c", snippet],
+        cwd=cwd,
+        stderr=stderr,
+    )
+    return result.decode("utf-8").strip()
+
+
 def _get_installed_version_within_target(
     path: Path, package: str = "llama-agents-appserver"
 ) -> Version | None:
     packages = [package, _OLD_DIST_NAME] if package == _NEW_DIST_NAME else [package]
     for pkg_name in packages:
         try:
-            result = subprocess.check_output(
-                [
-                    "uv",
-                    "run",
-                    "python",
-                    "-c",
-                    dedent(f"""
-                            from importlib.metadata import version
-                            try:
-                                print(version("{pkg_name}"))
-                            except Exception:
-                                pass
-                           """),
-                ],
-                cwd=path,
+            output = _uv_run_python(
+                path,
+                dedent(f"""
+                        from importlib.metadata import version
+                        try:
+                            print(version("{pkg_name}"))
+                        except Exception:
+                            pass
+                       """),
                 stderr=subprocess.DEVNULL,
             )
             try:
-                return Version(result.decode("utf-8").strip())
+                return Version(output)
             except InvalidVersion:
                 continue
         except subprocess.CalledProcessError:
@@ -324,22 +333,10 @@ def _resolve_project_venv(source_root: Path, path: Path) -> Path:
     Return the venv path uv would use for this project.
 
     Must be called after ``uv sync`` so the venv is guaranteed to exist. Asks uv
-    itself (via ``uv run``) rather than reimplementing uv's workspace / project
-    resolution. This keeps the install side aligned with ``start_*_in_target_venv``,
-    which also uses bare ``uv run`` and so targets the same venv uv picks here.
+    itself rather than reimplementing uv's workspace / project resolution, so the
+    install side stays aligned with ``start_*_in_target_venv`` (also bare ``uv run``).
     """
-    result = subprocess.check_output(
-        [
-            "uv",
-            "run",
-            "--no-progress",
-            "python",
-            "-c",
-            "import sys; print(sys.prefix)",
-        ],
-        cwd=source_root / path,
-    )
-    return Path(result.decode("utf-8").strip())
+    return Path(_uv_run_python(source_root / path, "import sys; print(sys.prefix)"))
 
 
 def _install_and_add_appserver_if_missing(
@@ -386,18 +383,17 @@ def _install_and_add_appserver_if_missing(
     elif editable:
         same_python_version = _same_python_version(venv_path)
         if not same_python_version.is_same:
-            logger.error(
-                f"Python version mismatch at {venv_path}: runtime "
-                f"{same_python_version.current_version} != venv "
-                f"{same_python_version.target_version}. In editable-appserver mode the "
-                f"target venv must run the same Python as the appserver process, "
-                f"otherwise the appserver cannot be installed."
-            )
-            raise RuntimeError(
+            msg = (
                 f"Python version mismatch at {venv_path}: runtime "
                 f"{same_python_version.current_version} != venv "
                 f"{same_python_version.target_version}"
             )
+            logger.error(
+                f"{msg}. In editable-appserver mode the target venv must run "
+                f"the same Python as the appserver process, otherwise the "
+                f"appserver cannot be installed."
+            )
+            raise RuntimeError(msg)
         pyproject = _find_development_pyproject()
         if pyproject is None:
             raise RuntimeError("No pyproject.toml found in llama-agents-appserver")

--- a/packages/llama-agents-appserver/tests/test_workflow_loader_install.py
+++ b/packages/llama-agents-appserver/tests/test_workflow_loader_install.py
@@ -22,6 +22,19 @@ from llama_agents.core.path_util import validate_path_traversal
 from packaging.version import Version
 
 
+@pytest.fixture
+def resolve_venv_to_pkg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Stub ``_resolve_project_venv`` to return ``<source_root>/<path>/.venv``,
+    mirroring uv's choice for a non-workspace target. Tests that simulate a
+    workspace layout override this by patching ``_resolve_project_venv`` directly.
+    """
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
+    )
+
+
 def test_ensure_uv_available_success_and_bootstrap(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -68,7 +81,7 @@ def test_ensure_uv_available_success_and_bootstrap(
 
 
 def test_add_appserver_pypi_install_calls_uv_with_prefix(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolve_venv_to_pkg: None
 ) -> None:
     pkg_dir = tmp_path / "pkg"
     pkg_dir.mkdir()
@@ -93,10 +106,6 @@ def test_add_appserver_pypi_install_calls_uv_with_prefix(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
-    )
-    monkeypatch.setattr(
-        "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: source_root / path / ".venv",
     )
 
     _install_and_add_appserver_if_missing(Path("pkg"), tmp_path)
@@ -110,23 +119,22 @@ def test_add_appserver_pypi_install_calls_uv_with_prefix(
     assert install_cmd[install_cmd.index("--prefix") + 1] == str(pkg_dir / ".venv")
 
 
-def test_add_appserver_workspace_install_targets_resolved_venv(
+def test_add_appserver_install_targets_resolved_venv_when_outside_pkg(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """
-    When the target template is a uv workspace member, install must target the
-    venv uv itself would pick (the workspace venv), not <template>/.venv.
-    Regression guard for the install/runtime venv-path disagreement that
-    broke ``llamactl dev validate`` for workspace templates.
+    Install must target whichever venv ``_resolve_project_venv`` returns, even
+    when that path is outside ``<pkg>/.venv`` (e.g. a uv workspace member whose
+    venv lives at the workspace root). Regression guard for the install/runtime
+    venv-path disagreement that broke ``llamactl dev validate`` in workspace
+    layouts.
     """
-    workspace_root = tmp_path
-    (workspace_root / "pyproject.toml").write_text(
-        '[project]\nname="ws"\n[tool.uv.workspace]\nmembers = ["pkg"]\n'
-    )
-    pkg_dir = workspace_root / "pkg"
+    pkg_dir = tmp_path / "pkg"
     pkg_dir.mkdir()
     (pkg_dir / "pyproject.toml").write_text("[project]\nname='x'\n")
-    workspace_venv = workspace_root / ".venv"
+    # Simulate uv picking a venv outside the target dir (what happens when the
+    # target is a workspace member).
+    resolved_venv = tmp_path / "elsewhere" / ".venv"
 
     cmds: list[list[str]] = []
 
@@ -148,28 +156,22 @@ def test_add_appserver_workspace_install_targets_resolved_venv(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
     )
-    # Simulate uv resolving the workspace venv rather than <pkg>/.venv
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: workspace_venv,
+        lambda source_root, path: resolved_venv,
     )
 
-    _install_and_add_appserver_if_missing(Path("pkg"), workspace_root)
+    _install_and_add_appserver_if_missing(Path("pkg"), tmp_path)
 
     install_cmd = cmds[-1]
     assert install_cmd[:3] == ["uv", "pip", "install"]
     assert "--prefix" in install_cmd
-    assert install_cmd[install_cmd.index("--prefix") + 1] == str(workspace_venv)
-    # The per-template venv must NOT be the install target.
+    assert install_cmd[install_cmd.index("--prefix") + 1] == str(resolved_venv)
     assert str(pkg_dir / ".venv") not in install_cmd
-
-    # uv sync must not be scoped to a hard-coded venv via UV_PROJECT_ENVIRONMENT.
-    sync_cmds = [c for c in cmds if c[:2] == ["uv", "sync"]]
-    assert len(sync_cmds) == 1
 
 
 def test_add_appserver_sdists_install(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolve_venv_to_pkg: None
 ) -> None:
     pkg_dir = tmp_path / "pkg"
     pkg_dir.mkdir()
@@ -187,10 +189,6 @@ def test_add_appserver_sdists_install(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
-    )
-    monkeypatch.setattr(
-        "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: source_root / path / ".venv",
     )
 
     s1 = tmp_path / "d1" / "a-0.1.0.tar.gz"
@@ -210,7 +208,7 @@ def test_add_appserver_sdists_install(
 
 
 def test_add_appserver_editable_install(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolve_venv_to_pkg: None
 ) -> None:
     pkg_dir = tmp_path / "pkg"
     pkg_dir.mkdir()
@@ -244,10 +242,6 @@ def test_add_appserver_editable_install(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
-    )
-    monkeypatch.setattr(
-        "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: source_root / path / ".venv",
     )
 
     _install_and_add_appserver_if_missing(Path("pkg"), tmp_path)
@@ -393,7 +387,7 @@ def test_current_and_outdated_logic(
 
 
 def test_add_appserver_target_version_installs_from_pypi(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolve_venv_to_pkg: None
 ) -> None:
     """When target_version is set, install that exact version from PyPI."""
     pkg_dir = tmp_path / "pkg"
@@ -416,10 +410,6 @@ def test_add_appserver_target_version_installs_from_pypi(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
     )
-    monkeypatch.setattr(
-        "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: source_root / path / ".venv",
-    )
 
     _install_and_add_appserver_if_missing(
         Path("pkg"), tmp_path, target_version="0.4.15"
@@ -434,7 +424,7 @@ def test_add_appserver_target_version_installs_from_pypi(
 
 
 def test_add_appserver_target_version_ignored_in_editable_mode(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolve_venv_to_pkg: None
 ) -> None:
     """In editable mode, target_version is ignored — editable installs use local source."""
     pkg_dir = tmp_path / "pkg"
@@ -469,10 +459,6 @@ def test_add_appserver_target_version_ignored_in_editable_mode(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
     )
-    monkeypatch.setattr(
-        "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: source_root / path / ".venv",
-    )
 
     _install_and_add_appserver_if_missing(
         Path("pkg"), tmp_path, target_version="0.4.15"
@@ -491,7 +477,7 @@ def test_add_appserver_target_version_ignored_in_editable_mode(
 
 
 def test_add_appserver_target_version_ignored_when_sdists_provided(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolve_venv_to_pkg: None
 ) -> None:
     """When sdists are provided, they take priority over target_version."""
     pkg_dir = tmp_path / "pkg"
@@ -510,10 +496,6 @@ def test_add_appserver_target_version_ignored_when_sdists_provided(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
-    )
-    monkeypatch.setattr(
-        "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: source_root / path / ".venv",
     )
 
     s1 = tmp_path / "d1" / "a-0.1.0.tar.gz"
@@ -704,7 +686,7 @@ def test_ensure_compatible_workflows_update_fails_raises(
 
 
 def test_install_calls_ensure_compatible_workflows(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, resolve_venv_to_pkg: None
 ) -> None:
     """Integration: _install_and_add_appserver_if_missing calls _ensure_compatible_workflows."""
     pkg_dir = tmp_path / "pkg"
@@ -735,10 +717,6 @@ def test_install_calls_ensure_compatible_workflows(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         mock_ensure_compat,
-    )
-    monkeypatch.setattr(
-        "llama_agents.appserver.workflow_loader._resolve_project_venv",
-        lambda source_root, path: source_root / path / ".venv",
     )
 
     _install_and_add_appserver_if_missing(Path("pkg"), tmp_path)

--- a/packages/llama-agents-appserver/tests/test_workflow_loader_install.py
+++ b/packages/llama-agents-appserver/tests/test_workflow_loader_install.py
@@ -94,6 +94,10 @@ def test_add_appserver_pypi_install_calls_uv_with_prefix(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
     )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
+    )
 
     _install_and_add_appserver_if_missing(Path("pkg"), tmp_path)
 
@@ -104,6 +108,64 @@ def test_add_appserver_pypi_install_calls_uv_with_prefix(
     assert any(arg == "llama-agents-appserver==1.2.3" for arg in install_cmd)
     assert "--prefix" in install_cmd
     assert install_cmd[install_cmd.index("--prefix") + 1] == str(pkg_dir / ".venv")
+
+
+def test_add_appserver_workspace_install_targets_resolved_venv(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """
+    When the target template is a uv workspace member, install must target the
+    venv uv itself would pick (the workspace venv), not <template>/.venv.
+    Regression guard for the install/runtime venv-path disagreement that
+    broke ``llamactl dev validate`` for workspace templates.
+    """
+    workspace_root = tmp_path
+    (workspace_root / "pyproject.toml").write_text(
+        '[project]\nname="ws"\n[tool.uv.workspace]\nmembers = ["pkg"]\n'
+    )
+    pkg_dir = workspace_root / "pkg"
+    pkg_dir.mkdir()
+    (pkg_dir / "pyproject.toml").write_text("[project]\nname='x'\n")
+    workspace_venv = workspace_root / ".venv"
+
+    cmds: list[list[str]] = []
+
+    def run_capture(cmd: list[str], **kwargs: Any) -> None:
+        cmds.append(cmd)
+        return None
+
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader.run_process", run_capture
+    )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader.are_we_editable_mode", lambda: False
+    )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._is_missing_or_outdated",
+        lambda p: Version("1.2.3"),
+    )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
+        lambda *a, **k: None,
+    )
+    # Simulate uv resolving the workspace venv rather than <pkg>/.venv
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: workspace_venv,
+    )
+
+    _install_and_add_appserver_if_missing(Path("pkg"), workspace_root)
+
+    install_cmd = cmds[-1]
+    assert install_cmd[:3] == ["uv", "pip", "install"]
+    assert "--prefix" in install_cmd
+    assert install_cmd[install_cmd.index("--prefix") + 1] == str(workspace_venv)
+    # The per-template venv must NOT be the install target.
+    assert str(pkg_dir / ".venv") not in install_cmd
+
+    # uv sync must not be scoped to a hard-coded venv via UV_PROJECT_ENVIRONMENT.
+    sync_cmds = [c for c in cmds if c[:2] == ["uv", "sync"]]
+    assert len(sync_cmds) == 1
 
 
 def test_add_appserver_sdists_install(
@@ -125,6 +187,10 @@ def test_add_appserver_sdists_install(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
     )
 
     s1 = tmp_path / "d1" / "a-0.1.0.tar.gz"
@@ -178,6 +244,10 @@ def test_add_appserver_editable_install(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
     )
 
     _install_and_add_appserver_if_missing(Path("pkg"), tmp_path)
@@ -346,6 +416,10 @@ def test_add_appserver_target_version_installs_from_pypi(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
     )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
+    )
 
     _install_and_add_appserver_if_missing(
         Path("pkg"), tmp_path, target_version="0.4.15"
@@ -395,6 +469,10 @@ def test_add_appserver_target_version_ignored_in_editable_mode(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
     )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
+    )
 
     _install_and_add_appserver_if_missing(
         Path("pkg"), tmp_path, target_version="0.4.15"
@@ -432,6 +510,10 @@ def test_add_appserver_target_version_ignored_when_sdists_provided(
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
     )
 
     s1 = tmp_path / "d1" / "a-0.1.0.tar.gz"
@@ -533,7 +615,7 @@ def test_ensure_compatible_workflows_compatible_noop(
 
     monkeypatch.setattr("llama_agents.appserver.workflow_loader.run_uv", track_run_uv)
 
-    _ensure_compatible_workflows(tmp_path, Path("."), tmp_path / ".venv")
+    _ensure_compatible_workflows(tmp_path, Path("."))
     assert len(uv_calls) == 0
 
 
@@ -565,7 +647,7 @@ def test_ensure_compatible_workflows_incompatible_auto_updates(
 
     monkeypatch.setattr("llama_agents.appserver.workflow_loader.run_uv", track_run_uv)
 
-    _ensure_compatible_workflows(tmp_path, Path("."), tmp_path / ".venv")
+    _ensure_compatible_workflows(tmp_path, Path("."))
     assert len(uv_calls) == 1
     cmd, args = uv_calls[0]
     assert cmd == "add"
@@ -593,7 +675,7 @@ def test_ensure_compatible_workflows_not_installed_noop(
         lambda *a, **k: uv_calls.append(1),
     )
 
-    _ensure_compatible_workflows(tmp_path, Path("."), tmp_path / ".venv")
+    _ensure_compatible_workflows(tmp_path, Path("."))
     assert len(uv_calls) == 0
 
 
@@ -618,7 +700,7 @@ def test_ensure_compatible_workflows_update_fails_raises(
     monkeypatch.setattr("llama_agents.appserver.workflow_loader.run_uv", fail_run_uv)
 
     with pytest.raises(RuntimeError, match="conflicting constraints"):
-        _ensure_compatible_workflows(tmp_path, Path("."), tmp_path / ".venv")
+        _ensure_compatible_workflows(tmp_path, Path("."))
 
 
 def test_install_calls_ensure_compatible_workflows(
@@ -647,12 +729,16 @@ def test_install_calls_ensure_compatible_workflows(
 
     compat_called = {"called": False}
 
-    def mock_ensure_compat(source_root: Path, path: Path, venv_path: Path) -> None:
+    def mock_ensure_compat(source_root: Path, path: Path) -> None:
         compat_called["called"] = True
 
     monkeypatch.setattr(
         "llama_agents.appserver.workflow_loader._ensure_compatible_workflows",
         mock_ensure_compat,
+    )
+    monkeypatch.setattr(
+        "llama_agents.appserver.workflow_loader._resolve_project_venv",
+        lambda source_root, path: source_root / path / ".venv",
     )
 
     _install_and_add_appserver_if_missing(Path("pkg"), tmp_path)


### PR DESCRIPTION
The appserver install always used `<dir>/.venv`. `uv run` at start time uses whatever uv picks, which for a workspace-member template is `<workspace>/.venv` and `llama_agents.appserver` wasn't importable.

Fixed by instead asking uv where the venv is (`uv run python -c "import sys; print(sys.prefix)"`), then use that path for every `uv pip install --prefix`.

Also drops the editable-mode force-recreate of the venv (destructive when it's a shared workspace venv). `--reinstall-package` and `_same_python_version` should cover what the recreate was guarding.