### PR TITLE
Rename llama_deploy_version to appserver_version

### DIFF
--- a/.changeset/rename-appserver-version.md
+++ b/.changeset/rename-appserver-version.md
@@ -1,0 +1,7 @@
+---
+"llama-agents-core": minor
+"llama-agents-control-plane": minor
+"llamactl": minor
+---
+
+Rename deployment field `llama_deploy_version` to `appserver_version`. The old name remains as a deprecated input/output alias so existing clients and servers keep working.

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
@@ -857,7 +857,7 @@ def _llamadeployment_to_response(
         if not filtered_secret_names:
             filtered_secret_names = None
 
-    # Derive llama_deploy_version from imageTag when tag follows appserver-X.Y.Z convention
+    # Derive appserver_version from imageTag when tag follows appserver-X.Y.Z convention
     derived_version = image_tag_to_version(spec.imageTag) if spec.imageTag else None
 
     # Map internal operator phases to backward-compatible values for old clients
@@ -889,7 +889,7 @@ def _llamadeployment_to_response(
         apiserver_url=HttpUrl(apiserver_url) if apiserver_url else None,
         status=phase,
         warning=warning,
-        llama_deploy_version=derived_version,
+        appserver_version=derived_version,
         suspended=spec.suspended,
     )
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
@@ -122,7 +122,7 @@ class DeploymentService(AbstractDeploymentsService):
         else:
             validated = None
 
-        requested_version = deployment_data.llama_deploy_version
+        requested_version = deployment_data.appserver_version
         if not settings.should_stamp_image_tag:
             # Defer to operator's LLAMA_DEPLOY_IMAGE_TAG env var
             requested_image_tag = None
@@ -153,7 +153,7 @@ class DeploymentService(AbstractDeploymentsService):
         )
 
         # Propagate version in response for clients
-        deployment_response.llama_deploy_version = requested_version
+        deployment_response.appserver_version = requested_version
 
         # Return deployment response with warning header if there are git issues
         if validated is not None and validated.error_message:
@@ -259,11 +259,11 @@ class DeploymentService(AbstractDeploymentsService):
             # Defer to operator's LLAMA_DEPLOY_IMAGE_TAG env var
             # Local-dev only: this does not clear an already pinned CRD spec.imageTag.
             # Existing dev deployments may need one-time recreation/manual field clear.
-            update_data.llama_deploy_version = None
+            update_data.appserver_version = None
             update_data.image_tag = None
         elif (
             update_data.bump_to_latest_appserver
-            and not update_data.llama_deploy_version
+            and not update_data.appserver_version
             and not update_data.image_tag
         ):
             update_data.image_tag = settings.default_appserver_image_tag

--- a/packages/llama-agents-control-plane/tests/test_endpoints.py
+++ b/packages/llama-agents-control-plane/tests/test_endpoints.py
@@ -216,7 +216,7 @@ def test_create_deployment_success(mock_create_deployment: MagicMock) -> None:
         "repo_url": "https://github.com/user/repo.git",
         "personal_access_token": "ghp_token123",
         "secrets": {"API_KEY": "secret_value"},
-        "llama_deploy_version": "0.3.0",
+        "appserver_version": "0.3.0",
     }
 
     response = client.post(
@@ -414,7 +414,7 @@ def test_update_deployment_success(
         has_personal_access_token=True,
         secret_names=["NEW_SECRET"],  # updated
         apiserver_url=HttpUrl("http://test-deploy.example.com"),
-        llama_deploy_version="0.3.1",
+        appserver_version="0.3.1",
     )
 
     update_data = {
@@ -425,7 +425,7 @@ def test_update_deployment_success(
             "NEW_SECRET": "new_value",
             "OLD_SECRET": None,  # remove this secret
         },
-        "llama_deploy_version": "0.3.1",
+        "appserver_version": "0.3.1",
     }
 
     response = client.patch(
@@ -441,6 +441,8 @@ def test_update_deployment_success(
     assert data["git_ref"] == "main"
     assert data["has_personal_access_token"] is True
     assert data["secret_names"] == ["NEW_SECRET"]
+    assert data["appserver_version"] == "0.3.1"
+    # Old clients reading the response see the deprecated key populated
     assert data["llama_deploy_version"] == "0.3.1"
 
     # Verify the update function was called with correct parameters
@@ -452,7 +454,7 @@ def test_update_deployment_success(
     assert update_arg.deployment_file_path == "new_deploy.yml"
     assert update_arg.personal_access_token == "ghp_newtoken"
     assert update_arg.secrets == {"NEW_SECRET": "new_value", "OLD_SECRET": None}
-    assert update_arg.llama_deploy_version == "0.3.1"
+    assert update_arg.appserver_version == "0.3.1"
 
 
 @patch("llama_agents.control_plane.k8s_client.update_deployment")
@@ -1004,7 +1006,7 @@ def test_update_deployment_operator_default_ignores_client_version(
     assert response.status_code == 200
 
     update_arg = mock_update_deployment.call_args[1]["update"]
-    assert update_arg.llama_deploy_version is None
+    assert update_arg.appserver_version is None
     assert update_arg.image_tag is None
 
 

--- a/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
@@ -37,7 +37,7 @@ INTERNAL_CODE_REPO_SCHEME = "internal://"
 
 
 def version_to_image_tag(version: str) -> str:
-    """Convert a llama_deploy_version like '0.4.2' to an image tag like '0.4.2'."""
+    """Convert an appserver_version like '0.4.2' to an image tag like '0.4.2'."""
     return version
 
 
@@ -120,7 +120,7 @@ class DeploymentResponse(Base):
     events: list[DeploymentEvent] | None = Field(
         default=None, description="Recent Kubernetes events for this deployment"
     )
-    llama_deploy_version: str | None = Field(
+    appserver_version: str | None = Field(
         default=None, description="Appserver version (e.g. '0.4.2')"
     )
     suspended: bool = Field(
@@ -132,13 +132,20 @@ class DeploymentResponse(Base):
     def name(self) -> str:
         return self.display_name
 
+    @computed_field(description="Deprecated: use appserver_version")
+    @property
+    def llama_deploy_version(self) -> str | None:
+        return self.appserver_version
+
     @model_validator(mode="before")
     @classmethod
-    def _compat_name(cls, data: dict) -> dict:  # type: ignore[type-arg]
-        """Accept 'name' in input for backwards compatibility."""
+    def _compat_aliases(cls, data: dict) -> dict:  # type: ignore[type-arg]
+        """Accept deprecated 'name' and 'llama_deploy_version' input aliases."""
         if isinstance(data, dict):
             if not data.get("display_name") and data.get("name"):
                 data["display_name"] = data["name"]
+            if not data.get("appserver_version") and data.get("llama_deploy_version"):
+                data["appserver_version"] = data["llama_deploy_version"]
         return data
 
 
@@ -171,7 +178,7 @@ class DeploymentCreate(Base):
         default=None,
         description="Key-value pairs to store as deployment secrets",
     )
-    llama_deploy_version: str | None = Field(
+    appserver_version: str | None = Field(
         default=None,
         description="Appserver version to use (e.g. '0.4.2'). "
         "If omitted, server may set based on client version.",
@@ -179,17 +186,24 @@ class DeploymentCreate(Base):
 
     @model_validator(mode="before")
     @classmethod
-    def _compat_name(cls, data: dict) -> dict:  # type: ignore[type-arg]
-        """Accept deprecated 'name' field as alias for 'display_name'."""
+    def _compat_aliases(cls, data: dict) -> dict:  # type: ignore[type-arg]
+        """Accept deprecated 'name' and 'llama_deploy_version' input aliases."""
         if isinstance(data, dict):
             if data.get("name") and not data.get("display_name"):
                 data["display_name"] = data.pop("name")
+            if data.get("llama_deploy_version") and not data.get("appserver_version"):
+                data["appserver_version"] = data.pop("llama_deploy_version")
         return data
 
     @computed_field(description="Deprecated: use display_name")
     @property
     def name(self) -> str:
         return self.display_name
+
+    @computed_field(description="Deprecated: use appserver_version")
+    @property
+    def llama_deploy_version(self) -> str | None:
+        return self.appserver_version
 
     @model_validator(mode="after")
     def _require_id_format(self) -> "DeploymentCreate":
@@ -302,12 +316,12 @@ class DeploymentUpdate(Base):
     static_assets_path: Path | None = Field(
         default=None, description="Path to prebuilt UI assets (set by service layer)"
     )
-    llama_deploy_version: str | None = Field(
+    appserver_version: str | None = Field(
         default=None, description="Updated appserver version selector"
     )
     image_tag: str | None = Field(
         default=None,
-        description="Explicit image tag (takes precedence over llama_deploy_version)",
+        description="Explicit image tag (takes precedence over appserver_version)",
     )
     bump_to_latest_appserver: bool = Field(
         default=False,
@@ -326,13 +340,20 @@ class DeploymentUpdate(Base):
     def name(self) -> str | None:
         return self.display_name
 
+    @computed_field(description="Deprecated: use appserver_version")
+    @property
+    def llama_deploy_version(self) -> str | None:
+        return self.appserver_version
+
     @model_validator(mode="before")
     @classmethod
-    def _compat_name(cls, data: dict) -> dict:  # type: ignore[type-arg]
-        """Accept deprecated 'name' field as alias for 'display_name'."""
+    def _compat_aliases(cls, data: dict) -> dict:  # type: ignore[type-arg]
+        """Accept deprecated 'name' and 'llama_deploy_version' input aliases."""
         if isinstance(data, dict):
             if data.get("name") and not data.get("display_name"):
                 data["display_name"] = data.pop("name")
+            if data.get("llama_deploy_version") and not data.get("appserver_version"):
+                data["appserver_version"] = data.pop("llama_deploy_version")
         return data
 
     def has_git_fields(self) -> bool:
@@ -356,7 +377,7 @@ class DeploymentUpdate(Base):
                 self.personal_access_token is not None,
                 self.secrets is not None,
                 self.image_tag is not None,
-                self.llama_deploy_version is not None,
+                self.appserver_version is not None,
                 self.bump_to_latest_appserver,
             ]
         )
@@ -454,8 +475,8 @@ def apply_deployment_update(
     # Handle image tag / version selector (image_tag takes precedence)
     if update.image_tag is not None:
         updated_spec.imageTag = update.image_tag
-    elif update.llama_deploy_version is not None:
-        updated_spec.imageTag = version_to_image_tag(update.llama_deploy_version)
+    elif update.appserver_version is not None:
+        updated_spec.imageTag = version_to_image_tag(update.appserver_version)
 
     # Bump buildGeneration to force a rebuild (e.g. retry after transient failure)
     if update.rebuild:

--- a/packages/llama-agents-core/tests/test_schema.py
+++ b/packages/llama-agents-core/tests/test_schema.py
@@ -91,6 +91,115 @@ def test_deployment_response_deserializes_old_server_name() -> None:
     assert resp.display_name == "Old Server Deploy"
 
 
+# -- Backwards compatibility: llama_deploy_version <-> appserver_version --
+
+
+def test_deployment_create_accepts_deprecated_llama_deploy_version() -> None:
+    """Old callers passing 'llama_deploy_version' should still work."""
+    deployment = DeploymentCreate(
+        display_name="App",
+        repo_url="https://example.com",
+        llama_deploy_version="0.4.2",  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+    )
+    assert deployment.appserver_version == "0.4.2"
+
+
+def test_deployment_create_canonical_wins_on_conflict() -> None:
+    """When both fields are sent, canonical 'appserver_version' wins silently."""
+    deployment = DeploymentCreate.model_validate(
+        {
+            "display_name": "App",
+            "repo_url": "https://example.com",
+            "appserver_version": "0.4.2",
+            "llama_deploy_version": "0.3.0",
+        }
+    )
+    assert deployment.appserver_version == "0.4.2"
+
+
+def test_deployment_create_neither_version_field_set() -> None:
+    """With neither field set, appserver_version is None."""
+    deployment = DeploymentCreate(display_name="App", repo_url="https://example.com")
+    assert deployment.appserver_version is None
+
+
+def test_deployment_create_serializes_llama_deploy_version_for_old_servers() -> None:
+    """Serialized payload must include 'llama_deploy_version' so old servers accept it."""
+    deployment = DeploymentCreate(
+        display_name="App",
+        repo_url="https://example.com",
+        appserver_version="0.4.2",
+    )
+    data = deployment.model_dump()
+    assert data["appserver_version"] == "0.4.2"
+    assert data["llama_deploy_version"] == "0.4.2"
+
+
+def test_deployment_update_accepts_deprecated_llama_deploy_version() -> None:
+    """Old callers patching 'llama_deploy_version' should still work."""
+    update = DeploymentUpdate(llama_deploy_version="0.4.2")  # type: ignore[call-arg]  # ty: ignore[unknown-argument]
+    assert update.appserver_version == "0.4.2"
+
+
+def test_deployment_update_canonical_wins_on_conflict() -> None:
+    """When both fields are sent, canonical 'appserver_version' wins silently."""
+    update = DeploymentUpdate.model_validate(
+        {"appserver_version": "0.4.2", "llama_deploy_version": "0.3.0"}
+    )
+    assert update.appserver_version == "0.4.2"
+
+
+def test_deployment_update_serializes_llama_deploy_version_for_old_servers() -> None:
+    """Serialized PATCH payload must include 'llama_deploy_version' so old servers accept it."""
+    update = DeploymentUpdate(appserver_version="0.4.2")
+    data = update.model_dump()
+    assert data["appserver_version"] == "0.4.2"
+    assert data["llama_deploy_version"] == "0.4.2"
+
+
+def test_deployment_update_llama_deploy_version_none_when_unset() -> None:
+    """When appserver_version is not set, llama_deploy_version should also be None."""
+    update = DeploymentUpdate()
+    data = update.model_dump()
+    assert data["appserver_version"] is None
+    assert data["llama_deploy_version"] is None
+
+
+def test_deployment_response_accepts_old_server_llama_deploy_version() -> None:
+    """An old server emits only llama_deploy_version; new client should map it through."""
+    resp = DeploymentResponse.model_validate(
+        {
+            "id": "dep-1",
+            "display_name": "App",
+            "project_id": "proj-1",
+            "repo_url": "https://example.com",
+            "git_ref": "main",
+            "deployment_file_path": "",
+            "status": "Running",
+            "has_personal_access_token": False,
+            "llama_deploy_version": "0.4.2",
+        }
+    )
+    assert resp.appserver_version == "0.4.2"
+
+
+def test_deployment_response_serializes_both_version_fields() -> None:
+    """Responses include both keys so old clients keep working."""
+    resp = DeploymentResponse(
+        id="dep-1",
+        display_name="App",
+        project_id="proj-1",
+        repo_url="https://example.com",
+        git_ref="main",
+        deployment_file_path="",
+        status="Running",
+        appserver_version="0.4.2",
+    )
+    data = resp.model_dump()
+    assert data["appserver_version"] == "0.4.2"
+    assert data["llama_deploy_version"] == "0.4.2"
+
+
 def test_deployment_create_optional_fields() -> None:
     """Test DeploymentCreate with optional fields"""
 
@@ -530,7 +639,7 @@ def test_appserver_tag_prefix_constant() -> None:
 
 
 def test_apply_deployment_update_image_tag_precedence() -> None:
-    """image_tag takes precedence over llama_deploy_version"""
+    """image_tag takes precedence over appserver_version"""
     existing_spec = LlamaDeploymentSpec(
         displayName="my-deployment",
         projectId="test-project",
@@ -538,7 +647,7 @@ def test_apply_deployment_update_image_tag_precedence() -> None:
     )
 
     update = DeploymentUpdate(
-        llama_deploy_version="0.3.0",
+        appserver_version="0.3.0",
         image_tag="appserver-0.4.2",
     )
 
@@ -656,13 +765,13 @@ def test_apply_deployment_update_static_assets_path_not_cleared() -> None:
 
 
 def test_apply_deployment_update_version_sets_image_tag() -> None:
-    """llama_deploy_version is converted to imageTag when image_tag is not set"""
+    """appserver_version is converted to imageTag when image_tag is not set"""
     existing_spec = LlamaDeploymentSpec(
         displayName="my-deployment",
         projectId="test-project",
         repoUrl="https://github.com/user/repo.git",
     )
 
-    update = DeploymentUpdate(llama_deploy_version="0.3.1")
+    update = DeploymentUpdate(appserver_version="0.3.1")
     result = apply_deployment_update(update, existing_spec)
     assert result.updated_spec.imageTag == "0.3.1"

--- a/packages/llamactl/src/llama_agents/cli/textual/deployment_form.py
+++ b/packages/llamactl/src/llama_agents/cli/textual/deployment_form.py
@@ -88,7 +88,7 @@ class DeploymentForm:
     env_info_messages: str | None = None
     # appserver version fields
     installed_appserver_version: str | None = None
-    existing_llama_deploy_version: str | None = None
+    existing_appserver_version: str | None = None
     selected_appserver_version: str | None = None
     # required secret names from config
     required_secret_names: list[str] = field(default_factory=list)
@@ -108,7 +108,7 @@ class DeploymentForm:
         secret_names = deployment.secret_names or []
 
         installed = get_installed_appserver_version()
-        existing = deployment.llama_deploy_version
+        existing = deployment.appserver_version
         # If versions match (or existing is None), treat as non-editable like create
         selected = existing or installed
 
@@ -128,7 +128,7 @@ class DeploymentForm:
             initial_secrets=set(secret_names),
             is_editing=True,
             installed_appserver_version=installed,
-            existing_llama_deploy_version=existing,
+            existing_appserver_version=existing,
             selected_appserver_version=selected,
             push_mode=is_internal,
             is_local_git_repo=has_git,
@@ -171,7 +171,7 @@ class DeploymentForm:
                 else self.personal_access_token
             ),
             secrets=secrets,
-            llama_deploy_version=appserver_version,
+            appserver_version=appserver_version,
         )
 
         return data
@@ -187,7 +187,7 @@ class DeploymentForm:
             git_ref=self.git_ref or "main",
             personal_access_token=self.personal_access_token,
             secrets=self.secrets,
-            llama_deploy_version=appserver_version,
+            appserver_version=appserver_version,
         )
 
 
@@ -356,14 +356,14 @@ class DeploymentFormWidget(Widget):
             versions_differ = (
                 self.form_data.is_editing
                 and self.form_data.installed_appserver_version
-                and self.form_data.existing_llama_deploy_version
+                and self.form_data.existing_appserver_version
                 and self.form_data.installed_appserver_version
-                != self.form_data.existing_llama_deploy_version
+                != self.form_data.existing_appserver_version
             )
             if versions_differ:
                 # Show dropdown selector for version choice
                 installed_version = self.form_data.installed_appserver_version
-                existing_version = self.form_data.existing_llama_deploy_version
+                existing_version = self.form_data.existing_appserver_version
                 current_selection = (
                     self.form_data.selected_appserver_version
                     or existing_version
@@ -389,7 +389,7 @@ class DeploymentFormWidget(Widget):
                 # Non-editable display of version
                 readonly_version = (
                     self.form_data.installed_appserver_version
-                    or self.form_data.existing_llama_deploy_version
+                    or self.form_data.existing_appserver_version
                     or "unknown"
                 )
                 yield Static(readonly_version, id="appserver_version_readonly")
@@ -525,7 +525,7 @@ class DeploymentFormWidget(Widget):
                 updated_prior_secrets
             ),
             installed_appserver_version=self.form_data.installed_appserver_version,
-            existing_llama_deploy_version=self.form_data.existing_llama_deploy_version,
+            existing_appserver_version=self.form_data.existing_appserver_version,
             selected_appserver_version=self.form_data.selected_appserver_version,
             required_secret_names=self.form_data.required_secret_names,
             push_mode=self.form_data.push_mode,

--- a/packages/llamactl/tests/textual/test_deployment_form.py
+++ b/packages/llamactl/tests/textual/test_deployment_form.py
@@ -621,7 +621,7 @@ async def test_deployment_edit_app_end_to_end_update(
         project_id="proj-456",
         apiserver_url=None,
         status="Running",
-        llama_deploy_version="0.9.0",
+        appserver_version="0.9.0",
     )
 
     initial_data = DeploymentForm.from_deployment(existing_deployment)
@@ -638,7 +638,7 @@ async def test_deployment_edit_app_end_to_end_update(
         project_id="proj-456",
         apiserver_url=None,
         status="Running",
-        llama_deploy_version="1.0.0",
+        appserver_version="1.0.0",
     )
 
     mock_client.update_deployment.return_value = mock_updated_deployment
@@ -678,7 +678,7 @@ async def test_deployment_edit_app_end_to_end_update(
         assert isinstance(update_data, DeploymentUpdate)
         assert update_data.repo_url == "https://github.com/user/new-repo"
         assert update_data.git_ref == "main"
-        assert update_data.llama_deploy_version == "1.0.0"
+        assert update_data.appserver_version == "1.0.0"
 
         # Close monitor to exit app
         app.screen.post_message(MonitorCloseMessage())
@@ -929,7 +929,7 @@ async def test_appserver_version_selector_edit_when_different(
         project_id="proj-111",
         apiserver_url=None,
         status="Running",
-        llama_deploy_version="0.9.0",
+        appserver_version="0.9.0",
     )
 
     form = DeploymentForm.from_deployment(existing_deployment)
@@ -978,7 +978,7 @@ async def test_appserver_version_readonly_when_same(
         project_id="proj-222",
         apiserver_url=None,
         status="Running",
-        llama_deploy_version="1.0.0",
+        appserver_version="1.0.0",
     )
 
     form = DeploymentForm.from_deployment(existing_deployment)


### PR DESCRIPTION
## Summary

- `DeploymentCreate`, `DeploymentResponse`, and `DeploymentUpdate` now expose `appserver_version` as the canonical field. `llama_deploy_version` stays as a deprecated input alias and a serialized-output mirror, so old clients reading new servers and new clients reading old servers both keep working.
- Internal callers (control plane `deployments_service`, `k8s_client`, llamactl deployment form) read and write `appserver_version`.
- Schema tests cover input alias, output alias, both-fields-set precedence (canonical wins), and unset. Wire-compat endpoint tests still post `llama_deploy_version` JSON to lock the contract.