### PR TITLE
Document compatible llama-agents-crds version in llama-agents chart

### DIFF
--- a/.changeset/document-crds-compat-version.md
+++ b/.changeset/document-crds-compat-version.md
@@ -1,0 +1,5 @@
+---
+"llama-agents": patch
+---
+
+Document the compatible `llama-agents-crds` chart version via a new `crds.version` values field, auto-synced at release time and surfaced in the README.

--- a/charts/llama-agents/README.md
+++ b/charts/llama-agents/README.md
@@ -11,7 +11,7 @@ This chart deploys two components:
 
 CRDs (`LlamaDeployment`, `LlamaDeploymentTemplate`) are included in the chart's `crds/` directory and installed automatically on first `helm install`. They are **not** modified on upgrade or removed on uninstall (standard Helm CRD behavior).
 
-For managed CRD upgrades, use the companion [`llama-agents-crds`](../llama-agents-crds/) chart.
+For managed CRD upgrades, use the companion [`llama-agents-crds`](../llama-agents-crds/) chart. Each release of `llama-agents` pins the compatible CRD chart version in `crds.version` (see the values table below) — use that version when installing or upgrading the CRD chart.
 
 ## Prerequisites
 
@@ -36,8 +36,8 @@ CRDs are installed automatically from the `crds/` directory.
 If you prefer explicit CRD lifecycle management (recommended for production):
 
 ```bash
-# Install CRD chart first
-helm install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds
+# Install CRD chart first — pin to the compatible version from `crds.version` below
+helm install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds --version <crds.version>
 
 # Install main chart, skipping bundled CRDs
 helm install llama-agents oci://docker.io/llamaindex/llama-agents --skip-crds \
@@ -47,8 +47,8 @@ helm install llama-agents oci://docker.io/llamaindex/llama-agents --skip-crds \
 ## Upgrading
 
 ```bash
-# If CRD schema has changed, upgrade CRDs first
-helm upgrade --install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds
+# If CRD schema has changed, upgrade CRDs first — pin to `crds.version` from the values table
+helm upgrade --install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds --version <crds.version>
 
 # Then upgrade the main chart
 helm upgrade llama-agents oci://docker.io/llamaindex/llama-agents
@@ -143,6 +143,12 @@ install requires draining and recreating `LlamaDeployment` CRs.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | apps.namespace | string | `""` | Namespace where LlamaDeployment CRs and all operator-managed child resources live. Empty = release namespace. When set, the operator + control plane stay in the release namespace and target this namespace for all app resources. |
+
+### CRDs
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| crds.version | string | `"0.7.2"` | Compatible `llama-agents-crds` chart version for this release. Documentation only; not read by templates. Auto-synced at release time. |
 
 ### Operator
 

--- a/charts/llama-agents/README.md.gotmpl
+++ b/charts/llama-agents/README.md.gotmpl
@@ -11,7 +11,7 @@ This chart deploys two components:
 
 CRDs (`LlamaDeployment`, `LlamaDeploymentTemplate`) are included in the chart's `crds/` directory and installed automatically on first `helm install`. They are **not** modified on upgrade or removed on uninstall (standard Helm CRD behavior).
 
-For managed CRD upgrades, use the companion [`llama-agents-crds`](../llama-agents-crds/) chart.
+For managed CRD upgrades, use the companion [`llama-agents-crds`](../llama-agents-crds/) chart. Each release of `llama-agents` pins the compatible CRD chart version in `crds.version` (see the values table below) — use that version when installing or upgrading the CRD chart.
 
 ## Prerequisites
 
@@ -36,8 +36,8 @@ CRDs are installed automatically from the `crds/` directory.
 If you prefer explicit CRD lifecycle management (recommended for production):
 
 ```bash
-# Install CRD chart first
-helm install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds
+# Install CRD chart first — pin to the compatible version from `crds.version` below
+helm install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds --version <crds.version>
 
 # Install main chart, skipping bundled CRDs
 helm install llama-agents oci://docker.io/llamaindex/llama-agents --skip-crds \
@@ -47,8 +47,8 @@ helm install llama-agents oci://docker.io/llamaindex/llama-agents --skip-crds \
 ## Upgrading
 
 ```bash
-# If CRD schema has changed, upgrade CRDs first
-helm upgrade --install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds
+# If CRD schema has changed, upgrade CRDs first — pin to `crds.version` from the values table
+helm upgrade --install llama-agents-crds oci://docker.io/llamaindex/llama-agents-crds --version <crds.version>
 
 # Then upgrade the main chart
 helm upgrade llama-agents oci://docker.io/llamaindex/llama-agents

--- a/charts/llama-agents/package.json
+++ b/charts/llama-agents/package.json
@@ -13,7 +13,8 @@
     "values.yaml": {
       "images.controlPlane.tag": "{llama-agents-control-plane:dockerTag}",
       "images.operator.tag": "{llama-agents-operator:dockerTag}",
-      "images.appserver.tag": "{llama-agents-appserver:dockerTag}"
+      "images.appserver.tag": "{llama-agents-appserver:dockerTag}",
+      "crds.version": "{llama-agents-crds:version}"
     }
   },
   "postVersion": [

--- a/charts/llama-agents/values.yaml
+++ b/charts/llama-agents/values.yaml
@@ -167,6 +167,11 @@ apps:
   # @section -- Apps
   namespace: ""
 
+crds:
+  # -- Compatible `llama-agents-crds` chart version for this release. Documentation only; not read by templates. Auto-synced at release time.
+  # @section -- CRDs
+  version: "0.7.2"
+
 operator:
   # -- Deploy the operator
   # @section -- Operator


### PR DESCRIPTION
## Summary

- Adds a `crds.version` values field pinning the compatible `llama-agents-crds` chart version for each release.
- Wires `syncValues` to auto-rewrite `crds.version` from the workspace package on release, so the two charts can't drift.
- README prose + install/upgrade snippets now point readers at the pinned version so copy-paste lands on a compatible pair.
- Value is documentation-only; no template logic reads it, so `helm template` / `helm install` output is unchanged.