### PR TITLE
llamactl: deployments get/list/logs

### DIFF
--- a/.changeset/llamactl-deployments-get-logs.md
+++ b/.changeset/llamactl-deployments-get-logs.md
@@ -2,4 +2,4 @@
 "llamactl": minor
 ---
 
-`deployments get` now does double duty: with a name it shows that deployment (no auto-launching the TUI); without one it prints a kubectl-style table of all deployments. Adds `-o text|json|yaml|wide`, `--project <id>` to override the active profile, friendlier 404 messages, and a new `deployments logs` command (`--follow`/`--json`/`--tail`/`--since-seconds`/`--include-init-containers`). The old `deployments list` is kept as a hidden alias.
+`deployments get` now shows one deployment with a name and lists all of them without; adds `-o text|json|yaml|wide`, `--project`, and a new `deployments logs` command.

--- a/.changeset/llamactl-deployments-get-logs.md
+++ b/.changeset/llamactl-deployments-get-logs.md
@@ -1,0 +1,5 @@
+---
+"llamactl": minor
+---
+
+`deployments get` now does double duty: with a name it shows that deployment (no auto-launching the TUI); without one it prints a kubectl-style table of all deployments. Adds `-o text|json|yaml|wide`, `--project <id>` to override the active profile, friendlier 404 messages, and a new `deployments logs` command (`--follow`/`--json`/`--tail`/`--since-seconds`/`--include-init-containers`). The old `deployments list` is kept as a hidden alias.

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -13,6 +13,7 @@ import click
 from llama_agents.cli.commands.auth import validate_authenticated_profile
 from llama_agents.cli.param_types import DeploymentType, GitShaType
 from llama_agents.cli.styles import HEADER_COLOR, MUTED_COL, PRIMARY_COL, WARNING
+from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import (
     INTERNAL_CODE_REPO_SCHEME,
     DeploymentHistoryResponse,
@@ -21,11 +22,19 @@ from llama_agents.core.schema.deployments import (
 )
 from rich import print as rprint
 from rich.table import Table
-from rich.text import Text
 
 from ..app import app, console
 from ..client import get_project_client, project_client_context
-from ..options import global_options, interactive_option
+from ..display import DeploymentDisplay
+from ..log_format import parse_log_body, render_plain
+from ..options import (
+    global_options,
+    interactive_option,
+    output_option,
+    project_option,
+    render_output,
+)
+from ..render import short_sha
 from ..utils.capabilities import probe_code_push_support
 from ..utils.git_push import (
     configure_git_remote,
@@ -46,105 +55,115 @@ def deployments() -> None:
     pass
 
 
-# Deployments commands
-@deployments.command("list")
-@global_options
-@interactive_option
-def list_deployments(interactive: bool) -> None:
-    """List deployments for the configured project."""
-    validate_authenticated_profile(interactive)
-    try:
-        client = get_project_client()
-        deployments = asyncio.run(client.list_deployments())
+def friendly_http_error(
+    exc: Exception,
+    *,
+    deployment_id: str | None = None,
+    project_id: str | None = None,
+) -> str | None:
+    """Translate well-known HTTP errors into a one-line CLI message.
 
-        if not deployments:
-            rprint(
-                f"[{WARNING}]No deployments found for project {client.project_id}[/]"
-            )
+    Returns ``None`` when the caller should fall back to the verbose default
+    rendering. We only collapse the cases where a richer message would just
+    be debug noise to the user — currently a 404 on a known deployment id.
+    Other 4xx/5xx and non-HTTP errors keep their existing message so we
+    don't swallow useful info on unexpected paths.
+    """
+    # Defer httpx import: `llamactl --help` is held to a no-httpx startup
+    # budget by tests/test_cli_imports.py; only error paths need the type.
+    import httpx
+
+    if not isinstance(exc, httpx.HTTPStatusError):
+        return None
+    if exc.response.status_code != 404 or not deployment_id:
+        return None
+    msg = f"deployment '{deployment_id}' not found"
+    if project_id:
+        msg += f" in project '{project_id}'"
+    return msg
+
+
+def _do_get(
+    deployment_id: str | None,
+    interactive: bool,
+    output: str,
+    project: str | None,
+) -> None:
+    """Implementation of ``deployments get`` shared with the hidden ``list`` alias.
+
+    No ``deployment_id`` → list all deployments (kubectl-style). With an ID →
+    a single-row table for that deployment. Never launches the TUI; for a
+    live view use ``deployments logs --follow``.
+    """
+    validate_authenticated_profile(interactive)
+    # Fall back to the user-supplied override if client construction itself
+    # raises; `client.project_id` resolves the active project when no override.
+    effective_project: str | None = project
+    try:
+        client = get_project_client(project_id_override=project)
+        effective_project = client.project_id
+
+        if not deployment_id:
+            deployments = asyncio.run(client.list_deployments())
+
+            if not deployments and output == "text":
+                rprint(
+                    f"[{WARNING}]No deployments found for project {client.project_id}[/]"
+                )
+                return
+
+            displays = [DeploymentDisplay.from_response(d) for d in deployments]
+            render_output(displays, output)
             return
 
-        table = Table(show_edge=False, box=None, header_style=f"bold {HEADER_COLOR}")
-        table.add_column("Name", style=PRIMARY_COL)
-        table.add_column("ID", style=MUTED_COL)
-        table.add_column("Status", style=MUTED_COL)
-        table.add_column("URL", style=MUTED_COL)
-        table.add_column("Repository", style=MUTED_COL)
-
-        for deployment in deployments:
-            display_name = deployment.display_name
-            status = deployment.status
-            repo_url = deployment.repo_url
-            gh = "https://github.com/"
-            if repo_url.startswith(gh):
-                repo_url = "gh:" + repo_url.removeprefix(gh)
-
-            table.add_row(
-                display_name,
-                deployment.id,
-                status,
-                str(deployment.apiserver_url or ""),
-                repo_url,
-            )
-
-        console.print(table)
+        deployment = asyncio.run(client.get_deployment(deployment_id))
+        display = DeploymentDisplay.from_response(deployment)
+        render_output(display, output)
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
+        friendly = friendly_http_error(
+            e, deployment_id=deployment_id, project_id=effective_project
+        )
+        message = friendly if friendly is not None else str(e)
+        rprint(f"[red]Error: {message}[/red]")
         raise click.Abort()
 
 
 @deployments.command("get")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@output_option
+@project_option
 @interactive_option
-def get_deployment(deployment_id: str | None, interactive: bool) -> None:
-    """Get details of a specific deployment"""
-    # Keep this import local: `llamactl --help` eagerly imports command modules,
-    # and import-time profiling showed Textual adds material startup cost here.
-    # Avoid adding other local imports unless instrumentation shows they are slow.
-    from ..textual.deployment_monitor import monitor_deployment_screen
+def get_deployment(
+    deployment_id: str | None,
+    interactive: bool,
+    output: str,
+    project: str | None,
+) -> None:
+    """Get one or more deployments.
 
-    validate_authenticated_profile(interactive)
-    try:
-        client = get_project_client()
+    With no argument: lists all deployments in the project (kubectl-style).
+    With a deployment ID: prints details for that deployment.
 
-        deployment_id = select_deployment(deployment_id, interactive=interactive)
-        if not deployment_id:
-            rprint(f"[{WARNING}]No deployment selected[/]")
-            return
-        if interactive:
-            monitor_deployment_screen(deployment_id)
-            return
+    Use ``-o json`` or ``-o yaml`` for machine-readable output. Use
+    ``llamactl deployments logs <name> --follow`` to stream logs.
+    """
+    _do_get(deployment_id, interactive, output, project)
 
-        deployment = asyncio.run(client.get_deployment(deployment_id))
 
-        table = Table(show_edge=False, box=None, header_style=f"bold {HEADER_COLOR}")
-        table.add_column("Property", style=MUTED_COL, justify="right")
-        table.add_column("Value", style=PRIMARY_COL)
-
-        table.add_row("Name", Text(deployment.display_name))
-        table.add_row("ID", Text(deployment.id))
-        table.add_row("Project ID", Text(deployment.project_id))
-        table.add_row("Status", Text(deployment.status))
-        table.add_row("Repository", Text(deployment.repo_url))
-        table.add_row("Deployment File", Text(deployment.deployment_file_path))
-        table.add_row("Git Ref", Text(deployment.git_ref or "-"))
-        table.add_row("Last Deployed Commit", Text((deployment.git_sha or "-")[:7]))
-
-        apiserver_url = deployment.apiserver_url
-        table.add_row(
-            "API Server URL",
-            Text(str(apiserver_url) if apiserver_url else "-"),
-        )
-
-        secret_names = deployment.secret_names or []
-        table.add_row("Secrets", Text("\n".join(secret_names), style="italic"))
-
-        console.print(table)
-
-    except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+@deployments.command("list", hidden=True)
+@global_options
+@output_option
+@project_option
+@interactive_option
+def list_deployments(
+    interactive: bool,
+    output: str,
+    project: str | None,
+) -> None:
+    """Hidden alias for ``deployments get``. Kept for backward compatibility."""
+    _do_get(None, interactive, output, project)
 
 
 @deployments.command("create")
@@ -164,7 +183,6 @@ def create_deployment(
     # Avoid adding other local imports unless instrumentation shows they are slow.
     from ..textual.deployment_form import create_deployment_form
 
-    # Use interactive creation
     deployment_form = create_deployment_form(
         server_supports_code_push=probe_code_push_support(),
     )
@@ -180,8 +198,11 @@ def create_deployment(
 @deployments.command("configure-git-remote")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@project_option
 @interactive_option
-def configure_git_remote_cmd(deployment_id: str | None, interactive: bool) -> None:
+def configure_git_remote_cmd(
+    deployment_id: str | None, interactive: bool, project: str | None
+) -> None:
     """Configure a git remote for a deployment.
 
     Sets up authentication and a git remote named 'llamaagents-<deployment_id>'
@@ -193,7 +214,6 @@ def configure_git_remote_cmd(deployment_id: str | None, interactive: bool) -> No
     """
     validate_authenticated_profile(interactive)
     try:
-        # Verify we're in a git repo
         result = subprocess.run(
             ["git", "rev-parse", "--git-dir"],
             capture_output=True,
@@ -202,12 +222,14 @@ def configure_git_remote_cmd(deployment_id: str | None, interactive: bool) -> No
         if result.returncode != 0:
             raise click.ClickException("Not a git repository")
 
-        deployment_id = select_deployment(deployment_id, interactive=interactive)
+        deployment_id = select_deployment(
+            deployment_id, interactive=interactive, project_id_override=project
+        )
         if not deployment_id:
             rprint(f"[{WARNING}]No deployment selected[/]")
             return
 
-        client = get_project_client()
+        client = get_project_client(project_id_override=project)
         git_url = get_deployment_git_url(client.base_url, deployment_id)
         api_key = get_api_key()
         remote_name = configure_git_remote(
@@ -229,8 +251,11 @@ def configure_git_remote_cmd(deployment_id: str | None, interactive: bool) -> No
 @deployments.command("delete")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@project_option
 @interactive_option
-def delete_deployment(deployment_id: str | None, interactive: bool) -> None:
+def delete_deployment(
+    deployment_id: str | None, interactive: bool, project: str | None
+) -> None:
     """Delete a deployment"""
     # Keep this import local: the helper imports `questionary`, which import-time
     # profiling showed is a noticeable CLI startup cost. Avoid other local
@@ -239,9 +264,11 @@ def delete_deployment(deployment_id: str | None, interactive: bool) -> None:
 
     validate_authenticated_profile(interactive)
     try:
-        client = get_project_client()
+        client = get_project_client(project_id_override=project)
 
-        deployment_id = select_deployment(deployment_id, interactive=interactive)
+        deployment_id = select_deployment(
+            deployment_id, interactive=interactive, project_id_override=project
+        )
         if not deployment_id:
             rprint(f"[{WARNING}]No deployment selected[/]")
             return
@@ -262,8 +289,11 @@ def delete_deployment(deployment_id: str | None, interactive: bool) -> None:
 @deployments.command("edit")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@project_option
 @interactive_option
-def edit_deployment(deployment_id: str | None, interactive: bool) -> None:
+def edit_deployment(
+    deployment_id: str | None, interactive: bool, project: str | None
+) -> None:
     """Interactively edit a deployment"""
     # Keep this import local: `llamactl --help` eagerly imports command modules,
     # and import-time profiling showed Textual adds material startup cost here.
@@ -272,17 +302,17 @@ def edit_deployment(deployment_id: str | None, interactive: bool) -> None:
 
     validate_authenticated_profile(interactive)
     try:
-        client = get_project_client()
+        client = get_project_client(project_id_override=project)
 
-        deployment_id = select_deployment(deployment_id, interactive=interactive)
+        deployment_id = select_deployment(
+            deployment_id, interactive=interactive, project_id_override=project
+        )
         if not deployment_id:
             rprint(f"[{WARNING}]No deployment selected[/]")
             return
 
-        # Get current deployment details
         current_deployment = asyncio.run(client.get_deployment(deployment_id))
 
-        # Use the interactive edit form
         updated_deployment = edit_deployment_form(
             current_deployment,
             server_supports_code_push=probe_code_push_support(),
@@ -300,7 +330,11 @@ def edit_deployment(deployment_id: str | None, interactive: bool) -> None:
         raise click.Abort()
 
 
-def _push_internal_for_update(deployment_id: str, git_ref: str | None = None) -> None:
+def _push_internal_for_update(
+    deployment_id: str,
+    git_ref: str | None = None,
+    project_id_override: str | None = None,
+) -> None:
     """Push local code to the internal repo before updating.
 
     This ensures the S3-stored bare repo has the latest commits so the
@@ -315,13 +349,13 @@ def _push_internal_for_update(deployment_id: str, git_ref: str | None = None) ->
         )
         return
 
-    client = get_project_client()
+    client = get_project_client(project_id_override=project_id_override)
     api_key = get_api_key()
     git_url = get_deployment_git_url(client.base_url, deployment_id)
     remote_name = configure_git_remote(
         git_url, api_key, client.project_id, deployment_id
     )
-    local_ref, target_ref = _internal_push_refspec(git_ref)
+    local_ref, target_ref = internal_push_refspec(git_ref)
     with console.status("Pushing code..."):
         push_result = push_to_remote(
             remote_name, local_ref=local_ref, target_ref=target_ref
@@ -335,12 +369,6 @@ def _push_internal_for_update(deployment_id: str, git_ref: str | None = None) ->
         )
 
 
-def _internal_push_refspec(git_ref: str | None) -> tuple[str, str]:
-    # Delegate to the shared implementation in git_push.py.
-    # Keep this thin wrapper so existing call sites and tests don't break.
-    return internal_push_refspec(git_ref)
-
-
 @deployments.command("update")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
@@ -349,22 +377,26 @@ def _internal_push_refspec(git_ref: str | None) -> tuple[str, str]:
     help="Reference branch, tag, or commit SHA for the deployment. If not provided, the current reference and latest commit on it will be used.",
     default=None,
 )
+@project_option
 @interactive_option
 def refresh_deployment(
-    deployment_id: str | None, git_ref: str | None, interactive: bool
+    deployment_id: str | None,
+    git_ref: str | None,
+    interactive: bool,
+    project: str | None,
 ) -> None:
     """Update the deployment, pulling the latest code from it's branch"""
     validate_authenticated_profile(interactive)
     try:
-        deployment_id = select_deployment(deployment_id, interactive=interactive)
+        deployment_id = select_deployment(
+            deployment_id, interactive=interactive, project_id_override=project
+        )
         if not deployment_id:
             rprint(f"[{WARNING}]No deployment selected[/]")
             return
 
-        # Get current deployment details to show what we're refreshing
-        current_deployment = asyncio.run(
-            get_project_client().get_deployment(deployment_id)
-        )
+        client = get_project_client(project_id_override=project)
+        current_deployment = asyncio.run(client.get_deployment(deployment_id))
         deployment_name = current_deployment.display_name
         old_git_sha = current_deployment.git_sha or ""
 
@@ -372,24 +404,22 @@ def refresh_deployment(
         # latest commits to resolve against.
         effective_git_ref = git_ref or current_deployment.git_ref
         if current_deployment.repo_url == INTERNAL_CODE_REPO_SCHEME:
-            _push_internal_for_update(deployment_id, effective_git_ref)
+            _push_internal_for_update(
+                deployment_id, effective_git_ref, project_id_override=project
+            )
 
         # Re-resolves the branch to the latest commit SHA.
         with console.status(f"Refreshing {deployment_name}..."):
-            deployment_update = DeploymentUpdate(
-                git_ref=effective_git_ref,
-            )
             updated_deployment = asyncio.run(
-                get_project_client().update_deployment(
+                client.update_deployment(
                     deployment_id,
-                    deployment_update,
+                    DeploymentUpdate(git_ref=effective_git_ref),
                 )
             )
 
-        # Show the git SHA change with short SHAs
         new_git_sha = updated_deployment.git_sha or ""
-        old_short = old_git_sha[:7] if old_git_sha else "none"
-        new_short = new_git_sha[:7] if new_git_sha else "none"
+        old_short = short_sha(old_git_sha) if old_git_sha else "-"
+        new_short = short_sha(new_git_sha) if new_git_sha else "-"
 
         if old_git_sha == new_git_sha:
             rprint(f"No changes: already at {new_short}")
@@ -520,7 +550,119 @@ def rollback(deployment_id: str | None, git_sha: str | None, interactive: bool) 
         raise click.Abort()
 
 
-def select_deployment(deployment_id: str | None, interactive: bool) -> str | None:
+@deployments.command("logs")
+@global_options
+@click.argument("deployment_id", required=False, type=DeploymentType())
+@click.option(
+    "--follow",
+    "-f",
+    is_flag=True,
+    default=False,
+    help="Stream logs continuously until interrupted (Ctrl-C).",
+)
+@click.option(
+    "--json",
+    "json_lines",
+    is_flag=True,
+    default=False,
+    help="Output one LogEvent JSON object per line (jsonl).",
+)
+@click.option(
+    "--tail",
+    "tail",
+    type=click.IntRange(min=1),
+    default=200,
+    show_default=True,
+    help="Number of lines to retrieve from the end of the logs initially.",
+)
+@click.option(
+    "--since-seconds",
+    "since_seconds",
+    type=click.IntRange(min=0),
+    default=None,
+    help="Only return logs newer than this many seconds.",
+)
+@click.option(
+    "--include-init-containers",
+    is_flag=True,
+    default=False,
+    help="Include init container logs.",
+)
+@project_option
+@interactive_option
+def deployment_logs(
+    deployment_id: str | None,
+    follow: bool,
+    json_lines: bool,
+    tail: int,
+    since_seconds: int | None,
+    include_init_containers: bool,
+    interactive: bool,
+    project: str | None,
+) -> None:
+    """Stream or fetch logs for a deployment.
+
+    By default, prints recent logs and exits. Use ``--follow`` to keep the
+    stream open until you Ctrl-C. Use ``--json`` to emit one JSON
+    ``LogEvent`` per line for downstream tooling (jsonl).
+    """
+    validate_authenticated_profile(interactive)
+
+    deployment_id = select_deployment(
+        deployment_id, interactive=interactive, project_id_override=project
+    )
+    if not deployment_id:
+        rprint(f"[{WARNING}]No deployment selected[/]")
+        return
+
+    async def _consume() -> int:
+        events_seen = 0
+        async with project_client_context(project_id_override=project) as client:
+            async for ev in client.stream_deployment_logs(
+                deployment_id,
+                include_init_containers=include_init_containers,
+                tail_lines=tail,
+                since_seconds=since_seconds,
+                follow=follow,
+            ):
+                events_seen += 1
+                _emit_log_event(ev, json_lines=json_lines)
+        return events_seen
+
+    try:
+        events_seen = asyncio.run(_consume())
+    except KeyboardInterrupt:
+        # Clean exit on Ctrl-C; no traceback.
+        return
+    except Exception as e:
+        rprint(f"[red]Error: {e}[/red]")
+        raise click.Abort()
+
+    if events_seen == 0 and not follow:
+        click.echo("no logs available yet", err=True)
+
+
+def _emit_log_event(ev: LogEvent, *, json_lines: bool) -> None:
+    """Render a single LogEvent to stdout per the requested format."""
+    if json_lines:
+        click.echo(ev.model_dump_json())
+        return
+
+    parsed = parse_log_body(ev.text)
+    body = render_plain(parsed)
+    pod = f"{ev.pod}/{ev.container}"
+    # Skip the envelope timestamp when the structured body already carries one,
+    # otherwise structlog lines render with two side-by-side timestamps.
+    ts = "" if parsed.timestamp else (ev.timestamp.isoformat() if ev.timestamp else "")
+    prefix = " ".join(p for p in (ts, pod) if p)
+    click.echo(f"{prefix} {body}" if prefix else body)
+
+
+def select_deployment(
+    deployment_id: str | None,
+    interactive: bool,
+    project_id_override: str | None = None,
+) -> str | None:
     """
     Select a deployment interactively if ID not provided.
     Returns the selected deployment ID or None if cancelled.
@@ -538,7 +680,7 @@ def select_deployment(deployment_id: str | None, interactive: bool) -> str | Non
     # Don't attempt interactive selection in non-interactive sessions
     if not interactive:
         return None
-    client = get_project_client()
+    client = get_project_client(project_id_override=project_id_override)
     deployments = asyncio.run(client.list_deployments())
 
     if not deployments:

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -26,7 +26,13 @@ import types
 from dataclasses import dataclass
 from typing import Any, Callable, Union, get_args, get_origin
 
-from pydantic import BaseModel
+from llama_agents.cli.render import gh_short, short_sha
+from llama_agents.core.schema.deployments import (
+    DeploymentResponse,
+    LlamaDeploymentPhase,
+)
+from pydantic import BaseModel, ConfigDict
+from typing_extensions import Annotated
 
 SECRET_MASK = "********"
 
@@ -162,3 +168,107 @@ def render_columns(
     for row in rows:
         table_rows.append({c.column.header: _extract_cell(row, c) for c in cols})
     render_table(table_rows, columns)
+
+
+class DeploymentSpec(BaseModel):
+    """Editable deployment fields.
+
+    These are the fields a user can set via ``apply``. ``personal_access_token``
+    is a leaky abstraction over the server-side ``GITHUB_PAT`` secret — it is
+    surfaced here as a dedicated field rather than mixed into ``secrets`` so
+    the apply input shape is explicit.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    display_name: str
+    repo_url: Annotated[str, Column("REPO", format=gh_short)]
+    deployment_file_path: str
+    git_ref: Annotated[str | None, Column("GIT_REF", default="-")] = None
+    appserver_version: Annotated[
+        str | None, Column("APPSERVER", default="-", wide=True)
+    ] = None
+    suspended: Annotated[bool, Column("SUSPENDED", wide=True)] = False
+    secrets: dict[str, str] | None = None
+    personal_access_token: str | None = None
+
+
+class DeploymentStatus(BaseModel):
+    """Read-only / system-set deployment status block.
+
+    These fields reflect runtime state and are not editable via ``apply``.
+    ``warning`` is intentionally always serialized (explicit ``null`` when no
+    warning is present) — absence vs. explicit-null carries meaning for the
+    future ``describe`` command.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    phase: Annotated[LlamaDeploymentPhase, Column("PHASE")]
+    git_sha: Annotated[
+        str | None, Column("GIT_SHA", format=short_sha, default="-", wide=True)
+    ] = None
+    apiserver_url: Annotated[
+        str | None, Column("APISERVER_URL", default="-", wide=True)
+    ] = None
+    project_id: Annotated[str, Column("PROJECT", wide=True)]
+    warning: str | None = None
+
+
+class DeploymentDisplay(BaseModel):
+    """CLI projection of a deployment.
+
+    Top-level ``name`` is the stable id (immutable on update). ``spec``
+    carries the editable surface. ``status`` carries everything set by the
+    server. Use :meth:`from_response` to translate a ``DeploymentResponse``
+    into this shape; use :meth:`to_output_dict` to obtain a dict suitable for
+    JSON/YAML emission with the omit-when-empty rules applied.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str, Column("NAME")]
+    spec: DeploymentSpec
+    status: DeploymentStatus | None = None
+
+    @classmethod
+    def from_response(cls, r: DeploymentResponse) -> DeploymentDisplay:
+        """Project a wire ``DeploymentResponse`` into the CLI display shape."""
+        secret_names = r.secret_names or []
+        secrets: dict[str, str] | None = (
+            {name: SECRET_MASK for name in secret_names} if secret_names else None
+        )
+        pat = SECRET_MASK if r.has_personal_access_token else None
+        spec = DeploymentSpec(
+            display_name=r.display_name,
+            repo_url=r.repo_url,
+            deployment_file_path=r.deployment_file_path,
+            git_ref=r.git_ref,
+            appserver_version=r.appserver_version,
+            suspended=r.suspended,
+            secrets=secrets,
+            personal_access_token=pat,
+        )
+        status = DeploymentStatus(
+            phase=r.status,
+            git_sha=r.git_sha,
+            apiserver_url=str(r.apiserver_url) if r.apiserver_url else None,
+            project_id=r.project_id,
+            warning=r.warning,
+        )
+        return cls(name=r.id, spec=spec, status=status)
+
+    def to_output_dict(self) -> dict[str, Any]:
+        """Return the dict shape used for JSON/YAML rendering.
+
+        Omits fields inside ``spec`` whose value is None (e.g., unset
+        ``personal_access_token``, empty ``secrets``). The nested ``status``
+        block is preserved verbatim so its ``warning`` key remains explicit
+        even when ``null``.
+        """
+        spec_data = self.spec.model_dump(mode="json")
+        spec_data = {k: v for k, v in spec_data.items() if v is not None}
+        data: dict[str, Any] = {"name": self.name, "spec": spec_data}
+        if self.status is not None:
+            data["status"] = self.status.model_dump(mode="json")
+        return data

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -188,7 +188,8 @@ class DeploymentSpec(BaseModel):
     appserver_version: Annotated[
         str | None, Column("APPSERVER", default="-", wide=True)
     ] = None
-    suspended: Annotated[bool, Column("SUSPENDED", wide=True)] = False
+    # No Column: suspended state is already visible via status.phase.
+    suspended: bool = False
     secrets: dict[str, str] | None = None
     personal_access_token: str | None = None
 

--- a/packages/llamactl/tests/conftest.py
+++ b/packages/llamactl/tests/conftest.py
@@ -1,8 +1,12 @@
 import os
 import shutil
 import tempfile
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
+from llama_agents.core.schema.deployments import DeploymentResponse
 
 """Test session configuration for isolating per-worker state.
 
@@ -32,3 +36,55 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: pytest.ExitCode) -
         shutil.rmtree(_TEST_HOME, ignore_errors=True)
     except Exception:
         pass
+
+
+def make_deployment(
+    deployment_id: str = "my-app", **overrides: Any
+) -> DeploymentResponse:
+    """Build a DeploymentResponse with sensible defaults for command tests."""
+    base: dict[str, Any] = {
+        "id": deployment_id,
+        "display_name": deployment_id,
+        "repo_url": "https://github.com/example/repo",
+        "deployment_file_path": "llama_deploy.yaml",
+        "git_ref": "main",
+        "git_sha": "abc1234567890",
+        "project_id": "proj_default",
+        "secret_names": [],
+        "apiserver_url": None,
+        "status": "Running",
+    }
+    base.update(overrides)
+    return DeploymentResponse.model_validate(base)
+
+
+def patch_project_client(client_mock: MagicMock) -> Any:
+    """Patch ProjectClient construction inside ``cli.client.get_project_client``."""
+    return patch(
+        "llama_agents.core.client.manage_client.ProjectClient",
+        return_value=client_mock,
+    )
+
+
+@pytest.fixture
+def fake_profile() -> SimpleNamespace:
+    return SimpleNamespace(
+        api_url="http://test:8011",
+        project_id="proj_default",
+        api_key="key",
+        device_oidc=None,
+        name="prof",
+    )
+
+
+@pytest.fixture
+def patched_auth(fake_profile: SimpleNamespace) -> Any:
+    """Patch the env service so commands use a fake authenticated profile."""
+    with patch("llama_agents.cli.config.env_service.service") as mock_service:
+        mock_auth_svc = MagicMock()
+        mock_auth_svc.get_current_profile.return_value = fake_profile
+        mock_auth_svc.list_profiles.return_value = [fake_profile]
+        mock_auth_svc.env = SimpleNamespace(requires_auth=True)
+        mock_auth_svc.auth_middleware.return_value = None
+        mock_service.current_auth_service.return_value = mock_auth_svc
+        yield mock_service

--- a/packages/llamactl/tests/test_deployments_get_output.py
+++ b/packages/llamactl/tests/test_deployments_get_output.py
@@ -1,0 +1,375 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``deployments get`` output modes, ``--project`` override, and the
+``deployments list`` hidden alias."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import httpx
+import yaml
+from click.testing import CliRunner
+from conftest import make_deployment, patch_project_client
+from llama_agents.cli.app import app
+from llama_agents.core.schema.deployments import DeploymentResponse
+
+
+def _make_client_mock(deployments: list[DeploymentResponse]) -> MagicMock:
+    """A mock ProjectClient stand-in with the methods the commands hit."""
+
+    async def _list() -> list[DeploymentResponse]:
+        return list(deployments)
+
+    async def _get(
+        deployment_id: str, include_events: bool = False
+    ) -> DeploymentResponse:
+        for d in deployments:
+            if d.id == deployment_id:
+                return d
+        raise RuntimeError(f"deployment not found: {deployment_id}")
+
+    client = MagicMock()
+    client.list_deployments.side_effect = _list
+    client.get_deployment.side_effect = _get
+    client.project_id = "proj_default"
+    client.base_url = "http://test:8011"
+    return client
+
+
+def test_deployments_get_text_no_args_lists(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [make_deployment("app-a"), make_deployment("app-b")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(app, ["deployments", "get", "--no-interactive"])
+    assert result.exit_code == 0, result.output
+    assert "app-a" in result.output
+    assert "app-b" in result.output
+    # Plain-table headers, no Rich markup, no truncation ellipsis.
+    assert "NAME" in result.output
+    assert "PHASE" in result.output
+    assert "\x1b[" not in result.output  # no ANSI escapes
+    assert "…" not in result.output
+
+
+def test_deployments_get_json_array(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [make_deployment("app-a"), make_deployment("app-b")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "--no-interactive", "-o", "json"]
+        )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert {d["name"] for d in data} == {"app-a", "app-b"}
+    # All deployments returned should expose ``status``.
+    assert all("status" in d for d in data)
+    assert all("phase" in d["status"] for d in data)
+    # Deprecated aliases / leaked flags must not appear.
+    for d in data:
+        assert "id" not in d
+        assert "llama_deploy_version" not in d
+        assert "has_personal_access_token" not in d
+        assert "secret_names" not in d
+
+
+def test_deployments_get_yaml_list(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [make_deployment("only-one")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "--no-interactive", "-o", "yaml"]
+        )
+    assert result.exit_code == 0, result.output
+    parsed = yaml.safe_load(result.output)
+    assert isinstance(parsed, list)
+    assert parsed[0]["name"] == "only-one"
+
+
+def test_deployments_get_single_text_no_tui(patched_auth: Any) -> None:
+    """``deployments get <name>`` should never launch the Textual monitor."""
+    runner = CliRunner()
+    deployments = [make_deployment("my-app")]
+    client_mock = _make_client_mock(deployments)
+    with (
+        patch_project_client(client_mock),
+        patch(
+            "llama_agents.cli.textual.deployment_monitor.monitor_deployment_screen"
+        ) as mock_monitor,
+    ):
+        # Even if interactive=True, get must print a table — TUI is gone.
+        result = runner.invoke(app, ["deployments", "get", "my-app", "--interactive"])
+    assert result.exit_code == 0, result.output
+    assert mock_monitor.call_count == 0
+    assert "my-app" in result.output
+    # Single-row uses the same column layout as the list view.
+    assert "NAME" in result.output
+    assert "PHASE" in result.output
+
+
+def test_deployments_get_single_json(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [make_deployment("my-app")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "my-app", "--no-interactive", "-o", "json"]
+        )
+    assert result.exit_code == 0, result.output
+    obj = json.loads(result.output)
+    assert isinstance(obj, dict)
+    assert obj["name"] == "my-app"
+    assert "spec" in obj
+    assert obj["status"]["phase"] == "Running"
+    assert obj["status"]["project_id"] == "proj_default"
+    # warning is always-explicit-null
+    assert obj["status"]["warning"] is None
+    # No deprecated aliases / leaks
+    assert "id" not in obj
+    assert "llama_deploy_version" not in obj
+    assert "has_personal_access_token" not in obj
+    assert "secret_names" not in obj
+    # Empty secrets / no PAT means the keys are omitted entirely from spec.
+    assert "secrets" not in obj["spec"]
+    assert "personal_access_token" not in obj["spec"]
+
+
+def test_deployments_get_single_yaml(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [make_deployment("my-app")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "my-app", "--no-interactive", "-o", "yaml"]
+        )
+    assert result.exit_code == 0, result.output
+    obj = yaml.safe_load(result.output)
+    assert isinstance(obj, dict)
+    assert obj["name"] == "my-app"
+    assert obj["status"]["phase"] == "Running"
+
+
+def test_deployments_get_secrets_and_pat_masked(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [
+        make_deployment(
+            "secret-app",
+            secret_names=["LLAMA_CLOUD_API_KEY", "OPENAI_API_KEY"],
+            has_personal_access_token=True,
+        )
+    ]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "secret-app", "--no-interactive", "-o", "json"]
+        )
+    assert result.exit_code == 0, result.output
+    obj = json.loads(result.output)
+    assert obj["spec"]["secrets"] == {
+        "LLAMA_CLOUD_API_KEY": "********",
+        "OPENAI_API_KEY": "********",
+    }
+    assert obj["spec"]["personal_access_token"] == "********"
+
+
+def test_deployments_get_empty_json_is_array(patched_auth: Any) -> None:
+    runner = CliRunner()
+    client_mock = _make_client_mock([])
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "--no-interactive", "-o", "json"]
+        )
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == []
+
+
+def test_deployments_list_hidden_alias_works(patched_auth: Any) -> None:
+    """The hidden ``deployments list`` alias should still produce JSON output."""
+    runner = CliRunner()
+    deployments = [make_deployment("app-a")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "list", "--no-interactive", "-o", "json"]
+        )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert [d["name"] for d in data] == ["app-a"]
+
+
+def test_deployments_list_hidden_in_help(patched_auth: Any) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "--help"])
+    assert result.exit_code == 0
+    # `list` should be hidden (not surfaced in `--help`), but `get` should be.
+    assert "  list " not in result.output
+    assert "  get " in result.output
+
+
+def test_deployments_get_project_override_threads_to_client(
+    patched_auth: Any,
+) -> None:
+    """``--project foo`` should construct a ProjectClient with project_id='foo'."""
+    runner = CliRunner()
+    deployments = [make_deployment("app-a", project_id="proj_other")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock) as ctor:
+        result = runner.invoke(
+            app,
+            [
+                "deployments",
+                "get",
+                "--no-interactive",
+                "--project",
+                "proj_other",
+                "-o",
+                "json",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    # ProjectClient was called with project_id='proj_other'
+    args, kwargs = ctor.call_args
+    # Positional: (api_url, project_id, api_key, auth_middleware)
+    assert args[1] == "proj_other"
+
+
+def _http_status_error(
+    status: int, *, url: str = "http://internal/api"
+) -> httpx.HTTPStatusError:
+    """Build an HTTPStatusError with a real Response for friendly-error tests."""
+    request = httpx.Request("GET", url)
+    response = httpx.Response(status, request=request, text='{"detail":"x"}')
+    return httpx.HTTPStatusError(
+        f"HTTP {status} for url {url} - {response.text}",
+        request=request,
+        response=response,
+    )
+
+
+def test_deployments_get_404_renders_friendly_message(patched_auth: Any) -> None:
+    runner = CliRunner()
+    client_mock = _make_client_mock([])
+
+    async def _raise_404(deployment_id: str, include_events: bool = False) -> None:
+        raise _http_status_error(404)
+
+    client_mock.get_deployment.side_effect = _raise_404
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app,
+            ["deployments", "get", "nonexistent-app", "--no-interactive"],
+        )
+    assert result.exit_code != 0
+    assert (
+        "deployment 'nonexistent-app' not found in project 'proj_default'"
+        in result.output
+    )
+    # No URL, no JSON body should leak through.
+    assert "http://" not in result.output
+    assert "detail" not in result.output
+
+
+def test_deployments_get_404_with_project_includes_project(
+    patched_auth: Any,
+) -> None:
+    runner = CliRunner()
+    client_mock = _make_client_mock([])
+    client_mock.project_id = "proj_other"
+
+    async def _raise_404(deployment_id: str, include_events: bool = False) -> None:
+        raise _http_status_error(404)
+
+    client_mock.get_deployment.side_effect = _raise_404
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app,
+            [
+                "deployments",
+                "get",
+                "nonexistent-app",
+                "--no-interactive",
+                "--project",
+                "proj_other",
+            ],
+        )
+    assert result.exit_code != 0
+    assert (
+        "deployment 'nonexistent-app' not found in project 'proj_other'"
+        in result.output
+    )
+
+
+def test_deployments_get_500_keeps_verbose_message(patched_auth: Any) -> None:
+    runner = CliRunner()
+    client_mock = _make_client_mock([])
+
+    async def _raise_500(deployment_id: str, include_events: bool = False) -> None:
+        raise _http_status_error(500)
+
+    client_mock.get_deployment.side_effect = _raise_500
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app,
+            ["deployments", "get", "boom", "--no-interactive"],
+        )
+    assert result.exit_code != 0
+    # Non-404 keeps the verbose default message (URL + body) for debug-visibility.
+    assert "HTTP 500" in result.output
+    assert "http://" in result.output
+
+
+def test_deployments_get_text_column_order(patched_auth: Any) -> None:
+    """Text mode columns are in declaration order: NAME, REPO, GIT_REF, PHASE."""
+    runner = CliRunner()
+    deployments = [make_deployment("app-a")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(app, ["deployments", "get", "--no-interactive"])
+    assert result.exit_code == 0, result.output
+    header = result.output.splitlines()[0]
+    name_idx = header.index("NAME")
+    repo_idx = header.index("REPO")
+    ref_idx = header.index("GIT_REF")
+    phase_idx = header.index("PHASE")
+    assert name_idx < repo_idx < ref_idx < phase_idx
+
+
+def test_deployments_get_text_no_wide_columns(patched_auth: Any) -> None:
+    """``-o text`` excludes wide-only columns (GIT_SHA, APISERVER_URL, ...)."""
+    runner = CliRunner()
+    deployments = [make_deployment("app-a")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(app, ["deployments", "get", "--no-interactive"])
+    assert result.exit_code == 0, result.output
+    assert "GIT_SHA" not in result.output
+    assert "APISERVER_URL" not in result.output
+    assert "PROJECT" not in result.output
+    assert "APPSERVER" not in result.output
+    assert "SUSPENDED" not in result.output
+
+
+def test_deployments_get_wide_includes_extra_columns(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [
+        make_deployment("app-a", git_sha="abc1234567", appserver_version="0.4.2")
+    ]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "--no-interactive", "-o", "wide"]
+        )
+    assert result.exit_code == 0, result.output
+    header = result.output.splitlines()[0]
+    # Default columns still present; wide columns now appear too.
+    for h in ("NAME", "REPO", "GIT_REF", "PHASE", "APPSERVER", "GIT_SHA"):
+        assert h in header
+    # Wide columns slot into their natural positions, interleaved.
+    # APPSERVER (spec) should appear before PHASE (status).
+    assert header.index("APPSERVER") < header.index("PHASE")

--- a/packages/llamactl/tests/test_deployments_logs.py
+++ b/packages/llamactl/tests/test_deployments_logs.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``deployments logs``."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, AsyncIterator
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+from conftest import patch_project_client
+from llama_agents.cli.app import app
+from llama_agents.core.schema import LogEvent
+
+
+def _make_log_events(n: int = 3) -> list[LogEvent]:
+    base_ts = datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc)
+    return [
+        LogEvent(
+            pod="pod-x",
+            container="app",
+            text=(
+                f'{{"event": "msg-{i}", "level": "info", '
+                f'"timestamp": "2026-04-26T12:00:0{i}.000Z"}}'
+            ),
+            timestamp=base_ts.replace(second=i),
+        )
+        for i in range(n)
+    ]
+
+
+def _make_logs_client(events: list[LogEvent]) -> MagicMock:
+    """Project-client mock with stream_deployment_logs + aclose."""
+
+    async def _stream(*args: Any, **kwargs: Any) -> AsyncIterator[LogEvent]:
+        for ev in events:
+            yield ev
+
+    async def _aclose() -> None:
+        return None
+
+    client = MagicMock()
+    # SAM: side_effect on a non-async returning an async iterator works because
+    # the command does `async for ev in client.stream_deployment_logs(...)`.
+    # The mock returns the async generator object directly when called.
+    client.stream_deployment_logs = MagicMock(side_effect=_stream)
+    client.get_deployment = MagicMock()
+    client.aclose = MagicMock(side_effect=_aclose)
+    client.project_id = "proj_default"
+    client.base_url = "http://test:8011"
+    return client
+
+
+def test_logs_default_prints_recent_and_exits(patched_auth: Any) -> None:
+    runner = CliRunner()
+    events = _make_log_events(3)
+    client = _make_logs_client(events)
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "logs", "my-app", "--no-interactive"]
+        )
+    assert result.exit_code == 0, result.output
+    # Three log lines, one per event.
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 3
+    assert "msg-0" in result.output
+    assert "msg-2" in result.output
+    # Verify follow=False was passed.
+    kwargs = client.stream_deployment_logs.call_args.kwargs
+    assert kwargs["follow"] is False
+
+
+def test_logs_structured_text_uses_body_timestamp_once(patched_auth: Any) -> None:
+    runner = CliRunner()
+    events = _make_log_events(1)
+    client = _make_logs_client(events)
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "logs", "my-app", "--no-interactive"]
+        )
+
+    assert result.exit_code == 0, result.output
+    line = result.output.strip()
+    assert line.startswith("pod-x/app 12:00:00.000")
+    assert line.count("12:00:00") == 1
+
+
+def test_logs_unstructured_text_uses_envelope_timestamp(patched_auth: Any) -> None:
+    runner = CliRunner()
+    event = LogEvent(
+        pod="pod-x",
+        container="app",
+        text="plain stdout line",
+        timestamp=datetime(2026, 4, 26, 12, 0, 0, tzinfo=timezone.utc),
+    )
+    client = _make_logs_client([event])
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "logs", "my-app", "--no-interactive"]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert result.output.strip() == (
+        "2026-04-26T12:00:00+00:00 pod-x/app plain stdout line"
+    )
+
+
+def test_logs_follow_passes_follow_true(patched_auth: Any) -> None:
+    runner = CliRunner()
+    events = _make_log_events(2)
+    client = _make_logs_client(events)
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "logs", "my-app", "--no-interactive", "--follow"],
+        )
+    assert result.exit_code == 0, result.output
+    kwargs = client.stream_deployment_logs.call_args.kwargs
+    assert kwargs["follow"] is True
+
+
+def test_logs_json_outputs_jsonl(patched_auth: Any) -> None:
+    runner = CliRunner()
+    events = _make_log_events(2)
+    client = _make_logs_client(events)
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "logs", "my-app", "--no-interactive", "--json"],
+        )
+    assert result.exit_code == 0, result.output
+    lines = [ln for ln in result.output.splitlines() if ln.strip()]
+    assert len(lines) == 2
+    parsed = [json.loads(ln) for ln in lines]
+    # Each line is a LogEvent envelope.
+    for obj in parsed:
+        assert obj["pod"] == "pod-x"
+        assert obj["container"] == "app"
+        assert "text" in obj
+        assert "timestamp" in obj
+
+
+def test_logs_no_events_emits_stderr_note(patched_auth: Any) -> None:
+    runner = CliRunner()
+    client = _make_logs_client([])
+    with patch_project_client(client):
+        # mix_stderr=False so we can inspect stderr separately.
+        result = runner.invoke(
+            app,
+            ["deployments", "logs", "my-app", "--no-interactive"],
+        )
+    assert result.exit_code == 0, result.output
+    # stderr message present in combined output (CliRunner default).
+    assert "no logs available yet" in result.output
+
+
+def test_logs_rejects_zero_tail(patched_auth: Any) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["deployments", "logs", "my-app", "--no-interactive", "--tail", "0"],
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid value for '--tail'" in result.output
+
+
+def test_logs_rejects_negative_since_seconds(patched_auth: Any) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "deployments",
+            "logs",
+            "my-app",
+            "--no-interactive",
+            "--since-seconds",
+            "-1",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid value for '--since-seconds'" in result.output
+
+
+def test_deployments_status_command_removed() -> None:
+    """``deployments status`` was removed in Slice A.5; ``get`` covers the use case."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "--help"])
+    assert result.exit_code == 0
+    assert "  status " not in result.output
+
+    result = runner.invoke(app, ["deployments", "status", "--no-interactive"])
+    assert result.exit_code != 0

--- a/packages/llamactl/tests/test_display.py
+++ b/packages/llamactl/tests/test_display.py
@@ -1,19 +1,191 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
-"""Tests for the declarative ``Column`` framework in ``cli.display``."""
+"""Tests for the CLI ``DeploymentDisplay`` projection model."""
 
 from __future__ import annotations
 
-from typing import Any, Literal
+from typing import Any
 
 import pytest
+from conftest import make_deployment
 from llama_agents.cli.display import (
+    SECRET_MASK,
+    DeploymentDisplay,
+    DeploymentSpec,
+    DeploymentStatus,
+)
+from pydantic import ValidationError
+
+
+def test_from_response_translates_spec_fields() -> None:
+    response = make_deployment(
+        "my-app",
+        display_name="My App",
+        repo_url="https://github.com/example/repo",
+        deployment_file_path="llama_deploy.yaml",
+        git_ref="main",
+        appserver_version="0.4.2",
+        suspended=True,
+    )
+    display = DeploymentDisplay.from_response(response)
+
+    # ``name`` is the stable id, NOT the deprecated ``r.name`` alias.
+    assert display.name == "my-app"
+    assert isinstance(display.spec, DeploymentSpec)
+    assert display.spec.display_name == "My App"
+    assert display.spec.repo_url == "https://github.com/example/repo"
+    assert display.spec.deployment_file_path == "llama_deploy.yaml"
+    assert display.spec.git_ref == "main"
+    assert display.spec.appserver_version == "0.4.2"
+    assert display.spec.suspended is True
+
+
+def test_from_response_status_block() -> None:
+    response = make_deployment(
+        "my-app",
+        git_sha="abc123",
+        apiserver_url="http://my-app.svc.cluster.local/",
+        warning="upgrade me",
+    )
+    display = DeploymentDisplay.from_response(response)
+
+    assert isinstance(display.status, DeploymentStatus)
+    assert display.status.phase == "Running"
+    assert display.status.git_sha == "abc123"
+    assert display.status.apiserver_url == "http://my-app.svc.cluster.local/"
+    assert display.status.project_id == "proj_default"
+    assert display.status.warning == "upgrade me"
+
+
+def test_from_response_secrets_masked() -> None:
+    response = make_deployment(
+        "my-app", secret_names=["LLAMA_CLOUD_API_KEY", "OPENAI_API_KEY"]
+    )
+    display = DeploymentDisplay.from_response(response)
+
+    assert display.spec.secrets == {
+        "LLAMA_CLOUD_API_KEY": SECRET_MASK,
+        "OPENAI_API_KEY": SECRET_MASK,
+    }
+
+
+def test_from_response_no_secrets_is_none() -> None:
+    response = make_deployment("my-app", secret_names=[])
+    display = DeploymentDisplay.from_response(response)
+    assert display.spec.secrets is None
+
+    response = make_deployment("my-app", secret_names=None)
+    display = DeploymentDisplay.from_response(response)
+    assert display.spec.secrets is None
+
+
+def test_from_response_pat_masking() -> None:
+    response = make_deployment("my-app", has_personal_access_token=True)
+    display = DeploymentDisplay.from_response(response)
+    assert display.spec.personal_access_token == SECRET_MASK
+
+    response = make_deployment("my-app", has_personal_access_token=False)
+    display = DeploymentDisplay.from_response(response)
+    assert display.spec.personal_access_token is None
+
+
+def test_to_output_dict_omits_empty_spec_fields() -> None:
+    response = make_deployment("my-app")  # no secrets, no PAT
+    data = DeploymentDisplay.from_response(response).to_output_dict()
+
+    spec = data["spec"]
+    assert "secrets" not in spec
+    assert "personal_access_token" not in spec
+    # Editable defaults still surface inside spec so apply round-trips cleanly.
+    assert data["name"] == "my-app"
+    assert spec["suspended"] is False
+
+
+def test_to_output_dict_keeps_explicit_status_warning_null() -> None:
+    response = make_deployment("my-app", warning=None)
+    data = DeploymentDisplay.from_response(response).to_output_dict()
+    assert data["status"]["warning"] is None
+
+
+def test_to_output_dict_includes_secrets_and_pat_when_set() -> None:
+    response = make_deployment(
+        "my-app",
+        secret_names=["KEY"],
+        has_personal_access_token=True,
+    )
+    data = DeploymentDisplay.from_response(response).to_output_dict()
+    assert data["spec"]["secrets"] == {"KEY": SECRET_MASK}
+    assert data["spec"]["personal_access_token"] == SECRET_MASK
+
+
+def test_display_model_forbids_extra_fields() -> None:
+    """Adding an unknown wire field should fail loudly during translation."""
+    with pytest.raises(ValidationError):
+        DeploymentDisplay.model_validate(
+            {
+                "name": "x",
+                "spec": {
+                    "display_name": "x",
+                    "repo_url": "https://github.com/x/y",
+                    "deployment_file_path": ".",
+                },
+                "novel_field": "leak",
+            }
+        )
+
+
+def test_spec_model_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        DeploymentSpec.model_validate(
+            {
+                "display_name": "x",
+                "repo_url": "https://github.com/x/y",
+                "deployment_file_path": ".",
+                "novel_field": "leak",
+            }
+        )
+
+
+def test_status_model_forbids_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        DeploymentStatus.model_validate(
+            {"phase": "Running", "project_id": "proj", "extra_field": "x"}
+        )
+
+
+def test_no_legacy_aliases_in_output(monkeypatch: Any) -> None:
+    """Sanity: deprecated wire aliases (``id``, ``llama_deploy_version``,
+    ``has_personal_access_token``, ``secret_names``) must not leak."""
+    response = make_deployment(
+        "my-app",
+        secret_names=["KEY"],
+        has_personal_access_token=True,
+        appserver_version="0.4.2",
+    )
+    data = DeploymentDisplay.from_response(response).to_output_dict()
+    for forbidden in (
+        "id",
+        "llama_deploy_version",
+        "has_personal_access_token",
+        "secret_names",
+    ):
+        assert forbidden not in data
+
+
+# ---------------------------------------------------------------------------
+# Column framework — walker
+# ---------------------------------------------------------------------------
+
+
+from typing import Literal  # noqa: E402
+
+from llama_agents.cli.display import (  # noqa: E402
     Column,
     render_columns,
     resolve_columns,
 )
-from pydantic import BaseModel
-from typing_extensions import Annotated
+from pydantic import BaseModel  # noqa: E402
+from typing_extensions import Annotated  # noqa: E402
 
 
 class _Flat(BaseModel):


### PR DESCRIPTION
## Summary

- `deployments get <name>` shows a single deployment (no auto-launching the TUI; `deployments logs --follow` or `deployments edit` get you the live view).
- `deployments get` (no args) prints a kubectl-style table of all deployments. `list` stays as a hidden alias.
- New `deployments logs <name>`: prints recent logs and exits by default; `--follow` to stream. Also `--json` (jsonl), `--tail`, `--since-seconds`, `--include-init-containers`.
- `-o text|json|yaml|wide` on `get` / `list` / `logs`. Text excludes `wide=True` columns; `wide` interleaves them into their natural positions.
- `--project <id>` overrides the active profile's project for one command.
- 404 from the control plane renders as `Deployment <id> not found in project <project>` instead of the verbose URL + body dump. Other status codes keep the verbose message.
- Per-command display models (`DeploymentDisplay` / `DeploymentSpec` / `DeploymentStatus`) layered on top of the column framework. Secrets surface as masked `{name: "********"}` dicts; `personal_access_token` shows as `********` when set, omitted when not.

Stacked on:
- adrian/llamactl-cli-infra (#585) — the column framework / render helpers / log_format / `--project` plumbing.
- adrian/server-logs-follow-flag (#584) — needed at runtime for `deployments logs` (no-`--follow`) to bound the request server-side.