### PR TITLE
fix(server): prevent zombie handler resume loop and collapse duplicate rows

### DIFF
--- a/.changeset/replay-ticks-stream.md
+++ b/.changeset/replay-ticks-stream.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": minor
+---
+
+Add replay_ticks_stream and ReplayResult to surface the last exit-indicating command from tick replay

--- a/.changeset/zombie-handler-resume.md
+++ b/.changeset/zombie-handler-resume.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-server": patch
+---
+
+fix(server): classify zombie handlers on resume and collapse duplicate handler rows on write

--- a/.changeset/zombie-handler-resume.md
+++ b/.changeset/zombie-handler-resume.md
@@ -2,4 +2,4 @@
 "llama-agents-server": patch
 ---
 
-fix(server): classify zombie handlers on resume and collapse duplicate handler rows on write
+Classify zombie handlers on resume and collapse duplicate handler rows on write.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ npx changeset              # Add a changeset
 npx changeset status       # Check pending changes
 ```
 
-Changeset descriptions should be a single line. Keep it short and simple.
+Changeset descriptions should be a single line in plain English. Keep it short and simple. Do not use conventional-commit prefixes (no `fix(scope):`, `feat(scope):`, etc.).
 
 ## Development Environment
 

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -260,9 +260,10 @@ class DBOSIdleReleaseDecorator(BaseRuntimeDecorator):
     ) -> BrokerState:
         """Rebuild BrokerState from persisted ticks."""
         init_state = BrokerState.from_workflow(workflow)
-        return await rebuild_state_from_ticks_stream(
+        replay = await rebuild_state_from_ticks_stream(
             init_state, stream_workflow_ticks(self._store, run_id)
         )
+        return replay.state
 
     async def _do_resume(
         self,

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -260,10 +260,9 @@ class DBOSIdleReleaseDecorator(BaseRuntimeDecorator):
     ) -> BrokerState:
         """Rebuild BrokerState from persisted ticks."""
         init_state = BrokerState.from_workflow(workflow)
-        replay = await rebuild_state_from_ticks_stream(
+        return await rebuild_state_from_ticks_stream(
             init_state, stream_workflow_ticks(self._store, run_id)
         )
-        return replay.state
 
     async def _do_resume(
         self,

--- a/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
+++ b/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
@@ -24,8 +24,11 @@ class FakeAgentDataBackend:
     """
 
     def __init__(self) -> None:
-        # (deployment_name, collection) → list[{id, deployment_name, collection, data}]
+        # (deployment_name, collection) → list[{id, deployment_name, collection, data, created_at}]
         self._items: dict[tuple[str, str], list[dict[str, Any]]] = {}
+        # Monotonic counter used to synthesize row-level created_at, matching
+        # how the real backend auto-assigns a created_at column per row.
+        self._create_counter: int = 0
 
     def _key(self, deployment_name: str, collection: str) -> tuple[str, str]:
         return (deployment_name, collection)
@@ -51,7 +54,12 @@ class FakeAgentDataBackend:
             parts = order_by.split()
             field = parts[0]
             reverse = len(parts) > 1 and parts[1].lower() == "desc"
-            matched.sort(key=lambda item: item["data"].get(field, 0), reverse=reverse)
+            # Row-level fields (e.g. created_at) live on the item itself, not
+            # in data. Fall back to data for user fields.
+            matched.sort(
+                key=lambda item: item.get(field, item["data"].get(field, 0)),
+                reverse=reverse,
+            )
 
         return matched[:page_size]
 
@@ -76,11 +84,13 @@ class FakeAgentDataBackend:
         self, deployment_name: str, collection: str, data: dict[str, Any]
     ) -> dict[str, Any]:
         items = self._get_items(deployment_name, collection)
+        self._create_counter += 1
         item = {
             "id": str(uuid.uuid4()),
             "deployment_name": deployment_name,
             "collection": collection,
             "data": data,
+            "created_at": self._create_counter,
         }
         items.append(item)
         return item

--- a/packages/llama-agents-server/pyproject.toml
+++ b/packages/llama-agents-server/pyproject.toml
@@ -24,7 +24,7 @@ description = "HTTP server for deploying and serving LlamaIndex workflows as web
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "llama-index-workflows>=2.19.1,<3.0.0",
+  "llama-index-workflows>=2.20.0,<3.0.0",
   "llama-agents-client>=0.2.0",
   "starlette>=0.39.0",
   "uvicorn>=0.32.0",

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/idle_release_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/idle_release_runtime.py
@@ -215,7 +215,8 @@ class IdleReleaseDecorator(BaseRuntimeDecorator):
         workflow = self._persistence.get_tracked_workflow(handler.workflow_name)
         if workflow is None:
             raise ValueError(f"Workflow {handler.workflow_name} not found")
-        context = await self._persistence.context_from_ticks(workflow, run_id)
+        replayed = await self._persistence.context_from_ticks(workflow, run_id)
+        context = replayed.context if replayed is not None else None
         workflow.run(ctx=context, run_id=run_id)
         self._active_run_ids.add(run_id)
         await self._store.update_handler_status(run_id, idle_since=None)

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -23,7 +23,7 @@ from workflows.context.context_types import SerializedContext
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.errors import WorkflowCancelledByUser
 from workflows.events import IdleReleasedEvent, StartEvent, StopEvent
-from workflows.runtime.control_loop import rebuild_state_from_ticks_stream
+from workflows.runtime.control_loop import replay_ticks_stream
 from workflows.runtime.runtime_decorators import (
     BaseInternalRunAdapterDecorator,
     BaseRuntimeDecorator,
@@ -230,7 +230,7 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
                 async for tick in tick_stream:
                     yield tick
 
-            replay = await rebuild_state_from_ticks_stream(init_state, _with_first())
+            replay = await replay_ticks_stream(init_state, _with_first())
             init_state = replay.state
             if replay.exit_command is not None:
                 terminal = _terminal_from_exit_command(replay.exit_command)

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -64,26 +64,19 @@ class ReplayedContext:
 
     Attributes:
         context: Rebuilt Context ready to be passed to ``workflow.run()``.
-        terminal: Resolved terminal info if the tick stream terminated, else
-            None. Derived from the reducer's own exit commands so it matches
-            runtime semantics exactly.
+        exit_command: The reducer-emitted terminal command if the tick stream
+            terminated, else None. Callers map this to handler status (see
+            :func:`handler_status_from_exit_command`).
     """
 
     context: Context
-    terminal: _TerminalInfo | None = None
+    exit_command: CommandCompleteRun | CommandFailWorkflow | CommandHalt | None = None
 
 
-@dataclass
-class _TerminalInfo:
-    status: Status
-    result: StopEvent | None = None
-    error: str | None = None
-
-
-def _terminal_from_exit_command(
+def handler_status_from_exit_command(
     command: CommandCompleteRun | CommandFailWorkflow | CommandHalt,
-) -> _TerminalInfo | None:
-    """Map a reducer exit command to handler-status terminal info.
+) -> tuple[Status, StopEvent | None, str | None] | None:
+    """Map a reducer exit command to (status, result, error).
 
     Returns None for CommandCompleteRun(IdleReleasedEvent) — idle release is
     not a real completion, just how the reducer signals the runner to exit.
@@ -91,13 +84,13 @@ def _terminal_from_exit_command(
     if isinstance(command, CommandCompleteRun):
         if isinstance(command.result, IdleReleasedEvent):
             return None
-        return _TerminalInfo(status="completed", result=command.result)
+        return ("completed", command.result, None)
     if isinstance(command, CommandFailWorkflow):
-        return _TerminalInfo(status="failed", error=str(command.exception))
+        return ("failed", None, str(command.exception))
     # CommandHalt: timeout or cancel (both reach this replay path)
     if isinstance(command.exception, WorkflowCancelledByUser):
-        return _TerminalInfo(status="cancelled")
-    return _TerminalInfo(status="failed", error=str(command.exception))
+        return ("cancelled", None, None)
+    return ("failed", None, str(command.exception))
 
 
 class _PersistenceInternalRunAdapter(BaseInternalRunAdapterDecorator):
@@ -199,9 +192,9 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
     ) -> ReplayedContext | None:
         """Rebuild a Context from persisted ticks (and legacy ctx if available).
 
-        Returns the Context plus any terminal info surfaced by the reducer
-        during replay. Callers use ``terminal`` to finalize handlers whose
-        tick stream already reached a terminal state.
+        Returns the Context plus the reducer's exit command if the tick
+        stream already terminated. Callers use ``exit_command`` to finalize
+        handlers instead of resuming them.
         """
         serializer = JsonSerializer()
         legacy_ctx = self._get_legacy_ctx(run_id)
@@ -222,7 +215,9 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         else:
             init_state = BrokerState.from_workflow(workflow)
 
-        terminal: _TerminalInfo | None = None
+        exit_command: CommandCompleteRun | CommandFailWorkflow | CommandHalt | None = (
+            None
+        )
         if first_tick is not None:
 
             async def _with_first() -> AsyncIterator[WorkflowTick]:
@@ -232,14 +227,13 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
 
             replay = await replay_ticks_stream(init_state, _with_first())
             init_state = replay.state
-            if replay.exit_command is not None:
-                terminal = _terminal_from_exit_command(replay.exit_command)
+            exit_command = replay.exit_command
 
         serialized = init_state.to_serialized(serializer)
         context = Context.from_dict(
             workflow=workflow, data=serialized.model_dump(), serializer=serializer
         )
-        return ReplayedContext(context=context, terminal=terminal)
+        return ReplayedContext(context=context, exit_command=exit_command)
 
     def _get_legacy_ctx(self, run_id: str) -> dict[str, Any] | None:
         legacy_store = as_legacy_context_store(self._store)
@@ -351,20 +345,25 @@ class PersistenceDecorator(TickPersistenceDecorator):
                     )
                     continue
 
-                if replayed.terminal is not None:
-                    info = replayed.terminal
+                finalize = (
+                    handler_status_from_exit_command(replayed.exit_command)
+                    if replayed.exit_command is not None
+                    else None
+                )
+                if finalize is not None:
+                    status, result, error = finalize
                     logger.warning(
                         "Replay for handler %s (workflow %s) terminated as %s; "
                         "finalizing without resume",
                         persistent.handler_id,
                         persistent.workflow_name,
-                        info.status,
+                        status,
                     )
                     await self._store.update_handler_status(
                         run_id,
-                        status=info.status,
-                        result=info.result,
-                        error=info.error,
+                        status=status,
+                        result=result,
+                        error=error,
                     )
                     continue
 

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -341,7 +341,7 @@ class PersistenceDecorator(TickPersistenceDecorator):
                     await self._store.update_handler_status(
                         run_id,
                         status="failed",
-                        error="no ticks to replay on resume — handler was never persisted past creation",
+                        error="handler crashed before persisting any state; cannot resume",
                     )
                     continue
 

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -14,14 +14,13 @@ import asyncio
 import logging
 import sqlite3
 from collections.abc import AsyncIterator, Coroutine
-from datetime import datetime, timezone
 from typing import Any
 
 from typing_extensions import override
 from workflows import Context
 from workflows.context.context_types import SerializedContext
 from workflows.context.serializers import BaseSerializer, JsonSerializer
-from workflows.events import StartEvent
+from workflows.events import StartEvent, StopEvent
 from workflows.runtime.control_loop import rebuild_state_from_ticks_stream
 from workflows.runtime.runtime_decorators import (
     BaseInternalRunAdapterDecorator,
@@ -33,8 +32,11 @@ from workflows.runtime.types.plugin import (
     InternalRunAdapter,
     Runtime,
 )
+from workflows.runtime.types.results import StepWorkerFailed, StepWorkerResult
 from workflows.runtime.types.ticks import (
+    TickCancelRun,
     TickStepResult,
+    TickTimeout,
     WorkflowTick,
     WorkflowTickAdapter,
 )
@@ -43,7 +45,7 @@ from workflows.workflow import Workflow
 from .._store.abstract_workflow_store import (
     AbstractWorkflowStore,
     HandlerQuery,
-    PersistentHandler,
+    Status,
     as_legacy_context_store,
     stream_workflow_ticks,
 )
@@ -276,29 +278,91 @@ class PersistenceDecorator(TickPersistenceDecorator):
                 continue
             try:
                 context = await self.context_from_ticks(workflow, run_id)
+
+                if context is None:
+                    # No ticks and no legacy ctx: the handler crashed before
+                    # any state landed. A fresh-start attempt would try to
+                    # build a StartEvent from empty kwargs and loop forever.
+                    logger.warning(
+                        "No replayable state for handler %s (workflow %s); "
+                        "marking as failed",
+                        persistent.handler_id,
+                        persistent.workflow_name,
+                    )
+                    await self._store.update_handler_status(
+                        run_id,
+                        status="failed",
+                        error="no ticks to replay on resume — handler was never persisted past creation",
+                    )
+                    continue
+
+                if not context.is_running:
+                    # Replay ended in a terminal transition. Classify from the
+                    # tick stream and finalize the handler.
+                    (
+                        status,
+                        result,
+                        error,
+                    ) = await self._classify_terminal_from_ticks(run_id)
+                    logger.warning(
+                        "Replay for handler %s (workflow %s) terminated as %s; "
+                        "finalizing without resume",
+                        persistent.handler_id,
+                        persistent.workflow_name,
+                        status,
+                    )
+                    await self._store.update_handler_status(
+                        run_id, status=status, result=result, error=error
+                    )
+                    continue
+
                 workflow.run(ctx=context, run_id=run_id)
             except Exception as e:
                 logger.error(
                     f"Failed to resume handler {persistent.handler_id} for workflow {persistent.workflow_name}: {e}"
                 )
                 try:
-                    now = datetime.now(timezone.utc)
-                    await self._store.update(
-                        PersistentHandler(
-                            handler_id=persistent.handler_id,
-                            workflow_name=persistent.workflow_name,
-                            status="failed",
-                            run_id=persistent.run_id,
-                            error=str(e),
-                            result=None,
-                            started_at=persistent.started_at,
-                            updated_at=now,
-                            completed_at=now,
-                        )
+                    await self._store.update_handler_status(
+                        run_id, status="failed", error=str(e)
                     )
                 except Exception:
                     pass
                 continue
+
+    async def _classify_terminal_from_ticks(
+        self, run_id: str
+    ) -> tuple[Status, StopEvent | None, str | None]:
+        """Walk ticks to extract the most recent terminal transition.
+
+        Returns (status, result, error). The last terminal-looking tick wins;
+        retries produce earlier StepWorkerFailed entries that are superseded
+        by later successful results.
+        """
+        status: Status = "failed"
+        result: StopEvent | None = None
+        error: str | None = "workflow terminated without a recognizable terminal event"
+        async for tick in stream_workflow_ticks(self._store, run_id):
+            if isinstance(tick, TickStepResult):
+                for step_result in tick.result:
+                    if isinstance(step_result, StepWorkerResult) and isinstance(
+                        step_result.result, StopEvent
+                    ):
+                        status = "completed"
+                        result = step_result.result
+                        error = None
+                    elif isinstance(step_result, StepWorkerFailed):
+                        status = "failed"
+                        result = None
+                        error = str(step_result.exception)
+            elif isinstance(tick, TickTimeout):
+                status = "failed"
+                result = None
+                error = f"Workflow timed out after {tick.timeout}s"
+            elif isinstance(tick, TickCancelRun):
+                status = "cancelled"
+                result = None
+                error = None
+        return status, result, error
 
     @override
     async def destroy(self) -> None:

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -15,17 +15,23 @@ import logging
 import sqlite3
 from collections.abc import AsyncIterator, Coroutine
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 from typing_extensions import override
 from workflows import Context
 from workflows.context.context_types import SerializedContext
 from workflows.context.serializers import BaseSerializer, JsonSerializer
-from workflows.events import StartEvent, StopEvent
+from workflows.errors import WorkflowCancelledByUser
+from workflows.events import IdleReleasedEvent, StartEvent, StopEvent
 from workflows.runtime.control_loop import rebuild_state_from_ticks_stream
 from workflows.runtime.runtime_decorators import (
     BaseInternalRunAdapterDecorator,
     BaseRuntimeDecorator,
+)
+from workflows.runtime.types.commands import (
+    CommandCompleteRun,
+    CommandFailWorkflow,
+    CommandHalt,
 )
 from workflows.runtime.types.internal_state import BrokerState
 from workflows.runtime.types.plugin import (
@@ -33,11 +39,8 @@ from workflows.runtime.types.plugin import (
     InternalRunAdapter,
     Runtime,
 )
-from workflows.runtime.types.results import StepWorkerFailed, StepWorkerResult
 from workflows.runtime.types.ticks import (
-    TickCancelRun,
     TickStepResult,
-    TickTimeout,
     WorkflowTick,
     WorkflowTickAdapter,
 )
@@ -56,35 +59,45 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass
+class ReplayedContext:
+    """Result of replaying persisted ticks into a Context.
+
+    Attributes:
+        context: Rebuilt Context ready to be passed to ``workflow.run()``.
+        terminal: Resolved terminal info if the tick stream terminated, else
+            None. Derived from the reducer's own exit commands so it matches
+            runtime semantics exactly.
+    """
+
+    context: Context
+    terminal: _TerminalInfo | None = None
+
+
+@dataclass
 class _TerminalInfo:
     status: Status
     result: StopEvent | None = None
     error: str | None = None
 
 
-def _classify_tick(
-    tick: WorkflowTick, current: _TerminalInfo | None
+def _terminal_from_exit_command(
+    command: CommandCompleteRun | CommandFailWorkflow | CommandHalt,
 ) -> _TerminalInfo | None:
-    """Return updated terminal info if *tick* is a terminal transition.
+    """Map a reducer exit command to handler-status terminal info.
 
-    The last terminal-looking tick wins; retries produce earlier
-    StepWorkerFailed entries that are superseded by later successful results.
+    Returns None for CommandCompleteRun(IdleReleasedEvent) — idle release is
+    not a real completion, just how the reducer signals the runner to exit.
     """
-    if isinstance(tick, TickStepResult):
-        for step_result in tick.result:
-            if isinstance(step_result, StepWorkerResult) and isinstance(
-                step_result.result, StopEvent
-            ):
-                return _TerminalInfo(status="completed", result=step_result.result)
-            if isinstance(step_result, StepWorkerFailed):
-                return _TerminalInfo(status="failed", error=str(step_result.exception))
-    elif isinstance(tick, TickTimeout):
-        return _TerminalInfo(
-            status="failed", error=f"Workflow timed out after {tick.timeout}s"
-        )
-    elif isinstance(tick, TickCancelRun):
+    if isinstance(command, CommandCompleteRun):
+        if isinstance(command.result, IdleReleasedEvent):
+            return None
+        return _TerminalInfo(status="completed", result=command.result)
+    if isinstance(command, CommandFailWorkflow):
+        return _TerminalInfo(status="failed", error=str(command.exception))
+    # CommandHalt: timeout or cancel (both reach this replay path)
+    if isinstance(command.exception, WorkflowCancelledByUser):
         return _TerminalInfo(status="cancelled")
-    return current
+    return _TerminalInfo(status="failed", error=str(command.exception))
 
 
 class _PersistenceInternalRunAdapter(BaseInternalRunAdapterDecorator):
@@ -182,17 +195,13 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         return self._workflows_by_name.get(name)
 
     async def context_from_ticks(
-        self,
-        workflow: Workflow,
-        run_id: str,
-        *,
-        on_tick: Callable[[WorkflowTick], None] | None = None,
-    ) -> Context | None:
+        self, workflow: Workflow, run_id: str
+    ) -> ReplayedContext | None:
         """Rebuild a Context from persisted ticks (and legacy ctx if available).
 
-        If *on_tick* is provided, it is called once per tick as the stream is
-        consumed — lets callers classify terminal transitions in the same
-        pass that rebuilds state.
+        Returns the Context plus any terminal info surfaced by the reducer
+        during replay. Callers use ``terminal`` to finalize handlers whose
+        tick stream already reached a terminal state.
         """
         serializer = JsonSerializer()
         legacy_ctx = self._get_legacy_ctx(run_id)
@@ -213,25 +222,24 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         else:
             init_state = BrokerState.from_workflow(workflow)
 
+        terminal: _TerminalInfo | None = None
         if first_tick is not None:
 
             async def _with_first() -> AsyncIterator[WorkflowTick]:
-                if on_tick is not None:
-                    on_tick(first_tick)
                 yield first_tick
                 async for tick in tick_stream:
-                    if on_tick is not None:
-                        on_tick(tick)
                     yield tick
 
-            init_state = await rebuild_state_from_ticks_stream(
-                init_state, _with_first()
-            )
+            replay = await rebuild_state_from_ticks_stream(init_state, _with_first())
+            init_state = replay.state
+            if replay.exit_command is not None:
+                terminal = _terminal_from_exit_command(replay.exit_command)
 
         serialized = init_state.to_serialized(serializer)
-        return Context.from_dict(
+        context = Context.from_dict(
             workflow=workflow, data=serialized.model_dump(), serializer=serializer
         )
+        return ReplayedContext(context=context, terminal=terminal)
 
     def _get_legacy_ctx(self, run_id: str) -> dict[str, Any] | None:
         legacy_store = as_legacy_context_store(self._store)
@@ -323,17 +331,9 @@ class PersistenceDecorator(TickPersistenceDecorator):
             if run_id in self._active_run_ids:
                 continue
             try:
-                terminal: _TerminalInfo | None = None
+                replayed = await self.context_from_ticks(workflow, run_id)
 
-                def _observe(tick: WorkflowTick) -> None:
-                    nonlocal terminal
-                    terminal = _classify_tick(tick, terminal)
-
-                context = await self.context_from_ticks(
-                    workflow, run_id, on_tick=_observe
-                )
-
-                if context is None:
+                if replayed is None:
                     # A fresh-start attempt here would build a StartEvent from
                     # empty kwargs and loop on every boot for workflows with
                     # required fields. Mark failed so the handler stops being
@@ -351,11 +351,8 @@ class PersistenceDecorator(TickPersistenceDecorator):
                     )
                     continue
 
-                if not context.is_running:
-                    info = terminal or _TerminalInfo(
-                        status="failed",
-                        error="workflow terminated without a recognizable terminal event",
-                    )
+                if replayed.terminal is not None:
+                    info = replayed.terminal
                     logger.warning(
                         "Replay for handler %s (workflow %s) terminated as %s; "
                         "finalizing without resume",
@@ -371,7 +368,7 @@ class PersistenceDecorator(TickPersistenceDecorator):
                     )
                     continue
 
-                workflow.run(ctx=context, run_id=run_id)
+                workflow.run(ctx=replayed.context, run_id=run_id)
             except Exception as e:
                 logger.error(
                     f"Failed to resume handler {persistent.handler_id} for workflow {persistent.workflow_name}: {e}"

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -14,7 +14,8 @@ import asyncio
 import logging
 import sqlite3
 from collections.abc import AsyncIterator, Coroutine
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Callable
 
 from typing_extensions import override
 from workflows import Context
@@ -52,6 +53,38 @@ from .._store.abstract_workflow_store import (
 from .._store.sqlite.sqlite_state_store import SqliteStateStore
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _TerminalInfo:
+    status: Status
+    result: StopEvent | None = None
+    error: str | None = None
+
+
+def _classify_tick(
+    tick: WorkflowTick, current: _TerminalInfo | None
+) -> _TerminalInfo | None:
+    """Return updated terminal info if *tick* is a terminal transition.
+
+    The last terminal-looking tick wins; retries produce earlier
+    StepWorkerFailed entries that are superseded by later successful results.
+    """
+    if isinstance(tick, TickStepResult):
+        for step_result in tick.result:
+            if isinstance(step_result, StepWorkerResult) and isinstance(
+                step_result.result, StopEvent
+            ):
+                return _TerminalInfo(status="completed", result=step_result.result)
+            if isinstance(step_result, StepWorkerFailed):
+                return _TerminalInfo(status="failed", error=str(step_result.exception))
+    elif isinstance(tick, TickTimeout):
+        return _TerminalInfo(
+            status="failed", error=f"Workflow timed out after {tick.timeout}s"
+        )
+    elif isinstance(tick, TickCancelRun):
+        return _TerminalInfo(status="cancelled")
+    return current
 
 
 class _PersistenceInternalRunAdapter(BaseInternalRunAdapterDecorator):
@@ -149,9 +182,18 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         return self._workflows_by_name.get(name)
 
     async def context_from_ticks(
-        self, workflow: Workflow, run_id: str
+        self,
+        workflow: Workflow,
+        run_id: str,
+        *,
+        on_tick: Callable[[WorkflowTick], None] | None = None,
     ) -> Context | None:
-        """Rebuild a Context from persisted ticks (and legacy ctx if available)."""
+        """Rebuild a Context from persisted ticks (and legacy ctx if available).
+
+        If *on_tick* is provided, it is called once per tick as the stream is
+        consumed — lets callers classify terminal transitions in the same
+        pass that rebuilds state.
+        """
         serializer = JsonSerializer()
         legacy_ctx = self._get_legacy_ctx(run_id)
 
@@ -174,8 +216,12 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         if first_tick is not None:
 
             async def _with_first() -> AsyncIterator[WorkflowTick]:
+                if on_tick is not None:
+                    on_tick(first_tick)
                 yield first_tick
                 async for tick in tick_stream:
+                    if on_tick is not None:
+                        on_tick(tick)
                     yield tick
 
             init_state = await rebuild_state_from_ticks_stream(
@@ -277,12 +323,21 @@ class PersistenceDecorator(TickPersistenceDecorator):
             if run_id in self._active_run_ids:
                 continue
             try:
-                context = await self.context_from_ticks(workflow, run_id)
+                terminal: _TerminalInfo | None = None
+
+                def _observe(tick: WorkflowTick) -> None:
+                    nonlocal terminal
+                    terminal = _classify_tick(tick, terminal)
+
+                context = await self.context_from_ticks(
+                    workflow, run_id, on_tick=_observe
+                )
 
                 if context is None:
-                    # No ticks and no legacy ctx: the handler crashed before
-                    # any state landed. A fresh-start attempt would try to
-                    # build a StartEvent from empty kwargs and loop forever.
+                    # A fresh-start attempt here would build a StartEvent from
+                    # empty kwargs and loop on every boot for workflows with
+                    # required fields. Mark failed so the handler stops being
+                    # picked up by the next resume query.
                     logger.warning(
                         "No replayable state for handler %s (workflow %s); "
                         "marking as failed",
@@ -297,22 +352,22 @@ class PersistenceDecorator(TickPersistenceDecorator):
                     continue
 
                 if not context.is_running:
-                    # Replay ended in a terminal transition. Classify from the
-                    # tick stream and finalize the handler.
-                    (
-                        status,
-                        result,
-                        error,
-                    ) = await self._classify_terminal_from_ticks(run_id)
+                    info = terminal or _TerminalInfo(
+                        status="failed",
+                        error="workflow terminated without a recognizable terminal event",
+                    )
                     logger.warning(
                         "Replay for handler %s (workflow %s) terminated as %s; "
                         "finalizing without resume",
                         persistent.handler_id,
                         persistent.workflow_name,
-                        status,
+                        info.status,
                     )
                     await self._store.update_handler_status(
-                        run_id, status=status, result=result, error=error
+                        run_id,
+                        status=info.status,
+                        result=info.result,
+                        error=info.error,
                     )
                     continue
 
@@ -326,43 +381,11 @@ class PersistenceDecorator(TickPersistenceDecorator):
                         run_id, status="failed", error=str(e)
                     )
                 except Exception:
-                    pass
+                    logger.exception(
+                        "Failed to mark resume-failed handler %s as failed",
+                        persistent.handler_id,
+                    )
                 continue
-
-    async def _classify_terminal_from_ticks(
-        self, run_id: str
-    ) -> tuple[Status, StopEvent | None, str | None]:
-        """Walk ticks to extract the most recent terminal transition.
-
-        Returns (status, result, error). The last terminal-looking tick wins;
-        retries produce earlier StepWorkerFailed entries that are superseded
-        by later successful results.
-        """
-        status: Status = "failed"
-        result: StopEvent | None = None
-        error: str | None = "workflow terminated without a recognizable terminal event"
-        async for tick in stream_workflow_ticks(self._store, run_id):
-            if isinstance(tick, TickStepResult):
-                for step_result in tick.result:
-                    if isinstance(step_result, StepWorkerResult) and isinstance(
-                        step_result.result, StopEvent
-                    ):
-                        status = "completed"
-                        result = step_result.result
-                        error = None
-                    elif isinstance(step_result, StepWorkerFailed):
-                        status = "failed"
-                        result = None
-                        error = str(step_result.exception)
-            elif isinstance(tick, TickTimeout):
-                status = "failed"
-                result = None
-                error = f"Workflow timed out after {tick.timeout}s"
-            elif isinstance(tick, TickCancelRun):
-                status = "cancelled"
-                result = None
-                error = None
-        return status, result, error
 
     @override
     async def destroy(self) -> None:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -277,25 +277,11 @@ class AgentDataStore(AbstractWorkflowStore):
                 await self._client.update_item(item_id, data)
                 return
 
-            # Duplicate handler rows — converge to one survivor.
-            # Only dedupe when every sibling shares the handler's run_id;
-            # mismatching run_ids are a different class of duplicate (client
-            # retry with a reused handler_id) that we must not collapse.
-            run_id = handler.run_id
-            sibling_run_ids = {item["data"].get("run_id") for item in items}
-            if run_id is None or sibling_run_ids != {run_id}:
-                logger.warning(
-                    "Duplicate rows for handler %s have mismatched run_ids %s; "
-                    "falling back to newest-wins without dedupe",
-                    handler_id,
-                    sibling_run_ids,
-                )
-                item_id = items[0]["id"]
-                self._id_cache.put(handler_id, item_id)
-                await self._client.update_item(item_id, data)
-                return
-
-            # Oldest survivor preserves the row created at handler submission.
+            # Duplicate handler rows — converge to one survivor. The
+            # invariant is one row per handler_id; run_id is a mutable field
+            # on the row, so mismatched run_ids just mean an earlier run was
+            # superseded. Collapse regardless. Oldest survivor preserves the
+            # row's original created_at.
             survivor_id = items[-1]["id"]
             victim_ids = [item["id"] for item in items[:-1]]
             logger.warning(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -258,10 +258,13 @@ class AgentDataStore(AbstractWorkflowStore):
                 await self._client.update_item(cached_id, data)
                 return
 
-            # Search for existing item
+            # Search for existing item. Sort newest-first so that items[-1]
+            # is deterministically the oldest row — relied on by the
+            # dedupe-survivor choice below.
             items = await self._client.search(
                 self._collection,
                 {"handler_id": {"eq": handler_id}},
+                order_by="created_at desc",
             )
             if not items:
                 result = await self._client.create(self._collection, data)
@@ -293,7 +296,6 @@ class AgentDataStore(AbstractWorkflowStore):
                 return
 
             # Oldest survivor preserves the row created at handler submission.
-            # Default search order is created_at DESC, so items[-1] is oldest.
             survivor_id = items[-1]["id"]
             victim_ids = [item["id"] for item in items[:-1]]
             logger.warning(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -290,7 +290,22 @@ class AgentDataStore(AbstractWorkflowStore):
                 handler_id,
                 survivor_id,
             )
-            await asyncio.gather(*(self._client.delete_item(vid) for vid in victim_ids))
+            # Tolerate partial delete failures. The next update() will see
+            # whatever duplicates remain and retry; letting one failed delete
+            # abort the whole operation would also skip the survivor write,
+            # leaving the row stale.
+            results = await asyncio.gather(
+                *(self._client.delete_item(vid) for vid in victim_ids),
+                return_exceptions=True,
+            )
+            for vid, outcome in zip(victim_ids, results):
+                if isinstance(outcome, BaseException):
+                    logger.warning(
+                        "Failed to delete duplicate handler row %s for %s: %s",
+                        vid,
+                        handler_id,
+                        outcome,
+                    )
             self._id_cache.put(handler_id, survivor_id)
             await self._client.update_item(survivor_id, data)
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -263,13 +263,48 @@ class AgentDataStore(AbstractWorkflowStore):
                 self._collection,
                 {"handler_id": {"eq": handler_id}},
             )
-            if items:
+            if not items:
+                result = await self._client.create(self._collection, data)
+                self._id_cache.put(handler_id, result["id"])
+                return
+
+            if len(items) == 1:
                 item_id = items[0]["id"]
                 self._id_cache.put(handler_id, item_id)
                 await self._client.update_item(item_id, data)
-            else:
-                result = await self._client.create(self._collection, data)
-                self._id_cache.put(handler_id, result["id"])
+                return
+
+            # Duplicate handler rows — converge to one survivor.
+            # Only dedupe when every sibling shares the handler's run_id;
+            # mismatching run_ids are a different class of duplicate (client
+            # retry with a reused handler_id) that we must not collapse.
+            run_id = handler.run_id
+            sibling_run_ids = {item["data"].get("run_id") for item in items}
+            if run_id is None or sibling_run_ids != {run_id}:
+                logger.warning(
+                    "Duplicate rows for handler %s have mismatched run_ids %s; "
+                    "falling back to newest-wins without dedupe",
+                    handler_id,
+                    sibling_run_ids,
+                )
+                item_id = items[0]["id"]
+                self._id_cache.put(handler_id, item_id)
+                await self._client.update_item(item_id, data)
+                return
+
+            # Oldest survivor preserves the row created at handler submission.
+            # Default search order is created_at DESC, so items[-1] is oldest.
+            survivor_id = items[-1]["id"]
+            victim_ids = [item["id"] for item in items[:-1]]
+            logger.warning(
+                "Collapsing %d duplicate rows for handler %s; survivor=%s",
+                len(items),
+                handler_id,
+                survivor_id,
+            )
+            await asyncio.gather(*(self._client.delete_item(vid) for vid in victim_ids))
+            self._id_cache.put(handler_id, survivor_id)
+            await self._client.update_item(survivor_id, data)
 
     async def delete(self, query: HandlerQuery) -> int:
         filters = self._build_handler_filters(query)

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -215,24 +215,22 @@ async def test_update_collapses_duplicates_with_matching_run_id(
 
 
 @pytest.mark.asyncio
-async def test_update_preserves_duplicates_with_mismatched_run_id(
-    store: AgentDataStore,
-    backend: FakeAgentDataBackend,
-    caplog: pytest.LogCaptureFixture,
+async def test_update_collapses_duplicates_with_mismatched_run_id(
+    store: AgentDataStore, backend: FakeAgentDataBackend
 ) -> None:
-    """Rows for the same handler_id but different run_ids must not be collapsed."""
+    """Duplicates collapse regardless of run_id — one row per handler_id."""
     _seed_raw_handler(backend, handler_id="dup-2", run_id="run-a", status="running")
     _seed_raw_handler(backend, handler_id="dup-2", run_id="run-b", status="running")
 
-    with caplog.at_level("WARNING"):
-        await store.update(
-            make_handler(handler_id="dup-2", run_id="run-b", status="completed")
-        )
+    await store.update(
+        make_handler(handler_id="dup-2", run_id="run-b", status="completed")
+    )
 
     rows = backend._get_items("test-deploy", "handlers")
     handler_rows = [r for r in rows if r["data"].get("handler_id") == "dup-2"]
-    assert len(handler_rows) == 2
-    assert any("mismatched run_ids" in rec.message for rec in caplog.records)
+    assert len(handler_rows) == 1
+    assert handler_rows[0]["data"]["run_id"] == "run-b"
+    assert handler_rows[0]["data"]["status"] == "completed"
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -176,6 +176,65 @@ async def test_delete_invalidates_cache(store: AgentDataStore) -> None:
     assert store._id_cache.get("h1") is None
 
 
+def _seed_raw_handler(
+    backend: FakeAgentDataBackend,
+    *,
+    handler_id: str,
+    run_id: str | None,
+    status: Status = "running",
+    workflow_name: str = "wf",
+) -> str:
+    """Insert a raw handler row into the fake backend, bypassing update()."""
+    handler = PersistentHandler(
+        handler_id=handler_id,
+        workflow_name=workflow_name,
+        status=status,
+        run_id=run_id,
+    )
+    item = backend.create("test-deploy", "handlers", handler.model_dump(mode="json"))
+    return item["id"]
+
+
+@pytest.mark.asyncio
+async def test_update_collapses_duplicates_with_matching_run_id(
+    store: AgentDataStore, backend: FakeAgentDataBackend
+) -> None:
+    """Duplicate rows for the same handler_id/run_id collapse to one row."""
+    # Seed two rows for the same handler with identical run_id
+    _seed_raw_handler(backend, handler_id="dup-1", run_id="run-dup", status="running")
+    _seed_raw_handler(backend, handler_id="dup-1", run_id="run-dup", status="failed")
+
+    await store.update(
+        make_handler(handler_id="dup-1", run_id="run-dup", status="completed")
+    )
+
+    rows = backend._get_items("test-deploy", "handlers")
+    handler_rows = [r for r in rows if r["data"].get("handler_id") == "dup-1"]
+    assert len(handler_rows) == 1
+    assert handler_rows[0]["data"]["status"] == "completed"
+
+
+@pytest.mark.asyncio
+async def test_update_preserves_duplicates_with_mismatched_run_id(
+    store: AgentDataStore,
+    backend: FakeAgentDataBackend,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Rows for the same handler_id but different run_ids must not be collapsed."""
+    _seed_raw_handler(backend, handler_id="dup-2", run_id="run-a", status="running")
+    _seed_raw_handler(backend, handler_id="dup-2", run_id="run-b", status="running")
+
+    with caplog.at_level("WARNING"):
+        await store.update(
+            make_handler(handler_id="dup-2", run_id="run-b", status="completed")
+        )
+
+    rows = backend._get_items("test-deploy", "handlers")
+    handler_rows = [r for r in rows if r["data"].get("handler_id") == "dup-2"]
+    assert len(handler_rows) == 2
+    assert any("mismatched run_ids" in rec.message for rec in caplog.records)
+
+
 @pytest.mark.asyncio
 async def test_query_multiple_run_ids(store: AgentDataStore) -> None:
     await store.update(make_handler(handler_id="h1", run_id="run-1"))

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -199,9 +199,15 @@ def _seed_raw_handler(
 async def test_update_collapses_duplicates_with_matching_run_id(
     store: AgentDataStore, backend: FakeAgentDataBackend
 ) -> None:
-    """Duplicate rows for the same handler_id/run_id collapse to one row."""
-    # Seed two rows for the same handler with identical run_id
-    _seed_raw_handler(backend, handler_id="dup-1", run_id="run-dup", status="running")
+    """Duplicate rows for the same handler_id/run_id collapse to one row.
+
+    The survivor is the oldest row, so its created_at is preserved.
+    """
+    # Seed two rows for the same handler with identical run_id. The first
+    # insert gets the smaller row-level created_at and should be the survivor.
+    oldest_id = _seed_raw_handler(
+        backend, handler_id="dup-1", run_id="run-dup", status="running"
+    )
     _seed_raw_handler(backend, handler_id="dup-1", run_id="run-dup", status="failed")
 
     await store.update(
@@ -211,6 +217,7 @@ async def test_update_collapses_duplicates_with_matching_run_id(
     rows = backend._get_items("test-deploy", "handlers")
     handler_rows = [r for r in rows if r["data"].get("handler_id") == "dup-1"]
     assert len(handler_rows) == 1
+    assert handler_rows[0]["id"] == oldest_id
     assert handler_rows[0]["data"]["status"] == "completed"
 
 
@@ -218,8 +225,14 @@ async def test_update_collapses_duplicates_with_matching_run_id(
 async def test_update_collapses_duplicates_with_mismatched_run_id(
     store: AgentDataStore, backend: FakeAgentDataBackend
 ) -> None:
-    """Duplicates collapse regardless of run_id — one row per handler_id."""
-    _seed_raw_handler(backend, handler_id="dup-2", run_id="run-a", status="running")
+    """Duplicates collapse regardless of run_id — one row per handler_id.
+
+    The survivor is the oldest row; the latest write's run_id and status are
+    what ends up persisted on it.
+    """
+    oldest_id = _seed_raw_handler(
+        backend, handler_id="dup-2", run_id="run-a", status="running"
+    )
     _seed_raw_handler(backend, handler_id="dup-2", run_id="run-b", status="running")
 
     await store.update(
@@ -229,6 +242,7 @@ async def test_update_collapses_duplicates_with_mismatched_run_id(
     rows = backend._get_items("test-deploy", "handlers")
     handler_rows = [r for r in rows if r["data"].get("handler_id") == "dup-2"]
     assert len(handler_rows) == 1
+    assert handler_rows[0]["id"] == oldest_id
     assert handler_rows[0]["data"]["run_id"] == "run-b"
     assert handler_rows[0]["data"]["status"] == "completed"
 

--- a/packages/llama-agents-server/tests/server/test_durable_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_durable_runtime.py
@@ -250,7 +250,7 @@ async def test_on_server_start_marks_no_ticks_handler_as_failed(
     async with server.contextmanager():
         handler = await wait_handler_status(memory_store, handler_id, "failed")
         assert handler.error is not None
-        assert "no ticks" in handler.error
+        assert "crashed before persisting any state" in handler.error
 
 
 @pytest.mark.asyncio
@@ -695,7 +695,7 @@ async def test_no_legacy_ctx_no_ticks_marked_failed(
     async with server.contextmanager():
         handler = await wait_handler_status(sqlite_store, "fresh-1", "failed")
         assert handler.error is not None
-        assert "no ticks" in handler.error
+        assert "crashed before persisting any state" in handler.error
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-server/tests/server/test_durable_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_durable_runtime.py
@@ -223,33 +223,16 @@ class FailingResumeWorkflow(Workflow):
 
 
 @pytest.mark.asyncio
-async def test_on_server_start_resumes_running_handlers(
+async def test_on_server_start_marks_no_ticks_handler_as_failed(
     memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
 ) -> None:
-    """Seed store with a running handler; after server start it should complete."""
-    handler_id = "resume-1"
-    run_id = "run-resume-1"
-    await memory_store.update(
-        PersistentHandler(
-            handler_id=handler_id,
-            workflow_name="test",
-            status="running",
-            run_id=run_id,
-        )
-    )
+    """A handler with no persisted ticks cannot safely fresh-start.
 
-    server = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
-    server.add_workflow("test", simple_test_workflow)
-
-    async with server.contextmanager():
-        await wait_handler_status(memory_store, handler_id, "completed")
-
-
-@pytest.mark.asyncio
-async def test_on_server_start_resumes_handler_with_no_ticks_as_fresh(
-    memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
-) -> None:
-    """A handler with no persisted ticks should run fresh from StartEvent."""
+    Such a row represents a zombie: the handler crashed before its first
+    tick landed. Attempting a fresh run builds a StartEvent from empty
+    kwargs, which fails for any workflow with required fields. Mark the
+    handler as failed so it is not retried on every boot.
+    """
     handler_id = "no-ticks-1"
     run_id = "run-no-ticks-1"
     await memory_store.update(
@@ -265,14 +248,89 @@ async def test_on_server_start_resumes_handler_with_no_ticks_as_fresh(
     server.add_workflow("test", simple_test_workflow)
 
     async with server.contextmanager():
+        handler = await wait_handler_status(memory_store, handler_id, "failed")
+        assert handler.error is not None
+        assert "no ticks" in handler.error
+
+
+@pytest.mark.asyncio
+async def test_on_server_start_finalizes_terminal_replay_as_completed(
+    memory_store: MemoryWorkflowStore,
+) -> None:
+    """A handler whose ticks replay to a terminal StopEvent is marked completed."""
+    from server_test_fixtures import SimpleTestWorkflow  # type: ignore[import]
+
+    handler_id = "terminal-replay-1"
+
+    # Phase 1: run the workflow to completion so ticks are persisted.
+    server1 = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    server1.add_workflow("test", SimpleTestWorkflow())
+    async with server1.contextmanager():
+        wf1 = server1._service._runtime.get_workflow("test")
+        assert wf1 is not None
+        await server1._service.start_workflow(wf1, handler_id)
         await wait_handler_status(memory_store, handler_id, "completed")
+
+    # Phase 2: force the handler back to 'running' so the resume loop picks it
+    # up on next boot — simulates the zombie-row scenario where ticks reached a
+    # terminal state but the handler row was never updated.
+    found = await memory_store.query(HandlerQuery(handler_id_in=[handler_id]))
+    zombie = found[0]
+    zombie.status = "running"
+    zombie.result = None
+    zombie.completed_at = None
+    await memory_store.update(zombie)
+
+    server2 = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    server2.add_workflow("test", SimpleTestWorkflow())
+    async with server2.contextmanager():
+        handler = await wait_handler_status(memory_store, handler_id, "completed")
+        assert handler.result is not None
+        assert handler.result.result == "processed: default"
+
+
+@pytest.mark.asyncio
+async def test_on_server_start_finalizes_terminal_replay_as_failed(
+    memory_store: MemoryWorkflowStore,
+) -> None:
+    """A handler whose ticks replay to a terminal failure is marked failed."""
+    from server_test_fixtures import ErrorWorkflow  # type: ignore[import]
+
+    handler_id = "terminal-replay-fail-1"
+
+    server1 = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    server1.add_workflow("failing", ErrorWorkflow())
+    async with server1.contextmanager():
+        wf1 = server1._service._runtime.get_workflow("failing")
+        assert wf1 is not None
+        await server1._service.start_workflow(wf1, handler_id)
+        await wait_handler_status(memory_store, handler_id, "failed")
+
+    # Force back to running to simulate the zombie state.
+    found = await memory_store.query(HandlerQuery(handler_id_in=[handler_id]))
+    zombie = found[0]
+    zombie.status = "running"
+    zombie.error = None
+    zombie.completed_at = None
+    await memory_store.update(zombie)
+
+    server2 = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    server2.add_workflow("failing", ErrorWorkflow())
+    async with server2.contextmanager():
+        handler = await wait_handler_status(memory_store, handler_id, "failed")
+        assert handler.error is not None
 
 
 @pytest.mark.asyncio
 async def test_on_server_start_ignores_unregistered_workflows(
     memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
 ) -> None:
-    """Only handlers for registered workflows should be resumed."""
+    """Only handlers for registered workflows should be touched by resume.
+
+    Both handlers have no ticks. The known-workflow handler gets classified
+    and marked failed by the resume loop; the unknown-workflow handler is
+    skipped entirely and stays untouched.
+    """
 
     # Seed handlers for both registered and unregistered workflow
     await memory_store.update(
@@ -298,11 +356,15 @@ async def test_on_server_start_ignores_unregistered_workflows(
     async with server.contextmanager():
         idle_release = _get_idle_release(server)
 
-        # Known handler should resume and complete
-        await wait_handler_status(memory_store, "known-1", "completed")
+        # Known handler is classified and marked failed (no ticks → zombie)
+        await wait_handler_status(memory_store, "known-1", "failed")
 
         # Unknown handler's run_id should NOT be in active runs
         assert "run-unknown-1" not in idle_release._active_run_ids
+
+        # Unknown handler is untouched — still reports running
+        unknown = await memory_store.query(HandlerQuery(handler_id_in=["unknown-1"]))
+        assert unknown[0].status == "running"
 
 
 @pytest.mark.asyncio
@@ -619,10 +681,10 @@ async def test_legacy_ctx_seeds_user_state(
 
 
 @pytest.mark.asyncio
-async def test_no_legacy_ctx_no_ticks_fresh_start(
+async def test_no_legacy_ctx_no_ticks_marked_failed(
     sqlite_store: SqliteWorkflowStore, simple_test_workflow: Workflow
 ) -> None:
-    """Handler with no ctx and no ticks runs fresh (regression test)."""
+    """Handler with no ctx and no ticks is a zombie; mark it failed on resume."""
     _insert_handler_with_ctx(
         sqlite_store.db_path, "fresh-1", "run-fresh-1", "test", None
     )
@@ -631,7 +693,9 @@ async def test_no_legacy_ctx_no_ticks_fresh_start(
     server.add_workflow("test", simple_test_workflow)
 
     async with server.contextmanager():
-        await wait_handler_status(sqlite_store, "fresh-1", "completed")
+        handler = await wait_handler_status(sqlite_store, "fresh-1", "failed")
+        assert handler.error is not None
+        assert "no ticks" in handler.error
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -590,15 +590,16 @@ class ReplayResult:
     exit_command: ExitCommand | None = None
 
 
-async def rebuild_state_from_ticks_stream(
+async def replay_ticks_stream(
     state: BrokerState,
     ticks: AsyncIterable[WorkflowTick],
 ) -> ReplayResult:
-    """Streaming variant of :func:`rebuild_state_from_ticks`.
+    """Replay a tick stream, returning state plus the last exit-indicating command.
 
-    Returns state plus the last exit-indicating command (if any). The reducer
-    already emits CommandCompleteRun / CommandFailWorkflow / CommandHalt when
-    it processes terminal ticks; we just surface them instead of discarding.
+    The reducer already emits CommandCompleteRun / CommandFailWorkflow /
+    CommandHalt when it processes terminal ticks; this surfaces them instead
+    of discarding, so callers can classify terminal outcome (success /
+    failure / cancel / timeout) without a second pass over the ticks.
     """
     state, _ = rewind_in_progress(state, time.time())
     exit_command: ExitCommand | None = None
@@ -611,6 +612,18 @@ async def rebuild_state_from_ticks_stream(
                 # Last wins: a successful retry supersedes earlier failures.
                 exit_command = command
     return ReplayResult(state=state, exit_command=exit_command)
+
+
+async def rebuild_state_from_ticks_stream(
+    state: BrokerState,
+    ticks: AsyncIterable[WorkflowTick],
+) -> BrokerState:
+    """Streaming variant of :func:`rebuild_state_from_ticks`.
+
+    Thin wrapper over :func:`replay_ticks_stream` that discards the exit
+    command. Prefer ``replay_ticks_stream`` when you need terminal info.
+    """
+    return (await replay_ticks_stream(state, ticks)).state
 
 
 def _reduce_tick(

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -11,7 +11,7 @@ import logging
 import time
 import traceback
 from collections.abc import AsyncIterable
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
 from workflows.errors import (
@@ -570,15 +570,47 @@ def rebuild_state_from_ticks(
     return state
 
 
+ExitCommand = CommandCompleteRun | CommandFailWorkflow | CommandHalt
+
+
+@dataclass
+class ReplayResult:
+    """Result of replaying a tick stream.
+
+    Attributes:
+        state: Rebuilt broker state after applying all ticks.
+        exit_command: The last exit-indicating command emitted during replay,
+            or None if the stream never terminated. Lets callers classify
+            terminal outcome (success / failure / cancel / timeout) using the
+            same command the runtime would have produced, without a second
+            pass over the ticks.
+    """
+
+    state: BrokerState
+    exit_command: ExitCommand | None = None
+
+
 async def rebuild_state_from_ticks_stream(
     state: BrokerState,
     ticks: AsyncIterable[WorkflowTick],
-) -> BrokerState:
-    """Streaming variant of :func:`rebuild_state_from_ticks`."""
+) -> ReplayResult:
+    """Streaming variant of :func:`rebuild_state_from_ticks`.
+
+    Returns state plus the last exit-indicating command (if any). The reducer
+    already emits CommandCompleteRun / CommandFailWorkflow / CommandHalt when
+    it processes terminal ticks; we just surface them instead of discarding.
+    """
     state, _ = rewind_in_progress(state, time.time())
+    exit_command: ExitCommand | None = None
     async for tick in ticks:
-        state, _ = _reduce_tick(tick, state, time.time())
-    return state
+        state, commands = _reduce_tick(tick, state, time.time())
+        for command in commands:
+            if isinstance(
+                command, (CommandCompleteRun, CommandFailWorkflow, CommandHalt)
+            ):
+                # Last wins: a successful retry supersedes earlier failures.
+                exit_command = command
+    return ReplayResult(state=state, exit_command=exit_command)
 
 
 def _reduce_tick(

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
@@ -42,6 +42,7 @@ from workflows.runtime.control_loop import (
     _reduce_tick,
     rebuild_state_from_ticks,
     rebuild_state_from_ticks_stream,
+    replay_ticks_stream,
     rewind_in_progress,
 )
 from workflows.runtime.types.commands import (
@@ -1136,7 +1137,7 @@ async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) ->
         ),
     ]
 
-    streamed = (await rebuild_state_from_ticks_stream(base_state, _aiter([]))).state
+    streamed = await rebuild_state_from_ticks_stream(base_state, _aiter([]))
 
     # rewind_in_progress re-assigns worker_id=0 starting fresh; in_progress preserved.
     assert len(streamed.workers["test_step"].in_progress) == 1
@@ -1150,9 +1151,9 @@ async def test_rebuild_state_from_ticks_stream_single_tick(
     # Freeze time so timestamp kludges don't diverge between paths.
     monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
     ticks: list[WorkflowTick] = [TickAddEvent(event=MyTestEvent(value=42))]
-    streamed = (
-        await rebuild_state_from_ticks_stream(base_state.deepcopy(), _aiter(ticks))
-    ).state
+    streamed = await rebuild_state_from_ticks_stream(
+        base_state.deepcopy(), _aiter(ticks)
+    )
     listed = rebuild_state_from_ticks(base_state.deepcopy(), ticks)
     assert streamed == listed
 
@@ -1162,11 +1163,9 @@ async def test_rebuild_state_from_ticks_stream_multi_tick_equivalence(
 ) -> None:
     monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
     ticks = _simple_step_tick_sequence()
-    streamed = (
-        await rebuild_state_from_ticks_stream(
-            base_state.deepcopy(), _aiter(list(ticks))
-        )
-    ).state
+    streamed = await rebuild_state_from_ticks_stream(
+        base_state.deepcopy(), _aiter(list(ticks))
+    )
     listed = rebuild_state_from_ticks(base_state.deepcopy(), list(ticks))
     assert streamed == listed
     assert streamed.is_running is False
@@ -1179,11 +1178,9 @@ async def test_rebuild_state_from_ticks_stream_large_history_equivalence(
     ticks: list[WorkflowTick] = [
         TickAddEvent(event=MyTestEvent(value=i)) for i in range(500)
     ]
-    streamed = (
-        await rebuild_state_from_ticks_stream(
-            base_state.deepcopy(), _aiter(list(ticks))
-        )
-    ).state
+    streamed = await rebuild_state_from_ticks_stream(
+        base_state.deepcopy(), _aiter(list(ticks))
+    )
     listed = rebuild_state_from_ticks(base_state.deepcopy(), list(ticks))
     assert streamed == listed
 
@@ -1229,8 +1226,24 @@ async def test_rebuild_state_from_ticks_stream_clears_in_progress(
         ),
     ]
 
-    replay = await rebuild_state_from_ticks_stream(base_state, _aiter(ticks))
-    final_state = replay.state
+    final_state = await rebuild_state_from_ticks_stream(base_state, _aiter(ticks))
 
     assert final_state.is_running is False
     assert len(final_state.workers["test_step"].in_progress) == 0
+
+
+async def test_replay_ticks_stream_surfaces_stop_event(base_state: BrokerState) -> None:
+    ticks = _simple_step_tick_sequence()
+    replay = await replay_ticks_stream(base_state, _aiter(list(ticks)))
+    assert replay.state.is_running is False
+    assert isinstance(replay.exit_command, CommandCompleteRun)
+    assert isinstance(replay.exit_command.result, StopEvent)
+    assert replay.exit_command.result.result == "done2"
+
+
+async def test_replay_ticks_stream_no_exit_command_when_running(
+    base_state: BrokerState,
+) -> None:
+    ticks: list[WorkflowTick] = [TickAddEvent(event=MyTestEvent(value=1))]
+    replay = await replay_ticks_stream(base_state, _aiter(ticks))
+    assert replay.exit_command is None

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
@@ -1136,7 +1136,7 @@ async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) ->
         ),
     ]
 
-    streamed = await rebuild_state_from_ticks_stream(base_state, _aiter([]))
+    streamed = (await rebuild_state_from_ticks_stream(base_state, _aiter([]))).state
 
     # rewind_in_progress re-assigns worker_id=0 starting fresh; in_progress preserved.
     assert len(streamed.workers["test_step"].in_progress) == 1
@@ -1150,9 +1150,9 @@ async def test_rebuild_state_from_ticks_stream_single_tick(
     # Freeze time so timestamp kludges don't diverge between paths.
     monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
     ticks: list[WorkflowTick] = [TickAddEvent(event=MyTestEvent(value=42))]
-    streamed = await rebuild_state_from_ticks_stream(
-        base_state.deepcopy(), _aiter(ticks)
-    )
+    streamed = (
+        await rebuild_state_from_ticks_stream(base_state.deepcopy(), _aiter(ticks))
+    ).state
     listed = rebuild_state_from_ticks(base_state.deepcopy(), ticks)
     assert streamed == listed
 
@@ -1162,9 +1162,11 @@ async def test_rebuild_state_from_ticks_stream_multi_tick_equivalence(
 ) -> None:
     monkeypatch.setattr("workflows.runtime.control_loop.time.time", lambda: 12345.0)
     ticks = _simple_step_tick_sequence()
-    streamed = await rebuild_state_from_ticks_stream(
-        base_state.deepcopy(), _aiter(list(ticks))
-    )
+    streamed = (
+        await rebuild_state_from_ticks_stream(
+            base_state.deepcopy(), _aiter(list(ticks))
+        )
+    ).state
     listed = rebuild_state_from_ticks(base_state.deepcopy(), list(ticks))
     assert streamed == listed
     assert streamed.is_running is False
@@ -1177,9 +1179,11 @@ async def test_rebuild_state_from_ticks_stream_large_history_equivalence(
     ticks: list[WorkflowTick] = [
         TickAddEvent(event=MyTestEvent(value=i)) for i in range(500)
     ]
-    streamed = await rebuild_state_from_ticks_stream(
-        base_state.deepcopy(), _aiter(list(ticks))
-    )
+    streamed = (
+        await rebuild_state_from_ticks_stream(
+            base_state.deepcopy(), _aiter(list(ticks))
+        )
+    ).state
     listed = rebuild_state_from_ticks(base_state.deepcopy(), list(ticks))
     assert streamed == listed
 
@@ -1225,7 +1229,8 @@ async def test_rebuild_state_from_ticks_stream_clears_in_progress(
         ),
     ]
 
-    final_state = await rebuild_state_from_ticks_stream(base_state, _aiter(ticks))
+    replay = await rebuild_state_from_ticks_stream(base_state, _aiter(ticks))
+    final_state = replay.state
 
     assert final_state.is_running is False
     assert len(final_state.workers["test_step"].in_progress) == 0


### PR DESCRIPTION
The resume loop's fallback for no-state-to-replay calls `workflow.run(ctx=None)`, which builds a StartEvent from empty kwargs and fails on any workflow with required fields. It compounds with duplicate rows in `workflow_contexts` (agent-data commit timeouts produce them): `update()` writes to `items[0]` (newest), so the resume-failure lands on one row while the stuck `running` row keeps getting picked up.

- Resume loop classifies before running. Handlers with no ticks are marked `failed`. Replays that end at `is_running=False` are finalized to `completed`/`failed`/`cancelled` from the terminal tick.
- `AgentDataStore.update()` converges duplicates when all siblings share the handler's `run_id`: delete the extras, write to the oldest survivor. Mismatched run_ids (handler_id reuse across runs) fall back to newest-wins without deleting.

If we want to root-cause the duplicates, it's either server-side idempotency keys on agent-data writes or a higher httpx timeout. Neither is cheap, so this change makes duplicates harmless instead.