### PR TITLE
Accept unknown deployment phase values as plain strings

### DIFF
--- a/.changeset/deployment-phase-forward-compat.md
+++ b/.changeset/deployment-phase-forward-compat.md
@@ -1,6 +1,0 @@
----
-"llama-agents-core": patch
-"llamactl": patch
----
-
-Accept unknown deployment phase values as plain strings instead of failing validation, so older clients keep working when a newer server emits a phase the client doesn't know about.

--- a/.changeset/deployment-phase-forward-compat.md
+++ b/.changeset/deployment-phase-forward-compat.md
@@ -1,0 +1,6 @@
+---
+"llama-agents-core": patch
+"llamactl": patch
+---
+
+Accept unknown deployment phase values as plain strings instead of failing validation, so older clients keep working when a newer server emits a phase the client doesn't know about.

--- a/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
@@ -112,7 +112,10 @@ class DeploymentResponse(Base):
     apiserver_url: HttpUrl | None = Field(
         default=None, description="URL of the deployment's API server"
     )
-    status: LlamaDeploymentPhase = Field(description="Current deployment phase")
+    # `LlamaDeploymentPhase | str`: tolerate unknown phase values from a newer
+    # server. Known phases still narrow to the Literal arm; unknown ones fall
+    # through to `str` instead of failing validation on older clients.
+    status: LlamaDeploymentPhase | str = Field(description="Current deployment phase")
     warning: str | None = Field(
         default=None,
         description="Warning message about the deployment state",

--- a/packages/llama-agents-core/tests/test_schema.py
+++ b/packages/llama-agents-core/tests/test_schema.py
@@ -532,6 +532,22 @@ def test_deployment_phases_all_valid() -> None:
         assert response.status == phase
 
 
+def test_unknown_phase_value_accepted() -> None:
+    """An unknown phase value (e.g. emitted by a newer server) is accepted as a
+    plain string instead of failing validation on older clients."""
+    response = DeploymentResponse(
+        id="deploy-future",
+        display_name="future-phase-deployment",
+        project_id="test-project",
+        repo_url="https://github.com/user/repo.git",
+        git_ref="main",
+        deployment_file_path="deploy.yml",
+        status="SomeFuturePhaseTheClientDoesNotKnow",
+        apiserver_url=HttpUrl("http://future.example.com"),
+    )
+    assert response.status == "SomeFuturePhaseTheClientDoesNotKnow"
+
+
 def test_rollingout_phase_response() -> None:
     """Test DeploymentResponse with RollingOut phase"""
     response = DeploymentResponse(

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -208,7 +208,9 @@ class DeploymentStatus(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    phase: Annotated[LlamaDeploymentPhase, Column("PHASE")]
+    # `LlamaDeploymentPhase | str` tolerates unknown phase values from a newer
+    # server; the column renders whatever string the server sent.
+    phase: Annotated[LlamaDeploymentPhase | str, Column("PHASE")]
     git_sha: Annotated[
         str | None, Column("GIT_SHA", format=short_sha, default="-", wide=True)
     ] = None


### PR DESCRIPTION
## Summary

- `DeploymentResponse.status` and the CLI's `DeploymentStatus.phase` widen from `LlamaDeploymentPhase` to `LlamaDeploymentPhase | str`. Known phases still match the literal arm; unknown ones fall through to `str` instead of failing validation.
- Forward-compat for the case where a newer server emits a phase value an older client doesn't yet know about. Today the control plane already maps internal phases down to the historical literal set, so this is belt-and-suspenders insurance against that mapping ever loosening.
- One test covering the unknown-phase-string case.