### PR TITLE
refactor(llama-index-workflows): Move workflow graph/event validation into representation.validate

### DIFF
--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -354,9 +354,7 @@ def _collect_events(steps: dict[str, StepConfig]) -> list[type[Event]]:
     reported. Walks both accepted and returned types of each step.
     """
     events_found: set[type[Event]] = set()
-    for name, cfg in steps.items():
-        if name == "_done":
-            continue
+    for cfg in steps.values():
         for event_type in cfg.return_types:
             if issubclass(event_type, Event):
                 events_found.add(event_type)
@@ -419,7 +417,7 @@ def _collect_catch_error_handlers(
     wildcard = wildcards[0] if wildcards else None
     if wildcard is not None:
         for step_name in all_step_names:
-            if step_name in handler_step_names or step_name == "_done":
+            if step_name in handler_step_names:
                 continue
             if step_name in handler_for_step:
                 continue
@@ -451,11 +449,10 @@ def _validate_event_connectivity(
     steps_accepting_stop_event: list[str] = []
 
     for name, cfg in steps.items():
-        if name != "_done":
-            for event_type in cfg.accepted_events:
-                if issubclass(event_type, StopEvent):
-                    steps_accepting_stop_event.append(name)
-                    break
+        for event_type in cfg.accepted_events:
+            if issubclass(event_type, StopEvent):
+                steps_accepting_stop_event.append(name)
+                break
         for event_type in cfg.accepted_events:
             consumed_events.add(event_type)
         for event_type in cfg.return_types:

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -581,9 +581,7 @@ async def _validate_resources(
             try:
                 await resource_manager.get(res_def.resource)
             except Exception as e:
-                errors.append(
-                    f"In step '{step_name}', parameter '{res_def.name}': {e}"
-                )
+                errors.append(f"In step '{step_name}', parameter '{res_def.name}': {e}")
     return errors
 
 

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -431,18 +431,16 @@ def collect_catch_error_handlers(
 def validate_event_connectivity(
     steps: dict[str, StepConfig],
     start_event_class: type[StartEvent],
-    stop_event_class: type[StopEvent],
 ) -> bool:
     """Validate event production/consumption across the step graph.
 
     Checks that:
     - No user step accepts ``StopEvent``.
-    - At least one ``StopEvent`` is produced.
     - Every consumed event is either produced or crosses the workflow
       boundary (``InputRequiredEvent``/``HumanResponseEvent``/``StopEvent``/
       ``StepFailedEvent``).
-    - Every produced event is consumed, except for the workflow's own
-      ``InputRequiredEvent``/``HumanResponseEvent``/configured stop event.
+    - Every produced event is consumed, except for
+      ``InputRequiredEvent``/``HumanResponseEvent``/``StopEvent`` subclasses.
 
     Returns ``True`` if the workflow uses human-in-the-loop
     (``InputRequiredEvent`` produced or ``HumanResponseEvent`` consumed).
@@ -474,9 +472,6 @@ def validate_event_connectivity(
             "Use a different Event type instead."
         )
 
-    if not any(issubclass(ev, StopEvent) for ev in produced_events):
-        raise WorkflowValidationError("No event of type StopEvent is produced.")
-
     unconsumed_events = {
         x
         for x in consumed_events - produced_events
@@ -494,7 +489,7 @@ def validate_event_connectivity(
     unused_events = {
         x
         for x in produced_events - consumed_events
-        if not issubclass(x, (InputRequiredEvent, HumanResponseEvent, stop_event_class))
+        if not issubclass(x, (InputRequiredEvent, HumanResponseEvent, StopEvent))
     }
     if unused_events:
         names = ", ".join(ev.__name__ for ev in unused_events)
@@ -505,28 +500,6 @@ def validate_event_connectivity(
     return (
         InputRequiredEvent in produced_events or HumanResponseEvent in consumed_events
     )
-
-
-def run_graph_validation(
-    steps: dict[str, StepConfig],
-    start_event_class: type[StartEvent],
-    skip_checks: set[WorkflowGraphCheck],
-    catch_error_steps: list[str],
-) -> None:
-    """Run structural graph checks and raise a combined ``WorkflowValidationError``.
-
-    Thin wrapper over :func:`validate_graph` that joins every
-    :class:`GraphValidationError` into a single message.
-    """
-    errors = validate_graph(
-        steps=steps,
-        start_event_class=start_event_class,
-        skip_checks=skip_checks,
-        catch_error_steps=catch_error_steps,
-    )
-    if errors:
-        detail = "\n".join(f"  - [{e.check}] {e.message}\n    {e.hint}" for e in errors)
-        raise WorkflowValidationError(f"Graph validation failed:\n{detail}")
 
 
 @dataclass
@@ -653,16 +626,21 @@ def validate_workflow(
     start_event_class = ensure_start_event_class(steps, workflow_cls_name)
     stop_event_class = ensure_stop_event_class(steps, workflow_cls_name)
 
-    uses_hitl = validate_event_connectivity(steps, start_event_class, stop_event_class)
+    uses_hitl = validate_event_connectivity(steps, start_event_class)
 
     catch_error_handlers, handler_for_step = collect_catch_error_handlers(steps)
 
-    run_graph_validation(
+    graph_errors = validate_graph(
         steps=steps,
         start_event_class=start_event_class,
         skip_checks=skip_graph_checks,
         catch_error_steps=list(catch_error_handlers.keys()),
     )
+    if graph_errors:
+        detail = "\n".join(
+            f"  - [{e.check}] {e.message}\n    {e.hint}" for e in graph_errors
+        )
+        raise WorkflowValidationError(f"Graph validation failed:\n{detail}")
 
     return WorkflowValidationResult(
         start_event_class=start_event_class,

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -289,7 +289,7 @@ def validate_catch_error_handlers(
     return errors
 
 
-def ensure_start_event_class(
+def _ensure_start_event_class(
     steps: dict[str, StepConfig], workflow_cls_name: str
 ) -> type[StartEvent]:
     """Infer and validate the single StartEvent subclass accepted by a workflow.
@@ -318,7 +318,7 @@ def ensure_start_event_class(
     return start_events_found.pop()
 
 
-def ensure_stop_event_class(
+def _ensure_stop_event_class(
     steps: dict[str, StepConfig], workflow_cls_name: str
 ) -> type[StopEvent]:
     """Infer and validate the single StopEvent subclass produced by a workflow.
@@ -347,7 +347,7 @@ def ensure_stop_event_class(
     return stop_events_found.pop()
 
 
-def collect_events(steps: dict[str, StepConfig]) -> list[type[Event]]:
+def _collect_events(steps: dict[str, StepConfig]) -> list[type[Event]]:
     """Return every ``Event`` subclass touched by the workflow's steps.
 
     Skips the runtime-injected ``_done`` step so only user-facing events are
@@ -366,7 +366,7 @@ def collect_events(steps: dict[str, StepConfig]) -> list[type[Event]]:
     return list(events_found)
 
 
-def collect_catch_error_handlers(
+def _collect_catch_error_handlers(
     steps: dict[str, StepConfig],
 ) -> tuple[dict[str, CatchErrorHandler], dict[str, str]]:
     """Discover ``@catch_error`` handlers and build the step->handler routing table.
@@ -428,7 +428,7 @@ def collect_catch_error_handlers(
     return {h.step_name: h for h in handlers}, handler_for_step
 
 
-def validate_event_connectivity(
+def _validate_event_connectivity(
     steps: dict[str, StepConfig],
     start_event_class: type[StartEvent],
 ) -> bool:
@@ -528,7 +528,7 @@ class _ResourceValidationContext:
         )
 
 
-def validate_resource_configs(steps: dict[str, StepConfig]) -> list[str]:
+def _validate_resource_configs(steps: dict[str, StepConfig]) -> list[str]:
     """Validate every resource config (and nested configs) by loading it.
 
     Returns a list of human-readable error messages; empty if all configs load
@@ -569,7 +569,7 @@ def validate_resource_configs(steps: dict[str, StepConfig]) -> list[str]:
     return errors
 
 
-async def validate_resources(
+async def _validate_resources(
     steps: dict[str, StepConfig], resource_manager: ResourceManager
 ) -> list[str]:
     """Resolve every resource via ``resource_manager``.
@@ -591,8 +591,8 @@ async def validate_resources(
 
 
 @dataclass
-class WorkflowValidationResult:
-    """Derived workflow state produced by :func:`validate_workflow`."""
+class _WorkflowValidationResult:
+    """Derived workflow state produced by :func:`_validate_workflow`."""
 
     start_event_class: type[StartEvent]
     stop_event_class: type[StopEvent]
@@ -601,11 +601,11 @@ class WorkflowValidationResult:
     uses_hitl: bool
 
 
-def validate_workflow(
+def _validate_workflow(
     steps: dict[str, StepConfig],
     workflow_cls_name: str,
     skip_graph_checks: set[WorkflowGraphCheck],
-) -> WorkflowValidationResult:
+) -> _WorkflowValidationResult:
     """Run every structural check on a workflow's step set.
 
     Orders checks so the most actionable errors surface first (missing steps,
@@ -614,7 +614,7 @@ def validate_workflow(
 
     Raises ``WorkflowConfigurationError`` or ``WorkflowValidationError`` on any
     violation. Resource validation is handled separately via
-    :func:`validate_resource_configs` and :func:`validate_resources`.
+    :func:`_validate_resource_configs` and :func:`_validate_resources`.
     """
     if not steps:
         raise WorkflowConfigurationError(
@@ -623,12 +623,12 @@ def validate_workflow(
             "free-function steps via @step(workflow=...)?"
         )
 
-    start_event_class = ensure_start_event_class(steps, workflow_cls_name)
-    stop_event_class = ensure_stop_event_class(steps, workflow_cls_name)
+    start_event_class = _ensure_start_event_class(steps, workflow_cls_name)
+    stop_event_class = _ensure_stop_event_class(steps, workflow_cls_name)
 
-    uses_hitl = validate_event_connectivity(steps, start_event_class)
+    uses_hitl = _validate_event_connectivity(steps, start_event_class)
 
-    catch_error_handlers, handler_for_step = collect_catch_error_handlers(steps)
+    catch_error_handlers, handler_for_step = _collect_catch_error_handlers(steps)
 
     graph_errors = validate_graph(
         steps=steps,
@@ -642,7 +642,7 @@ def validate_workflow(
         )
         raise WorkflowValidationError(f"Graph validation failed:\n{detail}")
 
-    return WorkflowValidationResult(
+    return _WorkflowValidationResult(
         start_event_class=start_event_class,
         stop_event_class=stop_event_class,
         catch_error_handlers=catch_error_handlers,

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -7,7 +7,15 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from workflows.decorators import CatchErrorHandler, StepConfig, WorkflowGraphCheck
-from workflows.events import HumanResponseEvent, InputRequiredEvent, StopEvent
+from workflows.errors import WorkflowConfigurationError, WorkflowValidationError
+from workflows.events import (
+    Event,
+    HumanResponseEvent,
+    InputRequiredEvent,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+)
 
 # Graph nodes: step names (str) for steps, event classes (type) for events.
 GraphNode = str | type
@@ -278,3 +286,243 @@ def validate_catch_error_handlers(
             claim_owner[target] = handler.step_name
 
     return errors
+
+
+def ensure_start_event_class(
+    steps: dict[str, StepConfig], workflow_cls_name: str
+) -> type[StartEvent]:
+    """Infer and validate the single StartEvent subclass accepted by a workflow.
+
+    Inspects every step's accepted events and returns the unique StartEvent
+    subclass. Raises ``WorkflowConfigurationError`` if zero or more than one
+    are found.
+    """
+    start_events_found: set[type[StartEvent]] = set()
+    for cfg in steps.values():
+        for event_type in cfg.accepted_events:
+            if issubclass(event_type, StartEvent):
+                start_events_found.add(event_type)
+
+    num_found = len(start_events_found)
+    if num_found == 0:
+        raise WorkflowConfigurationError(
+            "At least one Event of type StartEvent must be received by any step. "
+            f"(Workflow '{workflow_cls_name}' has no @step that accepts StartEvent.)"
+        )
+    if num_found > 1:
+        raise WorkflowConfigurationError(
+            f"Only one type of StartEvent is allowed per workflow, found {num_found}: "
+            f"{start_events_found} in workflow '{workflow_cls_name}'."
+        )
+    return start_events_found.pop()
+
+
+def ensure_stop_event_class(
+    steps: dict[str, StepConfig], workflow_cls_name: str
+) -> type[StopEvent]:
+    """Infer and validate the single StopEvent subclass produced by a workflow.
+
+    Inspects every step's return types and returns the unique StopEvent
+    subclass. Raises ``WorkflowConfigurationError`` if zero or more than one
+    are found.
+    """
+    stop_events_found: set[type[StopEvent]] = set()
+    for cfg in steps.values():
+        for event_type in cfg.return_types:
+            if issubclass(event_type, StopEvent):
+                stop_events_found.add(event_type)
+
+    num_found = len(stop_events_found)
+    if num_found == 0:
+        raise WorkflowConfigurationError(
+            "At least one Event of type StopEvent must be returned by any step. "
+            f"(Workflow '{workflow_cls_name}' has no @step that returns StopEvent.)"
+        )
+    if num_found > 1:
+        raise WorkflowConfigurationError(
+            f"Only one type of StopEvent is allowed per workflow, found {num_found}: "
+            f"{stop_events_found} in workflow '{workflow_cls_name}'."
+        )
+    return stop_events_found.pop()
+
+
+def collect_events(steps: dict[str, StepConfig]) -> list[type[Event]]:
+    """Return every ``Event`` subclass touched by the workflow's steps.
+
+    Skips the runtime-injected ``_done`` step so only user-facing events are
+    reported. Walks both accepted and returned types of each step.
+    """
+    events_found: set[type[Event]] = set()
+    for name, cfg in steps.items():
+        if name == "_done":
+            continue
+        for event_type in cfg.return_types:
+            if issubclass(event_type, Event):
+                events_found.add(event_type)
+        for event_type in cfg.accepted_events:
+            if issubclass(event_type, Event):
+                events_found.add(event_type)
+    return list(events_found)
+
+
+def collect_catch_error_handlers(
+    steps: dict[str, StepConfig],
+) -> tuple[dict[str, CatchErrorHandler], dict[str, str]]:
+    """Discover ``@catch_error`` handlers and build the step->handler routing table.
+
+    Validates the handler set (via :func:`validate_catch_error_handlers`) and
+    each handler's ``max_recoveries``; raises ``WorkflowValidationError`` on
+    any problem.
+
+    Returns ``(catch_error_handlers, handler_for_step)`` where
+    ``catch_error_handlers`` maps handler step name to its descriptor and
+    ``handler_for_step`` maps each covered step name to the handler that owns
+    it (scoped claims first, then the wildcard fills).
+    """
+    all_step_names = set(steps.keys())
+    handlers: list[CatchErrorHandler] = []
+    for name, cfg in steps.items():
+        if cfg.role != "catch_error":
+            continue
+        max_recoveries = cfg.catch_error_max_recoveries
+        if not isinstance(max_recoveries, int) or max_recoveries < 1:
+            raise WorkflowValidationError(
+                f"@catch_error handler '{name}' has max_recoveries="
+                f"{max_recoveries!r}; must be an integer >= 1."
+            )
+        handlers.append(
+            CatchErrorHandler(
+                step_name=name,
+                for_steps=(
+                    list(cfg.catch_error_for_steps)
+                    if cfg.catch_error_for_steps is not None
+                    else None
+                ),
+                max_recoveries=max_recoveries,
+            )
+        )
+
+    handler_errors = validate_catch_error_handlers(handlers, all_step_names)
+    if handler_errors:
+        raise WorkflowValidationError("\n".join(handler_errors))
+
+    handler_step_names = {h.step_name for h in handlers}
+    handler_for_step: dict[str, str] = {}
+    for handler in handlers:
+        if handler.for_steps is None:
+            continue
+        for target in handler.for_steps:
+            handler_for_step[target] = handler.step_name
+
+    wildcards = [h for h in handlers if h.for_steps is None]
+    wildcard = wildcards[0] if wildcards else None
+    if wildcard is not None:
+        for step_name in all_step_names:
+            if step_name in handler_step_names or step_name == "_done":
+                continue
+            if step_name in handler_for_step:
+                continue
+            handler_for_step[step_name] = wildcard.step_name
+
+    return {h.step_name: h for h in handlers}, handler_for_step
+
+
+def validate_event_connectivity(
+    steps: dict[str, StepConfig],
+    start_event_class: type[StartEvent],
+    stop_event_class: type[StopEvent],
+) -> bool:
+    """Validate event production/consumption across the step graph.
+
+    Checks that:
+    - No user step accepts ``StopEvent``.
+    - At least one ``StopEvent`` is produced.
+    - Every consumed event is either produced or crosses the workflow
+      boundary (``InputRequiredEvent``/``HumanResponseEvent``/``StopEvent``/
+      ``StepFailedEvent``).
+    - Every produced event is consumed, except for the workflow's own
+      ``InputRequiredEvent``/``HumanResponseEvent``/configured stop event.
+
+    Returns ``True`` if the workflow uses human-in-the-loop
+    (``InputRequiredEvent`` produced or ``HumanResponseEvent`` consumed).
+    Raises ``WorkflowValidationError`` on any violation.
+    """
+    produced_events: set[type] = {start_event_class}
+    consumed_events: set[type] = set()
+    steps_accepting_stop_event: list[str] = []
+
+    for name, cfg in steps.items():
+        if name != "_done":
+            for event_type in cfg.accepted_events:
+                if issubclass(event_type, StopEvent):
+                    steps_accepting_stop_event.append(name)
+                    break
+        for event_type in cfg.accepted_events:
+            consumed_events.add(event_type)
+        for event_type in cfg.return_types:
+            if event_type is type(None):
+                continue
+            produced_events.add(event_type)
+
+    if steps_accepting_stop_event:
+        step_names = "', '".join(steps_accepting_stop_event)
+        plural = "" if len(steps_accepting_stop_event) == 1 else "s"
+        raise WorkflowValidationError(
+            f"Step{plural} '{step_names}' cannot accept StopEvent. "
+            "StopEvent signals the end of the workflow. "
+            "Use a different Event type instead."
+        )
+
+    if not any(issubclass(ev, StopEvent) for ev in produced_events):
+        raise WorkflowValidationError("No event of type StopEvent is produced.")
+
+    unconsumed_events = {
+        x
+        for x in consumed_events - produced_events
+        if not issubclass(
+            x,
+            (InputRequiredEvent, HumanResponseEvent, StopEvent, StepFailedEvent),
+        )
+    }
+    if unconsumed_events:
+        names = ", ".join(ev.__name__ for ev in unconsumed_events)
+        raise WorkflowValidationError(
+            f"The following events are consumed but never produced: {names}"
+        )
+
+    unused_events = {
+        x
+        for x in produced_events - consumed_events
+        if not issubclass(x, (InputRequiredEvent, HumanResponseEvent, stop_event_class))
+    }
+    if unused_events:
+        names = ", ".join(ev.__name__ for ev in unused_events)
+        raise WorkflowValidationError(
+            f"The following events are produced but never consumed: {names}"
+        )
+
+    return (
+        InputRequiredEvent in produced_events or HumanResponseEvent in consumed_events
+    )
+
+
+def run_graph_validation(
+    steps: dict[str, StepConfig],
+    start_event_class: type[StartEvent],
+    skip_checks: set[WorkflowGraphCheck],
+    catch_error_steps: list[str],
+) -> None:
+    """Run structural graph checks and raise a combined ``WorkflowValidationError``.
+
+    Thin wrapper over :func:`validate_graph` that joins every
+    :class:`GraphValidationError` into a single message.
+    """
+    errors = validate_graph(
+        steps=steps,
+        start_event_class=start_event_class,
+        skip_checks=skip_checks,
+        catch_error_steps=catch_error_steps,
+    )
+    if errors:
+        detail = "\n".join(f"  - [{e.check}] {e.message}\n    {e.hint}" for e in errors)
+        raise WorkflowValidationError(f"Graph validation failed:\n{detail}")

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -16,6 +16,7 @@ from workflows.events import (
     StepFailedEvent,
     StopEvent,
 )
+from workflows.resource import ResourceDescriptor, ResourceManager, _ResourceConfig
 
 # Graph nodes: step names (str) for steps, event classes (type) for events.
 GraphNode = str | type
@@ -526,3 +527,147 @@ def run_graph_validation(
     if errors:
         detail = "\n".join(f"  - [{e.check}] {e.message}\n    {e.hint}" for e in errors)
         raise WorkflowValidationError(f"Graph validation failed:\n{detail}")
+
+
+@dataclass
+class _ResourceValidationContext:
+    """Tracks context for resource validation to provide clear error messages."""
+
+    resource: ResourceDescriptor
+    step_name: str
+    param_name: str
+    resource_chain: list[str] = field(default_factory=list)
+
+    def format_location(self) -> str:
+        if len(self.resource_chain) > 1:
+            chain_str = " -> ".join(self.resource_chain)
+            return (
+                f"step '{self.step_name}', parameter '{self.param_name}' ({chain_str})"
+            )
+        return f"step '{self.step_name}', parameter '{self.param_name}'"
+
+    def with_dependency(self, dep: ResourceDescriptor) -> _ResourceValidationContext:
+        return _ResourceValidationContext(
+            resource=dep,
+            step_name=self.step_name,
+            param_name=self.param_name,
+            resource_chain=[*self.resource_chain, dep.name],
+        )
+
+
+def validate_resource_configs(steps: dict[str, StepConfig]) -> list[str]:
+    """Validate every resource config (and nested configs) by loading it.
+
+    Returns a list of human-readable error messages; empty if all configs load
+    cleanly. Callers decide whether to raise.
+    """
+    errors: list[str] = []
+    seen: set[str] = set()
+
+    stack: list[_ResourceValidationContext] = []
+    for step_name, cfg in steps.items():
+        for res_def in cfg.resources:
+            res_def.resource.set_type_annotation(res_def.type_annotation)
+            stack.append(
+                _ResourceValidationContext(
+                    resource=res_def.resource,
+                    step_name=step_name,
+                    param_name=res_def.name,
+                    resource_chain=[res_def.resource.name],
+                )
+            )
+
+    while stack:
+        ctx = stack.pop()
+        if ctx.resource.name in seen:
+            continue
+        seen.add(ctx.resource.name)
+
+        for _dep_param, dep, type_ann in ctx.resource.get_dependencies():
+            dep.set_type_annotation(type_ann)
+            stack.append(ctx.with_dependency(dep))
+
+        if isinstance(ctx.resource, _ResourceConfig):
+            try:
+                ctx.resource.call()
+            except Exception as e:
+                errors.append(f"In {ctx.format_location()}: {e}")
+
+    return errors
+
+
+async def validate_resources(
+    steps: dict[str, StepConfig], resource_manager: ResourceManager
+) -> list[str]:
+    """Resolve every resource via ``resource_manager``.
+
+    Surfaces circular dependencies and factory-time failures. Returns a list of
+    error messages; empty if all resources resolve.
+    """
+    errors: list[str] = []
+    for step_name, cfg in steps.items():
+        for res_def in cfg.resources:
+            res_def.resource.set_type_annotation(res_def.type_annotation)
+            try:
+                await resource_manager.get(res_def.resource)
+            except Exception as e:
+                errors.append(
+                    f"In step '{step_name}', parameter '{res_def.name}': {e}"
+                )
+    return errors
+
+
+@dataclass
+class WorkflowValidationResult:
+    """Derived workflow state produced by :func:`validate_workflow`."""
+
+    start_event_class: type[StartEvent]
+    stop_event_class: type[StopEvent]
+    catch_error_handlers: dict[str, CatchErrorHandler]
+    handler_for_step: dict[str, str]
+    uses_hitl: bool
+
+
+def validate_workflow(
+    steps: dict[str, StepConfig],
+    workflow_cls_name: str,
+    skip_graph_checks: set[WorkflowGraphCheck],
+) -> WorkflowValidationResult:
+    """Run every structural check on a workflow's step set.
+
+    Orders checks so the most actionable errors surface first (missing steps,
+    then StartEvent, then StopEvent, then event connectivity, then catch_error
+    handlers, then graph reachability/dead-ends).
+
+    Raises ``WorkflowConfigurationError`` or ``WorkflowValidationError`` on any
+    violation. Resource validation is handled separately via
+    :func:`validate_resource_configs` and :func:`validate_resources`.
+    """
+    if not steps:
+        raise WorkflowConfigurationError(
+            f"Workflow '{workflow_cls_name}' has no configured steps. "
+            "Did you forget to annotate methods with @step or to register "
+            "free-function steps via @step(workflow=...)?"
+        )
+
+    start_event_class = ensure_start_event_class(steps, workflow_cls_name)
+    stop_event_class = ensure_stop_event_class(steps, workflow_cls_name)
+
+    uses_hitl = validate_event_connectivity(steps, start_event_class, stop_event_class)
+
+    catch_error_handlers, handler_for_step = collect_catch_error_handlers(steps)
+
+    run_graph_validation(
+        steps=steps,
+        start_event_class=start_event_class,
+        skip_checks=skip_graph_checks,
+        catch_error_steps=list(catch_error_handlers.keys()),
+    )
+
+    return WorkflowValidationResult(
+        start_event_class=start_event_class,
+        stop_event_class=stop_event_class,
+        catch_error_handlers=catch_error_handlers,
+        handler_for_step=handler_for_step,
+        uses_hitl=uses_hitl,
+    )

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -128,13 +128,14 @@ class Workflow(metaclass=WorkflowMeta):
         """
         # Inline imports: every module below imports ``Workflow`` transitively,
         # so deferring to call time breaks the cycle.
+        from workflows.plugins._context import get_current_runtime
+        from workflows.runtime.verbose import VerboseDecorator
+
         from .representation.validate import (
             _collect_events,
             _ensure_start_event_class,
             _ensure_stop_event_class,
         )
-        from workflows.plugins._context import get_current_runtime
-        from workflows.runtime.verbose import VerboseDecorator
 
         # Configuration
         self._timeout = timeout
@@ -469,7 +470,9 @@ class Workflow(metaclass=WorkflowMeta):
                 )
 
         if validate_resources:
-            errors = asyncio.run(_validate_resources(step_configs, self._resource_manager))
+            errors = asyncio.run(
+                _validate_resources(step_configs, self._resource_manager)
+            )
             if errors:
                 raise WorkflowValidationError(
                     "Resource validation failed:\n"

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -129,9 +129,9 @@ class Workflow(metaclass=WorkflowMeta):
         # Inline imports: every module below imports ``Workflow`` transitively,
         # so deferring to call time breaks the cycle.
         from .representation.validate import (
-            collect_events,
-            ensure_start_event_class,
-            ensure_stop_event_class,
+            _collect_events,
+            _ensure_start_event_class,
+            _ensure_stop_event_class,
         )
         from workflows.plugins._context import get_current_runtime
         from workflows.runtime.verbose import VerboseDecorator
@@ -147,12 +147,12 @@ class Workflow(metaclass=WorkflowMeta):
         step_configs = self._step_configs()
         cls_name = self.__class__.__name__
         # Detect StartEvent issues before StopEvent for clearer guidance
-        self._start_event_class = ensure_start_event_class(step_configs, cls_name)
-        self._stop_event_class = ensure_stop_event_class(step_configs, cls_name)
+        self._start_event_class = _ensure_start_event_class(step_configs, cls_name)
+        self._stop_event_class = _ensure_stop_event_class(step_configs, cls_name)
         # Populated by _validate(); empty until a successful validation runs.
         self._catch_error_handlers: dict[str, CatchErrorHandler] = {}
         self._handler_for_step: dict[str, str] = {}
-        self._events = collect_events(step_configs)
+        self._events = _collect_events(step_configs)
         # Resource management
         self._resource_manager = resource_manager or ResourceManager()
         # Instrumentation
@@ -447,13 +447,13 @@ class Workflow(metaclass=WorkflowMeta):
 
         # Inline import: ``representation`` transitively imports ``Workflow``.
         from .representation.validate import (
-            validate_resource_configs as _validate_resource_configs,
-            validate_resources as _validate_resources,
-            validate_workflow,
+            _validate_resource_configs,
+            _validate_resources,
+            _validate_workflow,
         )
 
         step_configs = self._step_configs()
-        result = validate_workflow(
+        result = _validate_workflow(
             step_configs, self.__class__.__name__, self._skip_graph_checks
         )
         self._start_event_class = result.start_event_class

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -24,14 +24,7 @@ from .errors import (
     WorkflowRuntimeError,
     WorkflowValidationError,
 )
-from .events import (
-    Event,
-    HumanResponseEvent,
-    InputRequiredEvent,
-    StartEvent,
-    StepFailedEvent,
-    StopEvent,
-)
+from .events import Event, StartEvent
 from .handler import WorkflowHandler
 from .resource import (
     ResourceDescriptor,
@@ -249,36 +242,19 @@ class Workflow(metaclass=WorkflowMeta):
             )
         self._workflow_name = name
 
+    def _step_configs(self) -> dict[str, StepConfig]:
+        """Return ``{step_name: StepConfig}`` for every registered step."""
+        return {name: func._step_config for name, func in self._get_steps().items()}
+
     def _ensure_start_event_class(self) -> type[StartEvent]:
-        """
-        Returns the StartEvent type used in this workflow.
+        # Inline import: ``workflow.py`` is the bootstrap chokepoint — the
+        # ``representation`` package imports ``workflows.Workflow`` transitively
+        # (representation/__init__ -> build -> Workflow), so importing it at
+        # module load time would re-enter a partially-loaded ``workflows``
+        # package. Deferring to call time breaks the cycle.
+        from .representation.validate import ensure_start_event_class
 
-        It works by inspecting the events received by the step methods.
-        """
-        start_events_found: set[type[StartEvent]] = set()
-        for step_func in self._get_steps().values():
-            step_config: StepConfig = step_func._step_config
-            for event_type in step_config.accepted_events:
-                if issubclass(event_type, StartEvent):
-                    start_events_found.add(event_type)
-
-        num_found = len(start_events_found)
-        if num_found == 0:
-            cls_name = self.__class__.__name__
-            msg = (
-                "At least one Event of type StartEvent must be received by any step. "
-                f"(Workflow '{cls_name}' has no @step that accepts StartEvent.)"
-            )
-            raise WorkflowConfigurationError(msg)
-        elif num_found > 1:
-            cls_name = self.__class__.__name__
-            msg = (
-                f"Only one type of StartEvent is allowed per workflow, found {num_found}: {start_events_found} "
-                f"in workflow '{cls_name}'."
-            )
-            raise WorkflowConfigurationError(msg)
-        else:
-            return start_events_found.pop()
+        return ensure_start_event_class(self._step_configs(), self.__class__.__name__)
 
     @property
     def start_event_class(self) -> type[StartEvent]:
@@ -297,57 +273,16 @@ class Workflow(metaclass=WorkflowMeta):
         return self._events
 
     def _ensure_events_collected(self) -> list[type[Event]]:
-        """Returns all known events emitted by this workflow.
+        # Inline import: see _ensure_start_event_class for the cycle rationale.
+        from .representation.validate import collect_events
 
-        Determined by inspecting step input/output types.
-        """
-        events_found: set[type[Event]] = set()
-        for step_func in self._get_steps().values():
-            step_config: StepConfig = step_func._step_config
-
-            # Do not collect events from the done step
-            if step_func.__name__ == "_done":
-                continue
-
-            for event_type in step_config.return_types:
-                if issubclass(event_type, Event):
-                    events_found.add(event_type)
-            for event_type in step_config.accepted_events:
-                if issubclass(event_type, Event):
-                    events_found.add(event_type)
-
-        return list(events_found)
+        return collect_events(self._step_configs())
 
     def _ensure_stop_event_class(self) -> type[RunResultT]:
-        """
-        Returns the StopEvent type used in this workflow.
+        # Inline import: see _ensure_start_event_class for the cycle rationale.
+        from .representation.validate import ensure_stop_event_class
 
-        It works by inspecting the events returned.
-        """
-        stop_events_found: set[type[StopEvent]] = set()
-        for step_func in self._get_steps().values():
-            step_config: StepConfig = step_func._step_config
-            for event_type in step_config.return_types:
-                if issubclass(event_type, StopEvent):
-                    stop_events_found.add(event_type)
-
-        num_found = len(stop_events_found)
-        if num_found == 0:
-            cls_name = self.__class__.__name__
-            msg = (
-                "At least one Event of type StopEvent must be returned by any step. "
-                f"(Workflow '{cls_name}' has no @step that returns StopEvent.)"
-            )
-            raise WorkflowConfigurationError(msg)
-        elif num_found > 1:
-            cls_name = self.__class__.__name__
-            msg = (
-                f"Only one type of StopEvent is allowed per workflow, found {num_found}: {stop_events_found} "
-                f"in workflow '{cls_name}'."
-            )
-            raise WorkflowConfigurationError(msg)
-        else:
-            return stop_events_found.pop()
+        return ensure_stop_event_class(self._step_configs(), self.__class__.__name__)
 
     @property
     def stop_event_class(self) -> type[RunResultT]:
@@ -489,97 +424,6 @@ class Workflow(metaclass=WorkflowMeta):
             workflow=self, start_event=start_event_instance, run_id=run_id
         )
 
-    def _validate_graph_structure(self) -> None:
-        """Check that all steps are reachable from input events and only output events are terminal.
-
-        Delegates to the pure ``validate_graph`` function in the representation
-        package and raises a single ``WorkflowValidationError`` listing every
-        problem found.
-        """
-        # Inline import: ``workflow.py`` is the bootstrap chokepoint — the
-        # ``representation`` package imports ``workflows.Workflow`` transitively
-        # (representation/__init__ -> build -> Workflow), so importing it here
-        # at module load time would re-enter a partially-loaded ``workflows``
-        # package. Deferring to call time breaks the cycle.
-        from .representation.validate import validate_graph
-
-        step_configs = {
-            name: func._step_config for name, func in self._get_steps().items()
-        }
-        errors = validate_graph(
-            steps=step_configs,
-            start_event_class=self._start_event_class,
-            skip_checks=self._skip_graph_checks,
-            catch_error_steps=list(self._catch_error_handlers.keys()),
-        )
-        if errors:
-            detail = "\n".join(
-                f"  - [{e.check}] {e.message}\n    {e.hint}" for e in errors
-            )
-            raise WorkflowValidationError(f"Graph validation failed:\n{detail}")
-
-    def _collect_catch_error_handlers(
-        self,
-    ) -> tuple[dict[str, CatchErrorHandler], dict[str, str]]:
-        """Discover ``@catch_error`` handlers and build the step->handler routing table.
-
-        Returns:
-            ``(catch_error_handlers, handler_for_step)`` where
-            ``catch_error_handlers`` maps handler step name to its descriptor
-            and ``handler_for_step`` maps each covered step name to the handler
-            that owns it (scoped claims first, then the wildcard fills).
-        """
-        all_step_names = set(self._get_steps().keys())
-        handlers: list[CatchErrorHandler] = []
-        for name, step_func in self._get_steps().items():
-            step_config: StepConfig = step_func._step_config
-            if step_config.role != "catch_error":
-                continue
-            max_recoveries = step_config.catch_error_max_recoveries
-            if not isinstance(max_recoveries, int) or max_recoveries < 1:
-                raise WorkflowValidationError(
-                    f"@catch_error handler '{name}' has max_recoveries="
-                    f"{max_recoveries!r}; must be an integer >= 1."
-                )
-            handlers.append(
-                CatchErrorHandler(
-                    step_name=name,
-                    for_steps=(
-                        list(step_config.catch_error_for_steps)
-                        if step_config.catch_error_for_steps is not None
-                        else None
-                    ),
-                    max_recoveries=max_recoveries,
-                )
-            )
-
-        # Inline import: see _validate_graph_structure for the cycle rationale.
-        from .representation.validate import validate_catch_error_handlers
-
-        handler_errors = validate_catch_error_handlers(handlers, all_step_names)
-        if handler_errors:
-            raise WorkflowValidationError("\n".join(handler_errors))
-
-        handler_step_names = {h.step_name for h in handlers}
-        handler_for_step: dict[str, str] = {}
-        for handler in handlers:
-            if handler.for_steps is None:
-                continue
-            for target in handler.for_steps:
-                handler_for_step[target] = handler.step_name
-
-        wildcards = [h for h in handlers if h.for_steps is None]
-        wildcard = wildcards[0] if wildcards else None
-        if wildcard is not None:
-            for step_name in all_step_names:
-                if step_name in handler_step_names or step_name == "_done":
-                    continue
-                if step_name in handler_for_step:
-                    continue
-                handler_for_step[step_name] = wildcard.step_name
-
-        return {h.step_name: h for h in handlers}, handler_for_step
-
     def _validate_resource_configs(self) -> list[str]:
         """Validate all resource configs (including nested ones) by loading them."""
         errors: list[str] = []
@@ -687,100 +531,41 @@ class Workflow(metaclass=WorkflowMeta):
         # Ensure at least one step is configured before inspecting events
         if not self._get_steps():
             cls_name = self.__class__.__name__
-            msg = (
+            raise WorkflowConfigurationError(
                 f"Workflow '{cls_name}' has no configured steps. "
                 "Did you forget to annotate methods with @step or to register "
                 "free-function steps via @step(workflow=...)?"
             )
-            raise WorkflowConfigurationError(msg)
+
+        # Inline import: see _ensure_start_event_class for the cycle rationale.
+        from .representation.validate import (
+            collect_catch_error_handlers,
+            run_graph_validation,
+            validate_event_connectivity,
+        )
+
+        step_configs = self._step_configs()
 
         # Recompute StartEvent and StopEvent classes here to support dynamic changes
         # and to surface StartEvent errors before StopEvent during validation.
         self._start_event_class = self._ensure_start_event_class()
         self._stop_event_class = self._ensure_stop_event_class()
 
-        produced_events: set[type] = {self._start_event_class}
-        consumed_events: set[type] = set()
-
-        # Check that no user-defined step accepts StopEvent (only _done step should)
-        steps_accepting_stop_event: list[str] = []
-
-        for name, step_func in self._get_steps().items():
-            step_config: StepConfig = step_func._step_config
-
-            if name != "_done":
-                for event_type in step_config.accepted_events:
-                    if issubclass(event_type, StopEvent):
-                        steps_accepting_stop_event.append(name)
-                        break
-
-            for event_type in step_config.accepted_events:
-                consumed_events.add(event_type)
-
-            for event_type in step_config.return_types:
-                if event_type is type(None):
-                    # some events may not trigger other events
-                    continue
-
-                produced_events.add(event_type)
-
-        if steps_accepting_stop_event:
-            step_names = "', '".join(steps_accepting_stop_event)
-            plural = "" if len(steps_accepting_stop_event) == 1 else "s"
-            msg = f"Step{plural} '{step_names}' cannot accept StopEvent. StopEvent signals the end of the workflow. Use a different Event type instead."
-            raise WorkflowValidationError(msg)
-
-        self._catch_error_handlers, self._handler_for_step = (
-            self._collect_catch_error_handlers()
+        uses_hitl = validate_event_connectivity(
+            step_configs, self._start_event_class, self._stop_event_class
         )
 
-        # Check if no StopEvent is produced
-        stop_ok = False
-        for ev in produced_events:
-            if issubclass(ev, StopEvent):
-                stop_ok = True
-                break
-        if not stop_ok:
-            msg = "No event of type StopEvent is produced."
-            raise WorkflowValidationError(msg)
+        self._catch_error_handlers, self._handler_for_step = (
+            collect_catch_error_handlers(step_configs)
+        )
 
-        # Check if all consumed events are produced. StepFailedEvent, HumanResponseEvent,
-        # and StopEvent are excluded because they cross the workflow boundary
-        # (emitted by the runtime or external consumer rather than by a step).
-        unconsumed_events = consumed_events - produced_events
-        unconsumed_events = {
-            x
-            for x in unconsumed_events
-            if not issubclass(
-                x,
-                (InputRequiredEvent, HumanResponseEvent, StopEvent, StepFailedEvent),
-            )
-        }
-        if unconsumed_events:
-            names = ", ".join(ev.__name__ for ev in unconsumed_events)
-            raise WorkflowValidationError(
-                f"The following events are consumed but never produced: {names}"
-            )
+        run_graph_validation(
+            steps=step_configs,
+            start_event_class=self._start_event_class,
+            skip_checks=self._skip_graph_checks,
+            catch_error_steps=list(self._catch_error_handlers.keys()),
+        )
 
-        # Check if there are any unused produced events (except specific built-in events)
-        unused_events = produced_events - consumed_events
-        unused_events = {
-            x
-            for x in unused_events
-            if not issubclass(
-                x, (InputRequiredEvent, HumanResponseEvent, self._stop_event_class)
-            )
-        }
-        if unused_events:
-            names = ", ".join(ev.__name__ for ev in unused_events)
-            raise WorkflowValidationError(
-                f"The following events are produced but never consumed: {names}"
-            )
-
-        # Graph structural checks: reachability from input events, terminal events
-        self._validate_graph_structure()
-
-        # Resource validation
         if validate_resource_configs:
             if errors := self._validate_resource_configs():
                 raise WorkflowValidationError(
@@ -796,11 +581,7 @@ class Workflow(metaclass=WorkflowMeta):
                     + "\n".join(f"  - {e}" for e in errors)
                 )
 
-        # Check if the workflow uses human-in-the-loop; cache result for subsequent run() calls
-        self._validation_result = (
-            InputRequiredEvent in produced_events
-            or HumanResponseEvent in consumed_events
-        )
+        self._validation_result = uses_hitl
         self._validated_version = self.__class__._step_functions_version
         return self._validation_result
 

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -126,6 +126,16 @@ class Workflow(metaclass=WorkflowMeta):
                 checks to skip (e.g. "reachability", "terminal_event"). Use to
                 allow intentional patterns that would otherwise fail validation.
         """
+        # Inline imports: every module below imports ``Workflow`` transitively,
+        # so deferring to call time breaks the cycle.
+        from .representation.validate import (
+            collect_events,
+            ensure_start_event_class,
+            ensure_stop_event_class,
+        )
+        from workflows.plugins._context import get_current_runtime
+        from workflows.runtime.verbose import VerboseDecorator
+
         # Configuration
         self._timeout = timeout
         self._verbose = verbose
@@ -133,16 +143,6 @@ class Workflow(metaclass=WorkflowMeta):
         self._num_concurrent_runs = num_concurrent_runs
         # Store explicit name (None means use computed name)
         self._workflow_name = workflow_name
-        # Inline import: ``workflow.py`` is the bootstrap chokepoint — the
-        # ``representation`` package imports ``workflows.Workflow`` transitively
-        # (representation/__init__ -> build -> Workflow), so importing it at
-        # module load time would re-enter a partially-loaded ``workflows``
-        # package. Deferring to call time breaks the cycle.
-        from .representation.validate import (
-            collect_events,
-            ensure_start_event_class,
-            ensure_stop_event_class,
-        )
 
         step_configs = self._step_configs()
         cls_name = self.__class__.__name__
@@ -173,20 +173,9 @@ class Workflow(metaclass=WorkflowMeta):
         self._skip_graph_checks: set[WorkflowGraphCheck] = checks
 
         # Runtime registration: explicit > context-scoped > basic_runtime
-        from workflows.plugins._context import get_current_runtime
-
-        if runtime is not None:
-            self._runtime = runtime
-        else:
-            # get_current_runtime() falls back to basic_runtime
-            self._runtime = get_current_runtime()
-
-        # Wrap with verbose decorator if requested
+        self._runtime = runtime if runtime is not None else get_current_runtime()
         if self._verbose:
-            from workflows.runtime.verbose import VerboseDecorator
-
             self._runtime = VerboseDecorator(self._runtime)
-
         # Register with runtime for tracking (no-op for BasicRuntime)
         self._runtime.track_workflow(self)
 
@@ -456,7 +445,7 @@ class Workflow(metaclass=WorkflowMeta):
         if not force and not stale and self._validation_result is not None:
             return self._validation_result
 
-        # Inline import: see __init__ for the cycle rationale.
+        # Inline import: ``representation`` transitively imports ``Workflow``.
         from .representation.validate import (
             validate_resource_configs as _validate_resource_configs,
             validate_resources as _validate_resources,

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -20,17 +19,12 @@ if TYPE_CHECKING:  # pragma: no cover
     from .runtime.types.plugin import Runtime
 from .decorators import CatchErrorHandler, StepConfig, StepFunction, WorkflowGraphCheck
 from .errors import (
-    WorkflowConfigurationError,
     WorkflowRuntimeError,
     WorkflowValidationError,
 )
 from .events import Event, StartEvent
 from .handler import WorkflowHandler
-from .resource import (
-    ResourceDescriptor,
-    ResourceManager,
-    _ResourceConfig,
-)
+from .resource import ResourceManager
 from .types import RunResultT
 from .utils import get_steps_from_class, get_steps_from_instance
 
@@ -139,16 +133,26 @@ class Workflow(metaclass=WorkflowMeta):
         self._num_concurrent_runs = num_concurrent_runs
         # Store explicit name (None means use computed name)
         self._workflow_name = workflow_name
+        # Inline import: ``workflow.py`` is the bootstrap chokepoint — the
+        # ``representation`` package imports ``workflows.Workflow`` transitively
+        # (representation/__init__ -> build -> Workflow), so importing it at
+        # module load time would re-enter a partially-loaded ``workflows``
+        # package. Deferring to call time breaks the cycle.
+        from .representation.validate import (
+            collect_events,
+            ensure_start_event_class,
+            ensure_stop_event_class,
+        )
+
+        step_configs = self._step_configs()
+        cls_name = self.__class__.__name__
         # Detect StartEvent issues before StopEvent for clearer guidance
-        self._start_event_class = self._ensure_start_event_class()
-        self._stop_event_class = self._ensure_stop_event_class()
-        # Set by _validate(); see that method for the enforcement rules.
-        # Handler step name -> CatchErrorHandler descriptor.
+        self._start_event_class = ensure_start_event_class(step_configs, cls_name)
+        self._stop_event_class = ensure_stop_event_class(step_configs, cls_name)
+        # Populated by _validate(); empty until a successful validation runs.
         self._catch_error_handlers: dict[str, CatchErrorHandler] = {}
-        # Step name -> handler step name that owns it (scoped wins, then
-        # wildcard fills). Handler steps themselves are not entries.
         self._handler_for_step: dict[str, str] = {}
-        self._events = self._ensure_events_collected()
+        self._events = collect_events(step_configs)
         # Resource management
         self._resource_manager = resource_manager or ResourceManager()
         # Instrumentation
@@ -246,16 +250,6 @@ class Workflow(metaclass=WorkflowMeta):
         """Return ``{step_name: StepConfig}`` for every registered step."""
         return {name: func._step_config for name, func in self._get_steps().items()}
 
-    def _ensure_start_event_class(self) -> type[StartEvent]:
-        # Inline import: ``workflow.py`` is the bootstrap chokepoint — the
-        # ``representation`` package imports ``workflows.Workflow`` transitively
-        # (representation/__init__ -> build -> Workflow), so importing it at
-        # module load time would re-enter a partially-loaded ``workflows``
-        # package. Deferring to call time breaks the cycle.
-        from .representation.validate import ensure_start_event_class
-
-        return ensure_start_event_class(self._step_configs(), self.__class__.__name__)
-
     @property
     def start_event_class(self) -> type[StartEvent]:
         """The `StartEvent` subclass accepted by this workflow.
@@ -271,18 +265,6 @@ class Workflow(metaclass=WorkflowMeta):
         Determined by inspecting step input/output types.
         """
         return self._events
-
-    def _ensure_events_collected(self) -> list[type[Event]]:
-        # Inline import: see _ensure_start_event_class for the cycle rationale.
-        from .representation.validate import collect_events
-
-        return collect_events(self._step_configs())
-
-    def _ensure_stop_event_class(self) -> type[RunResultT]:
-        # Inline import: see _ensure_start_event_class for the cycle rationale.
-        from .representation.validate import ensure_stop_event_class
-
-        return ensure_stop_event_class(self._step_configs(), self.__class__.__name__)
 
     @property
     def stop_event_class(self) -> type[RunResultT]:
@@ -424,60 +406,6 @@ class Workflow(metaclass=WorkflowMeta):
             workflow=self, start_event=start_event_instance, run_id=run_id
         )
 
-    def _validate_resource_configs(self) -> list[str]:
-        """Validate all resource configs (including nested ones) by loading them."""
-        errors: list[str] = []
-        seen: set[str] = set()
-
-        # Stack-based traversal of all resources and their dependencies
-        stack: list[_ResourceValidationContext] = []
-        for step_func in self._get_steps().values():
-            step_name = step_func.__name__
-            for res_def in step_func._step_config.resources:
-                res_def.resource.set_type_annotation(res_def.type_annotation)
-                stack.append(
-                    _ResourceValidationContext(
-                        resource=res_def.resource,
-                        step_name=step_name,
-                        param_name=res_def.name,
-                        resource_chain=[res_def.resource.name],
-                    )
-                )
-
-        while stack:
-            ctx = stack.pop()
-            if ctx.resource.name in seen:
-                continue
-            seen.add(ctx.resource.name)
-
-            # Add dependencies to stack
-            for _dep_param, dep, type_ann in ctx.resource.get_dependencies():
-                dep.set_type_annotation(type_ann)
-                stack.append(ctx.with_dependency(dep))
-
-            # Validate if it's a config
-            if isinstance(ctx.resource, _ResourceConfig):
-                try:
-                    ctx.resource.call()
-                except Exception as e:
-                    errors.append(f"In {ctx.format_location()}: {e}")
-
-        return errors
-
-    async def _validate_resources(self) -> list[str]:
-        """Validate all resources by resolving them (catches circular deps)."""
-        errors: list[str] = []
-        for step_func in self._get_steps().values():
-            step_name = step_func.__name__
-            for res_def in step_func._step_config.resources:
-                res_def.resource.set_type_annotation(res_def.type_annotation)
-                try:
-                    await self._resource_manager.get(res_def.resource)
-                except Exception as e:
-                    location = f"step '{step_name}', parameter '{res_def.name}'"
-                    errors.append(f"In {location}: {e}")
-        return errors
-
     def validate(
         self,
         *,
@@ -528,87 +456,37 @@ class Workflow(metaclass=WorkflowMeta):
         if not force and not stale and self._validation_result is not None:
             return self._validation_result
 
-        # Ensure at least one step is configured before inspecting events
-        if not self._get_steps():
-            cls_name = self.__class__.__name__
-            raise WorkflowConfigurationError(
-                f"Workflow '{cls_name}' has no configured steps. "
-                "Did you forget to annotate methods with @step or to register "
-                "free-function steps via @step(workflow=...)?"
-            )
-
-        # Inline import: see _ensure_start_event_class for the cycle rationale.
+        # Inline import: see __init__ for the cycle rationale.
         from .representation.validate import (
-            collect_catch_error_handlers,
-            run_graph_validation,
-            validate_event_connectivity,
+            validate_resource_configs as _validate_resource_configs,
+            validate_resources as _validate_resources,
+            validate_workflow,
         )
 
         step_configs = self._step_configs()
-
-        # Recompute StartEvent and StopEvent classes here to support dynamic changes
-        # and to surface StartEvent errors before StopEvent during validation.
-        self._start_event_class = self._ensure_start_event_class()
-        self._stop_event_class = self._ensure_stop_event_class()
-
-        uses_hitl = validate_event_connectivity(
-            step_configs, self._start_event_class, self._stop_event_class
+        result = validate_workflow(
+            step_configs, self.__class__.__name__, self._skip_graph_checks
         )
-
-        self._catch_error_handlers, self._handler_for_step = (
-            collect_catch_error_handlers(step_configs)
-        )
-
-        run_graph_validation(
-            steps=step_configs,
-            start_event_class=self._start_event_class,
-            skip_checks=self._skip_graph_checks,
-            catch_error_steps=list(self._catch_error_handlers.keys()),
-        )
+        self._start_event_class = result.start_event_class
+        self._stop_event_class = result.stop_event_class
+        self._catch_error_handlers = result.catch_error_handlers
+        self._handler_for_step = result.handler_for_step
 
         if validate_resource_configs:
-            if errors := self._validate_resource_configs():
+            if errors := _validate_resource_configs(step_configs):
                 raise WorkflowValidationError(
                     "Resource config validation failed:\n"
                     + "\n".join(f"  - {e}" for e in errors)
                 )
 
         if validate_resources:
-            errors = asyncio.run(self._validate_resources())
+            errors = asyncio.run(_validate_resources(step_configs, self._resource_manager))
             if errors:
                 raise WorkflowValidationError(
                     "Resource validation failed:\n"
                     + "\n".join(f"  - {e}" for e in errors)
                 )
 
-        self._validation_result = uses_hitl
+        self._validation_result = result.uses_hitl
         self._validated_version = self.__class__._step_functions_version
         return self._validation_result
-
-
-@dataclass
-class _ResourceValidationContext:
-    """Tracks context for resource validation to provide clear error messages."""
-
-    resource: ResourceDescriptor
-    step_name: str
-    param_name: str
-    resource_chain: list[str] = field(default_factory=list)
-
-    def format_location(self) -> str:
-        """Format the location string for error messages."""
-        if len(self.resource_chain) > 1:
-            chain_str = " -> ".join(self.resource_chain)
-            return (
-                f"step '{self.step_name}', parameter '{self.param_name}' ({chain_str})"
-            )
-        return f"step '{self.step_name}', parameter '{self.param_name}'"
-
-    def with_dependency(self, dep: ResourceDescriptor) -> _ResourceValidationContext:
-        """Create a new context for a dependency resource."""
-        return _ResourceValidationContext(
-            resource=dep,
-            step_name=self.step_name,
-            param_name=self.param_name,
-            resource_chain=[*self.resource_chain, dep.name],
-        )

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -617,6 +617,26 @@ async def test_workflow_validation_steps_cannot_accept_stop_event() -> None:
         await WorkflowTestRunner(InvalidWorkflowSingleStep()).run()
 
 
+class _OrphanEvent(Event):
+    pass
+
+
+def test_workflow_validation_consumed_but_never_produced() -> None:
+    class Flow(Workflow):
+        @step
+        async def a(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="ok")
+
+        @step
+        async def b(self, ev: _OrphanEvent) -> StopEvent:
+            return StopEvent(result="never")
+
+    with pytest.raises(
+        WorkflowValidationError, match="consumed but never produced"
+    ):
+        Flow().validate()
+
+
 class _CatchErrorMarker(Event):
     pass
 
@@ -677,6 +697,53 @@ def test_catch_error_max_recoveries_zero_invalid() -> None:
         @catch_error(max_recoveries=0)
         async def bad(self: Any, ctx: Context, ev: StepFailedEvent) -> StopEvent:
             return StopEvent()
+
+
+def test_catch_error_handler_cannot_cover_another_handler() -> None:
+    class BadFlow(Workflow):
+        @step
+        async def a(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="ok")
+
+        @catch_error(for_steps=["h2"])
+        async def h1(self, ctx: Context, ev: StepFailedEvent) -> StopEvent:
+            return StopEvent(result="one")
+
+        @catch_error(for_steps=["a"])
+        async def h2(self, ctx: Context, ev: StepFailedEvent) -> StopEvent:
+            return StopEvent(result="two")
+
+    with pytest.raises(
+        WorkflowValidationError, match="cannot cover another handler step"
+    ):
+        BadFlow().validate()
+
+
+def test_catch_error_max_recoveries_invalid_on_step_config() -> None:
+    class Flow(Workflow):
+        @step
+        async def a(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="ok")
+
+        @catch_error
+        async def handler(self, ctx: Context, ev: StepFailedEvent) -> StopEvent:
+            return StopEvent(result="caught")
+
+    wf = Flow()
+    # Simulate post-decoration corruption of the step config.
+    wf._get_steps()["handler"]._step_config.catch_error_max_recoveries = 0
+    with pytest.raises(WorkflowValidationError, match="max_recoveries"):
+        wf.validate()
+
+
+def test_unknown_skip_graph_check_name_invalid() -> None:
+    class Flow(Workflow):
+        @step
+        async def a(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="ok")
+
+    with pytest.raises(WorkflowValidationError, match="Unknown graph check names"):
+        Flow(skip_graph_checks={"not_a_real_check"})  # type: ignore[arg-type]
 
 
 def test_get_workflow_events() -> None:

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -631,9 +631,7 @@ def test_workflow_validation_consumed_but_never_produced() -> None:
         async def b(self, ev: _OrphanEvent) -> StopEvent:
             return StopEvent(result="never")
 
-    with pytest.raises(
-        WorkflowValidationError, match="consumed but never produced"
-    ):
+    with pytest.raises(WorkflowValidationError, match="consumed but never produced"):
         Flow().validate()
 
 


### PR DESCRIPTION
Workflow class was carrying all of its own validation (StartEvent/StopEvent inference, event connectivity, catch_error handler collection, graph reachability, resource configs). Most of it was pure computation that didn't need `self`. Moved it into `representation/validate.py` behind a single `validate_workflow()` entrypoint.

- `validate_workflow(steps, cls_name, skip_graph_checks)` returns a `WorkflowValidationResult` with the derived start/stop event classes, catch_error handler maps, and the uses-HITL bit.
- Resource config and async resource resolution moved over as `validate_resource_configs` / `validate_resources`.
- `workflow.py` drops from 833 to 492 lines. `Workflow._validate()` is a cache check, one call into `validate_workflow`, and an optional pair of resource checks.