### PR TITLE
llamactl auth login: friendly error when OIDC is disabled

### DIFF
--- a/.changeset/llamactl-auth-login-oidc-disabled.md
+++ b/.changeset/llamactl-auth-login-oidc-disabled.md
@@ -1,0 +1,5 @@
+---
+"llamactl": patch
+---
+
+`llamactl auth login` now prints a friendly hint pointing to `llamactl auth token` when the server has no OIDC browser-login configured, instead of dumping a raw 400 from the discovery endpoint.

--- a/packages/llamactl/src/llama_agents/cli/auth/client.py
+++ b/packages/llamactl/src/llama_agents/cli/auth/client.py
@@ -29,6 +29,10 @@ else:
 logger = logging.getLogger(__name__)
 
 
+class OIDCNotEnabledError(Exception):
+    """Raised when the server does not have OIDC browser-login configured."""
+
+
 class OidcDiscoveryResponse(BaseModel):
     discovery_url: str
     client_ids: dict[str, str] | None = None
@@ -98,6 +102,19 @@ class ClientContextManager(AsyncContextManager):
         await self.close()
 
 
+def _extract_detail(resp: httpx.Response) -> str | None:
+    """Best-effort extract of a FastAPI-style ``detail`` string from a response."""
+    try:
+        payload = resp.json()
+    except Exception:
+        return None
+    if isinstance(payload, dict):
+        detail = payload.get("detail")
+        if isinstance(detail, str):
+            return detail
+    return None
+
+
 class PlatformAuthDiscoveryClient(ClientContextManager):
     """Client for ad hoc auth endpoints under /api/v1/auth."""
 
@@ -106,6 +123,14 @@ class PlatformAuthDiscoveryClient(ClientContextManager):
 
     async def oidc_discovery(self) -> OidcDiscoveryResponse:
         resp = await self.client.get("/api/v1/auth/oidc/discovery", timeout=10.0)
+        if resp.status_code in (400, 404, 501):
+            # Server reachable but OIDC discovery isn't configured. Surface a
+            # typed error so callers can suggest the API key flow instead of
+            # leaking a raw HTTP status.
+            detail = _extract_detail(resp)
+            raise OIDCNotEnabledError(
+                detail or "Server does not have OIDC browser login enabled"
+            )
         resp.raise_for_status()
         return OidcDiscoveryResponse.model_validate(resp.json())
 

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -127,6 +127,7 @@ def create_api_key_profile(
 @global_options
 def device_login() -> None:
     """Login via web browser"""
+    from llama_agents.cli.auth.client import OIDCNotEnabledError
 
     try:
         created = _create_device_profile()
@@ -139,6 +140,17 @@ def device_login() -> None:
         rprint(f"[{WARNING}]Looks like this may be your first time logging in.[/]")
         rprint(
             f"[{WARNING}]Before you can get started, log in to https://cloud.llamaindex.ai to complete your account setup.[/]"
+        )
+        return
+
+    except OIDCNotEnabledError as e:
+        rprint(
+            f"[{WARNING}]This server does not have browser-based login (OIDC) configured.[/]"
+        )
+        if str(e):
+            rprint(f"[{MUTED_COL}]Server response: {e}[/]")
+        rprint(
+            "Use [cyan]llamactl auth token[/cyan] to log in with an API key instead."
         )
         return
 

--- a/packages/llamactl/tests/test_auth_login.py
+++ b/packages/llamactl/tests/test_auth_login.py
@@ -1,9 +1,17 @@
+from __future__ import annotations
+
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
+import httpx
 import pytest
-from llama_agents.cli.commands.auth import _create_device_profile
+from click.testing import CliRunner
+from llama_agents.cli.auth.client import (
+    OIDCNotEnabledError,
+    PlatformAuthDiscoveryClient,
+)
+from llama_agents.cli.commands.auth import _create_device_profile, device_login
 
 
 def _make_fake_device_oidc() -> SimpleNamespace:
@@ -69,3 +77,36 @@ def test_create_device_profile_cleans_up_on_api_key_failure() -> None:
             _create_device_profile()
 
     mock_auth_svc.delete_profile.assert_awaited_once_with(fake_profile.name)
+
+
+@pytest.mark.asyncio
+async def test_oidc_discovery_translates_disabled_400_to_typed_error() -> None:
+    """A 400 from /auth/oidc/discovery should surface as OIDCNotEnabledError."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(400, json={"detail": "Discovery URL is not enabled"})
+
+    transport = httpx.MockTransport(handler)
+    client = PlatformAuthDiscoveryClient("http://example.test")
+    client.client = httpx.AsyncClient(
+        base_url="http://example.test", transport=transport
+    )
+    try:
+        with pytest.raises(OIDCNotEnabledError, match="Discovery URL is not enabled"):
+            await client.oidc_discovery()
+    finally:
+        await client.close()
+
+
+def test_device_login_suggests_token_when_oidc_disabled() -> None:
+    """When OIDC is unavailable, login should print a friendly hint, not a stack trace."""
+
+    with patch(
+        "llama_agents.cli.commands.auth._create_device_profile",
+        side_effect=OIDCNotEnabledError("Discovery URL is not enabled"),
+    ):
+        result = CliRunner().invoke(device_login, [])
+
+    assert result.exit_code == 0, result.output
+    assert "browser-based login" in result.output
+    assert "llamactl auth token" in result.output


### PR DESCRIPTION
## Summary
- `llamactl auth login` against a server without OIDC browser-login configured was bubbling up the raw httpx 400 from `/api/v1/auth/oidc/discovery`. Now it prints a one-liner pointing at `llamactl auth token` instead.
- The discovery client translates 400/404/501 into a typed `OIDCNotEnabledError` so other callers can do the same. The server's `detail` (e.g. `"Discovery URL is not enabled"`) is surfaced as a muted secondary line.