### PR TITLE
llamactl: auth/env list and auth organizations on column framework

### DIFF
--- a/.changeset/llamactl-auth-env-retrofit.md
+++ b/.changeset/llamactl-auth-env-retrofit.md
@@ -1,0 +1,5 @@
+---
+"llamactl": minor
+---
+
+`auth list`, `auth env list`, and `auth organizations` now support `-o text|json|yaml|wide`. Plain-text tables replace the Rich-styled tables; JSON/YAML output round-trips. `auth list` no longer leaks `api_key` or OIDC tokens — `auth_type` reports `token`/`oidc`/`none`.

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -11,20 +11,13 @@ from typing import TYPE_CHECKING
 
 import click
 from llama_agents.cli.param_types import OrgType, ProfileType, ProjectType
-from llama_agents.cli.styles import (
-    ACTIVE_INDICATOR,
-    HEADER_COLOR,
-    MUTED_COL,
-    PRIMARY_COL,
-    WARNING,
-)
+from llama_agents.cli.styles import MUTED_COL, PRIMARY_COL, WARNING
 from llama_agents.cli.utils.capabilities import probe_organizations_support
 from rich import print as rprint
-from rich.table import Table
-from rich.text import Text
 
-from ..app import app, console
-from ..options import global_options, interactive_option
+from ..app import app
+from ..display import AuthProfileDisplay, OrgDisplay
+from ..options import global_options, interactive_option, output_option, render_output
 
 if TYPE_CHECKING:
     from llama_agents.cli.config.auth_service import AuthService
@@ -161,14 +154,15 @@ def device_login() -> None:
 
 @auth.command("list")
 @global_options
-def list_profiles() -> None:
+@output_option
+def list_profiles(output: str) -> None:
     """List all logged in users/tokens"""
     try:
         auth_svc = _get_service().current_auth_service()
         profiles = auth_svc.list_profiles()
         current = auth_svc.get_current_profile()
 
-        if not profiles:
+        if not profiles and output == "text":
             rprint(f"[{WARNING}]No profiles found[/]")
             if auth_svc.env.requires_auth:
                 rprint("Create one with: [cyan]llamactl auth login[/cyan]")
@@ -176,24 +170,12 @@ def list_profiles() -> None:
                 rprint("Create one with: [cyan]llamactl auth token[/cyan]")
             return
 
-        table = Table(show_edge=False, box=None, header_style=f"bold {HEADER_COLOR}")
-        table.add_column("  Name", style=PRIMARY_COL)
-        table.add_column("Active Project", style=MUTED_COL)
-
-        for profile in profiles:
-            text = Text()
-            if profile == current:
-                text.append("* ", style=ACTIVE_INDICATOR)
-            else:
-                text.append("  ")
-            text.append(profile.name)
-            active_project = profile.project_id or "-"
-            table.add_row(
-                text,
-                active_project,
-            )
-
-        console.print(table)
+        current_name = current.name if current else None
+        displays = [
+            AuthProfileDisplay.from_profile(p, current_name=current_name)
+            for p in profiles
+        ]
+        render_output(displays, output)
 
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")
@@ -301,34 +283,31 @@ def me() -> None:
 # Organizations commands
 @auth.command("organizations")
 @global_options
-def list_organizations() -> None:
+@output_option
+def list_organizations(output: str) -> None:
     """List organizations available to the current profile"""
     try:
         auth_svc = _get_service().current_auth_service()
         if not probe_organizations_support():
-            rprint(f"[{WARNING}]This server does not support organizations[/]")
+            if output == "text":
+                rprint(f"[{WARNING}]This server does not support organizations[/]")
+                return
+            # Structured outputs: emit an empty list so scripts get a
+            # well-typed answer instead of an unparsable warning.
+            render_output([], output)
             return
 
         organizations = _list_organizations(auth_svc)
-        if not organizations:
+        if not organizations and output == "text":
             rprint(f"[{WARNING}]No organizations found[/]")
             return
 
-        table = Table(show_edge=False, box=None, header_style=f"bold {HEADER_COLOR}")
-        table.add_column("  Org ID", style=PRIMARY_COL)
-        table.add_column("Name", style=MUTED_COL)
-        table.add_column("Default", style=MUTED_COL)
-
-        for org in organizations:
-            indicator = Text()
-            if org.is_default:
-                indicator.append("* ", style=ACTIVE_INDICATOR)
-            else:
-                indicator.append("  ")
-            indicator.append(org.org_id)
-            table.add_row(indicator, org.org_name, "yes" if org.is_default else "")
-
-        console.print(table)
+        default_org = next((o.org_id for o in organizations if o.is_default), None)
+        displays = [
+            OrgDisplay.from_org_summary(o, current_org_id=default_org)
+            for o in organizations
+        ]
+        render_output(displays, output)
 
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")

--- a/packages/llamactl/src/llama_agents/cli/commands/env.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/env.py
@@ -6,20 +6,12 @@ from typing import TYPE_CHECKING
 import click
 from llama_agents.cli.config.schema import Environment
 from llama_agents.cli.param_types import EnvironmentType
-from llama_agents.cli.styles import (
-    ACTIVE_INDICATOR,
-    HEADER_COLOR,
-    MUTED_COL,
-    PRIMARY_COL,
-    WARNING,
-)
+from llama_agents.cli.styles import WARNING
 from packaging import version as packaging_version
 from rich import print as rprint
-from rich.table import Table
-from rich.text import Text
 
-from ..app import console
-from ..options import global_options, interactive_option
+from ..display import EnvDisplay
+from ..options import global_options, interactive_option, output_option, render_output
 from .auth import auth
 
 if TYPE_CHECKING:
@@ -49,30 +41,22 @@ def env_group() -> None:
 
 @env_group.command("list")
 @global_options
-def list_environments_cmd() -> None:
+@output_option
+def list_environments_cmd(output: str) -> None:
     try:
         service = _env_service()
         envs = service.list_environments()
         current_env = service.get_current_environment()
 
-        if not envs:
+        if not envs and output == "text":
             rprint(f"[{WARNING}]No environments found[/]")
             return
 
-        table = Table(show_edge=False, box=None, header_style=f"bold {HEADER_COLOR}")
-        table.add_column("  API URL", style=PRIMARY_COL)
-        table.add_column("Requires Auth", style=MUTED_COL)
-
-        for env in envs:
-            text = Text()
-            if env == current_env:
-                text.append("* ", style=ACTIVE_INDICATOR)
-            else:
-                text.append("  ")
-            text.append(env.api_url)
-            table.add_row(text, Text("true" if env.requires_auth else "false"))
-
-        console.print(table)
+        current_url = current_env.api_url if current_env else None
+        displays = [
+            EnvDisplay.from_environment(env, current_url=current_url) for env in envs
+        ]
+        render_output(displays, output)
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")
         raise click.Abort()

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -24,13 +24,14 @@ from __future__ import annotations
 import functools
 import types
 from dataclasses import dataclass
-from typing import Any, Callable, Union, get_args, get_origin
+from typing import Any, Callable, Literal, Union, get_args, get_origin
 
-from llama_agents.cli.render import gh_short, short_sha
+from llama_agents.cli.render import gh_short, short_sha, star_marker
 from llama_agents.core.schema.deployments import (
     DeploymentResponse,
     LlamaDeploymentPhase,
 )
+from llama_agents.core.schema.projects import OrgSummary
 from pydantic import BaseModel, ConfigDict
 from typing_extensions import Annotated
 
@@ -273,3 +274,88 @@ class DeploymentDisplay(BaseModel):
         if self.status is not None:
             data["status"] = self.status.model_dump(mode="json")
         return data
+
+
+class AuthProfileDisplay(BaseModel):
+    """A locally-stored auth profile, projected for ``auth list``.
+
+    Secret material (``api_key``, OIDC tokens) is intentionally not surfaced.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: Annotated[str, Column("NAME")]
+    api_url: Annotated[str, Column("API_URL")]
+    project_id: Annotated[str | None, Column("PROJECT_ID", default="-")] = None
+    active: Annotated[bool, Column("ACTIVE", format=star_marker)] = False
+    auth_type: Annotated[Literal["none", "token", "oidc"], Column("AUTH")] = "none"
+
+    @classmethod
+    def from_profile(
+        cls, profile: Any, *, current_name: str | None
+    ) -> AuthProfileDisplay:
+        if profile.device_oidc:
+            auth_type: Literal["none", "token", "oidc"] = "oidc"
+        elif profile.api_key:
+            auth_type = "token"
+        else:
+            auth_type = "none"
+        return cls(
+            name=profile.name,
+            api_url=profile.api_url,
+            project_id=profile.project_id,
+            active=profile.name == current_name,
+            auth_type=auth_type,
+        )
+
+
+def _bool_str_lower(value: bool) -> str:
+    return "true" if value else "false"
+
+
+class EnvDisplay(BaseModel):
+    """A configured environment, projected for ``auth env list``.
+
+    ``min_llamactl_version`` is intentionally omitted — it isn't part of the
+    public env-list contract.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    api_url: Annotated[str, Column("API_URL")]
+    requires_auth: Annotated[bool, Column("REQUIRES_AUTH", format=_bool_str_lower)]
+    active: Annotated[bool, Column("ACTIVE", format=star_marker)] = False
+
+    @classmethod
+    def from_environment(cls, env: Any, *, current_url: str | None) -> EnvDisplay:
+        return cls(
+            api_url=env.api_url,
+            requires_auth=env.requires_auth,
+            active=env.api_url == current_url,
+        )
+
+
+def _yes_if_true(value: bool) -> str:
+    return "yes" if value else ""
+
+
+class OrgDisplay(BaseModel):
+    """An organization summary, projected for ``auth organizations``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    org_id: Annotated[str, Column("ORG_ID")]
+    org_name: Annotated[str, Column("NAME")]
+    is_default: Annotated[bool, Column("DEFAULT", format=_yes_if_true)]
+    active: Annotated[bool, Column("ACTIVE", format=star_marker)] = False
+
+    @classmethod
+    def from_org_summary(
+        cls, org: OrgSummary, *, current_org_id: str | None = None
+    ) -> OrgDisplay:
+        return cls(
+            org_id=org.org_id,
+            org_name=org.org_name,
+            is_default=org.is_default,
+            active=current_org_id is not None and org.org_id == current_org_id,
+        )

--- a/packages/llamactl/tests/test_auth_organizations_cli.py
+++ b/packages/llamactl/tests/test_auth_organizations_cli.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``llamactl auth organizations`` output modes."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import yaml
+from click.testing import CliRunner
+from llama_agents.cli.app import app
+from llama_agents.core.schema.projects import OrgSummary
+
+
+def test_auth_organizations_text_lists_orgs() -> None:
+    runner = CliRunner()
+    orgs = [
+        OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
+        OrgSummary(org_id="org-b", org_name="Beta"),
+    ]
+    with (
+        patch(
+            "llama_agents.cli.commands.auth.probe_organizations_support",
+            return_value=True,
+        ),
+        patch("llama_agents.cli.commands.auth._list_organizations", return_value=orgs),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["auth", "organizations"])
+    assert result.exit_code == 0, result.output
+    assert "ORG_ID" in result.output
+    assert "NAME" in result.output
+    assert "DEFAULT" in result.output
+    assert "ACTIVE" in result.output
+    assert "org-a" in result.output
+    assert "Acme" in result.output
+    # ANSI / Rich markup should not leak.
+    assert "\x1b[" not in result.output
+
+
+def test_auth_organizations_json() -> None:
+    runner = CliRunner()
+    orgs = [
+        OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
+        OrgSummary(org_id="org-b", org_name="Beta"),
+    ]
+    with (
+        patch(
+            "llama_agents.cli.commands.auth.probe_organizations_support",
+            return_value=True,
+        ),
+        patch("llama_agents.cli.commands.auth._list_organizations", return_value=orgs),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["auth", "organizations", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert {d["org_id"] for d in data} == {"org-a", "org-b"}
+    default = next(d for d in data if d["org_id"] == "org-a")
+    assert default["is_default"] is True
+    assert default["active"] is True
+
+
+def test_auth_organizations_yaml() -> None:
+    runner = CliRunner()
+    orgs = [OrgSummary(org_id="org-a", org_name="Acme", is_default=True)]
+    with (
+        patch(
+            "llama_agents.cli.commands.auth.probe_organizations_support",
+            return_value=True,
+        ),
+        patch("llama_agents.cli.commands.auth._list_organizations", return_value=orgs),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["auth", "organizations", "-o", "yaml"])
+    assert result.exit_code == 0, result.output
+    data = yaml.safe_load(result.output)
+    assert isinstance(data, list)
+    assert data[0]["org_id"] == "org-a"
+
+
+def test_auth_organizations_unsupported_text_warns() -> None:
+    runner = CliRunner()
+    with (
+        patch(
+            "llama_agents.cli.commands.auth.probe_organizations_support",
+            return_value=False,
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["auth", "organizations"])
+    assert result.exit_code == 0, result.output
+    assert "does not support organizations" in result.output
+
+
+def test_auth_organizations_unsupported_json_emits_empty_list() -> None:
+    """Structured outputs should be parseable even on unsupported servers."""
+    runner = CliRunner()
+    with (
+        patch(
+            "llama_agents.cli.commands.auth.probe_organizations_support",
+            return_value=False,
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["auth", "organizations", "-o", "json"])
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == []


### PR DESCRIPTION
## Summary

- `auth list`, `auth env list`, `auth organizations` all support `-o text|json|yaml|wide`. Rich-styled tables become plain-whitespace; JSON/YAML round-trip.
- `auth list -o json` no longer leaks `api_key` or OIDC tokens — `auth_type` reports `token` / `oidc` / `none`.
- `auth organizations` gets output modes for the first time; the empty case is `[]` rather than a Rich "no orgs" placeholder.
- `EnvDisplay` intentionally omits `min_llamactl_version` — that field isn't part of the public env-list contract.