### PR TITLE
llamactl: declarative Column framework + render/log_format helpers

### DIFF
--- a/packages/llamactl/src/llama_agents/cli/client.py
+++ b/packages/llamactl/src/llama_agents/cli/client.py
@@ -28,7 +28,13 @@ def get_control_plane_client() -> ControlPlaneClient:
     return ControlPlaneClient(resolved_base_url)
 
 
-def get_project_client() -> ProjectClient:
+def get_project_client(project_id_override: str | None = None) -> ProjectClient:
+    """Return a ProjectClient bound to the active profile.
+
+    If ``project_id_override`` is provided, the client uses that project ID
+    instead of the profile's default. Auth (API key + middleware) and base URL
+    still come from the active profile — this mirrors ``kubectl -n <ns>``.
+    """
     from llama_agents.cli.config.env_service import service
     from llama_agents.core.client.manage_client import ProjectClient
 
@@ -42,14 +48,17 @@ def get_project_client() -> ProjectClient:
         else:
             rprint("[cyan]llamactl auth token[/cyan]")
         raise SystemExit(1)
+    project_id = project_id_override or profile.project_id
     return ProjectClient(
-        profile.api_url, profile.project_id, profile.api_key, auth_svc.auth_middleware()
+        profile.api_url, project_id, profile.api_key, auth_svc.auth_middleware()
     )
 
 
 @asynccontextmanager
-async def project_client_context() -> AsyncGenerator[ProjectClient, None]:
-    client = get_project_client()
+async def project_client_context(
+    project_id_override: str | None = None,
+) -> AsyncGenerator[ProjectClient, None]:
+    client = get_project_client(project_id_override=project_id_override)
     try:
         yield client
     finally:

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Declarative column framework for tabular CLI read commands.
+
+A "tabular read command" emits a CLI-side display model whose fields carry
+:class:`Column` markers in their ``Annotated[]`` metadata. A small walker
+(``resolve_columns``) reads the markers; ``render_columns`` derives a
+plain-whitespace table; consumers compose this with ``render_output`` (in
+``cli.options``) to dispatch text/json/yaml/wide.
+
+The ``Annotated[]`` channel is intentionally open: future markers
+(``YamlComment`` for pedagogical comments in template output, ``Alias`` for
+legacy-name input tolerance on ``apply``, etc.) live alongside ``Column`` on
+the same fields. Each consumer reads ``field.metadata`` and filters on its own
+marker class via ``isinstance`` — markers do not register with the framework.
+
+Per-command display models (``DeploymentDisplay``, ``ReleaseDisplay``,
+``AuthProfileDisplay``, …) live with the commands that consume them and
+import the primitives from this module.
+"""
+
+from __future__ import annotations
+
+import functools
+import types
+from dataclasses import dataclass
+from typing import Any, Callable, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+SECRET_MASK = "********"
+
+
+@dataclass(frozen=True)
+class Column:
+    """Marker placed in a field's ``Annotated[]`` metadata to declare a column.
+
+    The marker is a pure data class; it carries no behaviour. The walker
+    (:func:`resolve_columns`) discovers ``Column`` instances and the renderer
+    (:func:`render_columns`) consumes them.
+
+    Args:
+        header: Column header rendered verbatim in the table.
+        format: Optional cell formatter. Called with the raw field value
+            (only when non-None). Must return a string.
+        default: Cell text when the value (or any nested-model parent on the
+            field path) is ``None``.
+        wide: When ``True``, the column appears only under ``-o wide``.
+    """
+
+    header: str
+    format: Callable[[Any], str] | None = None
+    default: str = ""
+    wide: bool = False
+
+
+@dataclass(frozen=True)
+class ResolvedColumn:
+    """A walker-derived column: its declaration path plus the marker."""
+
+    path: tuple[str, ...]
+    column: Column
+
+
+def _is_basemodel(tp: Any) -> bool:
+    return isinstance(tp, type) and issubclass(tp, BaseModel)
+
+
+def _unwrap_optional_model(annotation: Any) -> type[BaseModel] | None:
+    """If ``annotation`` is ``BaseModel``, ``Optional[BaseModel]`` or
+    ``BaseModel | None``, return the model class. Otherwise ``None``."""
+
+    if _is_basemodel(annotation):
+        return annotation  # type: ignore[return-value]
+    origin = get_origin(annotation)
+    if origin is Union or origin is types.UnionType:
+        non_none = [a for a in get_args(annotation) if a is not type(None)]
+        if len(non_none) == 1 and _is_basemodel(non_none[0]):
+            return non_none[0]
+    return None
+
+
+@functools.cache
+def resolve_columns(model_cls: type[BaseModel]) -> tuple[ResolvedColumn, ...]:
+    """Walk a display model in declaration order and return its columns.
+
+    Field annotations carrying a ``Column`` marker yield a leaf column at the
+    field's path. Fields whose annotation is a ``BaseModel`` (or
+    ``Optional[BaseModel]``) are descended into. All other fields are skipped.
+
+    A field carrying multiple ``Column`` markers is a typo: the walker raises
+    ``ValueError`` rather than silently picking one.
+
+    Display models are assumed to form a tree, not a graph — circular
+    references are not supported.
+    """
+
+    return tuple(_walk(model_cls, ()))
+
+
+def _walk(model_cls: type[BaseModel], prefix: tuple[str, ...]) -> list[ResolvedColumn]:
+    out: list[ResolvedColumn] = []
+    for name, info in model_cls.model_fields.items():
+        path = prefix + (name,)
+        cols = [m for m in info.metadata if isinstance(m, Column)]
+        if len(cols) > 1:
+            raise ValueError(
+                f"{model_cls.__name__}.{name}: multiple Column annotations on a single field"
+            )
+        if cols:
+            out.append(ResolvedColumn(path=path, column=cols[0]))
+            continue
+        nested = _unwrap_optional_model(info.annotation)
+        if nested is not None:
+            out.extend(_walk(nested, path))
+    return out
+
+
+def _extract_cell(row: BaseModel, column: ResolvedColumn) -> str:
+    value: Any = row
+    for part in column.path:
+        if value is None:
+            return column.column.default
+        value = getattr(value, part)
+    if value is None:
+        return column.column.default
+    if column.column.format is not None:
+        return column.column.format(value)
+    return str(value)
+
+
+def render_columns(
+    rows: list[BaseModel] | list[Any],
+    *,
+    wide: bool = False,
+) -> None:
+    """Render ``rows`` as a plain-whitespace table using ``Column`` metadata.
+
+    ``rows`` must be homogeneous; the row class is read from the first
+    element. An empty list still emits headers (matches ``render_table``'s
+    empty-row behaviour). Columns marked ``wide=True`` are filtered out unless
+    ``wide`` is ``True``.
+    """
+
+    from llama_agents.cli.render import render_table  # local: avoid cycle
+
+    if not rows:
+        # No row to derive a class from. Caller is expected to have emitted a
+        # status message ("No X found") before reaching here — but if not,
+        # we silently emit nothing rather than guessing the column layout.
+        return
+
+    row_cls = type(rows[0])
+    if not isinstance(rows[0], BaseModel):
+        raise TypeError(
+            f"render_columns expects BaseModel rows; got {row_cls.__name__}"
+        )
+
+    cols = [c for c in resolve_columns(row_cls) if wide or not c.column.wide]
+    columns = [(c.column.header, c.column.header) for c in cols]
+    table_rows: list[dict[str, str]] = []
+    for row in rows:
+        table_rows.append({c.column.header: _extract_cell(row, c) for c in cols})
+    render_table(table_rows, columns)

--- a/packages/llamactl/src/llama_agents/cli/log_format.py
+++ b/packages/llamactl/src/llama_agents/cli/log_format.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Pure body parser for structlog-formatted log lines.
+
+The control plane's log SSE endpoint emits ``LogEvent`` envelopes whose
+``text`` field is a single log line — typically a structlog JSON record like
+``{"event": "...", "level": "info", "timestamp": "...", "logger": "..."}``,
+but sometimes a plain string (e.g. application stdout). This module owns the
+parsing of that body and the plain-text renderer used by the
+``deployments logs`` CLI command. The Textual deployment-monitor renderer
+calls into the same parser and adds Rich styling on top.
+
+This module knows nothing about ``LogEvent.pod`` / ``LogEvent.container`` /
+``LogEvent.timestamp`` — those live on the envelope and are formatted by
+callers. The K8s leading timestamp is already stripped before bodies reach
+this parser (see ``k8s_client._parse_raw_log_lines``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+# structlog keys handled inline; everything else goes into ``extras``.
+_KNOWN_KEYS = frozenset({"event", "level", "timestamp", "logger", "request_id"})
+
+
+@dataclass
+class ParsedLogBody:
+    """Structured form of one structlog body line.
+
+    ``raw`` holds the original input. If the line wasn't structlog JSON,
+    ``event`` carries the raw text and ``structured`` is False.
+    """
+
+    raw: str
+    structured: bool
+    timestamp: str = ""
+    level: str = ""
+    logger: str = ""
+    event: str = ""
+    request_id: str = ""
+    extras: dict[str, object] = field(default_factory=dict)
+
+
+def parse_log_body(line: str) -> ParsedLogBody:
+    """Parse a structlog JSON body into a ``ParsedLogBody``.
+
+    Falls back to a non-structured ``ParsedLogBody`` (with ``event=line``)
+    when the input is not a structlog dict — which is fine, downstream
+    renderers just emit it as-is.
+    """
+    raw = line
+    stripped = line.strip()
+    if not stripped.startswith("{"):
+        return ParsedLogBody(raw=raw, structured=False, event=line)
+    try:
+        data = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return ParsedLogBody(raw=raw, structured=False, event=line)
+
+    if not isinstance(data, dict) or "event" not in data:
+        return ParsedLogBody(raw=raw, structured=False, event=line)
+
+    return ParsedLogBody(
+        raw=raw,
+        structured=True,
+        timestamp=str(data.get("timestamp", "")),
+        level=str(data.get("level", "")).lower(),
+        logger=str(data.get("logger", "")),
+        event=str(data.get("event", "")),
+        request_id=str(data.get("request_id", "")),
+        extras={k: v for k, v in data.items() if k not in _KNOWN_KEYS},
+    )
+
+
+def trim_timestamp(ts: str) -> str:
+    """Trim ISO timestamp to its time portion (shared with the Textual renderer)."""
+    if "T" in ts:
+        ts = ts.split("T", 1)[1]
+        for suffix in ("Z", "+00:00"):
+            ts = ts.removesuffix(suffix)
+    return ts
+
+
+def render_plain(parsed: ParsedLogBody) -> str:
+    """Render ``parsed`` as a plain string (no Rich/ANSI).
+
+    Used by ``llamactl deployments logs`` text mode. Mirrors the layout of
+    the Textual renderer so a single mental model applies.
+    """
+    if not parsed.structured:
+        return parsed.event or parsed.raw
+
+    parts: list[str] = []
+    ts = trim_timestamp(parsed.timestamp)
+    if ts:
+        parts.append(ts)
+    if parsed.level:
+        parts.append(f"{parsed.level.upper():8s}")
+    if parsed.logger:
+        parts.append(parsed.logger)
+    parts.append(parsed.event)
+
+    line = " ".join(p for p in parts if p)
+    if parsed.request_id:
+        line += f" req={parsed.request_id}"
+    if parsed.extras:
+        line += " " + " ".join(f"{k}={v}" for k, v in parsed.extras.items())
+    return line

--- a/packages/llamactl/src/llama_agents/cli/options.py
+++ b/packages/llamactl/src/llama_agents/cli/options.py
@@ -1,9 +1,12 @@
+import json
 import logging
 import os
-from typing import Callable, ParamSpec, TypeVar
+from typing import Any, Callable, ParamSpec, TypeVar
 
 import click
 from llama_agents.cli.interactive_prompts.session_utils import is_interactive_session
+from llama_agents.cli.param_types import ProjectType
+from pydantic import BaseModel
 
 from .debug import setup_file_logging
 
@@ -15,6 +18,120 @@ def global_options(f: Callable[P, R]) -> Callable[P, R]:
     """Common decorator to add global options to command groups"""
 
     return native_tls_option(file_logging(f))
+
+
+def output_option(f: Callable[P, R]) -> Callable[P, R]:
+    """Add a `-o/--output` option for read commands.
+
+    Choices: ``text`` (default), ``json``, ``yaml``, ``wide``. ``wide`` is
+    text mode with the less-common columns interleaved into their natural
+    positions (kubectl-style).
+    """
+
+    return click.option(
+        "-o",
+        "--output",
+        "output",
+        type=click.Choice(["text", "json", "yaml", "wide"], case_sensitive=False),
+        default="text",
+        show_default=True,
+        help=(
+            "Output format. 'json'/'yaml' for machine-readable output; "
+            "'wide' for the text table with extra columns."
+        ),
+    )(f)
+
+
+def project_option(f: Callable[P, R]) -> Callable[P, R]:
+    """Add a ``--project`` option to override the active profile's project for a command.
+
+    The value is exposed as the ``project`` keyword argument and should be
+    threaded into ``get_project_client()`` or ``project_client_context()`` via
+    the ``project_id_override`` parameter.
+    """
+
+    return click.option(
+        "--project",
+        "project",
+        type=ProjectType(),
+        default=None,
+        help="Project ID to use for this command (overrides active profile).",
+    )(f)
+
+
+def render_output(
+    payload: BaseModel | list[BaseModel] | Any,
+    output: str,
+    text_renderer: Callable[[], None] | None = None,
+) -> None:
+    """Render a payload according to ``output`` mode.
+
+    - ``text`` / ``wide``: if ``payload`` is a ``BaseModel`` (or list of
+      them) whose class declares ``Column`` annotations, the framework
+      derives the table directly. Otherwise (or if ``text_renderer`` is
+      provided as an explicit override) the supplied text renderer runs.
+      ``wide`` includes ``wide=True`` columns; ``text`` excludes them.
+    - ``json``: emit canonical JSON via ``click.echo`` (no Rich markup).
+    - ``yaml``: emit YAML via ``click.echo`` (the naive Pydantic shape).
+
+    ``payload`` may be a Pydantic model, a list of Pydantic models, or any
+    JSON-serializable value. Structured outputs go through ``click.echo`` so
+    they pipe cleanly even when Rich would otherwise insert markup.
+    """
+
+    # Defer the import: the framework lives in ``cli.display`` which has
+    # heavier transitive imports than ``options.py`` itself.
+    from llama_agents.cli.display import render_columns, resolve_columns
+
+    mode = output.lower()
+    if mode in {"text", "wide"}:
+        rows: list[BaseModel] | None = None
+        if isinstance(payload, BaseModel):
+            rows = [payload]
+        elif (
+            isinstance(payload, list) and payload and isinstance(payload[0], BaseModel)
+        ):
+            rows = list(payload)
+        if rows is not None and resolve_columns(type(rows[0])):
+            render_columns(rows, wide=(mode == "wide"))
+            return
+        if isinstance(payload, list) and not payload:
+            # Empty list in text/wide mode: caller is expected to have
+            # emitted a status line ("No X found"). Silently no-op rather
+            # than demanding a text_renderer for the degenerate case.
+            return
+        if text_renderer is None:
+            raise click.ClickException("No text renderer available for this payload.")
+        text_renderer()
+        return
+
+    def _to_json_safe(value: Any) -> Any:
+        # Models with a custom ``to_output_dict`` (e.g. ``DeploymentDisplay``)
+        # own their on-the-wire shape — including which null keys to keep —
+        # so prefer that over a raw ``model_dump``.
+        to_output = getattr(value, "to_output_dict", None)
+        if callable(to_output):
+            return to_output()
+        if isinstance(value, BaseModel):
+            return value.model_dump(mode="json")
+        if isinstance(value, list):
+            return [_to_json_safe(item) for item in value]
+        if isinstance(value, dict):
+            return {k: _to_json_safe(v) for k, v in value.items()}
+        return value
+
+    if mode == "json":
+        click.echo(json.dumps(_to_json_safe(payload), indent=2))
+        return
+    if mode == "yaml":
+        # Defer pyyaml import: it's a measurable chunk of CLI startup and
+        # only paid for by the (rare) `-o yaml` path.
+        import yaml
+
+        click.echo(yaml.safe_dump(_to_json_safe(payload), sort_keys=False))
+        return
+
+    raise click.ClickException(f"Unknown output mode: {output}")
 
 
 def interactive_option(f: Callable[P, R]) -> Callable[P, R]:

--- a/packages/llamactl/src/llama_agents/cli/param_types.py
+++ b/packages/llamactl/src/llama_agents/cli/param_types.py
@@ -23,10 +23,12 @@ def _safe_fetch(fn: Any, timeout: float = 2.0) -> list[Any]:
         pool.shutdown(wait=False)
 
 
-def _fetch_deployments() -> list[CompletionItem]:
+def _fetch_deployments(
+    project_id_override: str | None = None,
+) -> list[CompletionItem]:
     from llama_agents.cli.client import get_project_client
 
-    client = get_project_client()
+    client = get_project_client(project_id_override=project_id_override)
     deployments = asyncio.run(client.list_deployments())
     return [CompletionItem(d.id) for d in deployments]
 
@@ -59,10 +61,12 @@ def _fetch_organizations() -> list[CompletionItem]:
     ]
 
 
-def _fetch_deployment_history(deployment_id: str) -> list[CompletionItem]:
+def _fetch_deployment_history(
+    deployment_id: str, project_id_override: str | None = None
+) -> list[CompletionItem]:
     from llama_agents.cli.client import get_project_client
 
-    client = get_project_client()
+    client = get_project_client(project_id_override=project_id_override)
 
     async def _fetch() -> Any:
         return await client.get_deployment_history(deployment_id)
@@ -85,7 +89,11 @@ class DeploymentType(click.ParamType):
     def shell_complete(
         self, ctx: click.Context, param: click.Parameter, incomplete: str
     ) -> list[CompletionItem]:
-        return _filter(_safe_fetch(_fetch_deployments), incomplete)
+        project_id_override = ctx.params.get("project")
+        return _filter(
+            _safe_fetch(lambda: _fetch_deployments(project_id_override)),
+            incomplete,
+        )
 
 
 class ProfileType(click.ParamType):
@@ -165,7 +173,10 @@ class GitShaType(click.ParamType):
         deployment_id = ctx.params.get("deployment_id")
         if not deployment_id:
             return []
+        project_id_override = ctx.params.get("project")
         return _filter(
-            _safe_fetch(lambda: _fetch_deployment_history(deployment_id)),
+            _safe_fetch(
+                lambda: _fetch_deployment_history(deployment_id, project_id_override)
+            ),
             incomplete,
         )

--- a/packages/llamactl/src/llama_agents/cli/render.py
+++ b/packages/llamactl/src/llama_agents/cli/render.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Plain-whitespace table renderer for llamactl.
+
+No colors, no truncation, no Rich. Long values let the terminal wrap. The
+helper exists so every read command emits the same simple, grep-friendly
+shape.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import click
+
+GH_PREFIX = "https://github.com/"
+
+
+def gh_short(repo_url: str) -> str:
+    """Return ``gh:org/repo`` for github URLs, otherwise the input unchanged.
+
+    Used in table cells only; YAML/JSON keep the full URL.
+    """
+    if repo_url.startswith(GH_PREFIX):
+        return "gh:" + repo_url.removeprefix(GH_PREFIX)
+    return repo_url
+
+
+def short_sha(sha: str) -> str:
+    """Return the first 7 characters of ``sha``, or the input unchanged.
+
+    Used in table cells; JSON/YAML keep the full SHA. Safe on shorter input.
+    """
+    return sha[:7] if len(sha) > 7 else sha
+
+
+def star_marker(active: bool) -> str:
+    """Render a boolean as ``"*"`` (true) or ``""`` (false).
+
+    Used by the ``ACTIVE`` column on profile/env/org tables.
+    """
+    return "*" if active else ""
+
+
+def format_iso_z(dt: datetime) -> str:
+    """Format ``dt`` as a UTC ISO 8601 string with a ``Z`` suffix.
+
+    Tz-aware datetimes are converted to UTC. Naive datetimes are assumed to
+    already be UTC (the server emits UTC; this is a safety fallback rather
+    than an invitation to pass local time). Fractional seconds are dropped:
+    current data doesn't carry them and the table cell stays narrow.
+
+    The output (``YYYY-MM-DDTHH:MM:SSZ``) matches what Pydantic emits in
+    JSON mode, so text and JSON encodings of the same instant agree.
+    """
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def render_table(
+    rows: list[dict[str, str]],
+    columns: list[tuple[str, str]],
+) -> None:
+    """Render a plain whitespace table to stdout.
+
+    Args:
+        rows: Each row is a ``{column_key: cell_value}`` mapping. Cells must
+            already be strings (callers handle ``None`` → ``"-"``).
+        columns: Ordered ``(header, key)`` pairs. Headers are rendered
+            verbatim — callers pass uppercase headers if they want them.
+
+    Column widths are sized to the widest cell (header included) plus a
+    two-space gutter on the right except the last column. No truncation.
+    """
+    widths: list[int] = [
+        max(len(header), *(len(row.get(key, "")) for row in rows))
+        if rows
+        else len(header)
+        for header, key in columns
+    ]
+
+    def _format_line(values: list[str]) -> str:
+        parts: list[str] = []
+        last = len(values) - 1
+        for i, value in enumerate(values):
+            if i == last:
+                parts.append(value)
+            else:
+                parts.append(value.ljust(widths[i] + 2))
+        return "".join(parts).rstrip()
+
+    headers = [header for header, _ in columns]
+    click.echo(_format_line(headers))
+    for row in rows:
+        click.echo(_format_line([row.get(key, "") for _, key in columns]))

--- a/packages/llamactl/src/llama_agents/cli/textual/deployment_monitor.py
+++ b/packages/llamactl/src/llama_agents/cli/textual/deployment_monitor.py
@@ -3,17 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import functools
 import hashlib
-import json
 import logging
 import threading
 import webbrowser
+from collections import deque
 from collections.abc import AsyncGenerator
 from pathlib import Path
 
 from llama_agents.cli.client import (
     project_client_context,
 )
+from llama_agents.cli.log_format import parse_log_body, trim_timestamp
+from llama_agents.cli.render import short_sha
 from llama_agents.core.iter_utils import merge_generators
 from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import DeploymentResponse
@@ -31,7 +34,7 @@ from typing_extensions import Literal
 
 logger = logging.getLogger(__name__)
 
-# structlog JSON keys to display inline and their styles
+# structlog level → Rich style for Textual renderer.
 _LEVEL_STYLES: dict[str, str] = {
     "debug": "dim",
     "info": "cyan",
@@ -40,61 +43,52 @@ _LEVEL_STYLES: dict[str, str] = {
     "critical": "bold red reverse",
 }
 
-# Keys handled specially — everything else goes into extras
-_KNOWN_KEYS = {"event", "level", "timestamp", "logger", "request_id"}
+_CONTAINER_PALETTE = (
+    "bold magenta",
+    "bold cyan",
+    "bold blue",
+    "bold green",
+    "bold red",
+    "bold bright_blue",
+)
+
+# Bound the in-memory log buffer so long-running monitor sessions don't grow
+# unbounded. Matches the order of magnitude of RichLog's own viewport history.
+_LOG_BUFFER_MAX = 10_000
+
+
+@functools.lru_cache(maxsize=128)
+def _container_style(container_name: str) -> str:
+    """Pick a stable color per container name."""
+    h = int(hashlib.sha256(container_name.encode()).hexdigest(), 16)
+    return _CONTAINER_PALETTE[h % len(_CONTAINER_PALETTE)]
 
 
 def _format_log_line(line: str) -> Text:
-    """Parse a structlog JSON line into styled Rich Text, or pass through as-is."""
-    stripped = line.strip()
-    if not stripped.startswith("{"):
-        return Text(line)
-    try:
-        data = json.loads(stripped)
-    except (json.JSONDecodeError, ValueError):
-        return Text(line)
+    """Parse a structlog JSON line into styled Rich Text, or pass through as-is.
 
-    if not isinstance(data, dict) or "event" not in data:
-        return Text(line)
+    Delegates body parsing to ``log_format.parse_log_body`` and adds Rich
+    styling on top. Plain (non-structured) lines pass through unchanged.
+    """
+    parsed = parse_log_body(line)
+    if not parsed.structured:
+        return Text(parsed.event or parsed.raw)
 
     txt = Text()
-
-    # Timestamp
-    ts = data.get("timestamp", "")
+    ts = trim_timestamp(parsed.timestamp)
     if ts:
-        # Trim ISO timestamp to just time portion if it has a T
-        if "T" in str(ts):
-            ts = str(ts).split("T", 1)[1]
-            # Remove trailing Z or timezone offset for compactness
-            for suffix in ("Z", "+00:00"):
-                ts = ts.removesuffix(suffix)
         txt.append(f"{ts} ", style="dim")
-
-    # Level
-    level = str(data.get("level", "")).lower()
-    level_style = _LEVEL_STYLES.get(level, "")
-    if level:
-        txt.append(f"{level.upper():8s}", style=level_style)
-
-    # Logger name
-    logger_name = data.get("logger", "")
-    if logger_name:
-        txt.append(f"{logger_name} ", style="dim cyan")
-
-    # Event message
-    txt.append(str(data.get("event", "")))
-
-    # Request ID
-    req_id = data.get("request_id", "")
-    if req_id:
-        txt.append(f" req={req_id}", style="dim")
-
-    # Extra fields (everything not in _KNOWN_KEYS)
-    extras = {k: v for k, v in data.items() if k not in _KNOWN_KEYS}
-    if extras:
-        parts = " ".join(f"{k}={v}" for k, v in extras.items())
+    if parsed.level:
+        level_style = _LEVEL_STYLES.get(parsed.level, "")
+        txt.append(f"{parsed.level.upper():8s}", style=level_style)
+    if parsed.logger:
+        txt.append(f"{parsed.logger} ", style="dim cyan")
+    txt.append(parsed.event)
+    if parsed.request_id:
+        txt.append(f" req={parsed.request_id}", style="dim")
+    if parsed.extras:
+        parts = " ".join(f"{k}={v}" for k, v in parsed.extras.items())
         txt.append(f" {parts}", style="dim yellow")
-
     return txt
 
 
@@ -176,15 +170,15 @@ class DeploymentMonitorWidget(Widget):
         super().__init__()
         self.deployment_id = deployment_id
         self._stop_stream = threading.Event()
-        # Persist content written to the RichLog across recomposes
-        self._log_buffer: list[Text] = []
+        # Persist content written to the RichLog across recomposes (bounded so
+        # long sessions don't accumulate forever).
+        self._log_buffer: deque[Text] = deque(maxlen=_LOG_BUFFER_MAX)
         self._log_stream_started = False
 
     async def on_mount(self) -> None:
-        # Kick off initial fetch and start logs stream in background
-        self.run_worker(self._fetch_deployment())
+        # The poller below runs the initial deployment fetch on its first tick;
+        # a separate one-shot fetch would race it and double the startup load.
         self.run_worker(self._stream_logs())
-        # Start periodic polling of deployment status
         self.run_worker(self._poll_deployment_status())
 
     def compose(self) -> ComposeResult:
@@ -252,17 +246,6 @@ class DeploymentMonitorWidget(Widget):
                     + (self.deployment.git_sha or "")
                 )
 
-    async def _fetch_deployment(self) -> None:
-        try:
-            async with project_client_context() as client:
-                self.deployment = await client.get_deployment(
-                    self.deployment_id, include_events=True
-                )
-            # Clear any previous error on success
-            self.error_message = ""
-        except Exception as e:  # pragma: no cover - network errors
-            self.error_message = f"Failed to fetch deployment: {e}"
-
     async def _stream_logs(self) -> None:
         """Consume the async log iterator, batch updates, and reconnect with backoff."""
 
@@ -328,9 +311,7 @@ class DeploymentMonitorWidget(Widget):
     def _handle_log_events(self, events: list[LogEvent]) -> None:
         def to_text(event: LogEvent) -> Text:
             txt = Text()
-            txt.append(
-                f"[{event.container}] ", style=self._container_style(event.container)
-            )
+            txt.append(f"[{event.container}] ", style=_container_style(event.container))
             txt.append_text(_format_log_line(event.text))
             return txt
 
@@ -355,25 +336,9 @@ class DeploymentMonitorWidget(Widget):
         for text in texts:
             log_widget.write(text)
             self._log_buffer.append(text)
-        log_widget.refresh()
 
-        # One-time kick to ensure initial draw
-        # Clear any previous error once we successfully receive logs
         if self.error_message:
             self.error_message = ""
-
-    def _container_style(self, container_name: str) -> str:
-        palette = [
-            "bold magenta",
-            "bold cyan",
-            "bold blue",
-            "bold green",
-            "bold red",
-            "bold bright_blue",
-        ]
-        # Stable hash to pick a color per container name
-        h = int(hashlib.sha256(container_name.encode()).hexdigest(), 16)
-        return palette[h % len(palette)]
 
     def _status_icon_and_style(self, phase: str) -> tuple[str, str]:
         # Map deployment phase to a colored icon
@@ -465,8 +430,8 @@ class DeploymentMonitorWidget(Widget):
         deployment_link_button.label = (
             f"{str(self.deployment.apiserver_url or '') if self.deployment else ''}"
         )
-        if self.deployment:
-            last_commit_button.label = f"{(str(self.deployment.git_sha or '-'))[:7]}"
+        if self.deployment and self.deployment.git_sha:
+            last_commit_button.label = short_sha(self.deployment.git_sha)
         else:
             last_commit_button.label = "-"
         # Update last event line
@@ -507,10 +472,13 @@ class DeploymentMonitorWidget(Widget):
         while not self._stop_stream.is_set():
             try:
                 async with project_client_context() as client:
-                    self.deployment = await client.get_deployment(
+                    fresh = await client.get_deployment(
                         self.deployment_id, include_events=True
                     )
-                # Clear any previous error on success
+                # Skip the reactive write when nothing changed; otherwise the
+                # watcher rewrites every status widget on each tick.
+                if fresh != self.deployment:
+                    self.deployment = fresh
                 if self.error_message:
                     self.error_message = ""
             except Exception as e:  # pragma: no cover - network errors

--- a/packages/llamactl/tests/test_display.py
+++ b/packages/llamactl/tests/test_display.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for the declarative ``Column`` framework in ``cli.display``."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import pytest
+from llama_agents.cli.display import (
+    Column,
+    render_columns,
+    resolve_columns,
+)
+from pydantic import BaseModel
+from typing_extensions import Annotated
+
+
+class _Flat(BaseModel):
+    name: Annotated[str, Column("NAME")]
+    note: str  # no Column → skipped
+    age: Annotated[int, Column("AGE", format=lambda v: f"~{v}")]
+
+
+class _Inner(BaseModel):
+    phase: Annotated[str, Column("PHASE")]
+    secret: str  # no Column → skipped
+
+
+class _Nested(BaseModel):
+    name: Annotated[str, Column("NAME")]
+    inner: _Inner
+    optional_inner: _Inner | None = None
+
+
+class _Wide(BaseModel):
+    name: Annotated[str, Column("NAME")]
+    extra: Annotated[str, Column("EXTRA", wide=True)] = "x"
+
+
+def test_resolve_columns_flat_model_declaration_order() -> None:
+    cols = resolve_columns(_Flat)
+    assert [c.column.header for c in cols] == ["NAME", "AGE"]
+    assert [c.path for c in cols] == [("name",), ("age",)]
+
+
+def test_resolve_columns_descends_nested_models() -> None:
+    cols = resolve_columns(_Nested)
+    # Outer NAME, then inner PHASE (descended), then optional_inner PHASE.
+    assert [c.column.header for c in cols] == ["NAME", "PHASE", "PHASE"]
+    assert [c.path for c in cols] == [
+        ("name",),
+        ("inner", "phase"),
+        ("optional_inner", "phase"),
+    ]
+
+
+def test_resolve_columns_skips_field_without_column() -> None:
+    cols = resolve_columns(_Inner)
+    # ``secret`` carries no Column → excluded.
+    assert [c.column.header for c in cols] == ["PHASE"]
+
+
+def test_resolve_columns_supports_multiple_independent_markers() -> None:
+    """Forward-compat: extra markers on the same field don't perturb output."""
+
+    class _Marker:
+        pass
+
+    class _M(BaseModel):
+        name: Annotated[str, Column("NAME"), _Marker()]
+
+    cols = resolve_columns(_M)
+    assert len(cols) == 1
+    assert cols[0].column.header == "NAME"
+
+
+def test_resolve_columns_rejects_duplicate_columns_on_one_field() -> None:
+    class _Bad(BaseModel):
+        name: Annotated[str, Column("A"), Column("B")]
+
+    with pytest.raises(ValueError, match="multiple Column"):
+        resolve_columns(_Bad)
+
+
+def test_render_columns_filters_wide(capsys: Any) -> None:
+    rows = [_Wide(name="a"), _Wide(name="b", extra="z")]
+    render_columns(rows)
+    out = capsys.readouterr().out
+    assert "EXTRA" not in out
+    assert "NAME" in out
+
+    render_columns(rows, wide=True)
+    out = capsys.readouterr().out
+    assert "EXTRA" in out
+    assert "z" in out
+
+
+def test_render_columns_applies_format_and_default(capsys: Any) -> None:
+    class _M(BaseModel):
+        ref: Annotated[str | None, Column("REF", default="-")] = None
+        age: Annotated[int, Column("AGE", format=lambda v: f"~{v}")] = 0
+
+    render_columns([_M(ref=None, age=3), _M(ref="main", age=7)])
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    assert "REF" in lines[0]
+    # First row uses the default; format is applied to age.
+    assert "-" in lines[1]
+    assert "~3" in lines[1]
+    assert "main" in lines[2]
+    assert "~7" in lines[2]
+
+
+def test_render_columns_propagates_none_through_missing_nested_model(
+    capsys: Any,
+) -> None:
+    class _Inner2(BaseModel):
+        phase: Annotated[str, Column("PHASE", default="-")]
+
+    class _Outer(BaseModel):
+        name: Annotated[str, Column("NAME")]
+        inner: _Inner2 | None = None
+
+    render_columns([_Outer(name="a", inner=None)])
+    out = capsys.readouterr().out
+    lines = out.strip().splitlines()
+    assert "PHASE" in lines[0]
+    # Missing nested model → cell renders the column's default.
+    assert "-" in lines[1]
+
+
+def test_resolve_columns_handles_optional_basemodel_union() -> None:
+    cols = resolve_columns(_Nested)
+    paths = {c.path for c in cols}
+    assert ("optional_inner", "phase") in paths
+
+
+def test_resolve_columns_is_cached() -> None:
+    """Cache hit returns the same tuple instance."""
+    a = resolve_columns(_Flat)
+    b = resolve_columns(_Flat)
+    assert a is b
+
+
+def test_render_columns_literal_field_renders_value(capsys: Any) -> None:
+    class _M(BaseModel):
+        kind: Annotated[Literal["a", "b"], Column("KIND")] = "a"
+
+    render_columns([_M()])
+    out = capsys.readouterr().out
+    assert "a" in out

--- a/packages/llamactl/tests/test_log_format.py
+++ b/packages/llamactl/tests/test_log_format.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for the structlog body parser and plain renderer.
+
+Phase 2 of the llamactl Slice A redesign.
+"""
+
+from __future__ import annotations
+
+from llama_agents.cli.log_format import parse_log_body, render_plain
+
+
+def test_parse_plain_string_passes_through() -> None:
+    parsed = parse_log_body("plain stdout line")
+    assert parsed.structured is False
+    assert parsed.event == "plain stdout line"
+    assert render_plain(parsed) == "plain stdout line"
+
+
+def test_parse_invalid_json_passes_through() -> None:
+    parsed = parse_log_body("{not json")
+    assert parsed.structured is False
+    assert render_plain(parsed) == "{not json"
+
+
+def test_parse_dict_without_event_passes_through() -> None:
+    parsed = parse_log_body('{"level": "info"}')
+    assert parsed.structured is False
+
+
+def test_parse_structlog_extracts_fields() -> None:
+    line = (
+        '{"event": "request done", "level": "info", '
+        '"timestamp": "2026-04-26T12:34:56.789Z", '
+        '"logger": "app.api", "request_id": "abc", "duration_ms": 42}'
+    )
+    parsed = parse_log_body(line)
+    assert parsed.structured is True
+    assert parsed.event == "request done"
+    assert parsed.level == "info"
+    assert parsed.logger == "app.api"
+    assert parsed.request_id == "abc"
+    assert parsed.extras == {"duration_ms": 42}
+
+
+def test_render_plain_structured_layout() -> None:
+    parsed = parse_log_body(
+        '{"event": "ok", "level": "warning", '
+        '"timestamp": "2026-04-26T12:34:56.000Z", "logger": "x"}'
+    )
+    rendered = render_plain(parsed)
+    # Time portion only (not the full ISO date)
+    assert "12:34:56.000" in rendered
+    assert "WARNING" in rendered
+    assert "x" in rendered
+    assert "ok" in rendered
+    # No date prefix
+    assert "2026-04-26" not in rendered

--- a/packages/llamactl/tests/test_param_types.py
+++ b/packages/llamactl/tests/test_param_types.py
@@ -37,7 +37,7 @@ def test_deployment_type_returns_fetched_items(
     monkeypatch.setattr(
         pt,
         "_fetch_deployments",
-        lambda: [
+        lambda project_id_override=None: [
             CompletionItem("my-app"),
             CompletionItem("staging"),
         ],
@@ -54,10 +54,31 @@ def test_deployment_type_returns_fetched_items(
     assert items[0].value == "my-app"
 
 
+def test_deployment_type_passes_project_override_to_fetch(
+    ctx: click.Context, param: click.Parameter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_overrides: list[str | None] = []
+
+    def _fetch_deployments(
+        project_id_override: str | None = None,
+    ) -> list[CompletionItem]:
+        project_overrides.append(project_id_override)
+        return [CompletionItem("project-app")]
+
+    monkeypatch.setattr(pt, "_fetch_deployments", _fetch_deployments)
+    ctx.params["project"] = "project-123"
+
+    dt = DeploymentType()
+    items = dt.shell_complete(ctx, param, "")
+
+    assert [item.value for item in items] == ["project-app"]
+    assert project_overrides == ["project-123"]
+
+
 def test_deployment_type_fetch_failure(
     ctx: click.Context, param: click.Parameter, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    def _boom() -> list[CompletionItem]:
+    def _boom(project_id_override: str | None = None) -> list[CompletionItem]:
         raise RuntimeError("API down")
 
     monkeypatch.setattr(pt, "_fetch_deployments", _boom)
@@ -182,7 +203,7 @@ def test_git_sha_type_with_deployment_id(
     monkeypatch.setattr(
         pt,
         "_fetch_deployment_history",
-        lambda dep_id: [
+        lambda dep_id, project_id_override=None: [
             CompletionItem("abc1234", help="2026-01-01T00:00:00"),
             CompletionItem("def5678", help="2026-01-02T00:00:00"),
         ],
@@ -195,3 +216,24 @@ def test_git_sha_type_with_deployment_id(
     items = gt.shell_complete(ctx, param, "abc")
     assert len(items) == 1
     assert items[0].value == "abc1234"
+
+
+def test_git_sha_type_passes_project_override_to_fetch(
+    ctx: click.Context, param: click.Parameter, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project_overrides: list[str | None] = []
+
+    def _fetch_deployment_history(
+        deployment_id: str, project_id_override: str | None = None
+    ) -> list[CompletionItem]:
+        project_overrides.append(project_id_override)
+        return [CompletionItem("abc1234")]
+
+    monkeypatch.setattr(pt, "_fetch_deployment_history", _fetch_deployment_history)
+    ctx.params = {"deployment_id": "my-deploy", "project": "project-123"}
+
+    gt = GitShaType()
+    items = gt.shell_complete(ctx, param, "")
+
+    assert [item.value for item in items] == ["abc1234"]
+    assert project_overrides == ["project-123"]

--- a/packages/llamactl/tests/test_render.py
+++ b/packages/llamactl/tests/test_render.py
@@ -1,0 +1,124 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for the plain-whitespace table renderer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import click
+from click.testing import CliRunner
+from llama_agents.cli.render import (
+    format_iso_z,
+    gh_short,
+    render_table,
+    short_sha,
+    star_marker,
+)
+
+
+def _capture(rows: list[dict[str, str]], columns: list[tuple[str, str]]) -> str:
+    @click.command()
+    def _cmd() -> None:
+        render_table(rows, columns)
+
+    result = CliRunner().invoke(_cmd, [])
+    assert result.exit_code == 0, result.output
+    return result.output
+
+
+def test_render_table_emits_headers_and_rows() -> None:
+    output = _capture(
+        rows=[
+            {"name": "alpha", "phase": "Running"},
+            {"name": "beta", "phase": "Suspended"},
+        ],
+        columns=[("NAME", "name"), ("PHASE", "phase")],
+    )
+    lines = output.splitlines()
+    assert lines[0].startswith("NAME")
+    assert "PHASE" in lines[0]
+    assert "alpha" in lines[1]
+    assert "Running" in lines[1]
+    assert "beta" in lines[2]
+    assert "Suspended" in lines[2]
+
+
+def test_render_table_no_ansi_escapes_or_truncation() -> None:
+    long_value = "https://github.com/run-llama/template-workflow-classify-extract-sec"
+    output = _capture(
+        rows=[{"name": "a", "repo": long_value}],
+        columns=[("NAME", "name"), ("REPO", "repo")],
+    )
+    assert "\x1b[" not in output
+    assert "…" not in output
+    assert long_value in output
+
+
+def test_render_table_column_width_uses_widest_cell() -> None:
+    output = _capture(
+        rows=[
+            {"name": "short", "phase": "Pending"},
+            {"name": "much-longer-name", "phase": "RollingOut"},
+        ],
+        columns=[("NAME", "name"), ("PHASE", "phase")],
+    )
+    lines = output.splitlines()
+    # Header column 2 starts at the same column as data column 2.
+    header_phase_start = lines[0].index("PHASE")
+    row1_phase_start = lines[1].index("Pending")
+    row2_phase_start = lines[2].index("RollingOut")
+    assert header_phase_start == row1_phase_start == row2_phase_start
+
+
+def test_render_table_handles_empty_rows() -> None:
+    output = _capture(rows=[], columns=[("NAME", "name"), ("PHASE", "phase")])
+    # Header row only; trailing whitespace stripped.
+    assert output.strip().split("\n") == ["NAME  PHASE"]
+
+
+def test_gh_short_translates_github_urls() -> None:
+    assert (
+        gh_short("https://github.com/run-llama/template-workflow")
+        == "gh:run-llama/template-workflow"
+    )
+
+
+def test_gh_short_passes_through_non_github() -> None:
+    assert gh_short("https://gitlab.com/x/y") == "https://gitlab.com/x/y"
+    assert gh_short("internal://repo") == "internal://repo"
+
+
+def test_format_iso_z_tz_aware_utc() -> None:
+    dt = datetime(2026, 4, 25, 15, 1, 15, tzinfo=timezone.utc)
+    assert format_iso_z(dt) == "2026-04-25T15:01:15Z"
+
+
+def test_format_iso_z_tz_aware_non_utc_is_converted() -> None:
+    # Pacific (UTC-8 standard time): 07:01:15-08:00 == 15:01:15Z
+    from datetime import timedelta
+    from datetime import timezone as _tz
+
+    pst = _tz(timedelta(hours=-8))
+    dt = datetime(2026, 4, 25, 7, 1, 15, tzinfo=pst)
+    assert format_iso_z(dt) == "2026-04-25T15:01:15Z"
+
+
+def test_format_iso_z_naive_is_treated_as_utc() -> None:
+    # Documented behavior: naive datetimes are assumed to already be UTC.
+    dt = datetime(2026, 4, 25, 15, 1, 15)
+    assert format_iso_z(dt) == "2026-04-25T15:01:15Z"
+
+
+def test_short_sha_truncates_to_seven() -> None:
+    assert short_sha("a" * 40) == "aaaaaaa"
+
+
+def test_short_sha_passthrough_on_short_input() -> None:
+    assert short_sha("abc") == "abc"
+    assert short_sha("") == ""
+
+
+def test_star_marker_active_and_inactive() -> None:
+    assert star_marker(True) == "*"
+    assert star_marker(False) == ""


### PR DESCRIPTION
## Summary

Foundation work, no user-visible CLI behavior change. Lays the groundwork for the per-command display models that come next.

- `cli/display.py` — `Column` / `ResolvedColumn` / `resolve_columns` / `render_columns`. Field-annotation walker that derives plain-whitespace tables from a Pydantic model. Multiple-marker friendly: future markers (e.g. for `apply -f` aliases or YAML comments) live alongside `Column` on the same fields.
- `cli/render.py` — `render_table`, `gh_short`, `short_sha`, `format_iso_z`, `star_marker`. Pure helpers, no side effects.
- `cli/log_format.py` — `parse_log_body`, `trim_timestamp`, `render_plain`, `ParsedLogBody`. Lifted from `textual/deployment_monitor.py` so a non-Textual logs path can share the structlog parser.
- `cli/options.py` — `output_option` (`-o text|json|yaml|wide`), `project_option` (`--project`), `render_output` dispatcher. `yaml` is a lazy import so the cold-start cost only hits `-o yaml` users.
- `cli/client.py` — `get_project_client` / `project_client_context` accept `project_id_override`. `--project` threads through here.
- `cli/param_types.py` — `DeploymentType.shell_complete` and `GitShaType.shell_complete` read `project` off the click context, so completion targets the right project when `--project` is specified.
- `cli/textual/deployment_monitor.py` — refactored onto `log_format.py`. Capped the in-memory log buffer; cached the container-color resolver.

The framework primitives are all that lands here; per-command display models (`DeploymentDisplay`, `ReleaseDisplay`, `AuthProfileDisplay`, `EnvDisplay`, `OrgDisplay`) ship with their consumer commands in follow-ups.