### PR TITLE
llamactl: add deployment template output

### DIFF
--- a/.changeset/llamactl-deployments-template.md
+++ b/.changeset/llamactl-deployments-template.md
@@ -1,0 +1,5 @@
+---
+"llamactl": patch
+---
+
+Add `llamactl deployments template` and `deployments get -o template` to be used as templates to support `llamactl deployments apply`

--- a/packages/llama-agents-server/src/llama_agents/server/_store/migration_utils.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/migration_utils.py
@@ -2,21 +2,14 @@
 # Copyright (c) 2026 LlamaIndex Inc.
 from __future__ import annotations
 
-try:
-    from importlib.resources.abc import (  # type: ignore
-        Traversable,
-    )
-except ImportError:  # pre 3.11
-    from importlib.abc import (
-        Traversable,
-    )
 import re
 from importlib import import_module, resources
+from typing import Any
 
 VERSION_PATTERN = re.compile(r"--\s*migration:\s*(\d+)")
 
 
-def iter_migration_files(source_pkg: str) -> list[Traversable]:
+def iter_migration_files(source_pkg: str) -> list[Any]:
     """Return packaged SQL migration files in lexicographic order."""
     pkg = import_module(source_pkg)
     root = resources.files(pkg)

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -8,7 +8,7 @@ from typing_extensions import TypeVar
 from workflows.context.state_store import DictState
 from workflows.events import SerializableOptionalException
 
-MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)
+MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
 
 class SerializedContextV0(BaseModel):

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -342,7 +342,7 @@ class DictState(DictLikeModel):
 
 
 # Default state type is DictState for the generic type
-MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)
+MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
 
 @runtime_checkable

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -215,9 +215,7 @@ def template_deployment() -> None:
         )
         required = ("repo_url",)
 
-    display = DeploymentDisplay(
-        name=None, generate_name=preferred_name, spec=spec
-    )
+    display = DeploymentDisplay(name=None, generate_name=preferred_name, spec=spec)
 
     head: list[str] = [f"WARNING: {warning}" for warning in ctx.warnings]
     if ctx.warnings:

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -8,6 +8,7 @@ git ref, reads the config, and runs your app.
 
 import asyncio
 import subprocess
+from pathlib import Path
 
 import click
 from llama_agents.cli.commands.auth import validate_authenticated_profile
@@ -24,12 +25,19 @@ from rich import print as rprint
 
 from ..app import app, console
 from ..client import get_project_client, project_client_context
-from ..display import DeploymentDisplay, ReleaseDisplay
+from ..display import (
+    PUSH_MODE_REPO_URL,
+    DeploymentDisplay,
+    DeploymentSpec,
+    ReleaseDisplay,
+)
+from ..local_context import gather_local_context
 from ..log_format import parse_log_body, render_plain
 from ..options import (
     global_options,
     interactive_option,
     output_option,
+    output_option_with_template,
     project_option,
     render_output,
 )
@@ -42,6 +50,7 @@ from ..utils.git_push import (
     internal_push_refspec,
     push_to_remote,
 )
+from ..yaml_template import render as render_yaml_template
 
 
 @app.group(
@@ -94,6 +103,10 @@ def _do_get(
     a single-row table for that deployment. Never launches the TUI; for a
     live view use ``deployments logs --follow``.
     """
+    mode = output.lower()
+    if mode == "template" and not deployment_id:
+        raise click.ClickException("-o template requires a deployment name")
+
     validate_authenticated_profile(interactive)
     # Fall back to the user-supplied override if client construction itself
     # raises; `client.project_id` resolves the active project when no override.
@@ -105,7 +118,7 @@ def _do_get(
         if not deployment_id:
             deployments = asyncio.run(client.list_deployments())
 
-            if not deployments and output == "text":
+            if not deployments and mode == "text":
                 rprint(
                     f"[{WARNING}]No deployments found for project {client.project_id}[/]"
                 )
@@ -117,6 +130,9 @@ def _do_get(
 
         deployment = asyncio.run(client.get_deployment(deployment_id))
         display = DeploymentDisplay.from_response(deployment)
+        if mode == "template":
+            click.echo(render_yaml_template(display), nl=False)
+            return
         render_output(display, output)
 
     except Exception as e:
@@ -131,7 +147,7 @@ def _do_get(
 @deployments.command("get")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
-@output_option
+@output_option_with_template
 @project_option
 @interactive_option
 def get_deployment(
@@ -165,6 +181,85 @@ def list_deployments(
     _do_get(None, interactive, output, project)
 
 
+@deployments.command("template")
+@global_options
+def template_deployment() -> None:
+    """Print an apply-shaped YAML scaffold for a new deployment.
+
+    Reads the local working tree (git remote and ref, deployment config,
+    .env, required secrets) and emits a YAML scaffold with ``##`` instruction
+    comments. Edit the output, then run ``llamactl deployments apply -f
+    <file>``. Offline by design — no auth profile required.
+    """
+    ctx = gather_local_context()
+
+    cwd_name: str = Path.cwd().name
+    preferred_name: str = ctx.generate_name or cwd_name
+    secrets: dict[str, str | None] | None = None
+    if ctx.required_secret_names:
+        secrets = {name: f"${{{name}}}" for name in ctx.required_secret_names}
+
+    if ctx.is_git_repo:
+        spec = DeploymentSpec(
+            repo_url=PUSH_MODE_REPO_URL,
+            deployment_file_path=ctx.deployment_file_path,
+            git_ref=ctx.git_ref,
+            appserver_version=ctx.installed_appserver_version,
+            secrets=secrets,
+        )
+        required: tuple[str, ...] = ()
+    else:
+        spec = DeploymentSpec(
+            appserver_version=ctx.installed_appserver_version,
+            secrets=secrets,
+        )
+        required = ("repo_url",)
+
+    display = DeploymentDisplay(
+        name=None, generate_name=preferred_name, spec=spec
+    )
+
+    head: list[str] = [f"WARNING: {warning}" for warning in ctx.warnings]
+    if ctx.warnings:
+        head.append("")
+    head.append("Edit, then run: llamactl deployments apply -f <file>")
+    if not ctx.is_git_repo:
+        head.extend(
+            [
+                "",
+                "NOT IN A GIT REPO — set repo_url, or cd into a working tree "
+                "and re-run.",
+            ]
+        )
+
+    field_alternatives: dict[str, tuple[str, str]] = {}
+    if ctx.is_git_repo and ctx.repo_url:
+        field_alternatives["repo_url"] = (
+            ctx.repo_url,
+            "auto-detected from your git remotes",
+        )
+
+    secret_comments: dict[str, str] = {}
+    for name_ in ctx.required_secret_names:
+        if name_ in ctx.available_secrets:
+            secret_comments[name_] = "from your .env"
+        else:
+            secret_comments[name_] = "not in your .env — add it before apply"
+
+    click.echo(
+        render_yaml_template(
+            display,
+            head=head,
+            secret_comments=secret_comments,
+            field_alternatives=field_alternatives,
+            required=required,
+            name_example=preferred_name,
+            scaffold_generate_name=True,
+        ),
+        nl=False,
+    )
+
+
 @deployments.command("create")
 @global_options
 @interactive_option
@@ -189,9 +284,7 @@ def create_deployment(
         rprint(f"[{WARNING}]Cancelled[/]")
         return
 
-    rprint(
-        f"[green]Created deployment: {deployment_form.display_name} (id: {deployment_form.id})[/green]"
-    )
+    rprint(f"[green]Created deployment: {deployment_form.id}[/green]")
 
 
 @deployments.command("configure-git-remote")
@@ -321,7 +414,7 @@ def edit_deployment(
             return
 
         rprint(
-            f"[green]Successfully updated deployment: {updated_deployment.display_name}[/green]"
+            f"[green]Successfully updated deployment: {updated_deployment.id}[/green]"
         )
 
     except Exception as e:
@@ -700,12 +793,11 @@ def select_deployment(
 
     choices = []
     for deployment in deployments:
-        display_name = deployment.display_name
         deployment_id = deployment.id
         status = deployment.status
         choices.append(
             questionary.Choice(
-                title=f"{display_name} ({deployment_id}) - {status}",
+                title=f"{deployment_id} - {status}",
                 value=deployment_id,
             )
         )

--- a/packages/llamactl/src/llama_agents/cli/config/_migrations.py
+++ b/packages/llamactl/src/llama_agents/cli/config/_migrations.py
@@ -9,16 +9,10 @@ import logging
 import os
 import re
 import sqlite3
-import sys
 from contextlib import contextmanager
 from importlib import import_module, resources
 from pathlib import Path
-from typing import Generator
-
-if sys.version_info >= (3, 11):
-    from importlib.resources.abc import Traversable
-else:
-    from importlib.abc import Traversable
+from typing import Any, Generator
 
 logger = logging.getLogger(__name__)
 
@@ -63,11 +57,11 @@ def _file_lock(lock_path: Path) -> Generator[None, None, None]:
         lock_file.close()
 
 
-def _iter_migration_files() -> list[Traversable]:
+def _iter_migration_files() -> list[Any]:
     """Yield packaged SQL migration files in lexicographic order."""
     pkg = import_module(_MIGRATIONS_PKG)
     root = resources.files(pkg)
-    files: list[Traversable] = [p for p in root.iterdir() if p.name.endswith(".sql")]
+    files = [p for p in root.iterdir() if p.name.endswith(".sql")]
     if not files:
         raise ValueError("No migration files found")
     return sorted(files, key=lambda p: p.name)

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -39,6 +39,59 @@ from typing_extensions import Annotated
 
 SECRET_MASK = "********"
 
+# Sentinel value of ``DeploymentSpec.repo_url`` indicating push-mode (the CLI
+# pushes the local working tree on apply rather than pointing at a remote).
+PUSH_MODE_REPO_URL = ""
+
+
+def strip_masks(spec_data: dict[str, Any]) -> dict[str, Any]:
+    """Remove :data:`SECRET_MASK` sentinels from a serialized spec dict.
+
+    - ``secrets``: drop entries whose value equals the mask; drop the key
+      entirely if no entries remain.
+    - ``personal_access_token``: drop the key if its value equals the mask.
+
+    The filter runs at the emit boundary so masked values never leak back
+    into apply input via ``get | edit | apply`` round-trips.
+    """
+    out = dict(spec_data)
+    secrets = out.get("secrets")
+    if isinstance(secrets, dict):
+        filtered = {k: v for k, v in secrets.items() if v != SECRET_MASK}
+        if filtered:
+            out["secrets"] = filtered
+        else:
+            out.pop("secrets", None)
+    if out.get("personal_access_token") == SECRET_MASK:
+        out.pop("personal_access_token", None)
+    return out
+
+
+@dataclass(frozen=True)
+class Doc:
+    """Marker placed in a field's ``Annotated[]`` metadata to attach a doc comment.
+
+    Consumed by the YAML template renderer (``cli.yaml_template.render``):
+    each ``Doc(text)`` becomes one ``## <text>`` line per ``\\n``-separated
+    chunk above the field's key in the rendered output. ``Doc`` coexists with
+    :class:`Column` on the same field and is read independently via
+    ``isinstance`` filtering of ``field.metadata``.
+
+    Args:
+        text: The comment body. Rendered verbatim, prefixed with ``## ``. May
+            contain ``\\n`` for multi-line guidance — each line emits as its
+            own ``##`` comment in the output.
+    """
+
+    text: str
+
+
+@dataclass(frozen=True)
+class TrailingDoc:
+    """Marker for a short YAML note rendered after a field's scalar value."""
+
+    text: str
+
 
 @dataclass(frozen=True)
 class Column:
@@ -176,25 +229,61 @@ def render_columns(
 class DeploymentSpec(BaseModel):
     """Editable deployment fields.
 
-    These are the fields a user can set via ``apply``. ``personal_access_token``
-    is a leaky abstraction over the server-side ``GITHUB_PAT`` secret — it is
-    surfaced here as a dedicated field rather than mixed into ``secrets`` so
-    the apply input shape is explicit.
+    Every editable field is ``Optional`` (or has a default of ``None``) so the
+    same model serves three roles: (1) projection of a server-known deployment
+    (``DeploymentDisplay.from_response`` populates everything explicitly),
+    (2) input shape for ``apply`` (any subset is valid; create-time required
+    fields are enforced by the apply translator, not this model), (3) input
+    shape for partial updates (``model_dump(exclude_unset=True)`` produces a
+    clean patch payload).
+
+    ``personal_access_token`` is a leaky abstraction over the server-side
+    ``GITHUB_PAT`` secret — it is surfaced here as a dedicated field rather
+    than mixed into ``secrets`` so the apply input shape is explicit.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    display_name: str
-    repo_url: Annotated[str, Column("REPO", format=gh_short)]
-    deployment_file_path: str
-    git_ref: Annotated[str | None, Column("GIT_REF", default="-")] = None
+    repo_url: Annotated[
+        str | None,
+        Column("REPO", format=gh_short, default="-"),
+        Doc(
+            '"" = push your local working tree on apply.\n'
+            '"internal://" = reuse a previously-pushed working tree.\n'
+            "https://… = remote git URL (GitHub, GitLab, etc.)."
+        ),
+    ] = None
+    deployment_file_path: Annotated[
+        str | None,
+        TrailingDoc("pyproject.toml or llama_deploy.yaml"),
+    ] = None
+    git_ref: Annotated[
+        str | None,
+        Column("GIT_REF", default="-"),
+    ] = None
     appserver_version: Annotated[
-        str | None, Column("APPSERVER", default="-", wide=True)
+        str | None,
+        Column("APPSERVER", default="-", wide=True),
+        TrailingDoc("auto-pinned from local install"),
     ] = None
     # No Column: suspended state is already visible via status.phase.
-    suspended: bool = False
-    secrets: dict[str, str] | None = None
-    personal_access_token: str | None = None
+    suspended: Annotated[
+        bool | None,
+        TrailingDoc("scale to zero without deleting"),
+    ] = None
+    # ``str | None`` value type matches ``DeploymentUpdate.secrets`` on the wire:
+    # null values delete on apply.
+    secrets: Annotated[
+        dict[str, str | None] | None,
+        Doc(
+            "Secret env vars. ${VAR} reads from your local environment at apply time.\n"
+            "Values are masked after apply — set them, don't expect to read back."
+        ),
+    ] = None
+    personal_access_token: Annotated[
+        str | None,
+        TrailingDoc("private-repo access (GitHub PAT, GitLab access token)"),
+    ] = None
 
 
 class DeploymentStatus(BaseModel):
@@ -233,7 +322,20 @@ class DeploymentDisplay(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    name: Annotated[str, Column("NAME")]
+    # ``None`` is used by the ``deployments template`` command to render the
+    # top-level key as a commented-out example; ``from_response`` always
+    # populates it from the wire id.
+    name: Annotated[
+        str | None,
+        Column("NAME", default="-"),
+        Doc("Stable id for the deployment. Immutable on update."),
+    ] = None
+    # Slug seed used by the server when top-level ``name`` is unset. Surfaced
+    # at the identity tier (sibling to ``name``) since it answers a
+    # what-id-do-I-get question, not an editable-spec question. Wire-side
+    # the field is still ``display_name`` on ``DeploymentResponse``; the CLI
+    # flattens at :meth:`from_response`.
+    generate_name: str | None = None
     spec: DeploymentSpec
     status: DeploymentStatus | None = None
 
@@ -241,12 +343,11 @@ class DeploymentDisplay(BaseModel):
     def from_response(cls, r: DeploymentResponse) -> DeploymentDisplay:
         """Project a wire ``DeploymentResponse`` into the CLI display shape."""
         secret_names = r.secret_names or []
-        secrets: dict[str, str] | None = (
+        secrets: dict[str, str | None] | None = (
             {name: SECRET_MASK for name in secret_names} if secret_names else None
         )
         pat = SECRET_MASK if r.has_personal_access_token else None
         spec = DeploymentSpec(
-            display_name=r.display_name,
             repo_url=r.repo_url,
             deployment_file_path=r.deployment_file_path,
             git_ref=r.git_ref,
@@ -262,19 +363,24 @@ class DeploymentDisplay(BaseModel):
             project_id=r.project_id,
             warning=r.warning,
         )
-        return cls(name=r.id, spec=spec, status=status)
+        return cls(name=r.id, generate_name=r.display_name, spec=spec, status=status)
 
     def to_output_dict(self) -> dict[str, Any]:
         """Return the dict shape used for JSON/YAML rendering.
 
-        Omits fields inside ``spec`` whose value is None (e.g., unset
-        ``personal_access_token``, empty ``secrets``). The nested ``status``
-        block is preserved verbatim so its ``warning`` key remains explicit
-        even when ``null``.
+        Omits fields inside ``spec`` whose value is None and strips the
+        ``SECRET_MASK`` sentinel from ``secrets`` and ``personal_access_token``
+        so a ``get | edit | apply`` round-trip can't push a literal ``********``
+        back as the value. ``generate_name`` is emitted at the top level only
+        when set. The nested ``status`` block is preserved verbatim so its
+        ``warning`` key remains explicit even when ``null``.
         """
         spec_data = self.spec.model_dump(mode="json")
-        spec_data = {k: v for k, v in spec_data.items() if v is not None}
-        data: dict[str, Any] = {"name": self.name, "spec": spec_data}
+        spec_data = strip_masks({k: v for k, v in spec_data.items() if v is not None})
+        data: dict[str, Any] = {"name": self.name}
+        if self.generate_name is not None:
+            data["generate_name"] = self.generate_name
+        data["spec"] = spec_data
         if self.status is not None:
             data["status"] = self.status.model_dump(mode="json")
         return data

--- a/packages/llamactl/src/llama_agents/cli/local_context.py
+++ b/packages/llamactl/src/llama_agents/cli/local_context.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Gather local context for deployment scaffolding.
+
+Reads the current working directory: git remote / branch, deployment config,
+``.env`` secrets, and the installed appserver version. Produces a
+:class:`LocalContext` consumable by ``deployments template`` and the Textual
+deployment form.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from llama_agents.cli.env import load_env_secrets_from_string
+from llama_agents.cli.utils.version import get_installed_appserver_version
+from llama_agents.core.deployment_config import (
+    DEFAULT_DEPLOYMENT_NAME,
+    read_deployment_config,
+)
+from llama_agents.core.git.git_util import (
+    get_current_branch,
+    get_git_root,
+    is_git_repo,
+    list_remotes,
+)
+
+# Module-level — reused per remote in :func:`normalize_git_url_to_http`.
+_SCP_URL_RE = re.compile(r"^(?:(?P<user>[^@]+)@)?(?P<host>[^:/\s]+):(?P<path>[^/].+)$")
+
+
+@dataclass(frozen=True)
+class LocalContext:
+    """Local-machine signals used to scaffold a deployment YAML.
+
+    All fields are passive: this is a snapshot of what we observed, not a
+    decision about what the resulting deployment should look like.
+    """
+
+    is_git_repo: bool = False
+    repo_url: str | None = None
+    git_ref: str | None = None
+    generate_name: str | None = None
+    deployment_file_path: str | None = None
+    available_secrets: dict[str, str] = field(default_factory=dict)
+    required_secret_names: list[str] = field(default_factory=list)
+    installed_appserver_version: str | None = None
+    warnings: list[str] = field(default_factory=list)
+
+
+def gather_local_context() -> LocalContext:
+    """Read cwd-rooted signals into a :class:`LocalContext`.
+
+    Failures while parsing the deployment config become a warning rather than
+    an exception so the scaffolding command stays useful in broken trees.
+    """
+
+    warnings: list[str] = []
+    generate_name: str | None = None
+    deployment_file_path: str | None = None
+    required_secret_names: list[str] = []
+
+    has_git = is_git_repo()
+    try:
+        config = read_deployment_config(Path("."), Path("."))
+        if config.name != DEFAULT_DEPLOYMENT_NAME:
+            generate_name = config.name
+        required_secret_names = list(config.required_env_vars)
+    except Exception:
+        warnings.append("Could not parse local deployment config. It may be invalid.")
+
+    repo_url: str | None = None
+    git_ref: str | None = None
+    if has_git:
+        repo_url = pick_preferred_remote(list_remotes())
+        git_ref = get_current_branch()
+        try:
+            root = get_git_root()
+            if root != Path.cwd():
+                deployment_file_path = str(Path.cwd().relative_to(root))
+        except Exception:
+            pass
+
+    available_secrets: dict[str, str] = {}
+    try:
+        available_secrets = load_env_secrets_from_string(Path(".env").read_text())
+    except FileNotFoundError:
+        # No `.env` is the common offline path — no warning.
+        pass
+    except OSError as exc:
+        warnings.append(f"Could not read .env: {exc.strerror or exc}")
+
+    return LocalContext(
+        is_git_repo=has_git,
+        repo_url=repo_url,
+        git_ref=git_ref,
+        generate_name=generate_name,
+        deployment_file_path=deployment_file_path,
+        available_secrets=available_secrets,
+        required_secret_names=required_secret_names,
+        installed_appserver_version=get_installed_appserver_version(),
+        warnings=warnings,
+    )
+
+
+def pick_preferred_remote(remotes: list[str]) -> str | None:
+    """Normalize and dedupe remotes, preferring github.com over others."""
+    seen: set[str] = set()
+    best: str | None = None
+    for remote in remotes:
+        normalized = normalize_git_url_to_http(remote)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        if best is None or ("github.com" in normalized and "github.com" not in best):
+            best = normalized
+    return best
+
+
+def normalize_git_url_to_http(url: str) -> str:
+    """Best-effort normalize a git URL to an https URL.
+
+    Handles the common SSH/SCP shapes (``git@host:path``,
+    ``ssh://git@host:port/path``) and bare ``host/path`` strings. Strips
+    credentials and any explicit port.
+    """
+    candidate = (url or "").strip()
+
+    has_scheme = "://" in candidate
+    if not has_scheme:
+        scp_match = _SCP_URL_RE.match(candidate)
+        if scp_match:
+            host = scp_match.group("host")
+            path = scp_match.group("path").lstrip("/")
+            if path.endswith(".git"):
+                path = path[:-4]
+            return f"https://{host}/{path}"
+
+    parsed = urlsplit(candidate if has_scheme else f"https://{candidate}")
+    netloc = parsed.netloc.split("@", 1)[-1]
+    scheme = parsed.scheme.lower()
+    # SSH transport ports (e.g. :7999) are meaningless over HTTPS — drop them.
+    # HTTP/HTTPS ports are intentional (self-hosted on a non-standard port).
+    if scheme not in ("http", "https") and ":" in netloc:
+        netloc = netloc.split(":", 1)[0]
+    path = parsed.path.lstrip("/")
+    if path.endswith(".git"):
+        path = path[:-4]
+    if path:
+        return f"https://{netloc}/{path}"
+    return f"https://{netloc}"

--- a/packages/llamactl/src/llama_agents/cli/options.py
+++ b/packages/llamactl/src/llama_agents/cli/options.py
@@ -20,6 +20,28 @@ def global_options(f: Callable[P, R]) -> Callable[P, R]:
     return native_tls_option(file_logging(f))
 
 
+_BASE_OUTPUT_CHOICES = ("text", "json", "yaml", "wide")
+_BASE_OUTPUT_HELP = (
+    "Output format. 'json'/'yaml' for machine-readable output; "
+    "'wide' for the text table with extra columns."
+)
+
+
+def _output_option(
+    *extra_choices: str, help_text: str = _BASE_OUTPUT_HELP
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    choices = list(_BASE_OUTPUT_CHOICES) + list(extra_choices)
+    return click.option(
+        "-o",
+        "--output",
+        "output",
+        type=click.Choice(choices, case_sensitive=False),
+        default="text",
+        show_default=True,
+        help=help_text,
+    )
+
+
 def output_option(f: Callable[P, R]) -> Callable[P, R]:
     """Add a `-o/--output` option for read commands.
 
@@ -28,16 +50,23 @@ def output_option(f: Callable[P, R]) -> Callable[P, R]:
     positions (kubectl-style).
     """
 
-    return click.option(
-        "-o",
-        "--output",
-        "output",
-        type=click.Choice(["text", "json", "yaml", "wide"], case_sensitive=False),
-        default="text",
-        show_default=True,
-        help=(
-            "Output format. 'json'/'yaml' for machine-readable output; "
-            "'wide' for the text table with extra columns."
+    return _output_option()(f)
+
+
+def output_option_with_template(f: Callable[P, R]) -> Callable[P, R]:
+    """Variant of :func:`output_option` that adds the ``template`` choice.
+
+    ``template`` emits the apply-shaped YAML scaffold (annotated with ``#!``
+    docs, suitable for ``llamactl deployments apply -f``). It only makes sense
+    on a single-row read (``deployments get <name>``) and is opted-in per
+    command rather than advertised on every ``-o``-bearing command.
+    """
+
+    return _output_option(
+        "template",
+        help_text=(
+            f"{_BASE_OUTPUT_HELP[:-1]}; "
+            "'template' for an annotated YAML scaffold suitable for `apply`."
         ),
     )(f)
 
@@ -84,6 +113,14 @@ def render_output(
     from llama_agents.cli.display import render_columns, resolve_columns
 
     mode = output.lower()
+    if mode == "template":
+        # ``-o template`` is the apply-shaped scaffold output and only makes
+        # sense for ``deployments get <name>``. Each command that supports it
+        # short-circuits before calling ``render_output``; reaching here with
+        # ``template`` means the command does not.
+        raise click.ClickException(
+            "-o template is only supported for `llamactl deployments get <name>`"
+        )
     if mode in {"text", "wide"}:
         rows: list[BaseModel] | None = None
         if isinstance(payload, BaseModel):

--- a/packages/llamactl/src/llama_agents/cli/textual/deployment_form.py
+++ b/packages/llamactl/src/llama_agents/cli/textual/deployment_form.py
@@ -2,15 +2,14 @@
 
 import dataclasses
 import logging
-import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
 from typing import cast
-from urllib.parse import urlsplit
 
 from llama_agents.cli.client import get_project_client as get_client
 from llama_agents.cli.env import load_env_secrets_from_string
+from llama_agents.cli.local_context import pick_preferred_remote
 from llama_agents.cli.textual.deployment_help import (
     DeploymentHelpBackMessage,
     DeploymentHelpWidget,
@@ -1065,31 +1064,19 @@ def _initialize_deployment_data(
             "Current directory is not a git repository. If you are trying to deploy this directory, you will need to create a git repository and push it before creating a deployment."
         )
     else:
-        seen = set[str]()
-        remotes = list_remotes()
-        candidate_origins = []
-        for remote in remotes:
-            normalized_url = _normalize_to_http(remote)
-            if normalized_url not in seen:
-                candidate_origins.append(normalized_url)
-                seen.add(normalized_url)
-        preferred_origin = sorted(
-            candidate_origins, key=lambda x: "github.com" in x, reverse=True
-        )
-        if preferred_origin:
-            repo_url = preferred_origin[0]
+        repo_url = pick_preferred_remote(list_remotes())
         git_ref = get_current_branch()
         root = get_git_root()
         if root != Path.cwd():
             config_file_path = str(Path.cwd().relative_to(root))
 
-        if not preferred_origin:
+        if repo_url is None:
             warnings.append(
                 "No git remote was found. You will need to push your changes to a remote repository before creating a deployment from this repository."
             )
         else:
             # Working tree changes
-            if working_tree_has_changes() and preferred_origin:
+            if working_tree_has_changes():
                 warnings.append(
                     "Working tree has uncommitted or untracked changes. You may want to push them before creating a deployment from this branch."
                 )
@@ -1128,44 +1115,3 @@ def _initialize_deployment_data(
         server_supports_code_push=server_supports_code_push,
     )
     return form
-
-
-def _normalize_to_http(url: str) -> str:
-    """
-    normalize a git url to a best guess for a corresponding http(s) url
-    """
-    candidate = (url or "").strip()
-
-    # If no scheme, first try scp-like SSH syntax: [user@]host:path
-    has_scheme = "://" in candidate
-    if not has_scheme:
-        scp_match = re.match(
-            r"^(?:(?P<user>[^@]+)@)?(?P<host>[^:/\s]+):(?P<path>[^/].+)$",
-            candidate,
-        )
-        if scp_match:
-            host = scp_match.group("host")
-            path = scp_match.group("path").lstrip("/")
-            if path.endswith(".git"):
-                path = path[:-4]
-            return f"https://{host}/{path}"
-
-    # If no scheme (and not scp), assume host/path and prepend https
-    parsed = urlsplit(candidate if has_scheme else f"https://{candidate}")
-
-    # Drop credentials from netloc
-    netloc = parsed.netloc.split("@", 1)[-1]
-
-    # Drop explicit port (common for SSH like :7999 which is wrong for https)
-    if ":" in netloc:
-        netloc = netloc.split(":", 1)[0]
-
-    # Normalize path and strip .git
-    path = parsed.path.lstrip("/")
-    if path.endswith(".git"):
-        path = path[:-4]
-
-    if path:
-        return f"https://{netloc}/{path}"
-    else:
-        return f"https://{netloc}"

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -190,9 +190,7 @@ def _emit_set_field(
             )
         return
     out.append(
-        _with_trailing(
-            f"{_INDENT}{fname}: {_scalar(value)}", _trailing_doc(finfo)
-        )
+        _with_trailing(f"{_INDENT}{fname}: {_scalar(value)}", _trailing_doc(finfo))
     )
     alt = field_alternatives.get(fname)
     if alt is not None:

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Render a :class:`DeploymentDisplay` as commented apply-shaped YAML.
+
+One ``render()`` walks ``DeploymentDisplay``'s top-level identity fields
+(``name``, optionally ``generate_name``) and then ``DeploymentSpec.model_fields``
+in declaration order, appending lines to a list. Each spec field renders in
+one of three states:
+
+* **set** — ``<key>: <scalar>`` (uncommented), with the field's
+  :class:`~llama_agents.cli.display.Doc` text as ``## …`` lines above.
+  ``secrets`` is the only nested shape; its child keys render at indent 4.
+* **required-but-unset** — ``<key>: ~`` with a ``## Required …`` marker so a
+  ``grep`` or eyeball pass finds the gaps that block ``apply``.
+* **unset** — ``# <key>: <example>`` (commented out one-liner) with the doc
+  above. The schema-fixed ``_EXAMPLES`` table supplies the example value.
+
+Top-level ``name`` follows the set / unset split (no required path — the
+server slugifies an id when ``name`` is omitted, so a missing top-level
+``name`` is never an apply blocker). ``generate_name`` is special-cased: the
+caller opts in via ``scaffold_generate_name`` (only the offline ``deployments
+template`` flow does), and when emitted it always renders commented-out under
+the identity-tier comment block.
+
+A small ``field_alternatives`` mapping lets the caller surface a
+commented-out alternative under a *set* field (used to suggest the detected
+git remote under an empty ``repo_url``). Scalar quoting delegates to PyYAML;
+Single-character strings are force-quoted so values like ``"."`` read
+unambiguously rather than hitting YAML plain-scalar edge cases.
+
+Mask sentinels (``SECRET_MASK``) inside ``secrets`` and on
+``personal_access_token`` are stripped before rendering — the same filter
+:func:`~llama_agents.cli.display.strip_masks` applies to ``-o yaml`` /
+``-o json`` output, so a ``get -o template | apply`` round-trip can't push a
+literal ``********`` back as the value.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Any
+
+import yaml
+from llama_agents.cli.display import (
+    DeploymentDisplay,
+    DeploymentSpec,
+    Doc,
+    TrailingDoc,
+    strip_masks,
+)
+from pydantic.fields import FieldInfo
+
+_INDENT = "  "
+_MARKER = "## "
+_TRAILING_COLUMN = 45
+_SCAFFOLD_IDENTITY_DOCS = (
+    "Set 'name' for a stable id, or 'generate_name' to let the server pick a",
+    "unique id from this slug. Leave both unset → server generates from cwd.",
+)
+
+# Per-field example values shown when a spec field is unset (rendered commented).
+_EXAMPLES: dict[str, Any] = {
+    # The push-mode sentinel (``""``) is documented separately via
+    # :data:`~llama_agents.cli.display.PUSH_MODE_REPO_URL`; the example here
+    # shows a real URL so a user uncommenting the line gets a working shape.
+    "repo_url": "https://github.com/owner/repo",
+    "deployment_file_path": ".",
+    "git_ref": "main",
+    "appserver_version": "0.5.0",
+    "suspended": False,
+    "secrets": {"MY_SECRET": "${MY_SECRET}"},
+    "personal_access_token": "${GITHUB_TOKEN}",
+}
+
+
+def render(
+    display: DeploymentDisplay,
+    *,
+    head: Sequence[str] = (),
+    secret_comments: Mapping[str, str] = {},
+    field_alternatives: Mapping[str, tuple[str, str]] = {},
+    required: Iterable[str] = (),
+    name_example: str = "my-app",
+    scaffold_generate_name: bool = False,
+) -> str:
+    """Render ``display`` as a commented apply-shaped YAML string.
+
+    Args:
+        display: The deployment to render. ``status`` is unconditionally
+            omitted; only ``name``, ``generate_name``, and ``spec`` reach the
+            output.
+        head: Lines emitted at the top of the output as ``## `` comments,
+            before ``name:``. An empty-string entry becomes a bare ``##``.
+        secret_comments: Map of secret name → comment text. Each becomes a
+            trailing ``## `` note on the matching key inside the ``secrets:``
+            block. Ignored when ``secrets`` is unset.
+        field_alternatives: Map of field name → ``(suggestion, annotation)``.
+            For each *set* field listed, a commented-out
+            ``# <field>: <suggestion>  ## <annotation>`` line is emitted
+            directly under the field. Silently ignored for fields in the
+            ``required`` or ``unset`` states.
+        required: Field names (python attribute names on ``DeploymentSpec``)
+            to force-emit as ``<key>: ~`` with a ``## Required …`` marker
+            even when unset. The top-level ``name`` is *not* supported here —
+            it has no required path.
+        name_example: Example value rendered for an unset top-level ``name``
+            (and ``generate_name`` when it has no model value). Defaults to
+            ``"my-app"``; the offline template command passes the cwd name.
+        scaffold_generate_name: When ``True``, emit a commented-out
+            ``# generate_name: <value>`` line at the identity tier. When
+            ``False`` (the default), the
+            field is omitted entirely. Only the offline ``deployments
+            template`` flow opts in; ``get -o template`` does not.
+    """
+    required_set = set(required)
+    out: list[str] = []
+
+    for line in head:
+        out.append("##" if line == "" else f"{_MARKER}{line}")
+    if head:
+        out.append("")
+
+    if scaffold_generate_name:
+        out.extend(_doc_lines(_SCAFFOLD_IDENTITY_DOCS, indent=""))
+    else:
+        name_docs = _docs(DeploymentDisplay.model_fields["name"])
+        out.extend(_doc_lines(name_docs, indent=""))
+    if display.name is None:
+        out.append(f"# name: {name_example}")
+    else:
+        out.append(f"name: {_scalar(display.name)}")
+
+    if scaffold_generate_name:
+        gn_value = display.generate_name or name_example
+        out.append(f"# generate_name: {_scalar(gn_value)}")
+
+    out.append("")
+    out.append("spec:")
+    spec_dump = display.spec.model_dump(mode="json", exclude_none=True)
+    spec_set = strip_masks(spec_dump)
+
+    for idx, (fname, finfo) in enumerate(DeploymentSpec.model_fields.items()):
+        if idx > 0 and fname in {
+            "deployment_file_path",
+            "secrets",
+            "personal_access_token",
+        }:
+            out.append("")
+
+        docs = _docs(finfo)
+        if fname in required_set and fname not in spec_set:
+            docs = _required_docs(docs)
+        out.extend(_doc_lines(docs, indent=_INDENT))
+
+        if fname in spec_set:
+            _emit_set_field(
+                out,
+                fname,
+                spec_set[fname],
+                finfo,
+                secret_comments,
+                field_alternatives,
+            )
+        elif fname in required_set:
+            out.append(_with_trailing(f"{_INDENT}{fname}: ~", _trailing_doc(finfo)))
+        else:
+            _emit_unset_field(out, fname, finfo)
+
+    return "\n".join(out) + "\n"
+
+
+def _emit_set_field(
+    out: list[str],
+    fname: str,
+    value: Any,
+    finfo: FieldInfo,
+    secret_comments: Mapping[str, str],
+    field_alternatives: Mapping[str, tuple[str, str]],
+) -> None:
+    """Append lines for a spec field that has a value."""
+    if fname == "secrets" and isinstance(value, dict):
+        out.append(f"{_INDENT}{fname}:")
+        for sname, sval in value.items():
+            out.append(
+                _with_trailing(
+                    f"{_INDENT * 2}{sname}: {_scalar(sval)}",
+                    _one_line(secret_comments.get(sname)),
+                    align=False,
+                )
+            )
+        return
+    out.append(
+        _with_trailing(
+            f"{_INDENT}{fname}: {_scalar(value)}", _trailing_doc(finfo)
+        )
+    )
+    alt = field_alternatives.get(fname)
+    if alt is not None:
+        alt_value, alt_note = alt
+        out.append(_with_trailing(f"{_INDENT}# {fname}: {alt_value}", alt_note))
+
+
+def _emit_unset_field(out: list[str], fname: str, finfo: FieldInfo) -> None:
+    """Append a commented-out example line for an unset spec field."""
+    example = _EXAMPLES.get(fname, "")
+    if isinstance(example, dict):
+        out.append(f"{_INDENT}# {fname}:")
+        for k, v in example.items():
+            out.append(f"{_INDENT * 2}# {k}: {_scalar(v)}")
+    else:
+        out.append(
+            _with_trailing(
+                f"{_INDENT}# {fname}: {_scalar(example)}",
+                _trailing_doc(finfo),
+            )
+        )
+
+
+def _doc_lines(docs: Iterable[str], *, indent: str) -> list[str]:
+    """Return ``## <doc>`` lines at the given indent, trailing-stripped."""
+    return [f"{indent}{_MARKER}{d}".rstrip() for d in docs]
+
+
+def _docs(info: FieldInfo | None) -> tuple[str, ...]:
+    """Return the first ``Doc`` marker text on ``info``, split into lines."""
+    if info is None:
+        return ()
+    for marker in info.metadata:
+        if isinstance(marker, Doc):
+            return tuple(marker.text.split("\n"))
+    return ()
+
+
+def _trailing_doc(info: FieldInfo | None) -> str | None:
+    """Return the first ``TrailingDoc`` marker text on ``info``."""
+    if info is None:
+        return None
+    for marker in info.metadata:
+        if isinstance(marker, TrailingDoc):
+            return marker.text
+    return None
+
+
+def _required_docs(docs: tuple[str, ...]) -> tuple[str, ...]:
+    """Prefix required state onto the first doc line, or emit a fallback."""
+    if not docs:
+        return ("REQUIRED.",)
+    first, *rest = docs
+    return (f"REQUIRED. {first}", *rest)
+
+
+def _one_line(value: str | None) -> str | None:
+    if value is None:
+        return None
+    return " ".join(value.split())
+
+
+def _with_trailing(line: str, note: str | None, *, align: bool = True) -> str:
+    """Append an aligned trailing ``##`` note when ``note`` is present."""
+    if not note:
+        return line
+    gap = max(2, _TRAILING_COLUMN - len(line)) if align else 2
+    return f"{line}{' ' * gap}{_MARKER}{note}"
+
+
+def _scalar(value: Any) -> str:
+    """Render ``value`` as a YAML scalar suitable for the right-hand side of
+    a key line.
+
+    Delegates to PyYAML in mapping context (``{"_": value}``) so its
+    emitter applies block-context rules — plain for ``${VAR}``, URLs,
+    versions; quoted for reserved words / flow chars / values containing
+    ``: `` or `` #``. Carve-outs: ``None`` emits as ``~`` for parity with
+    the required-tilde rendering, ``""`` emits as ``""`` so the push-mode
+    signal isn't hidden as PyYAML's default ``''``, and single-character
+    strings (except ``"``) are force-quoted so values like ``"."`` read
+    unambiguously rather than hitting YAML plain-scalar edge cases.
+    """
+    if value is None:
+        return "~"
+    if value == "":
+        return '""'
+    if isinstance(value, str) and len(value) == 1 and value != '"':
+        return f'"{value}"'
+    return yaml.safe_dump(
+        {"_": value}, default_flow_style=False, width=1 << 30, allow_unicode=True
+    ).rstrip()[3:]

--- a/packages/llamactl/tests/test_deployments_get_output.py
+++ b/packages/llamactl/tests/test_deployments_get_output.py
@@ -160,7 +160,10 @@ def test_deployments_get_single_yaml(patched_auth: Any) -> None:
     assert obj["status"]["phase"] == "Running"
 
 
-def test_deployments_get_secrets_and_pat_masked(patched_auth: Any) -> None:
+def test_deployments_get_strips_secret_mask_sentinels(patched_auth: Any) -> None:
+    """``********`` mask sentinels never reach structured output; the keys
+    drop entirely so a ``get | edit | apply`` round-trip can't push the mask
+    back as the value."""
     runner = CliRunner()
     deployments = [
         make_deployment(
@@ -176,11 +179,9 @@ def test_deployments_get_secrets_and_pat_masked(patched_auth: Any) -> None:
         )
     assert result.exit_code == 0, result.output
     obj = json.loads(result.output)
-    assert obj["spec"]["secrets"] == {
-        "LLAMA_CLOUD_API_KEY": "********",
-        "OPENAI_API_KEY": "********",
-    }
-    assert obj["spec"]["personal_access_token"] == "********"
+    assert "secrets" not in obj["spec"]
+    assert "personal_access_token" not in obj["spec"]
+    assert "********" not in result.output
 
 
 def test_deployments_get_empty_json_is_array(patched_auth: Any) -> None:
@@ -464,3 +465,94 @@ def test_deployments_get_wide_includes_extra_columns(patched_auth: Any) -> None:
     # Wide columns slot into their natural positions, interleaved.
     # APPSERVER (spec) should appear before PHASE (status).
     assert header.index("APPSERVER") < header.index("PHASE")
+
+
+def test_deployments_get_template_single_emits_apply_shape(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployments = [
+        make_deployment(
+            "my-app",
+            secret_names=["OPENAI_API_KEY"],
+            has_personal_access_token=True,
+            appserver_version="0.5.0",
+        )
+    ]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app,
+            ["deployments", "get", "my-app", "--no-interactive", "-o", "template"],
+        )
+    assert result.exit_code == 0, result.output
+    out = result.output
+    parsed = yaml.safe_load(out)
+    assert parsed["name"] == "my-app"
+    assert "spec" in parsed
+    # Status is omitted from template output unconditionally.
+    assert "status" not in parsed
+    assert "phase" not in out
+    # Doc comments above fields.
+    assert "## Stable id for the deployment" in out
+    # Masked secrets / PAT are stripped at the emit boundary — they must not
+    # round-trip as literal ``********`` values into apply input.
+    assert "********" not in out
+    assert "secrets" not in (parsed["spec"] or {})
+    assert "personal_access_token" not in (parsed["spec"] or {})
+
+
+def test_deployments_get_template_does_not_scaffold_generate_name(
+    patched_auth: Any,
+) -> None:
+    """``get -o template`` is a faithful projection of an existing deployment;
+    it does not emit the ``# generate_name`` scaffolding line that the offline
+    ``deployments template`` command does."""
+    runner = CliRunner()
+    deployments = [make_deployment("my-app", display_name="My App")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app,
+            ["deployments", "get", "my-app", "--no-interactive", "-o", "template"],
+        )
+    assert result.exit_code == 0, result.output
+    assert "generate_name" not in result.output
+    assert "generateName" not in result.output
+
+
+def test_deployments_get_yaml_emits_generate_name_at_top_level(
+    patched_auth: Any,
+) -> None:
+    """``-o yaml`` lifts ``display_name`` out of ``spec`` to the top level
+    as ``generate_name`` (sibling to ``name``)."""
+    runner = CliRunner()
+    deployments = [make_deployment("my-app", display_name="My App")]
+    client_mock = _make_client_mock(deployments)
+    with patch_project_client(client_mock):
+        result = runner.invoke(
+            app, ["deployments", "get", "my-app", "--no-interactive", "-o", "yaml"]
+        )
+    assert result.exit_code == 0, result.output
+    obj = yaml.safe_load(result.output)
+    assert obj["generate_name"] == "My App"
+    assert "display_name" not in obj
+    assert "display_name" not in obj["spec"]
+
+
+def test_deployments_get_template_no_name_errors(patched_auth: Any) -> None:
+    """``deployments get -o template`` without a deployment name errors clearly."""
+    runner = CliRunner()
+    # No client interaction expected — fail fast before list_deployments.
+    result = runner.invoke(
+        app, ["deployments", "get", "--no-interactive", "-o", "template"]
+    )
+    assert result.exit_code != 0
+    assert "template requires a deployment name" in result.output
+
+
+def test_other_commands_reject_template_mode(patched_auth: Any) -> None:
+    """``-o template`` is only meaningful for ``deployments get``."""
+    runner = CliRunner()
+    result = runner.invoke(app, ["auth", "list", "-o", "template"])
+    # The choice is accepted but render_output rejects it with a clear message.
+    assert result.exit_code != 0
+    assert "only supported for" in result.output or "template" in result.output

--- a/packages/llamactl/tests/test_deployments_template_cmd.py
+++ b/packages/llamactl/tests/test_deployments_template_cmd.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``llamactl deployments template``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml as pyyaml
+from click.testing import CliRunner
+from llama_agents.cli.app import app
+from llama_agents.cli.local_context import LocalContext
+
+
+def _patch_git(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    is_repo: bool,
+    branch: str = "main",
+    remotes: list[str] | None = None,
+    git_root: Path | None = None,
+) -> None:
+    monkeypatch.setattr("llama_agents.cli.local_context.is_git_repo", lambda: is_repo)
+    monkeypatch.setattr(
+        "llama_agents.cli.local_context.list_remotes",
+        lambda: remotes if remotes is not None else [],
+    )
+    monkeypatch.setattr(
+        "llama_agents.cli.local_context.get_current_branch", lambda: branch
+    )
+    if git_root is not None:
+        monkeypatch.setattr(
+            "llama_agents.cli.local_context.get_git_root", lambda: git_root
+        )
+
+
+def test_template_in_git_repo_emits_expected_yaml(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "llama_deploy.yaml").write_text(
+        """
+name: my-app
+workflows:
+  svc: "module.workflow:flow"
+required_env_vars: ["API_KEY", "DB_URL"]
+""".strip()
+    )
+    (tmp_path / ".env").write_text("API_KEY=k\n")
+
+    _patch_git(
+        monkeypatch,
+        is_repo=True,
+        branch="develop",
+        remotes=["git@github.com:user/repo.git"],
+        git_root=tmp_path,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "template"])
+    assert result.exit_code == 0, result.output
+
+    out = result.output
+    # Identity tier: both keys commented-out; ``generate_name`` carries the
+    # config-derived name (``my-app`` from llama_deploy.yaml).
+    assert "\n# name: " in out
+    assert "# generate_name: my-app" in out
+    # Spec block has no legacy display_name / generateName.
+    assert "  display_name:" not in out
+    assert "generateName" not in out
+    # Push-mode signal: empty repo_url, double-quoted.
+    assert 'repo_url: ""' in out
+    # Detected remote alternative line follows directly under the empty repo_url.
+    repo_idx = out.index('repo_url: ""')
+    after = out[repo_idx:]
+    next_line = after.splitlines()[1]
+    assert "# repo_url: https://github.com/user/repo" in next_line
+    assert "## auto-detected from your git remotes" in next_line
+    # Detected branch.
+    assert "git_ref: develop" in out
+    # Required secrets rendered as ${VAR}.
+    assert "API_KEY: ${API_KEY}" in out
+    assert "DB_URL: ${DB_URL}" in out
+    # Set-mode secret annotations are trailing comments on the secret lines.
+    api_line = next(line for line in out.splitlines() if "API_KEY:" in line)
+    assert api_line.startswith("    API_KEY: ${API_KEY}")
+    assert api_line.endswith("## from your .env")
+    assert "    ## from your .env" not in out, out
+    # Missing-from-.env secret carries the explicit "not in your .env" comment.
+    db_line = next(line for line in out.splitlines() if "DB_URL:" in line)
+    assert db_line.startswith("    DB_URL: ${DB_URL}")
+    assert db_line.endswith("## not in your .env — add it before apply")
+    assert "Not in your .env" not in out
+    assert "before `apply`" not in out
+    # No "Optional fields" tail block — single-pass rendering.
+    assert "Optional fields" not in out
+    # Output parses as YAML when comments are stripped.
+    parsed = pyyaml.safe_load(out)
+    assert parsed["spec"]["repo_url"] == ""
+    assert parsed["spec"]["git_ref"] == "develop"
+
+
+def test_template_emits_local_context_warnings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "llama_agents.cli.commands.deployment.gather_local_context",
+        lambda: LocalContext(
+            is_git_repo=True,
+            repo_url="https://github.com/user/repo",
+            git_ref="main",
+            warnings=["Could not parse local deployment config. It may be invalid."],
+        ),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "template"])
+    assert result.exit_code == 0, result.output
+
+    lines = result.output.splitlines()
+    assert (
+        lines[0]
+        == "## WARNING: Could not parse local deployment config. It may be invalid."
+    )
+    assert lines[1] == "##"
+    assert lines[2] == "## Edit, then run: llamactl deployments apply -f <file>"
+
+
+def test_template_outside_git_repo_emits_compact_head_and_required_tildes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch, is_repo=False)
+    cwd_name = tmp_path.name
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "template"])
+    assert result.exit_code == 0, result.output
+
+    out = result.output
+    lines = out.splitlines()
+    assert lines[0] == "## Edit, then run: llamactl deployments apply -f <file>"
+    assert lines[1] == "##"
+    assert (
+        lines[2]
+        == "## NOT IN A GIT REPO — set repo_url, or cd into a working tree and re-run."
+    )
+    assert "═══" not in out
+    assert "Set repo_url below before running apply." not in out
+
+    # ``repo_url`` is the only required-tilde field outside a git repo;
+    # ``name`` and ``generate_name`` are commented-out (server defaults the id).
+    assert "  repo_url: ~" in out
+    repo_idx = out.index("  repo_url: ~")
+    assert (
+        '  ## REQUIRED. "" = push your local working tree on apply.' in out[:repo_idx]
+    )
+    assert "## Required — set before `apply`." not in out
+
+    # Top-level identity tier: both keys commented-out, cwd-derived defaults.
+    assert f"\n# name: {cwd_name}" in out
+    assert f"# generate_name: {cwd_name}" in out
+    # No uncommented identity-tier line.
+    assert "\nname:" not in out
+    assert "\ngenerate_name:" not in out
+    # Spec block does NOT contain the legacy display_name / generateName.
+    assert "  # generateName" not in out
+    assert "  display_name:" not in out
+
+    # Other unset fields render as commented-out one-liners in declaration
+    # order inside the spec block.
+    assert "  # deployment_file_path:" in out
+    assert "  # git_ref: main" in out
+    assert "  # suspended: false" in out
+    assert "  # secrets:" in out
+    assert "    # MY_SECRET: ${MY_SECRET}" in out
+    assert "  # personal_access_token:" in out
+
+    # No "Optional fields" tail block.
+    assert "Optional fields" not in out
+
+    # YAML round-trip: required ~ parses to None; commented keys are absent.
+    parsed = pyyaml.safe_load(out)
+    assert "name" not in parsed
+    assert "generate_name" not in parsed
+    assert "display_name" not in parsed["spec"]
+    assert parsed["spec"]["repo_url"] is None
+
+
+def test_template_emits_blank_lines_between_output_sections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch, is_repo=False)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "template"])
+    assert result.exit_code == 0, result.output
+
+    lines = result.output.splitlines()
+    assert lines[0] == "## Edit, then run: llamactl deployments apply -f <file>"
+    assert lines[1] == "##"
+    assert lines[3] == ""
+
+    generate_name_idx = next(
+        i for i, line in enumerate(lines) if line.startswith("# generate_name:")
+    )
+    spec_idx = lines.index("spec:")
+    assert lines[spec_idx - 1] == ""
+    assert spec_idx > generate_name_idx
+
+    repo_doc_idx = next(
+        i for i, line in enumerate(lines) if line.startswith("  ## REQUIRED.")
+    )
+    deploy_path_group_idx = next(
+        i
+        for i, line in enumerate(lines)
+        if line.startswith("  # deployment_file_path:")
+        or "pyproject.toml or llama_deploy.yaml" in line
+    )
+    assert lines[deploy_path_group_idx - 1] == ""
+    assert deploy_path_group_idx > repo_doc_idx
+
+
+def test_template_does_not_require_auth_profile(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The command must work without an auth profile configured.
+
+    The conftest's per-worker LLAMACTL_CONFIG_DIR is empty by default — no
+    ``patched_auth`` fixture is applied here, so a successful invocation is
+    proof the command did not call ``validate_authenticated_profile``.
+    """
+    monkeypatch.chdir(tmp_path)
+    _patch_git(monkeypatch, is_repo=False)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "template"])
+    assert result.exit_code == 0, result.output
+
+
+def test_template_has_no_display_name_or_name_flag() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["deployments", "template", "--help"])
+    assert result.exit_code == 0
+    assert "--display-name" not in result.output
+    assert "--name" not in result.output
+
+
+def test_template_advertises_template_only_on_deployments_get() -> None:
+    """`-o template` is local to ``deployments get`` — not advertised on
+    other read commands that share the same output decorator."""
+    runner = CliRunner()
+    for argv in (
+        ["auth", "organizations", "--help"],
+        ["auth", "env", "list", "--help"],
+        ["deployments", "history", "--help"],
+    ):
+        result = runner.invoke(app, argv)
+        assert result.exit_code == 0, result.output
+        assert "template" not in result.output.lower(), (
+            f"{argv} should not advertise template output: {result.output}"
+        )
+    result = runner.invoke(app, ["deployments", "get", "--help"])
+    assert result.exit_code == 0
+    assert "template" in result.output.lower()

--- a/packages/llamactl/tests/test_display.py
+++ b/packages/llamactl/tests/test_display.py
@@ -31,8 +31,10 @@ def test_from_response_translates_spec_fields() -> None:
 
     # ``name`` is the stable id, NOT the deprecated ``r.name`` alias.
     assert display.name == "my-app"
+    # ``display_name`` from the wire surfaces at the identity tier as
+    # ``generate_name`` — not on ``spec``.
+    assert display.generate_name == "My App"
     assert isinstance(display.spec, DeploymentSpec)
-    assert display.spec.display_name == "My App"
     assert display.spec.repo_url == "https://github.com/example/repo"
     assert display.spec.deployment_file_path == "llama_deploy.yaml"
     assert display.spec.git_ref == "main"
@@ -107,15 +109,29 @@ def test_to_output_dict_keeps_explicit_status_warning_null() -> None:
     assert data["status"]["warning"] is None
 
 
-def test_to_output_dict_includes_secrets_and_pat_when_set() -> None:
+def test_to_output_dict_strips_mask_sentinels() -> None:
+    """Mask sentinels are dropped at the emit boundary so a ``get | edit |
+    apply`` round-trip can't push the literal ``********`` back as the value."""
     response = make_deployment(
         "my-app",
         secret_names=["KEY"],
         has_personal_access_token=True,
     )
     data = DeploymentDisplay.from_response(response).to_output_dict()
-    assert data["spec"]["secrets"] == {"KEY": SECRET_MASK}
-    assert data["spec"]["personal_access_token"] == SECRET_MASK
+    # ``secrets`` had only mask values → key drops entirely.
+    assert "secrets" not in data["spec"]
+    # PAT mask drops too.
+    assert "personal_access_token" not in data["spec"]
+    # And ``SECRET_MASK`` should not appear anywhere serialized.
+    assert SECRET_MASK not in repr(data)
+
+
+def test_to_output_dict_emits_generate_name_when_set() -> None:
+    response = make_deployment("my-app", display_name="My App")
+    data = DeploymentDisplay.from_response(response).to_output_dict()
+    assert data["generate_name"] == "My App"
+    assert "display_name" not in data["spec"]
+    assert "display_name" not in data
 
 
 def test_display_model_forbids_extra_fields() -> None:
@@ -125,7 +141,6 @@ def test_display_model_forbids_extra_fields() -> None:
             {
                 "name": "x",
                 "spec": {
-                    "display_name": "x",
                     "repo_url": "https://github.com/x/y",
                     "deployment_file_path": ".",
                 },
@@ -138,12 +153,18 @@ def test_spec_model_forbids_extra_fields() -> None:
     with pytest.raises(ValidationError):
         DeploymentSpec.model_validate(
             {
-                "display_name": "x",
                 "repo_url": "https://github.com/x/y",
                 "deployment_file_path": ".",
                 "novel_field": "leak",
             }
         )
+
+
+def test_spec_model_no_longer_accepts_display_name() -> None:
+    """``display_name`` lives on ``DeploymentDisplay.generate_name`` now;
+    the spec model rejects it as an unknown field."""
+    with pytest.raises(ValidationError):
+        DeploymentSpec.model_validate({"display_name": "x"})
 
 
 def test_status_model_forbids_extra_fields() -> None:

--- a/packages/llamactl/tests/test_local_context.py
+++ b/packages/llamactl/tests/test_local_context.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``cli.local_context.gather_local_context``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from llama_agents.cli.local_context import (
+    LocalContext,
+    gather_local_context,
+    normalize_git_url_to_http,
+)
+
+
+def test_normalize_https_strip_creds_and_suffix() -> None:
+    assert (
+        normalize_git_url_to_http("https://user:pass@github.com/user/repo.git")
+        == "https://github.com/user/repo"
+    )
+
+
+def test_normalize_scp_style() -> None:
+    assert (
+        normalize_git_url_to_http("git@github.com:user/repo.git")
+        == "https://github.com/user/repo"
+    )
+
+
+def test_normalize_strips_ssh_port() -> None:
+    assert (
+        normalize_git_url_to_http("ssh://git@bitbucket.org:7999/team/repo.git")
+        == "https://bitbucket.org/team/repo"
+    )
+
+
+def test_normalize_preserves_https_port() -> None:
+    assert (
+        normalize_git_url_to_http("https://git.example.com:8443/org/repo.git")
+        == "https://git.example.com:8443/org/repo"
+    )
+
+
+def test_normalize_bare_host_path() -> None:
+    assert (
+        normalize_git_url_to_http("gitlab.com/group/sub/repo.git")
+        == "https://gitlab.com/group/sub/repo"
+    )
+
+
+def test_normalize_rewrites_http_to_https() -> None:
+    assert (
+        normalize_git_url_to_http("http://github.com/user/repo")
+        == "https://github.com/user/repo"
+    )
+
+
+def test_normalize_scp_style_no_dot_git_suffix() -> None:
+    assert (
+        normalize_git_url_to_http("github.com:user/repo")
+        == "https://github.com/user/repo"
+    )
+
+
+def testpick_preferred_remote_prefers_github() -> None:
+    from llama_agents.cli.local_context import pick_preferred_remote
+
+    assert (
+        pick_preferred_remote(
+            [
+                "ssh://git@bitbucket.org/team/repo.git",
+                "git@github.com:user/repo.git",
+            ]
+        )
+        == "https://github.com/user/repo"
+    )
+
+
+def testpick_preferred_remote_dedupes_and_handles_empty() -> None:
+    from llama_agents.cli.local_context import pick_preferred_remote
+
+    assert pick_preferred_remote([]) is None
+    assert (
+        pick_preferred_remote(
+            [
+                "git@github.com:user/repo.git",
+                "https://github.com/user/repo.git",
+            ]
+        )
+        == "https://github.com/user/repo"
+    )
+
+
+def test_gather_outside_git_repo_returns_safe_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("llama_agents.cli.local_context.is_git_repo", lambda: False)
+
+    ctx = gather_local_context()
+
+    assert isinstance(ctx, LocalContext)
+    assert ctx.is_git_repo is False
+    assert ctx.repo_url is None
+    assert ctx.git_ref is None
+    assert ctx.available_secrets == {}
+    assert ctx.required_secret_names == []
+    assert ctx.deployment_file_path is None
+    # Missing config files → silent default; no warning is emitted.
+    assert ctx.warnings == []
+
+
+def test_gather_in_git_repo_with_env_and_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "llama_deploy.yaml").write_text(
+        """
+name: my-app
+workflows:
+  svc: "module.workflow:flow"
+required_env_vars: ["API_KEY", "PORT"]
+""".strip()
+    )
+    (tmp_path / ".env").write_text("API_KEY=secret\nPORT=8080\n")
+
+    monkeypatch.setattr("llama_agents.cli.local_context.is_git_repo", lambda: True)
+    monkeypatch.setattr(
+        "llama_agents.cli.local_context.list_remotes",
+        lambda: [
+            "ssh://git@bitbucket.org/team/repo.git",
+            "git@github.com:user/repo.git",
+        ],
+    )
+    monkeypatch.setattr(
+        "llama_agents.cli.local_context.get_current_branch", lambda: "develop"
+    )
+    monkeypatch.setattr("llama_agents.cli.local_context.get_git_root", lambda: tmp_path)
+
+    ctx = gather_local_context()
+
+    assert ctx.is_git_repo is True
+    # github URL is preferred over bitbucket.
+    assert ctx.repo_url == "https://github.com/user/repo"
+    assert ctx.git_ref == "develop"
+    assert ctx.generate_name == "my-app"
+    assert ctx.available_secrets == {"API_KEY": "secret", "PORT": "8080"}
+    assert sorted(ctx.required_secret_names) == ["API_KEY", "PORT"]
+    # cwd == git_root → no nested deployment_file_path.
+    assert ctx.deployment_file_path is None
+
+
+def test_gather_subdir_of_git_repo_records_relative_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sub = tmp_path / "services" / "app"
+    sub.mkdir(parents=True)
+    (sub / "llama_deploy.yaml").write_text(
+        """
+name: app
+workflows:
+  svc: "x.y:flow"
+""".strip()
+    )
+    monkeypatch.chdir(sub)
+
+    monkeypatch.setattr("llama_agents.cli.local_context.is_git_repo", lambda: True)
+    monkeypatch.setattr("llama_agents.cli.local_context.list_remotes", lambda: [])
+    monkeypatch.setattr(
+        "llama_agents.cli.local_context.get_current_branch", lambda: "main"
+    )
+    monkeypatch.setattr("llama_agents.cli.local_context.get_git_root", lambda: tmp_path)
+
+    ctx = gather_local_context()
+
+    assert ctx.deployment_file_path == str(Path("services") / "app")
+
+
+def test_gather_with_invalid_config_records_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "llama_deploy.yaml").write_text("not: [valid: yaml")
+
+    monkeypatch.setattr("llama_agents.cli.local_context.is_git_repo", lambda: False)
+    ctx = gather_local_context()
+    assert any("Could not parse" in w for w in ctx.warnings)
+
+
+def test_gather_skips_default_named_config(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the config name is the default, ``generate_name`` is left unset."""
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "llama_deploy.yaml").write_text(
+        """
+workflows:
+  svc: "x.y:flow"
+""".strip()
+    )
+    monkeypatch.setattr("llama_agents.cli.local_context.is_git_repo", lambda: False)
+    ctx = gather_local_context()
+    assert ctx.generate_name is None

--- a/packages/llamactl/tests/test_yaml_template.py
+++ b/packages/llamactl/tests/test_yaml_template.py
@@ -1,0 +1,399 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``cli.yaml_template.render``."""
+
+from __future__ import annotations
+
+import yaml as pyyaml
+from llama_agents.cli.display import (
+    SECRET_MASK,
+    DeploymentDisplay,
+    DeploymentSpec,
+    DeploymentStatus,
+    Doc,
+    TrailingDoc,
+)
+from llama_agents.cli.yaml_template import render
+
+
+def _full_display() -> DeploymentDisplay:
+    return DeploymentDisplay(
+        name="my-app",
+        generate_name="My App",
+        spec=DeploymentSpec(
+            repo_url="https://github.com/example/repo",
+            deployment_file_path="llama_deploy.yaml",
+            git_ref="main",
+            appserver_version="0.5.0",
+            suspended=False,
+            secrets={"OPENAI_API_KEY": "sk-x"},
+            personal_access_token=None,
+        ),
+        status=DeploymentStatus(phase="Running", project_id="proj_default"),
+    )
+
+
+def test_render_omits_status_unconditionally() -> None:
+    out = render(_full_display())
+    assert "status:" not in out
+    assert "Running" not in out
+    assert "phase" not in out
+
+
+def test_render_emits_name_and_spec_in_declaration_order() -> None:
+    out = render(_full_display())
+    name_idx = out.index("name:")
+    spec_idx = out.index("spec:")
+    assert name_idx < spec_idx
+    body = out[spec_idx:]
+    fields_in_order = [
+        "repo_url:",
+        "deployment_file_path:",
+        "git_ref:",
+        "appserver_version:",
+        "suspended:",
+        "secrets:",
+    ]
+    last = -1
+    for f in fields_in_order:
+        idx = body.index(f)
+        assert idx > last, f"{f} out of declaration order in:\n{body}"
+        last = idx
+
+
+def test_render_attaches_doc_marker_text_above_each_set_field() -> None:
+    out = render(_full_display())
+    assert "## Stable id for the deployment" in out
+    assert '## "" = push your local working tree on apply.' in out
+
+
+def test_render_omits_generate_name_when_not_scaffolded() -> None:
+    """``scaffold_generate_name=False`` (default) skips the field entirely —
+    no comment block, no commented-out line."""
+    out = render(_full_display())
+    assert "generate_name" not in out
+    assert "name takes precedence" not in out
+
+
+def test_render_emits_generate_name_commented_when_scaffolded() -> None:
+    """``scaffold_generate_name=True`` emits the two-line identity explainer
+    once, then commented identity-tier examples."""
+    out = render(_full_display(), scaffold_generate_name=True)
+    lines = out.splitlines()
+    assert lines[0].startswith("## ")
+    assert lines[1].startswith("## ")
+    assert not lines[2].startswith("## ")
+    assert "## Stable id for the deployment" not in out
+    assert "name: my-app" in out
+    assert "# generate_name: My App" in out
+    # Commented-out (not authoritative).
+    assert "\ngenerate_name:" not in out
+
+
+def test_render_uses_name_example_for_unset_top_level_keys() -> None:
+    """``name=None`` and (with scaffold) ``generate_name=None`` both fall back
+    to the ``name_example`` argument."""
+    out = render(
+        DeploymentDisplay(name=None, spec=DeploymentSpec()),
+        name_example="cwd-name",
+        scaffold_generate_name=True,
+    )
+    assert "# name: cwd-name" in out
+    assert "# generate_name: cwd-name" in out
+
+
+def test_render_partial_spec_emits_unset_fields_as_commented_examples() -> None:
+    """Unset (not required) spec fields render as commented-out one-liners
+    with a doc above, in declaration order inside the spec block."""
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(),
+    )
+    out = render(display)
+    assert "  # repo_url:" in out
+    assert "  # git_ref: main" in out
+    assert "  # secrets:" in out
+    assert "    # MY_SECRET: ${MY_SECRET}" in out
+    git_ref_line = next(
+        line for line in out.splitlines() if line.startswith("  # git_ref:")
+    )
+    assert git_ref_line == "  # git_ref: main"
+
+
+def test_render_required_unset_prefixes_first_doc_line() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(),
+    )
+    out = render(display, required=("repo_url",))
+    assert "  repo_url: ~" in out
+    repo_idx = out.index("  repo_url: ~")
+    assert (
+        '  ## REQUIRED. "" = push your local working tree on apply.' in out[:repo_idx]
+    )
+    assert "## Required — set before `apply`." not in out
+
+
+def test_render_unset_top_level_name_is_commented() -> None:
+    """``DeploymentDisplay.name=None`` renders the top-level key commented-out
+    (the server slugifies an id when ``name`` is unset on apply)."""
+    display = DeploymentDisplay(
+        name=None,
+        spec=DeploymentSpec(),
+    )
+    out = render(display)
+    assert "\n# name: my-app" in out or out.startswith("# name: my-app")
+    # No bare ``name:`` line at the top level.
+    assert "\nname:" not in out
+    assert not out.startswith("name:")
+
+
+def test_render_alternatives_emit_commented_line_under_set_field() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(repo_url=""),
+    )
+    out = render(
+        display,
+        field_alternatives={
+            "repo_url": (
+                "https://github.com/owner/repo",
+                "auto-detected from your git remotes",
+            )
+        },
+    )
+    repo_idx = out.index('  repo_url: ""')
+    after = out[repo_idx:]
+    next_line = after.splitlines()[1]
+    assert next_line.startswith("  # repo_url: https://github.com/owner/repo")
+    assert next_line.endswith("## auto-detected from your git remotes")
+    parsed = pyyaml.safe_load(out)
+    assert parsed["spec"]["repo_url"] == ""
+
+
+def test_render_field_alternative_note_uses_template_marker() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(repo_url=""),
+    )
+    out = render(
+        display,
+        field_alternatives={
+            "repo_url": (
+                "https://github.com/owner/repo",
+                "auto-detected from your git remotes",
+            )
+        },
+    )
+    alt_line = next(
+        line for line in out.splitlines() if line.startswith("  # repo_url:")
+    )
+    assert "  ## auto-detected from your git remotes" in alt_line
+    assert "  # auto-detected from your git remotes" not in alt_line
+
+
+def test_render_alternatives_ignored_for_unset_field() -> None:
+    """An alternative on a field that's not set is silently ignored — the
+    alternative is conceptually 'a different value than the one you have',
+    not 'an example'."""
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(),
+    )
+    out = render(
+        display,
+        field_alternatives={
+            "repo_url": ("https://github.com/owner/repo", "detected"),
+        },
+    )
+    assert "# detected" not in out
+
+
+def test_render_doc_and_trailing_doc_emit_separately() -> None:
+    """A ``Doc`` block can render above one field while a ``TrailingDoc``
+    marker renders on another field's scalar line."""
+    out = render(_full_display())
+    head = out.split("repo_url:", 1)[0]
+    assert '  ## "" = push your local working tree on apply.' in head
+    deploy_path_line = next(
+        line for line in out.splitlines() if line.startswith("  deployment_file_path:")
+    )
+    assert deploy_path_line.endswith("## pyproject.toml or llama_deploy.yaml")
+
+
+def test_render_head_lines_emit_at_top_with_prefix() -> None:
+    out = render(
+        _full_display(),
+        head=("Edit, then run: llamactl deployments apply -f <file>",),
+    )
+    first = out.splitlines()[0]
+    assert first.startswith("## ")
+    assert "Edit, then run" in first
+
+
+def test_render_head_blank_line_emits_bare_marker() -> None:
+    out = render(
+        _full_display(),
+        head=("first", "", "third"),
+    )
+    lines = out.splitlines()
+    assert lines[0] == "## first"
+    assert lines[1] == "##"
+    assert lines[2] == "## third"
+
+
+def test_render_secret_comments_attach_inside_secrets_block() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(
+            secrets={"API_KEY": "${API_KEY}", "OTHER": "x"},
+        ),
+    )
+    out = render(display, secret_comments={"API_KEY": "from your .env"})
+    secrets_idx = out.index("secrets:")
+    block = out[secrets_idx:]
+    api_line = next(line for line in block.splitlines() if "API_KEY:" in line)
+    assert api_line.startswith("    API_KEY: ${API_KEY}")
+    assert api_line.endswith("## from your .env")
+    assert "    ## from your .env" not in block
+
+
+def test_render_trailing_doc_is_independent_from_doc() -> None:
+    repo_markers = DeploymentSpec.model_fields["repo_url"].metadata
+    path_markers = DeploymentSpec.model_fields["deployment_file_path"].metadata
+    assert any(isinstance(marker, Doc) for marker in repo_markers)
+    assert not any(isinstance(marker, TrailingDoc) for marker in repo_markers)
+    assert not any(isinstance(marker, Doc) for marker in path_markers)
+    assert any(isinstance(marker, TrailingDoc) for marker in path_markers)
+
+    out = render(
+        DeploymentDisplay(
+            name="my-app",
+            spec=DeploymentSpec(deployment_file_path="."),
+        )
+    )
+    deploy_path_line = next(
+        line
+        for line in out.splitlines()
+        if line.startswith('  deployment_file_path: "."')
+    )
+    assert deploy_path_line.endswith("## pyproject.toml or llama_deploy.yaml")
+
+
+def test_render_blank_lines_break_head_identity_and_spec_groups() -> None:
+    out = render(
+        _full_display(),
+        head=("Edit, then run: llamactl deployments apply -f <file>",),
+    )
+    lines = out.splitlines()
+    assert lines[0] == "## Edit, then run: llamactl deployments apply -f <file>"
+    assert lines[1] == ""
+
+    name_idx = lines.index("name: my-app")
+    spec_idx = lines.index("spec:")
+    assert lines[name_idx + 1] == ""
+    assert lines[spec_idx - 1] == ""
+
+    repo_idx = next(i for i, line in enumerate(lines) if line.startswith("  repo_url:"))
+    deployment_file_group_idx = next(
+        i
+        for i, line in enumerate(lines)
+        if "deployment_file_path:" in line
+        or "pyproject.toml or llama_deploy.yaml" in line
+    )
+    assert lines[deployment_file_group_idx - 1] == ""
+    assert deployment_file_group_idx > repo_idx
+
+
+def test_render_empty_string_repo_url_is_double_quoted() -> None:
+    """Empty repo_url is meaningful (push-mode signal). Render explicit ``""``."""
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(repo_url=""),
+    )
+    out = render(display)
+    assert 'repo_url: ""' in out
+
+
+def test_render_deployment_file_path_dot_is_quoted() -> None:
+    """Bare-dot path renders as ``"."`` so the value reads as a path string."""
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(deployment_file_path="."),
+    )
+    out = render(display)
+    assert 'deployment_file_path: "."' in out
+
+
+def test_render_strips_secret_mask_sentinels() -> None:
+    """``SECRET_MASK`` values inside ``secrets`` are dropped before render —
+    the mask must never round-trip into apply input."""
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(
+            secrets={"REAL": "${REAL}", "MASKED": SECRET_MASK},
+        ),
+    )
+    out = render(display)
+    assert SECRET_MASK not in out
+    assert "MASKED" not in out
+    # The remaining real secret is still rendered.
+    assert "REAL: ${REAL}" in out
+
+
+def test_render_drops_secrets_block_when_only_masks() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(
+            secrets={"ONLY_MASKED": SECRET_MASK},
+        ),
+    )
+    out = render(display)
+    # No uncommented secrets block — falls into the unset/example branch.
+    assert "  secrets:\n    ONLY_MASKED" not in out
+    assert SECRET_MASK not in out
+    # Commented-out example is what surfaces.
+    assert "  # secrets:" in out
+
+
+def test_render_strips_personal_access_token_mask() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(personal_access_token=SECRET_MASK),
+    )
+    out = render(display)
+    assert SECRET_MASK not in out
+    # Falls through to the commented example.
+    assert "  # personal_access_token:" in out
+
+
+def test_render_output_is_yaml_safe_loadable() -> None:
+    out = render(_full_display())
+    parsed = pyyaml.safe_load(out)
+    assert parsed["name"] == "my-app"
+    assert "display_name" not in parsed["spec"]
+    assert "generate_name" not in parsed["spec"]
+    assert "status" not in parsed
+
+
+def test_render_output_with_required_and_alternatives_is_yaml_safe_loadable() -> None:
+    display = DeploymentDisplay(
+        name=None,
+        spec=DeploymentSpec(repo_url=""),
+    )
+    out = render(
+        display,
+        head=("hint",),
+        required=("git_ref",),
+        field_alternatives={"repo_url": ("https://example.com/x", "detected")},
+    )
+    parsed = pyyaml.safe_load(out)
+    assert "name" not in parsed
+    assert parsed["spec"]["git_ref"] is None
+    assert parsed["spec"]["repo_url"] == ""
+
+
+def test_render_idempotent_for_same_input() -> None:
+    a = render(_full_display())
+    b = render(_full_display())
+    assert a == b

--- a/packages/llamactl/tests/textual/test_deployment_form.py
+++ b/packages/llamactl/tests/textual/test_deployment_form.py
@@ -23,7 +23,6 @@ from llama_agents.cli.textual.deployment_form import (
     StartValidationMessage,
     ValidationScreen,
     _initialize_deployment_data,
-    _normalize_to_http,
 )
 from llama_agents.cli.textual.deployment_monitor import MonitorCloseMessage
 from llama_agents.cli.textual.git_validation import (
@@ -89,43 +88,6 @@ async def _wait_for_widget(
         return
 
     raise AssertionError(f"Timed out waiting for widget {selector}")
-
-
-def test_normalize_to_http_https_basic() -> None:
-    assert (
-        _normalize_to_http("https://github.com/user/repo.git")
-        == "https://github.com/user/repo"
-    )
-    assert (
-        _normalize_to_http("http://github.com/user/repo")
-        == "https://github.com/user/repo"
-    )
-
-
-def test_normalize_to_http_ssh_scp_style() -> None:
-    assert (
-        _normalize_to_http("git@github.com:user/repo.git")
-        == "https://github.com/user/repo"
-    )
-    assert _normalize_to_http("github.com:user/repo") == "https://github.com/user/repo"
-
-
-def test_normalize_to_http_https_with_creds_and_port() -> None:
-    assert (
-        _normalize_to_http("https://user:pass@github.com/user/repo.git")
-        == "https://github.com/user/repo"
-    )
-    assert (
-        _normalize_to_http("ssh://git@bitbucket.org:7999/team/repo.git")
-        == "https://bitbucket.org/team/repo"
-    )
-
-
-def test_normalize_to_http_plain_host_path() -> None:
-    assert (
-        _normalize_to_http("gitlab.com/group/sub/repo.git")
-        == "https://gitlab.com/group/sub/repo"
-    )
 
 
 def test_initialize_deployment_data_happy_path(


### PR DESCRIPTION
Adds apply-shaped deployment YAML in two places: an offline scaffold from local project context, and a server projection for existing deployments.

- `llamactl deployments template` reads git remote, branch, deployment config, `.env` names, required secrets, and the installed appserver version without requiring auth.
- `llamactl deployments get <name> -o template` emits editable YAML from an existing deployment, with status omitted and masked secrets stripped.
- Deployment YAML now keeps identity at the top level (`name` / `generate_name`) and editable settings under `spec`.
- Template rendering has comments for required fields, local defaults, push-mode repo URLs, and secret placeholders.
- Fixes the post-rebase lint blockers from resource annotations and TypeVar defaults.