### PR TITLE
llamactl: deployments apply -f / delete -f + PUT upsert

### DIFF
--- a/.changeset/llamactl-deployments-apply.md
+++ b/.changeset/llamactl-deployments-apply.md
@@ -1,0 +1,7 @@
+---
+"llamactl": minor
+"llama-agents-core": minor
+"llama-agents-control-plane": minor
+---
+
+`deployments apply -f` upserts a deployment from YAML; `delete -f` deletes by name read from a file. Adds `PUT /api/v1beta1/deployments/{id}` (create-or-update) and a `DeploymentApply` schema.

--- a/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
+++ b/packages/llama-agents-control-plane/src/llama_agents/control_plane/manage_api/deployments_service.py
@@ -26,6 +26,8 @@ from llama_agents.core.iter_utils import (
 from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import (
     INTERNAL_CODE_REPO_SCHEME,
+    DeploymentApply,
+    DeploymentCreate,
     DeploymentHistoryResponse,
     DeploymentResponse,
     DeploymentUpdate,
@@ -397,6 +399,72 @@ class DeploymentService(AbstractDeploymentsService):
         if validated is not None and validated.error_message:
             updated_deployment.warning = validated.error_message
         return updated_deployment
+
+    @override
+    async def apply_deployment(
+        self,
+        project_id: str,
+        deployment_id: str,
+        apply_data: DeploymentApply,
+    ) -> tuple[DeploymentResponse, bool]:
+        """Declarative create-or-update for a deployment by stable id."""
+        try:
+            await self._get_deployment_or_raise(project_id, deployment_id)
+        except DeploymentNotFoundError:
+            if not apply_data.display_name:
+                raise HTTPException(
+                    status_code=422,
+                    detail=(
+                        "display_name is required when creating a new deployment "
+                        f"(no deployment '{deployment_id}' exists in project)."
+                    ),
+                )
+            create_data = DeploymentCreate(
+                id=deployment_id,
+                display_name=apply_data.display_name,
+                repo_url=apply_data.repo_url or "",
+                deployment_file_path=apply_data.deployment_file_path,
+                git_ref=apply_data.git_ref,
+                personal_access_token=apply_data.personal_access_token,
+                # On create, ``DeploymentCreate.secrets`` is ``dict[str, str]``;
+                # drop any ``None`` values (deletion semantics make no sense
+                # against a brand-new deployment).
+                secrets=(
+                    {k: v for k, v in apply_data.secrets.items() if v is not None}
+                    if apply_data.secrets is not None
+                    else None
+                ),
+                appserver_version=apply_data.appserver_version,
+            )
+            created = await self.create_deployment(
+                project_id=project_id, deployment_data=create_data
+            )
+            # ``suspended=True`` on create is unusual but supported via a
+            # follow-up update so the K8s spec reflects the requested state.
+            if apply_data.suspended:
+                created = await self.update_deployment(
+                    project_id=project_id,
+                    deployment_id=created.id,
+                    update_data=DeploymentUpdate(suspended=True),
+                )
+            return created, True
+
+        update_data = DeploymentUpdate(
+            display_name=apply_data.display_name,
+            repo_url=apply_data.repo_url,
+            deployment_file_path=apply_data.deployment_file_path,
+            git_ref=apply_data.git_ref,
+            personal_access_token=apply_data.personal_access_token,
+            secrets=apply_data.secrets,
+            appserver_version=apply_data.appserver_version,
+            suspended=apply_data.suspended,
+        )
+        updated = await self.update_deployment(
+            project_id=project_id,
+            deployment_id=deployment_id,
+            update_data=update_data,
+        )
+        return updated, False
 
     @override
     async def handle_git_request(

--- a/packages/llama-agents-control-plane/tests/deployments/test_deployments_service.py
+++ b/packages/llama-agents-control-plane/tests/deployments/test_deployments_service.py
@@ -732,3 +732,213 @@ async def test_handle_git_request_allows_push_mode_deployments(
     await_args = mock_handle_git_request.await_args
     assert await_args is not None
     assert await_args.kwargs["storage"] is mock_code_repo_storage
+
+
+# --- apply (declarative upsert) ---
+
+
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.update_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.create_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.get_deployment",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_apply_deployment_creates_when_missing(
+    mock_get_deployment: AsyncMock,
+    mock_create: AsyncMock,
+    mock_update: AsyncMock,
+) -> None:
+    """Missing deployment + display_name → delegates to create_deployment with explicit id."""
+    mock_get_deployment.return_value = None
+    created = _make_deployment(display_name="my-app")
+    mock_create.return_value = created
+
+    response, was_created = await deployments_service.apply_deployment(
+        project_id="proj-1",
+        deployment_id="my-app",
+        apply_data=schema.DeploymentApply(
+            display_name="my-app",
+            repo_url="https://example.com/repo.git",
+            git_ref="main",
+            secrets={"FOO": "bar", "BAZ": None},
+        ),
+    )
+
+    assert was_created is True
+    assert response.id == "my-app"
+    mock_create.assert_awaited_once()
+    assert mock_create.await_args is not None
+    create_kwargs = mock_create.await_args.kwargs
+    assert create_kwargs["project_id"] == "proj-1"
+    create_data = create_kwargs["deployment_data"]
+    assert create_data.id == "my-app"
+    assert create_data.display_name == "my-app"
+    assert create_data.repo_url == "https://example.com/repo.git"
+    assert create_data.git_ref == "main"
+    # ``None`` secret values are dropped on create — deletion semantics are
+    # only meaningful against existing state.
+    assert create_data.secrets == {"FOO": "bar"}
+    mock_update.assert_not_awaited()
+
+
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.update_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.create_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.get_deployment",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_apply_deployment_updates_when_present(
+    mock_get_deployment: AsyncMock,
+    mock_create: AsyncMock,
+    mock_update: AsyncMock,
+) -> None:
+    """Existing deployment → delegates to update_deployment with patch fields."""
+    existing = _make_deployment(display_name="my-app")
+    mock_get_deployment.return_value = existing
+    mock_update.return_value = existing.model_copy(update={"git_ref": "v2"})
+
+    response, was_created = await deployments_service.apply_deployment(
+        project_id="proj-1",
+        deployment_id="my-app",
+        apply_data=schema.DeploymentApply(
+            git_ref="v2",
+            secrets={"FOO": "bar", "DROP_ME": None},
+        ),
+    )
+
+    assert was_created is False
+    assert response.git_ref == "v2"
+    mock_update.assert_awaited_once()
+    assert mock_update.await_args is not None
+    update_kwargs = mock_update.await_args.kwargs
+    assert update_kwargs["project_id"] == "proj-1"
+    assert update_kwargs["deployment_id"] == "my-app"
+    update_data = update_kwargs["update_data"]
+    # Absent fields stay None so update_deployment doesn't clobber them.
+    assert update_data.git_ref == "v2"
+    assert update_data.repo_url is None
+    assert update_data.display_name is None
+    # Null secret values pass through verbatim — deletion handled in
+    # apply_deployment_update downstream.
+    assert update_data.secrets == {"FOO": "bar", "DROP_ME": None}
+    mock_create.assert_not_awaited()
+
+
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.create_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.get_deployment",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_apply_deployment_missing_display_name_on_create_returns_422(
+    mock_get_deployment: AsyncMock,
+    mock_create: AsyncMock,
+) -> None:
+    """No deployment + no display_name → 422; create is never called."""
+    mock_get_deployment.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await deployments_service.apply_deployment(
+            project_id="proj-1",
+            deployment_id="my-app",
+            apply_data=schema.DeploymentApply(git_ref="main"),
+        )
+
+    assert exc_info.value.status_code == 422
+    assert "display_name" in str(exc_info.value.detail)
+    mock_create.assert_not_awaited()
+
+
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.update_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.create_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.get_deployment",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_apply_deployment_create_with_suspended_follows_up_with_update(
+    mock_get_deployment: AsyncMock,
+    mock_create: AsyncMock,
+    mock_update: AsyncMock,
+) -> None:
+    """``suspended=True`` on create issues a follow-up update so K8s reflects it."""
+    mock_get_deployment.return_value = None
+    created = _make_deployment(display_name="my-app")
+    mock_create.return_value = created
+    mock_update.return_value = created.model_copy(update={"suspended": True})
+
+    response, was_created = await deployments_service.apply_deployment(
+        project_id="proj-1",
+        deployment_id="my-app",
+        apply_data=schema.DeploymentApply(
+            display_name="my-app",
+            suspended=True,
+        ),
+    )
+
+    assert was_created is True
+    assert response.suspended is True
+    mock_create.assert_awaited_once()
+    mock_update.assert_awaited_once()
+    assert mock_update.await_args is not None
+    update_kwargs = mock_update.await_args.kwargs
+    assert update_kwargs["update_data"].suspended is True
+
+
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.update_deployment",
+    new_callable=AsyncMock,
+)
+@patch(
+    "llama_agents.control_plane.manage_api.deployments_service.k8s_client.get_deployment",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_apply_deployment_project_mismatch_creates_with_explicit_id(
+    mock_get_deployment: AsyncMock,
+    mock_update: AsyncMock,
+) -> None:
+    """A deployment owned by a different project is invisible to apply.
+
+    The current project gets a fresh create attempt rather than a 409.
+    """
+    mock_get_deployment.return_value = _make_deployment(project_id="other")
+
+    with patch(
+        "llama_agents.control_plane.manage_api.deployments_service.DeploymentService.create_deployment",
+        new_callable=AsyncMock,
+    ) as mock_create:
+        mock_create.return_value = _make_deployment(
+            project_id="proj-1", display_name="my-app"
+        )
+        _, was_created = await deployments_service.apply_deployment(
+            project_id="proj-1",
+            deployment_id="my-app",
+            apply_data=schema.DeploymentApply(display_name="my-app"),
+        )
+
+    assert was_created is True
+    mock_update.assert_not_awaited()

--- a/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
+++ b/packages/llama-agents-core/src/llama_agents/core/client/manage_client.py
@@ -14,6 +14,7 @@ from llama_agents.core.schema.backups import (
     RestoreResponse,
 )
 from llama_agents.core.schema.deployments import (
+    DeploymentApply,
     DeploymentCreate,
     DeploymentHistoryResponse,
     DeploymentResponse,
@@ -258,6 +259,31 @@ class ProjectClient(BaseClient):
         )
         _raise_for_status(response)
         return DeploymentResponse.model_validate(response.json())
+
+    async def apply_deployment(
+        self,
+        deployment_id: str,
+        apply_data: DeploymentApply,
+    ) -> tuple[DeploymentResponse, bool]:
+        """Declarative create-or-update for a deployment by stable id.
+
+        Sends only the fields the caller explicitly set so unmentioned fields
+        on the server are left untouched. ``secrets`` with ``None`` values
+        pass through verbatim to trigger server-side deletion.
+
+        Returns ``(deployment, created)`` where ``created`` is ``True`` when
+        the server signalled a new deployment (HTTP 201) and ``False`` when
+        an existing one was updated (HTTP 200).
+        """
+        response = await self.client.put(
+            f"/api/v1beta1/deployments/{deployment_id}",
+            params={"project_id": self.project_id},
+            json=apply_data.model_dump(exclude_unset=True),
+        )
+        _raise_for_status(response)
+        return DeploymentResponse.model_validate(response.json()), (
+            response.status_code == 201
+        )
 
     async def get_deployment_history(
         self, deployment_id: str

--- a/packages/llama-agents-core/src/llama_agents/core/schema/__init__.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/__init__.py
@@ -7,6 +7,7 @@ from .backups import (
 )
 from .base import Base
 from .deployments import (
+    DeploymentApply,
     DeploymentCreate,
     DeploymentHistoryResponse,
     DeploymentResponse,
@@ -35,6 +36,7 @@ __all__ = [
     "RestoreResponse",
     "Base",
     "LogEvent",
+    "DeploymentApply",
     "DeploymentCreate",
     "DeploymentResponse",
     "DeploymentUpdate",

--- a/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
@@ -383,6 +383,51 @@ class DeploymentUpdate(Base):
         )
 
 
+class DeploymentApply(Base):
+    """
+    Declarative apply payload for ``PUT /deployments/{deployment_id}``.
+
+    Strict subset of ``DeploymentCreate`` ∪ ``DeploymentUpdate`` minus imperative
+    or service-managed fields (``rebuild``, ``bump_to_latest_appserver``,
+    ``git_sha``, ``static_assets_path``, ``image_tag``). The deployment id is
+    carried in the URL path, not the body.
+
+    Secrets follow ``DeploymentUpdate`` semantics: string values add/update,
+    ``None`` values remove. Absent fields are left untouched on existing
+    deployments.
+    """
+
+    display_name: str | None = Field(
+        default=None, description="User-facing display label"
+    )
+    repo_url: str | None = Field(
+        default=None, description="Git repository URL for the deployment source"
+    )
+    deployment_file_path: str | None = Field(
+        default=None,
+        description="Path to the deployment config file within the repository",
+    )
+    git_ref: str | None = Field(
+        default=None, description="Git reference (branch, tag, or commit) to deploy"
+    )
+    personal_access_token: str | None = Field(
+        default=None, description="Personal access token for private repo access"
+    )
+    secrets: dict[str, str | None] | None = Field(
+        default=None,
+        description="Secret updates: string values add/update, null values remove",
+    )
+    appserver_version: str | None = Field(
+        default=None,
+        description="Appserver version to use (e.g. '0.4.2'). "
+        "If omitted, server may set based on client version.",
+    )
+    suspended: bool | None = Field(
+        default=None,
+        description="Set to true to suspend (scale to 0), false to resume",
+    )
+
+
 class DeploymentUpdateResult(Base):
     """
     Result of applying a DeploymentUpdate to a LlamaDeploymentSpec.

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_abstract_deployments_service.py
@@ -149,6 +149,33 @@ class AbstractDeploymentsService(ABC):
         ...
 
     @abstractmethod
+    async def apply_deployment(
+        self,
+        project_id: str,
+        deployment_id: str,
+        apply_data: schema.DeploymentApply,
+    ) -> tuple[DeploymentResponse, bool]:
+        """
+        Declarative create-or-update for a deployment by stable id.
+
+        If a deployment with ``deployment_id`` exists in the project, the
+        non-None fields of ``apply_data`` are applied as a patch (delegating
+        to ``update_deployment``). If no deployment exists, a new one is
+        created with ``id=deployment_id`` (delegating to ``create_deployment``).
+        Creating a new deployment requires ``apply_data.display_name``.
+
+        Args:
+            project_id: The ID of the project the deployment lives in
+            deployment_id: The stable id (URL path component) to upsert
+            apply_data: The declarative payload
+
+        Returns:
+            ``(deployment, created)`` where ``created`` is True when a new
+            deployment was created and False when an existing one was updated.
+        """
+        ...
+
+    @abstractmethod
     async def get_deployment_history(
         self, project_id: str, deployment_id: str
     ) -> DeploymentHistoryResponse:

--- a/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
+++ b/packages/llama-agents-core/src/llama_agents/core/server/manage_api/_create_deployments_router.py
@@ -153,6 +153,29 @@ def create_v1beta1_deployments_router(
         except DeploymentNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e))
 
+    @router.put("/{deployment_id}", response_model=schema.DeploymentResponse)
+    async def apply_deployment(
+        project_id: Annotated[str, Depends(get_project_id)],
+        deployment_id: str,
+        apply_data: schema.DeploymentApply,
+    ) -> Response:
+        """Declarative create-or-update for a deployment by stable id.
+
+        Returns ``201`` when a new deployment was created and ``200`` when an
+        existing one was updated.
+        """
+        deployment_response, created = await deployments_service.apply_deployment(
+            project_id=project_id,
+            deployment_id=deployment_id,
+            apply_data=apply_data,
+        )
+
+        return Response(
+            content=deployment_response.model_dump_json(),
+            status_code=201 if created else 200,
+            media_type="application/json",
+        )
+
     @router.patch("/{deployment_id}", response_model=schema.DeploymentResponse)
     async def update_deployment(
         project_id: Annotated[str, Depends(get_project_id)],

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -17,6 +17,7 @@ from llama_agents.cli.styles import WARNING
 from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import (
     INTERNAL_CODE_REPO_SCHEME,
+    DeploymentCreate,
     DeploymentHistoryResponse,
     DeploymentResponse,
     DeploymentUpdate,
@@ -49,6 +50,11 @@ from ..utils.git_push import (
     get_deployment_git_url,
     internal_push_refspec,
     push_to_remote,
+)
+from ..yaml_format import (
+    ApplyYamlError,
+    UnresolvedVarsError,
+    parse_apply_yaml,
 )
 from ..yaml_template import render as render_yaml_template
 
@@ -268,6 +274,112 @@ def template_deployment() -> None:
     )
 
 
+@deployments.command("apply")
+@global_options
+@click.option(
+    "-f",
+    "--filename",
+    "filename",
+    required=True,
+    type=click.File("r"),
+    help="YAML file or `-` for stdin.",
+)
+@click.option(
+    "--dry-run",
+    "dry_run",
+    is_flag=False,
+    flag_value="client",
+    default=None,
+    type=click.Choice(["client", "server"], case_sensitive=False),
+    help=(
+        "Validate without applying. `client` (the default with bare flag) "
+        "prints the resolved payload; `server` is reserved for a future "
+        "server-side dry-run."
+    ),
+)
+@project_option
+def apply_deployment(
+    filename: click.utils.LazyFile,
+    dry_run: str | None,
+    project: str | None,
+) -> None:
+    """Apply a deployment declaratively from a YAML file.
+
+    With ``name:`` in the YAML the command upserts by stable id (server
+    creates when missing, updates when present). Without ``name:`` but with
+    ``display_name:`` it falls through to the existing create endpoint with
+    a server-generated id. ``${VAR}`` references resolve from the local
+    environment; missing names are surfaced as a single grouped error.
+    Non-interactive by design — run ``llamactl auth login`` first.
+    """
+    # ``yaml`` is unused on the auth-fail / unset-var paths and the import
+    # is held to a no-llamactl-startup budget by tests/test_cli_imports.py.
+    import yaml as pyyaml
+
+    validate_authenticated_profile(interactive=False)
+
+    source = filename.name if filename.name != "<stdin>" else "-"
+    try:
+        text = filename.read()
+        parsed = parse_apply_yaml(text, source=source)
+    except (ApplyYamlError, UnresolvedVarsError) as exc:
+        raise click.ClickException(str(exc))
+
+    if dry_run is not None and dry_run.lower() == "server":
+        raise click.ClickException("server-side dry-run not yet supported")
+
+    if dry_run is not None and dry_run.lower() == "client":
+        payload: dict[str, object] = {}
+        if parsed.name:
+            payload["name"] = parsed.name
+        payload.update(parsed.apply.model_dump(exclude_unset=True))
+        click.echo(pyyaml.safe_dump(payload, sort_keys=False), nl=False)
+        return
+
+    try:
+        client = get_project_client(project_id_override=project)
+
+        if parsed.name:
+            updated, created = asyncio.run(
+                client.apply_deployment(parsed.name, parsed.apply)
+            )
+            verb = "created" if created else "updated"
+            rprint(f"[green]{verb}[/green] {updated.id}")
+            return
+
+        if not parsed.apply.display_name:
+            raise click.ClickException(
+                "YAML must include `name` (for upsert by stable id) or "
+                "`display_name` (to create with auto-generated name)"
+            )
+
+        # Fallthrough: no stable id → existing create endpoint, server picks
+        # the id. ``DeploymentCreate.secrets`` is ``dict[str, str]`` so drop
+        # any ``None`` values (deletion semantics make no sense on create).
+        secrets_for_create: dict[str, str] | None = None
+        if parsed.apply.secrets is not None:
+            secrets_for_create = {
+                k: v for k, v in parsed.apply.secrets.items() if v is not None
+            }
+        create_data = DeploymentCreate(
+            display_name=parsed.apply.display_name,
+            repo_url=parsed.apply.repo_url or "",
+            deployment_file_path=parsed.apply.deployment_file_path,
+            git_ref=parsed.apply.git_ref,
+            personal_access_token=parsed.apply.personal_access_token,
+            secrets=secrets_for_create,
+            appserver_version=parsed.apply.appserver_version,
+        )
+        created_dep = asyncio.run(client.create_deployment(create_data))
+        rprint(f"[green]created[/green] {created_dep.id}")
+
+    except click.ClickException:
+        raise
+    except Exception as e:
+        rprint(f"[red]Error: {e}[/red]")
+        raise click.Abort()
+
+
 @deployments.command("create")
 @global_options
 @interactive_option
@@ -353,16 +465,45 @@ def configure_git_remote_cmd(
 @deployments.command("delete")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@click.option(
+    "-f",
+    "--filename",
+    "filename",
+    type=click.File("r"),
+    default=None,
+    help=(
+        "Read the deployment `name` from a YAML file (`-` for stdin) instead "
+        "of a positional argument. Mutually exclusive with the argument."
+    ),
+)
 @project_option
 @interactive_option
 def delete_deployment(
-    deployment_id: str | None, interactive: bool, project: str | None
+    deployment_id: str | None,
+    filename: click.utils.LazyFile | None,
+    interactive: bool,
+    project: str | None,
 ) -> None:
-    """Delete a deployment"""
+    """Delete a deployment by id or by ``name:`` in a YAML file."""
     # Keep this import local: the helper imports `questionary`, which import-time
     # profiling showed is a noticeable CLI startup cost. Avoid other local
     # imports unless instrumentation shows they are slow.
     from ..interactive_prompts.utils import confirm_action
+
+    if filename is not None and deployment_id:
+        raise click.ClickException("specify either `<deployment_id>` or `-f`, not both")
+
+    if filename is not None:
+        source = filename.name if filename.name != "<stdin>" else "-"
+        try:
+            parsed = parse_apply_yaml(filename.read(), source=source)
+        except (ApplyYamlError, UnresolvedVarsError) as exc:
+            raise click.ClickException(str(exc))
+        if not parsed.name:
+            raise click.ClickException(
+                f"{source}: YAML must include `name` to delete by reference"
+            )
+        deployment_id = parsed.name
 
     validate_authenticated_profile(interactive)
     try:

--- a/packages/llamactl/src/llama_agents/cli/yaml_format.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_format.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""YAML parsing for declarative ``llamactl deployments apply -f``.
+
+Resolves ``${VAR}`` references against the process environment, strips the
+``********`` mask passthrough convention used by ``get -o yaml``, preserves
+explicit ``null`` secret values (semantic deletion), and validates the
+result against :class:`DeploymentApply`.
+
+Conventions:
+
+* Top-level ``name:`` carries the stable deployment id (URL path on
+  ``PUT /deployments/{name}``); the rest of the document is the apply body.
+* ``${VAR}`` strings (in any field, not just secrets) resolve against the
+  passed environment. Strict mode raises with all unset names listed.
+* ``********`` secret values are passthroughs from ``get -o yaml`` and drop
+  out of the body so a round-trip is a no-op.
+* ``null`` secret values are preserved — server-side semantics delete them.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+import yaml
+from llama_agents.core.schema.deployments import DeploymentApply
+from pydantic import ValidationError
+
+# Same value as ``llama_agents.cli.display.SECRET_MASK`` — kept local so this
+# module can be imported without pulling the broader display graph.
+_SECRET_MASK = "********"
+
+_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+class UnresolvedVarsError(ValueError):
+    """Raised when one or more ``${VAR}`` references cannot be resolved."""
+
+    def __init__(self, names: list[str]) -> None:
+        self.names = sorted(set(names))
+        super().__init__(
+            "Unset environment variable(s): " + ", ".join(self.names)
+        )
+
+
+class ApplyYamlError(ValueError):
+    """Top-level error for malformed apply YAML (parse/validation)."""
+
+
+@dataclass(frozen=True)
+class ParsedApply:
+    """Result of :func:`parse_apply_yaml`.
+
+    ``name`` is the stable deployment id from the YAML — when present it
+    becomes the URL path component of ``PUT /deployments/{name}``. ``apply``
+    is the validated body. When ``name`` is ``None``, callers fall through to
+    the create endpoint using ``apply.display_name``.
+    """
+
+    name: str | None
+    apply: DeploymentApply
+
+
+def resolve_env_vars(
+    value: Any,
+    *,
+    env: Mapping[str, str] | None = None,
+    strict: bool = True,
+) -> tuple[Any, list[str]]:
+    """Recursively replace ``${VAR}`` with ``env[VAR]`` in every string scalar.
+
+    Returns ``(resolved, missing)``. In strict mode raises
+    :class:`UnresolvedVarsError` when ``missing`` is non-empty. In non-strict
+    mode unset references remain as the literal ``${VAR}`` string and are
+    surfaced via the second return value for warning paths (the eventual
+    editor flow). Walks dicts and lists recursively; non-string scalars pass
+    through unchanged.
+    """
+    env_map = os.environ if env is None else env
+    missing: list[str] = []
+
+    def _walk(v: Any) -> Any:
+        if isinstance(v, str):
+            def _sub(m: re.Match[str]) -> str:
+                name = m.group(1)
+                if name in env_map:
+                    return env_map[name]
+                missing.append(name)
+                return m.group(0)
+
+            return _VAR_RE.sub(_sub, v)
+        if isinstance(v, dict):
+            return {k: _walk(item) for k, item in v.items()}
+        if isinstance(v, list):
+            return [_walk(item) for item in v]
+        return v
+
+    resolved = _walk(value)
+    if strict and missing:
+        raise UnresolvedVarsError(missing)
+    return resolved, missing
+
+
+def parse_apply_yaml(
+    text: str,
+    *,
+    env: Mapping[str, str] | None = None,
+    strict: bool = True,
+    source: str | None = None,
+) -> ParsedApply:
+    """Parse declarative apply YAML into a :class:`ParsedApply`.
+
+    Args:
+        text: The YAML document body.
+        env: Override for environment-variable resolution; defaults to
+            ``os.environ``.
+        strict: When True (default), unset ``${VAR}`` references raise
+            :class:`UnresolvedVarsError`. When False, references stay literal.
+        source: Optional file path / ``"-"`` annotation prepended to error
+            messages so users can locate the offending document.
+    """
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ApplyYamlError(
+            _format_source(source, f"YAML parse error: {exc}")
+        ) from exc
+
+    if raw is None:
+        raise ApplyYamlError(_format_source(source, "empty YAML document"))
+    if not isinstance(raw, dict):
+        raise ApplyYamlError(
+            _format_source(
+                source,
+                f"YAML document must be a mapping, got {type(raw).__name__}",
+            )
+        )
+
+    resolved, _ = resolve_env_vars(raw, env=env, strict=strict)
+
+    name = resolved.pop("name", None)
+    if name is not None and not isinstance(name, str):
+        raise ApplyYamlError(_format_source(source, "'name' must be a string"))
+
+    secrets = resolved.get("secrets")
+    if isinstance(secrets, dict):
+        # Drop ``********`` mask passthrough; preserve explicit ``None`` as
+        # deletion. Non-string values fall through to schema validation.
+        resolved["secrets"] = {k: v for k, v in secrets.items() if v != _SECRET_MASK}
+
+    try:
+        apply = DeploymentApply.model_validate(resolved)
+    except ValidationError as exc:
+        raise ApplyYamlError(
+            _format_source(source, _format_validation(exc))
+        ) from exc
+
+    return ParsedApply(name=name, apply=apply)
+
+
+def _format_source(source: str | None, msg: str) -> str:
+    return f"{source}: {msg}" if source else msg
+
+
+def _format_validation(exc: ValidationError) -> str:
+    parts: list[str] = []
+    for err in exc.errors():
+        loc = ".".join(str(p) for p in err["loc"]) or "<root>"
+        parts.append(f"{loc}: {err['msg']}")
+    return "schema validation failed:\n  " + "\n  ".join(parts)

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -101,10 +101,12 @@ def render(
                 out.append(f"{_INDENT}secrets:")
                 for sname, sval in value.items():
                     if sname in secret_comments:
-                        out.extend(_doc_lines(
-                            secret_comments[sname].split("\n"),
-                            indent=_INDENT * 2,
-                        ))
+                        out.extend(
+                            _doc_lines(
+                                secret_comments[sname].split("\n"),
+                                indent=_INDENT * 2,
+                            )
+                        )
                     out.append(f"{_INDENT * 2}{sname}: {_scalar(sval)}")
             else:
                 out.append(f"{_INDENT}{fname}: {_scalar(value)}")

--- a/packages/llamactl/tests/test_deployments_apply_cmd.py
+++ b/packages/llamactl/tests/test_deployments_apply_cmd.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``llamactl deployments apply`` and ``deployments delete -f``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import yaml as pyyaml
+from click.testing import CliRunner
+from conftest import make_deployment, patch_project_client
+from llama_agents.cli.app import app
+from llama_agents.core.schema.deployments import (
+    DeploymentApply,
+    DeploymentCreate,
+    DeploymentResponse,
+)
+
+
+def _client_mock(
+    *,
+    apply_result: tuple[DeploymentResponse, bool] | None = None,
+    create_result: DeploymentResponse | None = None,
+    delete_ok: bool = True,
+) -> MagicMock:
+    async def _apply(
+        deployment_id: str, apply_data: DeploymentApply
+    ) -> tuple[DeploymentResponse, bool]:
+        assert apply_result is not None, "apply not expected"
+        return apply_result
+
+    async def _create(deployment_data: DeploymentCreate) -> DeploymentResponse:
+        assert create_result is not None, "create not expected"
+        return create_result
+
+    async def _delete(deployment_id: str) -> None:
+        if not delete_ok:
+            raise RuntimeError("delete not expected")
+
+    client = MagicMock()
+    client.apply_deployment.side_effect = _apply
+    client.create_deployment.side_effect = _create
+    client.delete_deployment.side_effect = _delete
+    client.project_id = "proj_default"
+    client.base_url = "http://test:8011"
+    return client
+
+
+def test_apply_with_name_calls_apply_endpoint_and_prints_updated(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("name: my-app\nrepo_url: https://example.com/r.git\n")
+    deployment = make_deployment("my-app")
+    client = _client_mock(apply_result=(deployment, False))
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "apply", "-f", str(yaml_file)]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "updated" in result.output
+    assert "my-app" in result.output
+    client.apply_deployment.assert_called_once()
+    args, _ = client.apply_deployment.call_args
+    assert args[0] == "my-app"
+    assert isinstance(args[1], DeploymentApply)
+    assert args[1].repo_url == "https://example.com/r.git"
+
+
+def test_apply_create_prints_created_when_server_signals_201(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("name: my-app\ndisplay_name: My App\n")
+    deployment = make_deployment("my-app", display_name="My App")
+    client = _client_mock(apply_result=(deployment, True))
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "apply", "-f", str(yaml_file)]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "created" in result.output
+    assert "my-app" in result.output
+
+
+def test_apply_without_name_falls_back_to_create_with_display_name(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("display_name: My App\nrepo_url: https://example.com/r.git\n")
+    deployment = make_deployment("auto-id", display_name="My App")
+    client = _client_mock(create_result=deployment)
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "apply", "-f", str(yaml_file)]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "created" in result.output
+    client.create_deployment.assert_called_once()
+    create_arg = client.create_deployment.call_args[0][0]
+    assert isinstance(create_arg, DeploymentCreate)
+    assert create_arg.display_name == "My App"
+    assert create_arg.repo_url == "https://example.com/r.git"
+    client.apply_deployment.assert_not_called()
+
+
+def test_apply_without_name_or_display_name_errors(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("git_ref: main\n")
+    client = _client_mock()
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "apply", "-f", str(yaml_file)]
+        )
+
+    assert result.exit_code != 0
+    assert "name" in result.output and "display_name" in result.output
+
+
+def test_apply_unresolved_var_errors_with_grouped_names(
+    patched_auth: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text(
+        "name: my-app\n"
+        "git_ref: ${BRANCH}\n"
+        "secrets:\n"
+        "  A: ${MISS_A}\n"
+        "  B: ${MISS_B}\n"
+    )
+    monkeypatch.delenv("BRANCH", raising=False)
+    monkeypatch.delenv("MISS_A", raising=False)
+    monkeypatch.delenv("MISS_B", raising=False)
+    client = _client_mock()
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "apply", "-f", str(yaml_file)]
+        )
+
+    assert result.exit_code != 0
+    assert "BRANCH" in result.output
+    assert "MISS_A" in result.output
+    assert "MISS_B" in result.output
+    client.apply_deployment.assert_not_called()
+
+
+def test_apply_dry_run_prints_resolved_payload_and_skips_api(
+    patched_auth: Any, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text(
+        "name: my-app\n"
+        "display_name: My App\n"
+        "git_ref: ${BRANCH}\n"
+        "secrets:\n"
+        "  KEY: ${KEY_VAL}\n"
+        "  MASKED: '********'\n"
+    )
+    monkeypatch.setenv("BRANCH", "v2")
+    monkeypatch.setenv("KEY_VAL", "sk-x")
+    client = _client_mock()
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "apply", "-f", str(yaml_file), "--dry-run"]
+        )
+
+    assert result.exit_code == 0, result.output
+    parsed = pyyaml.safe_load(result.output)
+    assert parsed["name"] == "my-app"
+    assert parsed["git_ref"] == "v2"
+    # ``********`` is dropped; resolved key remains.
+    assert parsed["secrets"] == {"KEY": "sk-x"}
+    client.apply_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+
+
+def test_apply_dry_run_server_is_reserved(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("name: my-app\n")
+    client = _client_mock()
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "apply", "-f", str(yaml_file), "--dry-run=server"],
+        )
+
+    assert result.exit_code != 0
+    assert "server-side dry-run not yet supported" in result.output
+
+
+def test_apply_stdin(patched_auth: Any) -> None:
+    runner = CliRunner()
+    deployment = make_deployment("my-app")
+    client = _client_mock(apply_result=(deployment, False))
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "apply", "-f", "-"],
+            input="name: my-app\ngit_ref: main\n",
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "updated" in result.output
+    client.apply_deployment.assert_called_once()
+
+
+def test_delete_with_filename_reads_name_from_yaml(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("name: my-app\ngit_ref: main\n")
+    client = _client_mock()
+
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "delete", "-f", str(yaml_file), "--no-interactive"],
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Deleted deployment: my-app" in result.output
+    client.delete_deployment.assert_called_once_with("my-app")
+
+
+def test_delete_filename_and_argument_are_mutually_exclusive(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("name: my-app\n")
+
+    result = runner.invoke(
+        app,
+        [
+            "deployments",
+            "delete",
+            "other-app",
+            "-f",
+            str(yaml_file),
+            "--no-interactive",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "either" in result.output.lower() or "not both" in result.output.lower()
+
+
+def test_delete_filename_without_name_errors(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    yaml_file = tmp_path / "d.yaml"
+    yaml_file.write_text("display_name: My App\n")
+
+    result = runner.invoke(
+        app,
+        ["deployments", "delete", "-f", str(yaml_file), "--no-interactive"],
+    )
+
+    assert result.exit_code != 0
+    assert "name" in result.output

--- a/packages/llamactl/tests/test_yaml_format.py
+++ b/packages/llamactl/tests/test_yaml_format.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``cli.yaml_format.parse_apply_yaml`` and helpers."""
+
+from __future__ import annotations
+
+import pytest
+from llama_agents.cli.yaml_format import (
+    ApplyYamlError,
+    UnresolvedVarsError,
+    parse_apply_yaml,
+    resolve_env_vars,
+)
+
+
+def test_parse_minimal_with_name() -> None:
+    parsed = parse_apply_yaml(
+        """
+        name: my-app
+        display_name: My App
+        repo_url: https://github.com/example/repo
+        git_ref: main
+        """,
+        env={},
+    )
+    assert parsed.name == "my-app"
+    assert parsed.apply.display_name == "My App"
+    assert parsed.apply.repo_url == "https://github.com/example/repo"
+    assert parsed.apply.git_ref == "main"
+
+
+def test_parse_without_name_returns_none() -> None:
+    parsed = parse_apply_yaml(
+        """
+        display_name: My App
+        """,
+        env={},
+    )
+    assert parsed.name is None
+    assert parsed.apply.display_name == "My App"
+
+
+def test_var_resolution_in_secrets_and_scalars() -> None:
+    parsed = parse_apply_yaml(
+        """
+        name: my-app
+        git_ref: ${BRANCH}
+        secrets:
+          OPENAI_API_KEY: ${OPENAI_KEY}
+          OTHER: literal
+        """,
+        env={"BRANCH": "main", "OPENAI_KEY": "sk-x"},
+    )
+    assert parsed.apply.git_ref == "main"
+    assert parsed.apply.secrets == {"OPENAI_API_KEY": "sk-x", "OTHER": "literal"}
+
+
+def test_unresolved_vars_strict_raises_with_all_names() -> None:
+    with pytest.raises(UnresolvedVarsError) as exc_info:
+        parse_apply_yaml(
+            """
+            name: my-app
+            git_ref: ${BRANCH}
+            secrets:
+              A: ${MISSING_A}
+              B: ${MISSING_B}
+            """,
+            env={},
+        )
+    assert "BRANCH" in exc_info.value.names
+    assert "MISSING_A" in exc_info.value.names
+    assert "MISSING_B" in exc_info.value.names
+
+
+def test_unresolved_vars_non_strict_keeps_literal() -> None:
+    resolved, missing = resolve_env_vars(
+        {"git_ref": "${BRANCH}"}, env={}, strict=False
+    )
+    assert resolved == {"git_ref": "${BRANCH}"}
+    assert missing == ["BRANCH"]
+
+
+def test_secret_mask_passthrough_is_dropped() -> None:
+    parsed = parse_apply_yaml(
+        """
+        name: my-app
+        secrets:
+          KEEP_ME: real-value
+          MASKED: ${MASK}
+        """,
+        # Resolves to the literal mask token, mimicking a get -o yaml round-trip.
+        env={"MASK": "********"},
+    )
+    assert parsed.apply.secrets == {"KEEP_ME": "real-value"}
+
+
+def test_null_secret_preserved_for_deletion() -> None:
+    parsed = parse_apply_yaml(
+        """
+        name: my-app
+        secrets:
+          DROP_ME: null
+          KEEP_ME: real
+        """,
+        env={},
+    )
+    assert parsed.apply.secrets == {"DROP_ME": None, "KEEP_ME": "real"}
+
+
+def test_empty_repo_url_preserved_for_push_mode() -> None:
+    parsed = parse_apply_yaml(
+        """
+        name: my-app
+        display_name: My App
+        repo_url: ""
+        """,
+        env={},
+    )
+    # Empty string is the documented push-mode sentinel — must not become None.
+    assert parsed.apply.repo_url == ""
+
+
+def test_schema_validation_error_includes_field_path() -> None:
+    with pytest.raises(ApplyYamlError) as exc_info:
+        parse_apply_yaml(
+            """
+            name: my-app
+            suspended: not-a-bool
+            """,
+            env={},
+        )
+    assert "suspended" in str(exc_info.value)
+
+
+def test_yaml_syntax_error_surfaces_as_apply_yaml_error() -> None:
+    with pytest.raises(ApplyYamlError) as exc_info:
+        parse_apply_yaml("name: my-app\n  bad: indent\n", env={})
+    assert "YAML parse error" in str(exc_info.value)
+
+
+def test_non_mapping_top_level_errors() -> None:
+    with pytest.raises(ApplyYamlError) as exc_info:
+        parse_apply_yaml("- not\n- a\n- mapping\n", env={})
+    assert "mapping" in str(exc_info.value)
+
+
+def test_empty_document_errors() -> None:
+    with pytest.raises(ApplyYamlError):
+        parse_apply_yaml("", env={})
+
+
+def test_source_appears_in_error_messages() -> None:
+    with pytest.raises(ApplyYamlError) as exc_info:
+        parse_apply_yaml("- not a mapping\n", env={}, source="deployment.yaml")
+    assert "deployment.yaml" in str(exc_info.value)
+
+
+def test_non_string_name_errors() -> None:
+    with pytest.raises(ApplyYamlError) as exc_info:
+        parse_apply_yaml("name: 123\n", env={})
+    assert "name" in str(exc_info.value)


### PR DESCRIPTION
Adds declarative apply for deployments end-to-end.

## Server
- New `DeploymentApply` schema — strict subset of create + update minus
  imperative fields (`rebuild`, `bump_to_latest_appserver`, `git_sha`,
  `static_assets_path`, `image_tag`).
- `PUT /api/v1beta1/deployments/{deployment_id}` create-or-update by stable
  id. 201 on create, 200 on update. Service delegates to existing
  `create_deployment` / `update_deployment` so git validation, internal-repo
  ref resolution, and secret deletion semantics fall out for free. Creating
  a new deployment without `display_name` returns 422.

## CLI
- `llamactl deployments apply -f <file|->` upserts by stable `name:` (PUT)
  or falls through to the create endpoint when only `display_name:` is
  given. `--dry-run` (alias `--dry-run=client`) prints the resolved
  payload; `--dry-run=server` is reserved.
- `llamactl deployments delete -f <file>` deletes by `name:` from the YAML
  file; mutually exclusive with the positional id.
- New `cli/yaml_format.py` centralizes YAML parsing for apply: `${VAR}`
  resolves from the environment (unset names raise grouped), `********`
  passthrough is dropped, `null` secret values are preserved for
  server-side deletion.

Stacked on #TBD (`adrian/llamactl-deployments-template`).