### PR TITLE
Add llamactl-qa skill and dev-cli sync-skills helper

### DIFF
--- a/.agents/skills/llamactl-qa/SKILL.md
+++ b/.agents/skills/llamactl-qa/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: llamactl-qa
+description: Plan and run a design-QA / "taste test" of llamactl changes against a real backend. Cooperatively builds a small matrix of cases worth eyeballing, runs them against a chosen backend (prod test project by default, local kind+tilt for new API contract changes), and writes a design-review report to `thoughts/shared/qa/`. Use this for changes to `llamactl` commands, output formats, auth, or control-plane API contracts. For UI/template smoke tests, use `llamactl_browser_test` instead.
+---
+
+# llamactl CLI QA
+
+A design QA, not an integration test. The goal is to put the actual rendered output in front of a human reviewer so they can judge whether the design is right — alignment, naming, key ordering, error wording, what's noisy, what's missing. The LLM's job is to set up well-chosen cases and call out what looks off; the human's job is to read the outputs and decide.
+
+Two halves. First, a planning pass that turns "I changed X" into a small, sign-off-able matrix of cases worth running. Second, an execution pass that runs them and writes a report whose body is mostly verbatim output plus design-review notes.
+
+Every row in the matrix is there because we agreed it covers a real risk or design question in the diff.
+
+### What this is NOT
+
+- **Not an automated integration test.** No `jq has(...)` shape assertions, no `python -c "assert ..."`. If a row reads as "the command works", drop it; if it reads as "let's see the output and judge it", keep it. Real integration tests are a separate task (authoring real pytest cases against the API), not this one.
+- **Not exhaustive coverage.** 4–8 well-chosen rows. The point is taste, not a regression matrix.
+- **Not pass/fail.** The report's job is "here's what the surface actually looks like", not "all green".
+
+llamactl is churning right now (multi-slice rework: output modes, apply/delete, template/apply-loop). Treat this skill as a living reference. When a run teaches you something about llamactl that isn't in here, edit the skill before closing the task. See "Self-update" at the bottom.
+
+## When to use
+
+- Changes to `llamactl` commands (new flags, new output modes, command splits, behavior changes).
+- Changes to control-plane API contracts that llamactl consumes.
+- Changes to auth / profile / project resolution.
+
+Skip when the change is fully covered by pytest, or when the failure mode is in the UI (use `llamactl_browser_test`).
+
+## Pick a backend
+
+1. **Prod against a test project.** Default. Read-only commands, and write commands targeting a deployment in a project explicitly designated for testing. Confirm the project name with the user before running anything mutating. Pin every command with `--project <test-project-id>` so an active-profile slip can't write into a real project.
+2. **Local kind + tilt.** When the change is a new API contract (new endpoint, new field, new behavior on the control plane) and you need to exercise it against a control plane that actually has the change. `uv run operator/dev.py up`. See `AGENTS.md` and `operator/AGENTS.md` for setup. Local mode runs with no auth: the `http://localhost:8011` env is preconfigured; switch to it with `llamactl auth env switch http://localhost:8011` (arg is the API URL, not a name) and a `default` profile is created automatically. No tokens, no `auth login`. Before drafting the matrix, list existing deployments with `kubectl get llamadeployments -A` — there's often something already in the cluster from prior work that you can target with `--project <id>`, saving the cost of a fresh `deployments create`.
+3. **Staging.** Rarely the right answer for this skill. Use prod-test-project or local instead.
+
+Ask the user which backend before drafting the matrix. The answer changes which rows are realistic.
+
+## llamactl mental model
+
+The bits that matter when designing a matrix.
+
+A profile is `(env, oauth tokens, active org, active project)`. The env is a control-plane URL. `--project <id>` overrides the profile's active project for one call. `llamactl auth list` shows the stack. `llamactl auth env list` shows envs.
+
+Read commands accept `-o text|json|yaml`. Text is human-facing; json/yaml are assertable. Prefer json for QA — exact-match assertions catch field-rename regressions text formatting hides.
+
+Read commands (`deployments get/list/history/logs`, `auth list`, `auth env list`) do not need `--no-interactive` when their argument is supplied. The flag is a no-op there post-Slice-A.5 and slated to be removed in the parent plan's Phase 3. Don't pad commands with it. Write/select commands (`deployments delete`, `deployments edit`, `deployments rollback` without `--git-sha`) still branch on the interactive flag — pass `--no-interactive` for those if you don't want a prompt, or supply every required arg.
+
+The command surface is moving. Run `--help` on any command you're testing before assuming flag names; don't go from memory.
+
+## Cooperative planning
+
+Don't run anything until the user has signed off on the matrix.
+
+1. Read the diff. `git diff <base>...HEAD --stat` and targeted reads on the command files. Identify the behavior surface: which subcommands, flags, output formats, endpoints changed.
+2. List design questions, not features. One line each. The right question reads as "would the user be happy seeing this output?", not "does the command run". Examples: "Does the `spec:` / `status:` split actually feel right when you eyeball `get -o yaml`?" "Does the plain-table list output stay readable for a deployment whose repo URL is 80 chars?" "Does the no-secrets case render as cleanly as the with-secrets case?"
+3. Map questions to a small matrix. One row per case. 4–8 rows is usually right; 12 means you're testing features.
+4. Present the matrix inline. Wait for the user to keep, cut, or add rows.
+
+Matrix row format. Note "Look for" replaces a pass-fail "Expect" — the reviewer is meant to read the output and judge against these prompts, not check a list of facts.
+
+| # | Command | Backend | Look for | Covers |
+|---|---|---|---|---|
+| 1 | `deployments get my-app -o yaml --project <test>` | prod-test | spec/status split reads cleanly; field ordering; null vs omitted; PAT presentation | new display model shape |
+| 2 | `deployments get --project <test>` | prod-test | column choices, alignment, behavior with long repo URLs | plain-table list mode |
+| 3 | `deployments get my-app --project <other-test>` vs default | prod-test | does the override actually retarget the project | `--project` override |
+
+If a row's "Look for" reads as "the command works", drop it. If it reads as "I'd want to eyeball this", keep it.
+
+## Execution
+
+Run rows top to bottom. For each, the goal is to capture the actual output the human reviewer will judge.
+
+Capture:
+
+- The exact command (including inline env vars).
+- Exit code and elapsed time (latency is part of UX).
+- **Verbatim stdout and stderr.** Don't trim, don't summarize, don't paraphrase. The report's body is the output, not your verdict on it. Truncation only when output is genuinely huge (200+ line log dumps); keep head, tail, and a `... <N> lines elided ...` marker.
+- Your design-review observations as one-line "Notes" — what a thoughtful reviewer would point at. "REPO column is 67 chars wide on a 100-char terminal — leaves no room for two repos to align." "`status.warning: null` reads cleanly; the omitted vs explicit-null asymmetry is visible." "Why are both `display_name` and `name` here when they're equal?"
+
+What NOT to do:
+
+- **No `jq has(...)` / `python -c "assert ..."` style assertions.** The report is for human judgment, not pass/fail. If you find yourself asserting a key exists, you're in the wrong skill — that's pytest territory.
+- **Don't pre-judge.** Notes flag things to look at; the reader judges. "Suspicious: `personal_access_token` shown as `********` even when the underlying secret name is also `GITHUB_PAT`" is fine. "Wrong: PAT should be unmasked" is not — that's the reader's call.
+- **Don't paper over surprises.** If a row produces a stack trace or an unexpected shape, capture it verbatim and call it out in Highlights. Re-running with different flags to make the symptom go away is forbidden; that's the QA finding.
+
+For comparison rows (`--project` override, `list` vs `get`, text vs json, with-data vs empty), capture both calls in the same row, side by side. The reader should be able to eyeball the difference without scrolling.
+
+Long-running commands (`serve`, `logs --follow`) go in the background with `run_in_background: true`. Stop them before moving on.
+
+### Storing raw transcripts
+
+Don't dump `.log` / `.out` / `.err` files into `thoughts/shared/qa/`. The report is the artifact. Embed verbatim outputs in the report with fenced blocks.
+
+If a single output is genuinely too large to embed (200+ lines of logs, many-deployment dumps), put it in `thoughts/shared/qa/raw/<date>-<scope>/<row-id>.txt` and link it from the report row. Default to embedding; the subdir is the exception, not the rule.
+
+## Report
+
+The report is a design and interaction review surface, not a test result. The reader scrolls through it and forms their own opinion: are columns aligned, is naming consistent, does this command feel right, is the error message clear. Your job is to put the evidence in front of them and flag the design questions worth their attention.
+
+Write to `thoughts/shared/qa/<date>-llamactl-<scope>.md`. Post a one-or-two-sentence pointer inline plus the file link. The user reads the file, not your inline summary.
+
+Template:
+
+````
+# llamactl QA: <one-line scope>
+
+Backend: <prod-test-project | local kind | other>
+Profile: <name> (<env URL>)
+Project: <test project id/name>
+Branch: <branch>  Commit: <short sha>
+
+## Design questions for the reviewer
+
+<3–6 bullets. These are the things you want the reader's eyes on. Not "all rows passed". Examples:
+- "Is `spec:` + `status:` the right split, or is the extra indent annoying?"
+- "REPO column gets pushed off-screen when the URL isn't a github short. Do we want a `--wide` mode or terminal-aware wrapping?"
+- "`auth list` text mode shows ACTIVE column but the indicator is `*` only — is that legible enough?"
+- "When secrets are unset, the JSON spec block is just `{display_name, repo_url, deployment_file_path, suspended: false}`. Is `suspended: false` worth showing on a fresh deploy or is it noise?"
+
+Lean open-ended. If a question has an obvious answer, it doesn't belong here.>
+
+## Rows
+
+### 1. <one-line description, e.g. "deployments get my-app -o yaml">
+
+Command:
+```
+$ <exact command>
+```
+
+Output (exit=<n>, <elapsed>):
+```
+<verbatim stdout>
+```
+<if stderr non-empty:>
+Stderr:
+```
+<verbatim stderr>
+```
+
+Notes:
+- <one-line observation a thoughtful reviewer would make>
+- <another, if there's something else worth flagging>
+
+### 2. <comparison row>
+
+Command A:
+```
+$ <command 1>
+```
+
+Output A (exit=<n>):
+```
+<output>
+```
+
+Command B:
+```
+$ <command 2>
+```
+
+Output B (exit=<n>):
+```
+<output>
+```
+
+Notes:
+- <what the side-by-side reveals>
+
+... same shape for remaining rows ...
+
+## Followups
+
+- <design questions that need a human answer>
+- <regressions or design choices that should turn into issues / changes>
+- <items the matrix didn't cover but the reader should know about>
+````
+
+Rules:
+
+- **Show, don't tell.** "Output shows a spec block with editable fields" → no. Paste the YAML. The reader can see the shape.
+- **Keep verbatim formatting.** Tables in fenced blocks preserve column rendering. Don't reformat or "clean up" output.
+- **Comparison rows live in one section.** Two adjacent fenced blocks labeled clearly beat two separate rows.
+- **Notes are observations, not verdicts.** Point at what's interesting; let the reader judge.
+- **No celebration.** If everything looks reasonable, the report just looks reasonable. Don't add "all green" framing.
+
+The inline chat reply is one or two sentences pointing at the file. Don't restate the report.
+
+## Common gotchas
+
+- Stale profile. `llamactl auth list` first, every session. A profile pointing at last week's env produces 401s that look like a code bug.
+- Active project drift. A test that "works on my machine" can fail elsewhere because the active project differs. Pin every prod row with `--project`.
+- Non-test project mutation. If you mutate without `--project`, the active profile decides where it lands. Always pin write commands.
+- TUI/prompt risk on write commands. `deployments delete/edit/rollback` and `create` will prompt when interactive. For QA, supply every required arg or pass `--no-interactive`. Read commands (`get`, `logs`, `history`, `auth list`, `auth env list`) don't need the flag.
+- `tee` ate a row of a multi-line table once during a run. Use shell `>` redirect for QA captures, not `tee`, when you need every line preserved.
+- `serve` vs tilt. `llamactl serve` runs the appserver locally with no kubernetes. Tilt runs the full cloud stack in kind. Different scopes; pick one.
+- Don't leak IDs. Deployment and org IDs are fine in your terminal and in `thoughts/`, not fine in a public PR description. Strip or alias them in anything that might leave the repo.
+
+## Self-update
+
+llamactl's command surface is moving. When a run teaches you a fact this skill doesn't have, edit it.
+
+Triggers for an edit:
+
+- A flag name, command path, or output shape was different from what the skill implied.
+- A failure mode showed up that isn't in "Common gotchas".
+- A backend setup step (especially local tilt) needed something the skill didn't say.
+
+What to add:
+
+- New gotchas go to "Common gotchas" as one-line entries.
+- New mental-model facts go to "llamactl mental model".
+- Tilt or backend changes go to "Pick a backend".
+
+Edit the file at `.agents/skills/llamactl-qa/SKILL.md` (the `.claude/skills/` entry is a symlink into here, maintained by `uv run dev sync-skills`). Keep the voice terse; don't pad. If you're unsure whether the fact is durable or just incidental to one run, leave it out. False additions are worse than missing ones.

--- a/src/dev_cli/cli.py
+++ b/src/dev_cli/cli.py
@@ -13,6 +13,7 @@ from . import gha, git_utils, index_html, versioning
 from .commands.changesets_cmd import changeset_publish, changeset_version
 from .commands.publish_cmd import changeset_plan, publish_action
 from .commands.pytest_cmd import pytest_cmd
+from .commands.skills_cmd import sync_skills
 
 # Known subcommands for argument injection
 _KNOWN_SUBCOMMANDS = {
@@ -23,6 +24,7 @@ _KNOWN_SUBCOMMANDS = {
     "publish-action",
     "compute-tag-metadata",
     "update-index-html",
+    "sync-skills",
 }
 
 
@@ -116,3 +118,4 @@ cli.add_command(changeset_publish)
 cli.add_command(changeset_plan)
 cli.add_command(publish_action)
 cli.add_command(pytest_cmd)
+cli.add_command(sync_skills)

--- a/src/dev_cli/commands/__init__.py
+++ b/src/dev_cli/commands/__init__.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 from .changesets_cmd import changeset_publish, changeset_version
 from .pytest_cmd import pytest_cmd
+from .skills_cmd import sync_skills
 
 __all__ = [
     "changeset_publish",
     "changeset_version",
     "pytest_cmd",
+    "sync_skills",
 ]

--- a/src/dev_cli/commands/skills_cmd.py
+++ b/src/dev_cli/commands/skills_cmd.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Sync repo-local agent skills into Claude Code's gitignored skills dir.
+
+Skills are checked in under `.agents/skills/<name>/` (the Codex-compatible
+location, see https://developers.openai.com/codex/skills). Claude Code reads
+from `.claude/skills/<name>/`, which is gitignored. This command symlinks the
+two so editing the checked-in copy is what Claude Code sees.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click
+
+
+def _repo_root() -> Path:
+    # cli is invoked from anywhere in the repo; resolve relative to this file.
+    return Path(__file__).resolve().parents[3]
+
+
+@click.command("sync-skills")
+@click.option(
+    "--check",
+    is_flag=True,
+    help="Exit non-zero if any link is missing or stale, without modifying anything.",
+)
+def sync_skills(check: bool) -> None:
+    """Symlink `.agents/skills/<name>` into `.claude/skills/<name>`.
+
+    Idempotent. Refuses to overwrite an existing non-symlink entry.
+    """
+    root = _repo_root()
+    src_dir = root / ".agents" / "skills"
+    dst_dir = root / ".claude" / "skills"
+
+    if not src_dir.is_dir():
+        click.echo(
+            f"no skills source dir at {src_dir.relative_to(root)}, nothing to do"
+        )
+        return
+
+    drift: list[str] = []
+    created: list[str] = []
+    ok: list[str] = []
+
+    if check:
+        if not dst_dir.is_dir():
+            click.echo(
+                f"drift    missing destination dir {dst_dir.relative_to(root)}",
+                err=True,
+            )
+            raise SystemExit(1)
+    else:
+        dst_dir.mkdir(parents=True, exist_ok=True)
+
+    for entry in sorted(src_dir.iterdir()):
+        if not entry.is_dir():
+            continue
+        name = entry.name
+        link = dst_dir / name
+        # Symlink target is relative to the link's parent dir, so the link
+        # survives moving the repo around.
+        target = Path(os.path.relpath(entry, dst_dir))
+
+        if link.is_symlink():
+            current = Path(os.readlink(link))
+            if current == target:
+                ok.append(name)
+                continue
+            if check:
+                drift.append(f"{name}: stale link -> {current}, want {target}")
+                continue
+            link.unlink()
+            link.symlink_to(target)
+            created.append(f"{name} (relinked)")
+            continue
+
+        if link.exists():
+            drift.append(
+                f"{name}: {link.relative_to(root)} exists and is not a symlink, "
+                f"refusing to overwrite"
+            )
+            continue
+
+        if check:
+            drift.append(f"{name}: missing link")
+            continue
+
+        link.symlink_to(target)
+        created.append(name)
+
+    for name in ok:
+        click.echo(f"ok       {name}")
+    for entry in created:
+        click.echo(f"linked   {entry}")
+    for entry in drift:
+        click.echo(f"drift    {entry}", err=True)
+
+    if drift:
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary

- New \`.agents/skills/llamactl-qa/SKILL.md\` describing how to plan and run a design-QA pass against a real backend (matrix of cases, verbatim outputs, design-review notes).
- New \`dev-cli sync-skills\` command that symlinks \`.agents/skills/<name>/\` into \`.claude/skills/<name>/\`, so the checked-in copy is what Claude Code reads. Idempotent; \`--check\` mode for CI.

Independently shippable; no product code.