### PR TITLE
llamactl: deployments history + rollback completion

### DIFF
--- a/.changeset/llamactl-history-rollback.md
+++ b/.changeset/llamactl-history-rollback.md
@@ -1,0 +1,5 @@
+---
+"llamactl": minor
+---
+
+`deployments history` now supports `-o text|json|yaml|wide` and `--project <id>`. Text output uses 7-char short SHAs and Z-suffixed UTC timestamps; JSON keeps full SHAs. `deployments rollback --git-sha` now offers shell completion from the deployment's history.

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -12,7 +12,7 @@ import subprocess
 import click
 from llama_agents.cli.commands.auth import validate_authenticated_profile
 from llama_agents.cli.param_types import DeploymentType, GitShaType
-from llama_agents.cli.styles import HEADER_COLOR, MUTED_COL, PRIMARY_COL, WARNING
+from llama_agents.cli.styles import WARNING
 from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import (
     INTERNAL_CODE_REPO_SCHEME,
@@ -21,11 +21,10 @@ from llama_agents.core.schema.deployments import (
     DeploymentUpdate,
 )
 from rich import print as rprint
-from rich.table import Table
 
 from ..app import app, console
 from ..client import get_project_client, project_client_context
-from ..display import DeploymentDisplay
+from ..display import DeploymentDisplay, ReleaseDisplay
 from ..log_format import parse_log_body, render_plain
 from ..options import (
     global_options,
@@ -434,40 +433,42 @@ def refresh_deployment(
 @deployments.command("history")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@output_option
+@project_option
 @interactive_option
-def show_history(deployment_id: str | None, interactive: bool) -> None:
+def show_history(
+    deployment_id: str | None,
+    interactive: bool,
+    output: str,
+    project: str | None,
+) -> None:
     """Show release history for a deployment."""
     validate_authenticated_profile(interactive)
     try:
-        deployment_id = select_deployment(deployment_id, interactive=interactive)
+        deployment_id = select_deployment(
+            deployment_id, interactive=interactive, project_id_override=project
+        )
         if not deployment_id:
             rprint(f"[{WARNING}]No deployment selected[/]")
             return
 
         async def _fetch_history() -> DeploymentHistoryResponse:
-            async with project_client_context() as client:
+            async with project_client_context(project_id_override=project) as client:
                 return await client.get_deployment_history(deployment_id)
 
         history = asyncio.run(_fetch_history())
-        items = history.history
-        if not items:
-            rprint(f"No history recorded for {deployment_id}")
-            return
-
-        table = Table(show_edge=False, box=None, header_style=f"bold {HEADER_COLOR}")
-        table.add_column("Released At", style=MUTED_COL)
-        table.add_column("Git SHA", style=PRIMARY_COL)
-        # newest first
         items_sorted = sorted(
-            items,
+            history.history,
             key=lambda it: it.released_at,
             reverse=True,
         )
-        for item in items_sorted:
-            ts = item.released_at.isoformat()
-            sha = item.git_sha
-            table.add_row(ts, sha)
-        console.print(table)
+
+        if not items_sorted and output == "text":
+            rprint(f"No history recorded for {deployment_id}")
+            return
+
+        displays = [ReleaseDisplay.from_response(item) for item in items_sorted]
+        render_output(displays, output)
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")
         raise click.Abort()
@@ -479,8 +480,14 @@ def show_history(deployment_id: str | None, interactive: bool) -> None:
 @click.option(
     "--git-sha", required=False, type=GitShaType(), help="Git SHA to roll back to"
 )
+@project_option
 @interactive_option
-def rollback(deployment_id: str | None, git_sha: str | None, interactive: bool) -> None:
+def rollback(
+    deployment_id: str | None,
+    git_sha: str | None,
+    interactive: bool,
+    project: str | None,
+) -> None:
     """Rollback a deployment to a previous git sha."""
     # Keep these imports local: profiling showed `questionary` is a noticeable
     # startup cost for `llamactl --help`. Avoid other local imports unless they
@@ -491,7 +498,9 @@ def rollback(deployment_id: str | None, git_sha: str | None, interactive: bool) 
 
     validate_authenticated_profile(interactive)
     try:
-        deployment_id = select_deployment(deployment_id, interactive=interactive)
+        deployment_id = select_deployment(
+            deployment_id, interactive=interactive, project_id_override=project
+        )
         if not deployment_id:
             rprint(f"[{WARNING}]No deployment selected[/]")
             return
@@ -501,7 +510,9 @@ def rollback(deployment_id: str | None, git_sha: str | None, interactive: bool) 
             async def _fetch_current_and_history() -> tuple[
                 DeploymentResponse, DeploymentHistoryResponse
             ]:
-                async with project_client_context() as client:
+                async with project_client_context(
+                    project_id_override=project
+                ) as client:
                     current = await client.get_deployment(deployment_id)
                     hist = await client.get_deployment_history(deployment_id)
                     return current, hist
@@ -509,12 +520,12 @@ def rollback(deployment_id: str | None, git_sha: str | None, interactive: bool) 
             current_deployment, history = asyncio.run(_fetch_current_and_history())
             current_sha = current_deployment.git_sha or ""
 
-            items = history.history or []
-            # Sort newest first
-            items_sorted = sorted(items, key=lambda it: it.released_at, reverse=True)
+            items_sorted = sorted(
+                history.history or [], key=lambda it: it.released_at, reverse=True
+            )
             choices = []
             for it in items_sorted:
-                short = it.git_sha[:7]
+                short = short_sha(it.git_sha)
                 suffix = (
                     " [current]" if current_sha and it.git_sha == current_sha else ""
                 )
@@ -532,19 +543,18 @@ def rollback(deployment_id: str | None, git_sha: str | None, interactive: bool) 
                 return
 
         if interactive and not confirm_action(
-            f"Rollback '{deployment_id}' to {git_sha[:7]}?"
+            f"Rollback '{deployment_id}' to {short_sha(git_sha)}?"
         ):
             rprint(f"[{WARNING}]Cancelled[/]")
             return
 
         async def _do_rollback() -> DeploymentResponse:
-            async with project_client_context() as client:
+            async with project_client_context(project_id_override=project) as client:
                 return await client.rollback_deployment(deployment_id, git_sha)
 
         updated = asyncio.run(_do_rollback())
-        rprint(
-            f"[green]Rollback initiated[/green]: {deployment_id} → {updated.git_sha[:7] if updated.git_sha else 'unknown'}"
-        )
+        new_short = short_sha(updated.git_sha) if updated.git_sha else "-"
+        rprint(f"[green]Rollback initiated[/green]: {deployment_id} → {new_short}")
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")
         raise click.Abort()

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -24,12 +24,14 @@ from __future__ import annotations
 import functools
 import types
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, Callable, Literal, Union, get_args, get_origin
 
-from llama_agents.cli.render import gh_short, short_sha, star_marker
+from llama_agents.cli.render import format_iso_z, gh_short, short_sha, star_marker
 from llama_agents.core.schema.deployments import (
     DeploymentResponse,
     LlamaDeploymentPhase,
+    ReleaseHistoryItem,
 )
 from llama_agents.core.schema.projects import OrgSummary
 from pydantic import BaseModel, ConfigDict
@@ -274,6 +276,24 @@ class DeploymentDisplay(BaseModel):
         if self.status is not None:
             data["status"] = self.status.model_dump(mode="json")
         return data
+
+
+class ReleaseDisplay(BaseModel):
+    """A single release-history entry, projected for table output."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    released_at: Annotated[datetime, Column("RELEASED_AT", format=format_iso_z)]
+    git_sha: Annotated[str, Column("GIT_SHA", format=short_sha)]
+    image_tag: Annotated[str | None, Column("IMAGE_TAG", default="-")] = None
+
+    @classmethod
+    def from_response(cls, item: ReleaseHistoryItem) -> ReleaseDisplay:
+        return cls(
+            released_at=item.released_at,
+            git_sha=item.git_sha,
+            image_tag=item.image_tag,
+        )
 
 
 class AuthProfileDisplay(BaseModel):

--- a/packages/llamactl/tests/test_deployments_get_output.py
+++ b/packages/llamactl/tests/test_deployments_get_output.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -14,7 +15,11 @@ import yaml
 from click.testing import CliRunner
 from conftest import make_deployment, patch_project_client
 from llama_agents.cli.app import app
-from llama_agents.core.schema.deployments import DeploymentResponse
+from llama_agents.core.schema.deployments import (
+    DeploymentHistoryResponse,
+    DeploymentResponse,
+    ReleaseHistoryItem,
+)
 
 
 def _make_client_mock(deployments: list[DeploymentResponse]) -> MagicMock:
@@ -237,6 +242,92 @@ def test_deployments_get_project_override_threads_to_client(
     args, kwargs = ctor.call_args
     # Positional: (api_url, project_id, api_key, auth_middleware)
     assert args[1] == "proj_other"
+
+
+def _full_sha(prefix: str) -> str:
+    """Return a 40-char hex string starting with ``prefix`` for history tests."""
+    return (prefix + "0" * 40)[:40]
+
+
+def _history_client_mock(items: list[ReleaseHistoryItem]) -> MagicMock:
+    client_mock = _make_client_mock([make_deployment("my-app")])
+
+    async def _hist(deployment_id: str) -> DeploymentHistoryResponse:
+        return DeploymentHistoryResponse(
+            deployment_id=deployment_id, history=list(items)
+        )
+
+    client_mock.get_deployment_history.side_effect = _hist
+    return client_mock
+
+
+def test_deployments_history_json_output(patched_auth: Any) -> None:
+    runner = CliRunner()
+    items = [
+        ReleaseHistoryItem(
+            git_sha=_full_sha("aaaaaaa1111"),
+            released_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        ),
+        ReleaseHistoryItem(
+            git_sha=_full_sha("bbbbbbb2222"),
+            released_at=datetime(2026, 2, 1, tzinfo=timezone.utc),
+        ),
+    ]
+    client_mock = _history_client_mock(items)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app,
+            [
+                "deployments",
+                "history",
+                "my-app",
+                "--no-interactive",
+                "-o",
+                "json",
+            ],
+        )
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    # Newest first
+    assert data[0]["git_sha"] == _full_sha("bbbbbbb2222")
+    assert data[1]["git_sha"] == _full_sha("aaaaaaa1111")
+    # JSON keeps full 40-char shas.
+    assert all(len(d["git_sha"]) == 40 for d in data)
+    # JSON timestamps are Z-suffixed (Pydantic default).
+    assert all(d["released_at"].endswith("Z") for d in data)
+
+
+def test_deployments_history_text_short_sha_and_z_timestamp(
+    patched_auth: Any,
+) -> None:
+    runner = CliRunner()
+    full_sha = _full_sha("640f764")
+    items = [
+        ReleaseHistoryItem(
+            git_sha=full_sha,
+            released_at=datetime(2026, 4, 25, 15, 1, 15, tzinfo=timezone.utc),
+            image_tag="0.11.1",
+        ),
+    ]
+    client_mock = _history_client_mock(items)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app,
+            ["deployments", "history", "my-app", "--no-interactive"],
+        )
+    assert result.exit_code == 0, result.output
+    # Header present.
+    assert "RELEASED_AT" in result.output
+    assert "GIT_SHA" in result.output
+    assert "IMAGE_TAG" in result.output
+    # Z-suffixed timestamp; no +00:00.
+    assert "2026-04-25T15:01:15Z" in result.output
+    assert "+00:00" not in result.output
+    # Short sha (7 chars) only — full sha must not appear.
+    assert "640f764" in result.output
+    assert full_sha not in result.output
+    assert "0.11.1" in result.output
 
 
 def _http_status_error(


### PR DESCRIPTION
## Summary

- `deployments history` joins the column framework: `-o text|json|yaml|wide`, `--project <id>`, sorted newest-first, Z-suffixed UTC timestamps. Text mode shows 7-char short SHAs; JSON keeps the full 40 chars.
- `deployments rollback --git-sha <TAB>` completes from the deployment's release history. Reads `deployment_id` + `project` off the click context. The interactive questionary fallback also moved to `short_sha` so the picker matches the new flag display.
- The rich-table rendering is gone — `ReleaseDisplay` carries the `Column` annotations and `render_output` picks the format.

Stacked on #586.