### PR TITLE
Restore VITE_/NEXT_PUBLIC_ env vars in llamactl serve

### DIFF
--- a/.changeset/open-rocks-drum.md
+++ b/.changeset/open-rocks-drum.md
@@ -2,4 +2,4 @@
 "llamactl": patch
 ---
 
-`llamactl serve` now injects `PUBLIC_`, `VITE_`, and `NEXT_PUBLIC_` prefixed copies of `LLAMA_CLOUD_API_KEY` and `LLAMA_CLOUD_BASE_URL` for local dev. `PUBLIC_` is the canonical prefix templates should read; production deployments must opt in explicitly rather than always exposing the token to client code.
+`llamactl serve` now exports `PUBLIC_LLAMA_CLOUD_API_KEY` and `PUBLIC_LLAMA_CLOUD_BASE_URL` (and `VITE_` / `NEXT_PUBLIC_` variants) so frontend templates can read cloud credentials in local dev.

--- a/.changeset/open-rocks-drum.md
+++ b/.changeset/open-rocks-drum.md
@@ -2,4 +2,4 @@
 "llamactl": patch
 ---
 
-`llamactl serve` now exports `PUBLIC_LLAMA_CLOUD_API_KEY` and `PUBLIC_LLAMA_CLOUD_BASE_URL` (and `VITE_` / `NEXT_PUBLIC_` variants) so frontend templates can read cloud credentials in local dev.
+Revert previous changes, `llamactl serve` now re-exports frontend API keys with public prefixes once again since this is necessary for local dev auth to work.

--- a/.changeset/open-rocks-drum.md
+++ b/.changeset/open-rocks-drum.md
@@ -1,0 +1,5 @@
+---
+"llamactl": patch
+---
+
+Restore VITE_/NEXT_PUBLIC_ prefixed LLAMA_CLOUD_* env vars in `llamactl serve` so Vite and Next.js dev servers can pick up local auth credentials.

--- a/.changeset/open-rocks-drum.md
+++ b/.changeset/open-rocks-drum.md
@@ -2,4 +2,4 @@
 "llamactl": patch
 ---
 
-Restore VITE_/NEXT_PUBLIC_ prefixed LLAMA_CLOUD_* env vars in `llamactl serve` so Vite and Next.js dev servers can pick up local auth credentials.
+`llamactl serve` now injects `PUBLIC_`, `VITE_`, and `NEXT_PUBLIC_` prefixed copies of `LLAMA_CLOUD_API_KEY` and `LLAMA_CLOUD_BASE_URL` for local dev. `PUBLIC_` is the canonical prefix templates should read; production deployments must opt in explicitly rather than always exposing the token to client code.

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -186,6 +186,10 @@ def _set_env_vars_from_env(env_vars: dict[str, str]) -> None:
 def _set_env_vars(key: str, url: str) -> None:
     os.environ["LLAMA_CLOUD_API_KEY"] = key
     os.environ["LLAMA_CLOUD_BASE_URL"] = url
+    # kludge for common web servers to inject local auth key
+    for prefix in ["VITE_", "NEXT_PUBLIC_"]:
+        os.environ[f"{prefix}LLAMA_CLOUD_API_KEY"] = key
+        os.environ[f"{prefix}LLAMA_CLOUD_BASE_URL"] = url
 
 
 def _set_project_id_from_env(env_vars: dict[str, str]) -> None:

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -186,8 +186,11 @@ def _set_env_vars_from_env(env_vars: dict[str, str]) -> None:
 def _set_env_vars(key: str, url: str) -> None:
     os.environ["LLAMA_CLOUD_API_KEY"] = key
     os.environ["LLAMA_CLOUD_BASE_URL"] = url
-    # kludge for common web servers to inject local auth key
-    for prefix in ["VITE_", "NEXT_PUBLIC_"]:
+    # Inject prefixed copies for local dev. PUBLIC_ is the canonical convention
+    # templates should read; VITE_ and NEXT_PUBLIC_ are kept for framework
+    # defaults. These are only set by the CLI so production deployments must
+    # opt in explicitly rather than always exposing the token to client code.
+    for prefix in ["PUBLIC_", "VITE_", "NEXT_PUBLIC_"]:
         os.environ[f"{prefix}LLAMA_CLOUD_API_KEY"] = key
         os.environ[f"{prefix}LLAMA_CLOUD_BASE_URL"] = url
 


### PR DESCRIPTION
## Summary
- `llamactl serve` injects `PUBLIC_`, `VITE_`, and `NEXT_PUBLIC_` prefixed `LLAMA_CLOUD_API_KEY` / `LLAMA_CLOUD_BASE_URL` for local dev.
- `PUBLIC_` is the canonical convention; templates should read that. `VITE_`/`NEXT_PUBLIC_` stay for framework defaults.
- CLI-only — production deployments opt in explicitly rather than always exposing the token to client code.