### PR TITLE
Add follow=false on /deployments/{id}/logs

### DIFF
--- a/.changeset/server-logs-follow-flag.md
+++ b/.changeset/server-logs-follow-flag.md
@@ -1,0 +1,6 @@
+---
+"llama-agents-control-plane": patch
+"llama-agents-core": patch
+---
+
+Add `follow=false` query param on `GET /deployments/{id}/logs` so clients can fetch currently-available logs and exit. The default stays `follow=true`; existing streaming consumers are unchanged.

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/k8s_client.py
@@ -1058,8 +1058,13 @@ async def stream_container_logs(
     *,
     since_seconds: int | None = None,
     tail_lines: int | None = None,
+    follow: bool = True,
 ) -> tuple[CancelFn, AsyncGenerator[str, None]]:
-    """generator for a single container's logs."""
+    """generator for a single container's logs.
+
+    When ``follow=False``, the underlying K8s read returns the currently
+    buffered log content and the generator ends naturally; no streaming.
+    """
 
     try:
         read_pod_log = cast(
@@ -1071,7 +1076,7 @@ async def stream_container_logs(
             name=pod_name,
             namespace=_k8s_client.namespace,
             container=container_name,
-            follow=True,
+            follow=follow,
             since_seconds=since_seconds,
             tail_lines=tail_lines,
             timestamps=True,
@@ -1087,6 +1092,19 @@ async def stream_container_logs(
     except ApiException as e:
         # Non-fatal conditions when the container isn't ready yet
         if e.status in (400, 404):
+            # In non-follow mode, just return an empty generator — the caller
+            # asked for "what's available now" and there's nothing yet.
+            if not follow:
+
+                async def empty() -> AsyncGenerator[str, None]:
+                    if False:
+                        yield ""  # marker to keep this an async generator
+                    return
+
+                async def noop_cancel() -> None:
+                    return None
+
+                return noop_cancel, empty()
 
             async def wait_and_retry() -> tuple[CancelFn, AsyncGenerator[str, None]]:
                 await asyncio.sleep(5)
@@ -1096,6 +1114,7 @@ async def stream_container_logs(
                     container_name,
                     since_seconds=since_seconds,
                     tail_lines=tail_lines,
+                    follow=follow,
                 )
 
             task = asyncio.create_task(wait_and_retry())
@@ -1230,6 +1249,7 @@ async def _stream_pod_container_logs(
     since_seconds: int | None = None,
     tail_lines: int | None = None,
     stop_event: asyncio.Event | None = None,
+    follow: bool = True,
 ) -> AsyncGenerator[LogLine, None]:
     """Stream and merge log lines from multiple pod/container pairs with shutdown support."""
     generators: list[AsyncGenerator[LogLine, None]] = []
@@ -1240,6 +1260,7 @@ async def _stream_pod_container_logs(
             container_name,
             since_seconds=since_seconds,
             tail_lines=tail_lines,
+            follow=follow,
         )
         cancel_fns.append(cancel)
         generators.append(_parse_raw_log_lines(pod_name, container_name, iterator))
@@ -1251,10 +1272,12 @@ async def _stream_pod_container_logs(
         yield "__SHUTDOWN__"
         return
 
-    merged = merge_generators(
-        *generators,
-        when_shutdown(),
-    )
+    gen_args: list[AsyncGenerator[LogLine | Literal["__SHUTDOWN__"], None]] = [
+        *generators
+    ]
+    if follow:
+        gen_args.append(when_shutdown())
+    merged = merge_generators(*gen_args)
 
     try:
         async for item in merged:
@@ -1272,10 +1295,12 @@ async def stream_replicaset_logs(
     since_seconds: int | None = None,
     tail_lines: int | None = None,
     stop_event: asyncio.Event | None = None,
+    follow: bool = True,
 ) -> AsyncGenerator[LogLine, None]:
     """Blocking generator that streams log lines for all pods/containers in the latest ReplicaSet.
 
-    Yields `LogLine` objects until the consumer closes the generator.
+    Yields `LogLine` objects until the consumer closes the generator (or, when
+    ``follow=False``, until the underlying K8s reads finish).
     """
     target_pods = await get_replicaset_pods_for_deployment(deployment_id)
 
@@ -1298,6 +1323,7 @@ async def stream_replicaset_logs(
         since_seconds=since_seconds,
         tail_lines=tail_lines,
         stop_event=stop_event,
+        follow=follow,
     ):
         yield line
 
@@ -1318,6 +1344,7 @@ async def stream_build_job_logs(
     since_seconds: int | None = None,
     tail_lines: int | None = None,
     stop_event: asyncio.Event | None = None,
+    follow: bool = True,
 ) -> AsyncGenerator[LogLine, None]:
     """Stream log lines from a build Job's pod.
 
@@ -1345,6 +1372,7 @@ async def stream_build_job_logs(
         since_seconds=since_seconds,
         tail_lines=tail_lines,
         stop_event=stop_event,
+        follow=follow,
     ):
         yield line
 

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
@@ -45,6 +45,57 @@ logger = logging.getLogger(__name__)
 DEFAULT_ORG = schema.OrgSummary(org_id="default", org_name="Default", is_default=True)
 
 
+async def _on_push_complete(
+    deployment_id: str,
+    new_sha: str | None,
+    git_ref: str | None,
+) -> None:
+    if new_sha is None:
+        logger.warning(
+            "Push to deployment %s completed but could not determine HEAD SHA",
+            deployment_id,
+        )
+        return
+
+    # Only update the CRD on the first push — when the deployment
+    # doesn't yet have an internal repo_url or is missing a git_sha.
+    # Subsequent pushes just upload code to S3; the user must use
+    # `llamactl deploy update` to explicitly advance the ref/sha.
+    current = await k8s_client.get_deployment(deployment_id)
+    if (
+        current is not None
+        and current.repo_url == INTERNAL_CODE_REPO_SCHEME
+        and current.git_sha
+    ):
+        logger.info(
+            "Push to deployment %s uploaded to S3; skipping CRD update "
+            "(already has repo_url and git_sha)",
+            deployment_id,
+        )
+        return
+
+    logger.info(
+        "First push to deployment %s: setting sha=%s ref=%s",
+        deployment_id,
+        new_sha,
+        git_ref,
+    )
+    update = DeploymentUpdate(
+        repo_url=INTERNAL_CODE_REPO_SCHEME,
+        git_sha=new_sha,
+        git_ref=git_ref,
+    )
+    result = await k8s_client.update_deployment(
+        deployment_id=deployment_id,
+        update=update,
+    )
+    if result is None:
+        logger.error(
+            "Failed to update deployment %s after push (not found)",
+            deployment_id,
+        )
+
+
 class PublicDeploymentService(AbstractPublicDeploymentsService):
     @override
     async def get_version(self) -> schema.VersionResponse:
@@ -64,13 +115,12 @@ class DeploymentService(AbstractDeploymentsService):
         self, project_id: str, deployment_id: str, include_events: bool = False
     ) -> DeploymentResponse:
         deployment = await k8s_client.get_deployment(deployment_id)
-        if include_events and deployment is not None:
-            events = await k8s_client.get_deployment_events(deployment_id)
-            deployment.events = events
         if deployment is None or deployment.project_id != project_id:
             raise DeploymentNotFoundError(
                 f"Deployment with id {deployment_id} not found"
             )
+        if include_events:
+            deployment.events = await k8s_client.get_deployment_events(deployment_id)
         return deployment
 
     @override
@@ -285,11 +335,8 @@ class DeploymentService(AbstractDeploymentsService):
         )
 
         validated = None
-        needs_internal_ref_resolution = any(
-            [
-                update_data.repo_url is not None,
-                update_data.git_ref is not None,
-            ]
+        needs_internal_ref_resolution = (
+            update_data.repo_url is not None or update_data.git_ref is not None
         )
         resolved_repo_url = update_data.repo_url or current_deployment.repo_url
         if clearing_repo_url:
@@ -299,10 +346,7 @@ class DeploymentService(AbstractDeploymentsService):
             needs_internal_ref_resolution
             and resolved_repo_url == INTERNAL_CODE_REPO_SCHEME
         ):
-            # Internal repo: resolve the ref from the S3-stored bare repo.
-            # Callers (e.g. the textual edit form, the `update` CLI command)
-            # are expected to push local code first so the bare repo is up to
-            # date before this resolves to a SHA.
+            # Internal repo: resolve the ref from the S3-stored bare repo
             git_ref_to_resolve = update_data.git_ref or current_deployment.git_ref
             if git_ref_to_resolve:
                 storage = code_repo_storage
@@ -381,56 +425,6 @@ class DeploymentService(AbstractDeploymentsService):
                 status_code=503,
             )
 
-        async def _on_push_complete(
-            deployment_id: str,
-            new_sha: str | None,
-            git_ref: str | None,
-        ) -> None:
-            if new_sha is None:
-                logger.warning(
-                    "Push to deployment %s completed but could not determine HEAD SHA",
-                    deployment_id,
-                )
-                return
-
-            # Only update the CRD on the first push — when the deployment
-            # doesn't yet have an internal repo_url or is missing a git_sha.
-            # Subsequent pushes just upload code to S3; the user must use
-            # `llamactl deploy update` to explicitly advance the ref/sha.
-            current = await k8s_client.get_deployment(deployment_id)
-            if (
-                current is not None
-                and current.repo_url == INTERNAL_CODE_REPO_SCHEME
-                and current.git_sha
-            ):
-                logger.info(
-                    "Push to deployment %s uploaded to S3; skipping CRD update "
-                    "(already has repo_url and git_sha)",
-                    deployment_id,
-                )
-                return
-
-            logger.info(
-                "First push to deployment %s: setting sha=%s ref=%s",
-                deployment_id,
-                new_sha,
-                git_ref,
-            )
-            update = DeploymentUpdate(
-                repo_url=INTERNAL_CODE_REPO_SCHEME,
-                git_sha=new_sha,
-                git_ref=git_ref,
-            )
-            result = await k8s_client.update_deployment(
-                deployment_id=deployment_id,
-                update=update,
-            )
-            if result is None:
-                logger.error(
-                    "Failed to update deployment %s after push (not found)",
-                    deployment_id,
-                )
-
         return await _handle_git_request(
             request=request,
             deployment_id=deployment_id,
@@ -464,6 +458,7 @@ class DeploymentService(AbstractDeploymentsService):
         deployment_id: str,
         since_seconds: int | None,
         tail_lines: int | None,
+        follow: bool = True,
     ) -> AsyncGenerator[LogEvent, None]:
         """Yield log events from the build Job, if one exists."""
         async for line in k8s_client.stream_build_job_logs(
@@ -471,6 +466,7 @@ class DeploymentService(AbstractDeploymentsService):
             since_seconds=since_seconds,
             tail_lines=tail_lines,
             stop_event=shutdown_event,
+            follow=follow,
         ):
             timestamp = line.timestamp or datetime.now(timezone.utc)
             yield LogEvent(
@@ -488,14 +484,16 @@ class DeploymentService(AbstractDeploymentsService):
         include_init_containers: bool = False,
         since_seconds: int | None = None,
         tail_lines: int | None = None,
+        follow: bool = True,
     ) -> AsyncGenerator[LogEvent, None]:
         """Stream logs for a deployment.
 
         Build job logs (if any) are automatically merged into the stream.
-        App logs stream from the latest ReplicaSet. When the RS changes
-        (e.g. build finishes and operator creates a Deployment), the inner
-        generators restart so logs continue seamlessly without requiring
-        the client to reconnect.
+        App logs stream from the latest ReplicaSet. When ``follow`` is True
+        and the RS changes (e.g. build finishes and operator creates a
+        Deployment), the inner generators restart so logs continue seamlessly
+        without requiring the client to reconnect. When ``follow`` is False,
+        the generator returns whatever logs are currently available and ends.
         """
 
         await self._get_deployment_or_raise(project_id, deployment_id)
@@ -510,6 +508,7 @@ class DeploymentService(AbstractDeploymentsService):
                 since_seconds=since_seconds,
                 tail_lines=tail_lines,
                 stop_event=shutdown_event,
+                follow=follow,
             )
 
             if include_build_logs:
@@ -517,6 +516,7 @@ class DeploymentService(AbstractDeploymentsService):
                     deployment_id=deployment_id,
                     since_seconds=since_seconds,
                     tail_lines=tail_lines,
+                    follow=follow,
                 )
                 include_build_logs = False
             else:
@@ -537,18 +537,48 @@ class DeploymentService(AbstractDeploymentsService):
                 max_window_seconds=0.5,
             )
 
-            when_changes = self._when_replicaset_changes(deployment_id, 0.05)
+            if follow:
+                when_changes = self._when_replicaset_changes(deployment_id, 0.05)
 
-            rs_changed = False
-            async for ev in merge_generators(
-                debounced_logs,
-                cast(AsyncGenerator[LogEvent | str, None], when_changes),
-                stop_on_first_completion=True,
-            ):
-                if isinstance(ev, str):
-                    # RS-change sentinel — restart inner generators
-                    rs_changed = True
-                    break
+                rs_changed = False
+                async for ev in merge_generators(
+                    debounced_logs,
+                    cast(AsyncGenerator[LogEvent | str, None], when_changes),
+                    stop_on_first_completion=True,
+                ):
+                    if isinstance(ev, str):
+                        # RS-change sentinel — restart inner generators
+                        rs_changed = True
+                        break
+                    timestamp = ev.timestamp or datetime.now(timezone.utc)
+                    yield LogEvent(
+                        pod=ev.pod,
+                        container=ev.container,
+                        text=ev.text,
+                        timestamp=timestamp,
+                    )
+
+                if rs_changed:
+                    # RS changed (e.g. build→deploy transition). Loop to pick up
+                    # the new RS's pods without dropping the SSE connection.
+                    continue
+
+                # All log generators completed without an RS change. Check if an
+                # RS appeared while we were streaming build logs (race window
+                # where debounced_logs finishes before _when_replicaset_changes
+                # polls).
+                if initial_rs_uid is None:
+                    current_uid = await self._current_rs_uid(deployment_id)
+                    if current_uid is not None:
+                        continue
+
+                # No new RS appeared — nothing more to stream.
+                break
+
+            # follow=False: drain whatever's available and exit. No RS-change
+            # watcher, no reconnect — the underlying read uses follow=False
+            # against k8s and terminates on its own.
+            async for ev in debounced_logs:
                 timestamp = ev.timestamp or datetime.now(timezone.utc)
                 yield LogEvent(
                     pod=ev.pod,
@@ -556,21 +586,6 @@ class DeploymentService(AbstractDeploymentsService):
                     text=ev.text,
                     timestamp=timestamp,
                 )
-
-            if rs_changed:
-                # RS changed (e.g. build→deploy transition). Loop to pick up
-                # the new RS's pods without dropping the SSE connection.
-                continue
-
-            # All log generators completed without an RS change. Check if an RS
-            # appeared while we were streaming build logs (race window where
-            # debounced_logs finishes before _when_replicaset_changes polls).
-            if initial_rs_uid is None:
-                current_uid = await self._current_rs_uid(deployment_id)
-                if current_uid is not None:
-                    continue
-
-            # No new RS appeared — nothing more to stream.
             break
 
 

--- a/packages/llama-agents-control-plane/tests/deployments/test_deployments_service.py
+++ b/packages/llama-agents-control-plane/tests/deployments/test_deployments_service.py
@@ -170,6 +170,69 @@ async def test_stream_logs_happy_path(
         since_seconds=None,
         tail_lines=None,
         stop_event=mock.ANY,
+        follow=True,
+    )
+
+
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.stream_build_job_logs"
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.stream_replicaset_logs"
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.get_latest_replicaset_for_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.get_deployment",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_stream_logs_follow_false_threads_through_and_terminates(
+    mock_get_deployment: AsyncMock,
+    mock_get_rs: AsyncMock,
+    mock_stream_logs: MagicMock,
+    mock_build_logs: MagicMock,
+) -> None:
+    """``follow=False`` skips the RS-change watcher and ends after one pass."""
+    mock_get_deployment.return_value = _make_deployment()
+    mock_get_rs.return_value = _rs("uid-1")
+
+    async def agen() -> AsyncGenerator[types.SimpleNamespace, None]:
+        yield _line("pod-1", "c", "a")
+
+    async def empty_gen() -> AsyncGenerator[types.SimpleNamespace, None]:
+        return
+        yield  # make it a generator
+
+    mock_stream_logs.return_value = agen()
+    mock_build_logs.return_value = empty_gen()
+
+    items = [
+        item
+        async for item in deployments_service.stream_deployment_logs(
+            project_id="proj-1", deployment_id="dep-1", follow=False
+        )
+    ]
+
+    # Stream completes after one pass.
+    assert len(items) == 1
+    # ``follow=False`` should propagate to the K8s read.
+    mock_stream_logs.assert_called_once_with(
+        deployment_id="dep-1",
+        include_init_containers=False,
+        since_seconds=None,
+        tail_lines=None,
+        stop_event=mock.ANY,
+        follow=False,
+    )
+    mock_build_logs.assert_called_once_with(
+        deployment_id="dep-1",
+        since_seconds=None,
+        tail_lines=None,
+        stop_event=mock.ANY,
+        follow=False,
     )
 
 

--- a/packages/llama-agents-control-plane/tests/test_endpoints.py
+++ b/packages/llama-agents-control-plane/tests/test_endpoints.py
@@ -766,6 +766,37 @@ def test_stream_deployment_logs_success(mock_stream: MagicMock) -> None:
         include_init_containers=True,
         since_seconds=10,
         tail_lines=5,
+        follow=True,
+    )
+
+
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.deployments_service.stream_deployment_logs"
+)
+def test_stream_deployment_logs_follow_false_threads_through(
+    mock_stream: MagicMock,
+) -> None:
+    """``?follow=false`` should be threaded into the service call."""
+
+    async def empty_gen() -> AsyncGenerator[LogEvent, None]:
+        if False:
+            yield LogEvent(pod="x", container="c", text="", timestamp=datetime.now())
+        return
+
+    mock_stream.return_value = empty_gen()
+
+    resp = client.get(
+        "/api/v1beta1/deployments/deploy-1/logs",
+        params={"project_id": "proj-1", "follow": "false"},
+    )
+    assert resp.status_code == 200
+    mock_stream.assert_called_once_with(
+        project_id="proj-1",
+        deployment_id="deploy-1",
+        include_init_containers=False,
+        since_seconds=None,
+        tail_lines=None,
+        follow=False,
     )
 
 

--- a/packages/llama-agents-control-plane/tests/test_k8s_client.py
+++ b/packages/llama-agents-control-plane/tests/test_k8s_client.py
@@ -1,5 +1,6 @@
 """Unit tests for k8s_client.py"""
 
+import asyncio
 import base64
 import sys
 from collections.abc import Iterator
@@ -989,6 +990,49 @@ async def test_stream_replicaset_logs_follow(mock_k8s: MagicMock) -> None:
 
         assert first == LogLine(pod="pod-1", container="app", text="hello")
         assert second == LogLine(pod="pod-1", container="app", text="world")
+
+
+@pytest.mark.asyncio
+async def test_stream_replicaset_logs_non_follow_completes_with_stop_event(
+    mock_k8s: MagicMock,
+) -> None:
+    with patch(
+        "llama_agents.control_plane.k8s_client.get_latest_replicaset_for_deployment",
+        return_value=V1ReplicaSet(metadata=V1ObjectMeta(uid="rs-uid")),
+    ):
+        pod = V1Pod(
+            metadata=V1ObjectMeta(
+                name="pod-1",
+                owner_references=[
+                    V1OwnerReference(
+                        api_version="apps/v1",
+                        kind="ReplicaSet",
+                        uid="rs-uid",
+                        name="rs",
+                    )
+                ],
+            ),
+            spec=V1PodSpec(containers=[V1Container(name="app")]),
+        )
+        mock_k8s.k8s_core_v1.list_namespaced_pod.return_value = Mock(items=[pod])
+        mock_k8s.k8s_core_v1.read_namespaced_pod_log.return_value = "hello\nworld\n"
+
+        async def collect_logs() -> list[LogLine]:
+            return [
+                line
+                async for line in k8s_client.stream_replicaset_logs(
+                    "dep",
+                    stop_event=asyncio.Event(),
+                    follow=False,
+                )
+            ]
+
+        lines = await asyncio.wait_for(collect_logs(), timeout=1)
+
+        assert lines == [
+            LogLine(pod="pod-1", container="app", text="hello"),
+            LogLine(pod="pod-1", container="app", text="world"),
+        ]
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
+++ b/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
@@ -305,14 +305,18 @@ class ProjectClient(BaseClient):
         include_init_containers: bool = False,
         since_seconds: int | None = None,
         tail_lines: int | None = None,
+        follow: bool = True,
     ) -> AsyncGenerator[LogEvent, None]:
         """Stream logs as LogEvent items from the control plane using SSE.
 
-        Yields `LogEvent` models until the stream ends (e.g., rollout completes).
+        Yields `LogEvent` models until the stream ends. With ``follow=False``
+        the server returns currently-available logs and ends the stream
+        naturally — useful for "fetch and exit" callers.
         """
         params_dict: dict[str, PrimitiveData] = {
             "project_id": self.project_id,
             "include_init_containers": include_init_containers,
+            "follow": follow,
         }
         if since_seconds is not None:
             params_dict["since_seconds"] = since_seconds

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
@@ -174,6 +174,7 @@ class AbstractDeploymentsService(ABC):
         include_init_containers: bool = False,
         since_seconds: int | None = None,
         tail_lines: int | None = None,
+        follow: bool = True,
     ) -> AsyncGenerator[LogEvent, None]:
         """
         Stream the logs for a deployment.
@@ -187,6 +188,9 @@ class AbstractDeploymentsService(ABC):
             include_init_containers: Whether to include init containers in the logs
             since_seconds: The number of seconds to stream the logs for
             tail_lines: The number of lines to stream the logs for
+            follow: If False, return only currently-available logs and end the
+                stream; if True (default), keep streaming and reconnect across
+                ReplicaSet changes.
 
         Returns:
             A generator of log events

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
@@ -191,11 +191,16 @@ def create_v1beta1_deployments_router(
         include_init_containers: Annotated[bool, Query()] = False,
         since_seconds: Annotated[int | None, Query()] = None,
         tail_lines: Annotated[int | None, Query()] = None,
+        follow: Annotated[bool, Query()] = True,
     ) -> StreamingResponse:
         """Stream logs for a deployment.
 
         Build job logs (if any) are automatically merged before application logs.
-        The stream ends when the latest ReplicaSet changes (e.g., a new rollout occurs).
+        With ``follow=true`` (default) the stream continues until the latest
+        ReplicaSet changes (e.g. a new rollout occurs). With ``follow=false``
+        the server returns whatever logs are currently available and ends the
+        SSE stream — useful for clients that want a bounded, "fetch and exit"
+        response.
         """
 
         try:
@@ -205,6 +210,7 @@ def create_v1beta1_deployments_router(
                 include_init_containers=include_init_containers,
                 since_seconds=since_seconds,
                 tail_lines=tail_lines,
+                follow=follow,
             )
 
             async def sse_lines() -> AsyncGenerator[str, None]:


### PR DESCRIPTION
## Summary

- New `follow` query param on `GET /deployments/{id}/logs` (default `true`). With `follow=false` the server returns currently-available logs and ends the SSE stream, instead of staying open across ReplicaSet changes.
- Threaded through `manage_client.stream_deployment_logs`, `DeploymentService.stream_deployment_logs`, `stream_replicaset_logs`, `stream_build_job_logs`, `_stream_pod_container_logs`, and `stream_container_logs`. The k8s read passes `follow=False` to `read_namespaced_pod_log`; 400/404 collapses to an empty generator (instead of wait-and-retry) when not following.
- Default behaviour unchanged for existing streaming clients.
- Drive-bys in `deployments_service.py`: hoist `_on_push_complete` to module scope; in `_get_deployment_or_raise`, skip the events fetch when the deployment is missing or in a different project.

Independently useful — any client (not just llamactl) can now call `?follow=false` to bound a logs request.