### PR TITLE
DBOSRuntime: share asyncpg pool through PoolProvider

### DIFF
--- a/.changeset/dbos-shared-asyncpg-pool.md
+++ b/.changeset/dbos-shared-asyncpg-pool.md
@@ -1,6 +1,6 @@
 ---
-"llama-agents-dbos": minor
-"llama-agents-server": minor
+"llama-agents-dbos": patch
+"llama-agents-server": patch
 ---
 
 Share a single asyncpg pool across DBOSRuntime, PostgresWorkflowStore, and ExecutorLeaseManager instead of each opening their own. Pool size is configurable via `DBOSRuntimeConfig.pool_size`. Also adds LISTEN reconnect with backoff to PostgresWorkflowStore.

--- a/.changeset/dbos-shared-asyncpg-pool.md
+++ b/.changeset/dbos-shared-asyncpg-pool.md
@@ -3,4 +3,4 @@
 "llama-agents-server": minor
 ---
 
-DBOSRuntime, PostgresWorkflowStore, and the executor lease manager now share a single asyncpg pool per runtime instead of each opening their own. The pool size is configurable via `DBOSRuntimeConfig.pool_size` / `pool_min_size` and defaults to DBOS's configured `sys_db` pool size. The `PostgresWorkflowStore` LISTEN connection also reconnects automatically with bounded backoff when the underlying connection drops.
+Share a single asyncpg pool across DBOSRuntime, PostgresWorkflowStore, and ExecutorLeaseManager instead of each opening their own. Pool size is configurable via `DBOSRuntimeConfig.pool_size`. Also adds LISTEN reconnect with backoff to PostgresWorkflowStore.

--- a/.changeset/dbos-shared-asyncpg-pool.md
+++ b/.changeset/dbos-shared-asyncpg-pool.md
@@ -1,0 +1,6 @@
+---
+"llama-agents-dbos": minor
+"llama-agents-server": minor
+---
+
+DBOSRuntime, PostgresWorkflowStore, and the executor lease manager now share a single asyncpg pool per runtime instead of each opening their own. The pool size is configurable via `DBOSRuntimeConfig.pool_size` / `pool_min_size` and defaults to DBOS's configured `sys_db` pool size. The `PostgresWorkflowStore` LISTEN connection also reconnects automatically with bounded backoff when the underlying connection drops.

--- a/.changeset/dbos-shared-asyncpg-pool.md
+++ b/.changeset/dbos-shared-asyncpg-pool.md
@@ -1,6 +1,6 @@
 ---
 "llama-agents-dbos": patch
-"llama-agents-server": patch
+"llama-agents-server": minor
 ---
 
 Share a single asyncpg pool across DBOSRuntime, PostgresWorkflowStore, and ExecutorLeaseManager instead of each opening their own. Pool size is configurable via `DBOSRuntimeConfig.pool_size`. Also adds LISTEN reconnect with backoff to PostgresWorkflowStore.

--- a/packages/llama-agents-appserver/pyproject.toml
+++ b/packages/llama-agents-appserver/pyproject.toml
@@ -27,7 +27,7 @@ authors = [
 requires-python = ">=3.10, <4"
 dependencies = [
   "llama-index-workflows>=2.16.0,<3.0.0",
-  "llama-agents-server>=0.2.2,<0.5.0",
+  "llama-agents-server>=0.2.2",
   "pydantic-settings>=2.10.1",
   "fastapi>=0.100.0",
   "websockets>=12.0",

--- a/packages/llama-agents-dbos/pyproject.toml
+++ b/packages/llama-agents-dbos/pyproject.toml
@@ -24,7 +24,7 @@ license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
   "dbos>=2.14.0",
-  "llama-agents-server[asyncpg]>=0.4.6",
+  "llama-agents-server[asyncpg]>=0.4.8",
   "llama-index-workflows>=2.19.1,<3.0.0"
 ]
 

--- a/packages/llama-agents-dbos/pyproject.toml
+++ b/packages/llama-agents-dbos/pyproject.toml
@@ -24,7 +24,7 @@ license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
   "dbos>=2.14.0",
-  "llama-agents-server[asyncpg]>=0.4.8",
+  "llama-agents-server[asyncpg]>=0.5.0",
   "llama-index-workflows>=2.19.1,<3.0.0"
 ]
 

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/executor_lease.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/executor_lease.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from collections.abc import Awaitable, Callable
 
 import asyncpg
 from llama_agents.dbos.journal.crud import _qualified_table_ref
@@ -19,11 +20,15 @@ class ExecutorLeaseManager:
     def __init__(
         self,
         dsn: str,
+        # ``pool_size`` here is the executor slot count (rows in
+        # executor_leases), NOT the asyncpg connection pool size. The asyncpg
+        # pool is configured on the runtime and shared via ``ensure_pool``.
         pool_size: int,
         heartbeat_interval: float = 10.0,
         lease_timeout: float = 30.0,
         slot_prefix: str = "executor",
         schema: str = "dbos",
+        ensure_pool: Callable[[], Awaitable[asyncpg.Pool]] | None = None,
     ) -> None:
         self._dsn = dsn
         self._pool_size = pool_size
@@ -34,6 +39,8 @@ class ExecutorLeaseManager:
 
         self._holder = str(uuid.uuid4())
         self._table = _qualified_table_ref("executor_leases", schema)
+        self._external_ensure_pool = ensure_pool
+        self._owns_pool = ensure_pool is None
         self._pool: asyncpg.Pool | None = None
         self._slot_id: str | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
@@ -65,7 +72,10 @@ class ExecutorLeaseManager:
                 )
 
     async def acquire(self, timeout: float | None = None) -> str:
-        self._pool = await asyncpg.create_pool(dsn=self._dsn)
+        if self._external_ensure_pool is not None:
+            self._pool = await self._external_ensure_pool()
+        else:
+            self._pool = await asyncpg.create_pool(dsn=self._dsn)
         await self._seed_slots()
 
         poll = 0.1
@@ -104,7 +114,8 @@ class ExecutorLeaseManager:
                         return slot_id
 
             if timeout is not None and elapsed >= timeout:
-                await self._pool.close()
+                if self._owns_pool:
+                    await self._pool.close()
                 self._pool = None
                 raise TimeoutError(
                     f"Could not acquire executor lease within {timeout}s"
@@ -139,7 +150,8 @@ class ExecutorLeaseManager:
         self._slot_id = None
 
         if self._pool is not None:
-            await self._pool.close()
+            if self._owns_pool:
+                await self._pool.close()
             self._pool = None
 
     async def _heartbeat_loop(self) -> None:

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/executor_lease.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/executor_lease.py
@@ -40,7 +40,6 @@ class ExecutorLeaseManager:
         self._holder = str(uuid.uuid4())
         self._table = _qualified_table_ref("executor_leases", schema)
         self._external_ensure_pool = ensure_pool
-        self._owns_pool = ensure_pool is None
         self._pool: asyncpg.Pool | None = None
         self._slot_id: str | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
@@ -57,7 +56,6 @@ class ExecutorLeaseManager:
         return self._lease_lost_event
 
     async def _seed_slots(self) -> None:
-        """Ensure slot rows exist in the executor_leases table."""
         assert self._pool is not None
         async with self._pool.acquire() as conn:
             for i in range(self._pool_size):
@@ -114,7 +112,7 @@ class ExecutorLeaseManager:
                         return slot_id
 
             if timeout is not None and elapsed >= timeout:
-                if self._owns_pool:
+                if self._external_ensure_pool is None:
                     await self._pool.close()
                 self._pool = None
                 raise TimeoutError(
@@ -150,7 +148,7 @@ class ExecutorLeaseManager:
         self._slot_id = None
 
         if self._pool is not None:
-            if self._owns_pool:
+            if self._external_ensure_pool is None:
                 await self._pool.close()
             self._pool = None
 

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/executor_lease.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/executor_lease.py
@@ -6,10 +6,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from collections.abc import Awaitable, Callable
 
 import asyncpg
 from llama_agents.dbos.journal.crud import _qualified_table_ref
+from llama_agents.server._pool import PoolProvider
 
 logger = logging.getLogger(__name__)
 
@@ -19,18 +19,16 @@ class ExecutorLeaseManager:
 
     def __init__(
         self,
-        dsn: str,
+        pool: PoolProvider,
         # ``pool_size`` here is the executor slot count (rows in
-        # executor_leases), NOT the asyncpg connection pool size. The asyncpg
-        # pool is configured on the runtime and shared via ``ensure_pool``.
+        # executor_leases), NOT the asyncpg connection pool size.
         pool_size: int,
         heartbeat_interval: float = 10.0,
         lease_timeout: float = 30.0,
         slot_prefix: str = "executor",
         schema: str = "dbos",
-        ensure_pool: Callable[[], Awaitable[asyncpg.Pool]] | None = None,
     ) -> None:
-        self._dsn = dsn
+        self._pool_provider = pool
         self._pool_size = pool_size
         self._heartbeat_interval = heartbeat_interval
         self._lease_timeout = lease_timeout
@@ -39,7 +37,6 @@ class ExecutorLeaseManager:
 
         self._holder = str(uuid.uuid4())
         self._table = _qualified_table_ref("executor_leases", schema)
-        self._external_ensure_pool = ensure_pool
         self._pool: asyncpg.Pool | None = None
         self._slot_id: str | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
@@ -70,10 +67,7 @@ class ExecutorLeaseManager:
                 )
 
     async def acquire(self, timeout: float | None = None) -> str:
-        if self._external_ensure_pool is not None:
-            self._pool = await self._external_ensure_pool()
-        else:
-            self._pool = await asyncpg.create_pool(dsn=self._dsn)
+        self._pool = await self._pool_provider.get()
         await self._seed_slots()
 
         poll = 0.1
@@ -112,8 +106,7 @@ class ExecutorLeaseManager:
                         return slot_id
 
             if timeout is not None and elapsed >= timeout:
-                if self._external_ensure_pool is None:
-                    await self._pool.close()
+                await self._pool_provider.close()
                 self._pool = None
                 raise TimeoutError(
                     f"Could not acquire executor lease within {timeout}s"
@@ -148,8 +141,7 @@ class ExecutorLeaseManager:
         self._slot_id = None
 
         if self._pool is not None:
-            if self._external_ensure_pool is None:
-                await self._pool.close()
+            await self._pool_provider.close()
             self._pool = None
 
     async def _heartbeat_loop(self) -> None:

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -22,6 +22,7 @@ from llama_agents.client.protocol.serializable_events import (
     EventEnvelopeWithMetadata,
 )
 from llama_agents.dbos._store import POSTGRES_MIGRATION_SOURCE, SQLITE_MIGRATION_SOURCE
+from llama_agents.server._pool import PoolProvider
 from llama_agents.server._runtime.event_interceptor import EventInterceptorDecorator
 from llama_agents.server._runtime.persistence_runtime import TickPersistenceDecorator
 from llama_agents.server._store import (
@@ -650,8 +651,9 @@ class DBOSRuntime(Runtime):
             journal_table_name=self.config.get(
                 "journal_table_name", DEFAULT_JOURNAL_TABLE_NAME
             ),
-            ensure_pool=self._ensure_pool if self._dsn is not None else None,
-            pool=self._pool,
+            pool=PoolProvider.borrowed(self._ensure_pool)
+            if self._dsn is not None
+            else None,
             db_path=self._db_path,
         )
 
@@ -689,7 +691,7 @@ class DBOSRuntime(Runtime):
                 return PostgresWorkflowStore(
                     dsn=dsn,
                     schema=schema,
-                    ensure_pool=self._ensure_pool,
+                    pool=PoolProvider.borrowed(self._ensure_pool),
                 )
 
             db_path = str(engine.url.database) if engine.url.database else ":memory:"
@@ -814,13 +816,12 @@ class DBOSRuntime(Runtime):
                 logger.info("Database migrations completed (pre-lease)")
 
             self._lease_manager = ExecutorLeaseManager(
-                dsn=dsn,
+                pool=PoolProvider.borrowed(self._ensure_pool),
                 pool_size=pool_size,
                 heartbeat_interval=lease_config.get("heartbeat_interval", 10.0),
                 lease_timeout=lease_config.get("lease_timeout", 30.0),
                 slot_prefix=lease_config.get("slot_prefix", "executor"),
                 schema=schema,
-                ensure_pool=self._ensure_pool,
             )
             acquire_timeout = lease_config.get("acquire_timeout", 60.0)
             await self._lease_manager.acquire(timeout=acquire_timeout)
@@ -982,22 +983,7 @@ class DBOSRuntime(Runtime):
                 else self._workflow_store
             )
             if isinstance(inner, PostgresWorkflowStore):
-                inner._closing = True
-                if (
-                    inner._reconnect_task is not None
-                    and not inner._reconnect_task.done()
-                ):
-                    inner._reconnect_task.cancel()
-                if inner._external_ensure_pool is None and inner._pool is not None:
-                    try:
-                        inner._pool.terminate()
-                    except Exception:
-                        logger.debug(
-                            "Failed to terminate workflow store pool during destroy",
-                            exc_info=True,
-                        )
-                inner._pool = None
-                inner._listen_conn = None
+                await inner.close()
             self._workflow_store = None
         if self._pool is not None:
             try:
@@ -1016,8 +1002,6 @@ class DBOSRuntime(Runtime):
         if destroy_dbos:
             DBOS.destroy()
 
-
-EnsurePoolFn = Callable[[], Awaitable[asyncpg.Pool]]
 
 _IO_STREAM_PUBLISHED_EVENTS_NAME = "published_events"
 _IO_STREAM_TICK_TOPIC = "ticks"
@@ -1043,8 +1027,7 @@ class InternalDBOSAdapter(InternalRunAdapter):
         schema: str | None = None,
         state_table_name: str = DEFAULT_STATE_TABLE_NAME,
         journal_table_name: str = DEFAULT_JOURNAL_TABLE_NAME,
-        ensure_pool: EnsurePoolFn | None = None,
-        pool: asyncpg.Pool | None = None,
+        pool: PoolProvider | None = None,
         db_path: str | None = None,
     ) -> None:
         self._run_id = run_id
@@ -1053,8 +1036,8 @@ class InternalDBOSAdapter(InternalRunAdapter):
         self._schema = schema
         self._state_table_name = state_table_name
         self._journal_table_name = journal_table_name
-        self._ensure_pool = ensure_pool
-        self._resolved_pool: asyncpg.Pool | None = pool
+        self._pool_provider = pool
+        self._resolved_pool: asyncpg.Pool | None = None
         self._db_path = db_path
         self._closed = False
         self._shutdown_event = asyncio.Event()
@@ -1128,11 +1111,11 @@ class InternalDBOSAdapter(InternalRunAdapter):
         """Resolve the asyncpg pool, lazily creating it via the runtime callback."""
         if self._resolved_pool is not None:
             return self._resolved_pool
-        if self._ensure_pool is None:
+        if self._pool_provider is None:
             raise RuntimeError(
                 "No asyncpg pool configured. Either not launched or using sqlite dialect."
             )
-        self._resolved_pool = await self._ensure_pool()
+        self._resolved_pool = await self._pool_provider.get()
         return self._resolved_pool
 
     def _get_or_create_state_store(self) -> StateStore[Any]:
@@ -1243,7 +1226,7 @@ class InternalDBOSAdapter(InternalRunAdapter):
             WaitForNextTaskResult with completed task and newly started NamedTasks.
         """
         # Resolve pool before journal creation (needed for postgres)
-        if self._ensure_pool is not None and self._resolved_pool is None:
+        if self._pool_provider is not None and self._resolved_pool is None:
             await self._resolve_pool()
 
         # Load journal before starting pending coroutines so the orphan purge

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -450,6 +450,10 @@ class DBOSRuntime(Runtime):
                 max_size = None
         if max_size is None:
             max_size = _DEFAULT_POOL_SIZE_FALLBACK
+        # The workflow store permanently holds one connection for LISTEN/NOTIFY,
+        # so the pool must have at least 2 to avoid deadlocking queries.
+        if max_size < 2:
+            max_size = 2
 
         min_size = self.config.get("pool_min_size", max_size)
         # Clamp min ≤ max defensively in case both were set.
@@ -968,14 +972,9 @@ class DBOSRuntime(Runtime):
         self._dsn = None
         self._db_path = None
         self._schema = None
-        if self._pool is not None:
-            try:
-                self._pool.terminate()
-            except Exception:
-                logger.debug(
-                    "Failed to terminate asyncpg pool during destroy", exc_info=True
-                )
-            self._pool = None
+        # Shut down the workflow store's listener before terminating the pool.
+        # Otherwise pool.terminate() kills the LISTEN connection, which fires
+        # _on_listen_termination and spawns a reconnect task during shutdown.
         if self._workflow_store is not None:
             inner = (
                 self._workflow_store._inner
@@ -983,9 +982,9 @@ class DBOSRuntime(Runtime):
                 else self._workflow_store
             )
             if isinstance(inner, PostgresWorkflowStore):
-                # The runtime owns the asyncpg pool now; the workflow store
-                # only holds a borrowed reference. Just null out its handles —
-                # the runtime's terminate above already tore down the pool.
+                inner._closing = True
+                if inner._reconnect_task is not None and not inner._reconnect_task.done():
+                    inner._reconnect_task.cancel()
                 if inner._external_ensure_pool is None and inner._pool is not None:
                     try:
                         inner._pool.terminate()
@@ -997,6 +996,14 @@ class DBOSRuntime(Runtime):
                 inner._pool = None
                 inner._listen_conn = None
             self._workflow_store = None
+        if self._pool is not None:
+            try:
+                self._pool.terminate()
+            except Exception:
+                logger.debug(
+                    "Failed to terminate asyncpg pool during destroy", exc_info=True
+                )
+            self._pool = None
         # Wait for cancelled tasks to unwind before destroying DBOS.
         tasks_to_cancel = [t for t in self._tasks if not t.done()]
         for task in tasks_to_cancel:

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -202,7 +202,15 @@ class DBOSRuntimeConfig(TypedDict, total=False):
     schema: str | None
     state_table_name: str
     journal_table_name: str
+    pool_size: int
+    pool_min_size: int
     _experimental_executor_lease: ExecutorLeaseConfig | None
+
+
+# Final fallback if neither config nor DBOS sys_db config can be read.
+# Matches asyncpg's stock create_pool default (10) and the previous hardcoded
+# value used here.
+_DEFAULT_POOL_SIZE_FALLBACK = 10
 
 
 DEFAULT_STATE_TABLE_NAME = STATE_TABLE_NAME
@@ -270,6 +278,13 @@ class DBOSRuntime(Runtime):
                     to force no schema even on PostgreSQL.
                 state_table_name: State table name. Default "workflow_state".
                 journal_table_name: Journal table name. Default "workflow_journal".
+                pool_size: Maximum size of the asyncpg pool shared across the
+                    runtime, workflow store, and (when configured) executor
+                    lease manager. Defaults to DBOS's configured ``sys_db``
+                    pool_size at launch, falling back to 10 when DBOS config
+                    is unavailable.
+                pool_min_size: Minimum size of the asyncpg pool. Defaults to
+                    ``pool_size``.
                 _experimental_executor_lease: Lease-based executor identity.
                     When set, the runtime acquires a named slot from a
                     Postgres-backed pool on launch and uses it as the DBOS
@@ -415,6 +430,33 @@ class DBOSRuntime(Runtime):
         self._sql_engine = sys_db.engine
         return self._sql_engine
 
+    def _resolve_pool_sizes(self) -> tuple[int, int]:
+        """Return ``(min_size, max_size)`` for the asyncpg pool.
+
+        Resolution order for max:
+          1. ``pool_size`` from DBOSRuntimeConfig.
+          2. DBOS's configured sys_db pool_size, if DBOS is constructed.
+          3. ``_DEFAULT_POOL_SIZE_FALLBACK``.
+
+        Min defaults to ``pool_min_size`` if explicitly set, else equals max.
+        """
+        max_size = self.config.get("pool_size")
+        if max_size is None:
+            try:
+                dbos_inst = _get_dbos_instance()
+                sys_kwargs = dbos_inst._config.get("sys_db_engine_kwargs") or {}
+                max_size = sys_kwargs.get("pool_size")
+            except Exception:
+                max_size = None
+        if max_size is None:
+            max_size = _DEFAULT_POOL_SIZE_FALLBACK
+
+        min_size = self.config.get("pool_min_size", max_size)
+        # Clamp min ≤ max defensively in case both were set.
+        if min_size > max_size:
+            min_size = max_size
+        return min_size, max_size
+
     async def _ensure_pool(self) -> asyncpg.Pool:
         """Get or lazily create the asyncpg connection pool.
 
@@ -429,7 +471,12 @@ class DBOSRuntime(Runtime):
                 raise RuntimeError(
                     "No asyncpg DSN configured. Either not launched or using sqlite dialect."
                 )
-            self._pool = await asyncpg.create_pool(dsn=self._dsn)
+            min_size, max_size = self._resolve_pool_sizes()
+            self._pool = await asyncpg.create_pool(
+                dsn=self._dsn,
+                min_size=min_size,
+                max_size=max_size,
+            )
             return self._pool
 
     async def run_migrations(self) -> None:
@@ -633,7 +680,13 @@ class DBOSRuntime(Runtime):
                 logger.info(
                     "Using PostgresWorkflowStore (asyncpg) for workflow storage"
                 )
-                return PostgresWorkflowStore(dsn=dsn, schema=schema)
+                # Share the runtime's asyncpg pool — PostgresWorkflowStore
+                # borrows it via the factory and never owns its lifecycle.
+                return PostgresWorkflowStore(
+                    dsn=dsn,
+                    schema=schema,
+                    ensure_pool=self._ensure_pool,
+                )
 
             db_path = str(engine.url.database) if engine.url.database else ":memory:"
             logger.info("Using SqliteWorkflowStore for workflow storage")
@@ -706,6 +759,21 @@ class DBOSRuntime(Runtime):
         if self._dbos_launched:
             return  # Already launched
 
+        # Set self._dsn early when the system database is postgres so the
+        # shared asyncpg pool is reachable before DBOS.launch completes
+        # (executor lease pre-launch path needs this). Best-effort — if DBOS
+        # isn't constructed yet (e.g. tests that monkeypatch the launch path),
+        # _finalize_launch will populate self._dsn after launch completes.
+        try:
+            dbos_inst_pre = _get_dbos_instance()
+            sys_db_url = dbos_inst_pre._config.get("system_database_url", "") or ""
+            if sys_db_url and not sys_db_url.startswith("sqlite"):
+                self._dsn = sys_db_url
+        except Exception:
+            logger.debug(
+                "Could not pre-resolve DSN before DBOS construction", exc_info=True
+            )
+
         # Acquire executor lease if configured.
         # Migrations must run first so the executor_leases table exists.
         lease_config = self.config.get("_experimental_executor_lease")
@@ -748,6 +816,9 @@ class DBOSRuntime(Runtime):
                 lease_timeout=lease_config.get("lease_timeout", 30.0),
                 slot_prefix=lease_config.get("slot_prefix", "executor"),
                 schema=schema,
+                # Share the runtime's asyncpg pool — the lease manager borrows
+                # it and never owns its lifecycle.
+                ensure_pool=self._ensure_pool,
             )
             acquire_timeout = lease_config.get("acquire_timeout", 60.0)
             await self._lease_manager.acquire(timeout=acquire_timeout)
@@ -915,10 +986,12 @@ class DBOSRuntime(Runtime):
                 else self._workflow_store
             )
             if isinstance(inner, PostgresWorkflowStore):
-                pool = inner._pool
-                if pool is not None:
+                # The runtime owns the asyncpg pool now; the workflow store
+                # only holds a borrowed reference. Just null out its handles —
+                # the runtime's terminate above already tore down the pool.
+                if inner._owns_pool and inner._pool is not None:
                     try:
-                        pool.terminate()
+                        inner._pool.terminate()
                     except Exception:
                         logger.debug(
                             "Failed to terminate workflow store pool during destroy",

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -816,8 +816,6 @@ class DBOSRuntime(Runtime):
                 lease_timeout=lease_config.get("lease_timeout", 30.0),
                 slot_prefix=lease_config.get("slot_prefix", "executor"),
                 schema=schema,
-                # Share the runtime's asyncpg pool — the lease manager borrows
-                # it and never owns its lifecycle.
                 ensure_pool=self._ensure_pool,
             )
             acquire_timeout = lease_config.get("acquire_timeout", 60.0)
@@ -956,7 +954,6 @@ class DBOSRuntime(Runtime):
                 pass
             self._lease_watch_task = None
 
-        # Release executor lease if held
         if self._lease_manager is not None:
             await self._lease_manager.release()
             self._lease_manager = None
@@ -989,7 +986,7 @@ class DBOSRuntime(Runtime):
                 # The runtime owns the asyncpg pool now; the workflow store
                 # only holds a borrowed reference. Just null out its handles —
                 # the runtime's terminate above already tore down the pool.
-                if inner._owns_pool and inner._pool is not None:
+                if inner._external_ensure_pool is None and inner._pool is not None:
                     try:
                         inner._pool.terminate()
                     except Exception:

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -654,6 +654,7 @@ class DBOSRuntime(Runtime):
             pool=PoolProvider.borrowed(self._ensure_pool)
             if self._dsn is not None
             else None,
+            resolved_pool=self._pool,
             db_path=self._db_path,
         )
 
@@ -1028,6 +1029,7 @@ class InternalDBOSAdapter(InternalRunAdapter):
         state_table_name: str = DEFAULT_STATE_TABLE_NAME,
         journal_table_name: str = DEFAULT_JOURNAL_TABLE_NAME,
         pool: PoolProvider | None = None,
+        resolved_pool: asyncpg.Pool | None = None,
         db_path: str | None = None,
     ) -> None:
         self._run_id = run_id
@@ -1037,7 +1039,7 @@ class InternalDBOSAdapter(InternalRunAdapter):
         self._state_table_name = state_table_name
         self._journal_table_name = journal_table_name
         self._pool_provider = pool
-        self._resolved_pool: asyncpg.Pool | None = None
+        self._resolved_pool = resolved_pool
         self._db_path = db_path
         self._closed = False
         self._shutdown_event = asyncio.Event()

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -983,7 +983,10 @@ class DBOSRuntime(Runtime):
             )
             if isinstance(inner, PostgresWorkflowStore):
                 inner._closing = True
-                if inner._reconnect_task is not None and not inner._reconnect_task.done():
+                if (
+                    inner._reconnect_task is not None
+                    and not inner._reconnect_task.done()
+                ):
                     inner._reconnect_task.cancel()
                 if inner._external_ensure_pool is None and inner._pool is not None:
                     try:

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -14,12 +14,15 @@ from types import SimpleNamespace
 from typing import Any, Generator, cast
 from unittest.mock import patch
 
+import asyncpg
 import pytest
 from dbos import DBOS, DBOSConfig
 from llama_agents.dbos import DBOSRuntime
 from llama_agents.dbos.journal.crud import SqliteJournalCrud
 from llama_agents.dbos.journal.task_journal import TaskJournal
 from llama_agents.dbos.runtime import InternalDBOSAdapter
+from llama_agents.server._pool import PoolProvider
+from llama_agents.server._store.postgres_state_store import PostgresStateStore
 from pydantic import Field
 from sqlalchemy.engine import Engine
 from workflows.context import Context
@@ -38,6 +41,27 @@ def _fake_sqlite_engine() -> Engine:
             url=SimpleNamespace(database=":memory:"),
         ),
     )
+
+
+def test_postgres_adapter_uses_resolved_pool_for_sync_state_store() -> None:
+    pool = cast(asyncpg.Pool, object())
+
+    async def factory() -> asyncpg.Pool:
+        raise AssertionError("resolved pool should be used synchronously")
+
+    adapter = InternalDBOSAdapter(
+        run_id="run-1",
+        engine=cast(
+            Engine, SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+        ),
+        pool=PoolProvider.borrowed(factory),
+        resolved_pool=pool,
+    )
+
+    state_store = adapter.get_state_store()
+
+    assert isinstance(state_store, PostgresStateStore)
+    assert state_store._pool is pool
 
 
 @pytest.fixture(scope="module")

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -369,3 +369,49 @@ def test_launch_sync_raises_with_executor_lease() -> None:
 
     with pytest.raises(RuntimeError, match="_experimental_executor_lease"):
         runtime.launch_sync()
+
+
+def test_resolve_pool_sizes_explicit_config() -> None:
+    """When pool_size is set in config it wins over DBOS sys_db config."""
+    runtime = DBOSRuntime(pool_size=7)
+    min_size, max_size = runtime._resolve_pool_sizes()
+    assert min_size == 7
+    assert max_size == 7
+
+
+def test_resolve_pool_sizes_explicit_min_and_max() -> None:
+    runtime = DBOSRuntime(pool_size=8, pool_min_size=2)
+    min_size, max_size = runtime._resolve_pool_sizes()
+    assert min_size == 2
+    assert max_size == 8
+
+
+def test_resolve_pool_sizes_min_clamped_to_max() -> None:
+    runtime = DBOSRuntime(pool_size=4, pool_min_size=10)
+    min_size, max_size = runtime._resolve_pool_sizes()
+    assert min_size == 4
+    assert max_size == 4
+
+
+def test_resolve_pool_sizes_falls_back_to_dbos_sys_db_pool_size() -> None:
+    """Without explicit config, picks up DBOS's configured sys_db pool_size."""
+    runtime = DBOSRuntime()
+    fake_dbos = SimpleNamespace(
+        _config={"sys_db_engine_kwargs": {"pool_size": 17}},
+    )
+    with patch("llama_agents.dbos.runtime._get_dbos_instance", return_value=fake_dbos):
+        min_size, max_size = runtime._resolve_pool_sizes()
+    assert max_size == 17
+    assert min_size == 17
+
+
+def test_resolve_pool_sizes_falls_back_to_constant_when_dbos_unavailable() -> None:
+    """If DBOS isn't constructed, defaults to the library's fallback constant."""
+    runtime = DBOSRuntime()
+    with patch(
+        "llama_agents.dbos.runtime._get_dbos_instance",
+        side_effect=RuntimeError("not constructed"),
+    ):
+        min_size, max_size = runtime._resolve_pool_sizes()
+    assert max_size == 10
+    assert min_size == 10

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -393,6 +393,14 @@ def test_resolve_pool_sizes_min_clamped_to_max() -> None:
     assert max_size == 4
 
 
+def test_resolve_pool_sizes_floor_at_two() -> None:
+    """pool_size=1 is bumped to 2 so the LISTEN connection doesn't starve queries."""
+    runtime = DBOSRuntime(pool_size=1)
+    min_size, max_size = runtime._resolve_pool_sizes()
+    assert max_size == 2
+    assert min_size == 2
+
+
 def test_resolve_pool_sizes_falls_back_to_dbos_sys_db_pool_size() -> None:
     """Without explicit config, picks up DBOS's configured sys_db pool_size."""
     runtime = DBOSRuntime()

--- a/packages/llama-agents-dbos/tests/test_executor_lease.py
+++ b/packages/llama-agents-dbos/tests/test_executor_lease.py
@@ -45,9 +45,8 @@ def make_manager(
     )
 
 
-def test_owns_pool_when_no_factory_provided() -> None:
+def test_creates_own_pool_when_no_factory_provided() -> None:
     mgr = ExecutorLeaseManager(dsn="postgresql://x/y", pool_size=1)
-    assert mgr._owns_pool is True
     assert mgr._external_ensure_pool is None
 
 
@@ -60,7 +59,6 @@ def test_borrows_pool_when_ensure_pool_provided() -> None:
         pool_size=1,
         ensure_pool=factory,
     )
-    assert mgr._owns_pool is False
     assert mgr._external_ensure_pool is factory
 
 

--- a/packages/llama-agents-dbos/tests/test_executor_lease.py
+++ b/packages/llama-agents-dbos/tests/test_executor_lease.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
-from typing import Any
+from typing import cast
 
 import asyncpg
 import pytest
 from llama_agents.dbos.executor_lease import ExecutorLeaseManager
+from llama_agents.server._pool import PoolProvider
 from llama_agents.server._store.postgres.migrate import run_migrations
 
 
@@ -37,7 +38,7 @@ def make_manager(
     lease_timeout: float = 5.0,
 ) -> ExecutorLeaseManager:
     return ExecutorLeaseManager(
-        dsn=dsn,
+        pool=PoolProvider.create(dsn, min_size=1, max_size=5),
         pool_size=pool_size,
         schema="test_lease",
         heartbeat_interval=heartbeat_interval,
@@ -45,21 +46,14 @@ def make_manager(
     )
 
 
-def test_creates_own_pool_when_no_factory_provided() -> None:
-    mgr = ExecutorLeaseManager(dsn="postgresql://x/y", pool_size=1)
-    assert mgr._external_ensure_pool is None
-
-
-def test_borrows_pool_when_ensure_pool_provided() -> None:
-    async def factory() -> Any:
-        raise AssertionError("not called in this test")
-
-    mgr = ExecutorLeaseManager(
-        dsn="postgresql://x/y",
-        pool_size=1,
-        ensure_pool=factory,
+def test_requires_pool_provider() -> None:
+    provider = PoolProvider.borrowed(
+        lambda: asyncio.sleep(0, result=cast(asyncpg.Pool, object()))
     )
-    assert mgr._external_ensure_pool is factory
+
+    mgr = ExecutorLeaseManager(pool=provider, pool_size=1)
+
+    assert mgr._pool_provider is provider
 
 
 @pytest.mark.docker

--- a/packages/llama-agents-dbos/tests/test_executor_lease.py
+++ b/packages/llama-agents-dbos/tests/test_executor_lease.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import AsyncGenerator
+from typing import Any
 
 import asyncpg
 import pytest
@@ -42,6 +43,25 @@ def make_manager(
         heartbeat_interval=heartbeat_interval,
         lease_timeout=lease_timeout,
     )
+
+
+def test_owns_pool_when_no_factory_provided() -> None:
+    mgr = ExecutorLeaseManager(dsn="postgresql://x/y", pool_size=1)
+    assert mgr._owns_pool is True
+    assert mgr._external_ensure_pool is None
+
+
+def test_borrows_pool_when_ensure_pool_provided() -> None:
+    async def factory() -> Any:
+        raise AssertionError("not called in this test")
+
+    mgr = ExecutorLeaseManager(
+        dsn="postgresql://x/y",
+        pool_size=1,
+        ensure_pool=factory,
+    )
+    assert mgr._owns_pool is False
+    assert mgr._external_ensure_pool is factory
 
 
 @pytest.mark.docker

--- a/packages/llama-agents-server/src/llama_agents/server/_pool.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_pool.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+
+import asyncpg
+
+
+class PoolProvider:
+    """Lazy asyncpg pool provider with explicit ownership semantics."""
+
+    def __init__(
+        self,
+        factory: Callable[[], Awaitable[asyncpg.Pool]],
+        *,
+        owns_pool: bool,
+    ) -> None:
+        self._factory = factory
+        self._owns_pool = owns_pool
+        self._lock = asyncio.Lock()
+        self._pool: asyncpg.Pool | None = None
+        self._closed = False
+        self._terminated = False
+
+    @classmethod
+    def create(cls, dsn: str, min_size: int, max_size: int) -> PoolProvider:
+        async def factory() -> asyncpg.Pool:
+            return await asyncpg.create_pool(
+                dsn,
+                min_size=min_size,
+                max_size=max_size,
+            )
+
+        return cls(factory, owns_pool=True)
+
+    @classmethod
+    def borrowed(
+        cls,
+        factory: Callable[[], Awaitable[asyncpg.Pool]],
+    ) -> PoolProvider:
+        return cls(factory, owns_pool=False)
+
+    async def get(self) -> asyncpg.Pool:
+        self._raise_if_shutdown()
+        if self._pool is not None:
+            return self._pool
+
+        async with self._lock:
+            self._raise_if_shutdown()
+            if self._pool is None:
+                self._pool = await self._factory()
+            return self._pool
+
+    async def close(self) -> None:
+        if not self._owns_pool:
+            return
+        if self._closed:
+            return
+        self._closed = True
+        if self._terminated:
+            return
+        if self._pool is not None:
+            await self._pool.close()
+
+    def terminate(self) -> None:
+        if not self._owns_pool:
+            return
+        if self._terminated:
+            return
+        self._terminated = True
+        if self._closed:
+            return
+        if self._pool is not None:
+            self._pool.terminate()
+
+    def _raise_if_shutdown(self) -> None:
+        if self._terminated:
+            raise RuntimeError("PoolProvider has been terminated.")
+        if self._closed:
+            raise RuntimeError("PoolProvider has been closed.")

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -8,7 +8,7 @@ import contextlib
 import json
 import logging
 import weakref
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 from typing import Any, Sequence, cast
 
@@ -17,6 +17,7 @@ from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMe
 from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
 
+from .._pool import PoolProvider
 from .abstract_workflow_store import (
     AbstractWorkflowStore,
     HandlerQuery,
@@ -53,15 +54,13 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         pool_min_size: int = 2,
         pool_max_size: int = 10,
         auto_migrate: bool = True,
-        ensure_pool: Callable[[], Awaitable[asyncpg.Pool]] | None = None,
+        pool: PoolProvider | None = None,
     ) -> None:
         """Construct a PostgresWorkflowStore.
 
-        When ``ensure_pool`` is provided, the store borrows the asyncpg pool
-        from the factory and never creates or closes one of its own. The
-        ``pool_min_size`` / ``pool_max_size`` kwargs are then unused. When
-        ``ensure_pool`` is ``None``, the store owns its pool: it creates one
-        in :py:meth:`start` and closes it in :py:meth:`close`.
+        When ``pool`` is provided, the provider controls ownership semantics.
+        When it is omitted, the store owns a lazily-created asyncpg pool using
+        the provided DSN and pool size settings.
         """
         self._dsn = dsn
         self._schema = schema
@@ -71,7 +70,11 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         self._pool_min_size = pool_min_size
         self._pool_max_size = pool_max_size
         self._auto_migrate = auto_migrate
-        self._external_ensure_pool = ensure_pool
+        self._pool_provider = pool or PoolProvider.create(
+            dsn,
+            min_size=pool_min_size,
+            max_size=pool_max_size,
+        )
         self._pool: asyncpg.Pool | None = None
         self._listen_conn: asyncpg.Connection | None = None
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
@@ -110,14 +113,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             return
         # Reset for re-start after a close().
         self._closing = False
-        if self._external_ensure_pool is not None:
-            self._pool = await self._external_ensure_pool()
-        else:
-            self._pool = await asyncpg.create_pool(
-                self._dsn,
-                min_size=self._pool_min_size,
-                max_size=self._pool_max_size,
-            )
+        self._pool = await self._pool_provider.get()
         if self._auto_migrate:
             await self.run_migrations()
         await self._setup_listener()
@@ -258,8 +254,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
                 )
             self._listen_conn = None
         if self._pool is not None:
-            if self._external_ensure_pool is None:
-                await self._pool.close()
+            await self._pool_provider.close()
             self._pool = None
 
     async def _ensure_pool(self) -> asyncpg.Pool:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -126,15 +126,19 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         """Set up a dedicated connection for LISTEN/NOTIFY."""
         assert self._pool is not None
         conn = cast(asyncpg.Connection, await self._pool.acquire())
-        await conn.add_listener(self._notify_channel, self._on_notify)
-        # Recover from network blips / Postgres restarts.
         try:
-            conn.add_termination_listener(self._on_listen_termination)
-        except AttributeError:
-            # asyncpg < 0.27 (or a stub during tests) may not expose this.
-            logger.debug(
-                "Connection.add_termination_listener unavailable; LISTEN reconnect disabled"
-            )
+            await conn.add_listener(self._notify_channel, self._on_notify)
+            # Recover from network blips / Postgres restarts.
+            try:
+                conn.add_termination_listener(self._on_listen_termination)
+            except AttributeError:
+                # asyncpg < 0.27 (or a stub during tests) may not expose this.
+                logger.debug(
+                    "Connection.add_termination_listener unavailable; LISTEN reconnect disabled"
+                )
+        except Exception:
+            await self._pool.release(conn)
+            raise
         self._listen_conn = conn
 
     def _on_notify(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -72,7 +72,6 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         self._pool_max_size = pool_max_size
         self._auto_migrate = auto_migrate
         self._external_ensure_pool = ensure_pool
-        self._owns_pool = ensure_pool is None
         self._pool: asyncpg.Pool | None = None
         self._listen_conn: asyncpg.Connection | None = None
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
@@ -255,7 +254,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
                 )
             self._listen_conn = None
         if self._pool is not None:
-            if self._owns_pool:
+            if self._external_ensure_pool is None:
                 await self._pool.close()
             self._pool = None
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -8,7 +8,7 @@ import contextlib
 import json
 import logging
 import weakref
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any, Sequence, cast
 
@@ -31,6 +31,10 @@ logger = logging.getLogger(__name__)
 
 _TICK_PAGE_SIZE = 100
 
+# Bounds for the LISTEN-connection reconnect backoff.
+_LISTEN_RECONNECT_INITIAL_DELAY = 0.5
+_LISTEN_RECONNECT_MAX_DELAY = 30.0
+
 
 def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
@@ -49,7 +53,16 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         pool_min_size: int = 2,
         pool_max_size: int = 10,
         auto_migrate: bool = True,
+        ensure_pool: Callable[[], Awaitable[asyncpg.Pool]] | None = None,
     ) -> None:
+        """Construct a PostgresWorkflowStore.
+
+        When ``ensure_pool`` is provided, the store borrows the asyncpg pool
+        from the factory and never creates or closes one of its own. The
+        ``pool_min_size`` / ``pool_max_size`` kwargs are then unused. When
+        ``ensure_pool`` is ``None``, the store owns its pool: it creates one
+        in :py:meth:`start` and closes it in :py:meth:`close`.
+        """
         self._dsn = dsn
         self._schema = schema
         self.poll_interval = poll_interval
@@ -58,11 +71,17 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         self._pool_min_size = pool_min_size
         self._pool_max_size = pool_max_size
         self._auto_migrate = auto_migrate
+        self._external_ensure_pool = ensure_pool
+        self._owns_pool = ensure_pool is None
         self._pool: asyncpg.Pool | None = None
         self._listen_conn: asyncpg.Connection | None = None
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
             weakref.WeakValueDictionary()
         )
+        # LISTEN reconnect bookkeeping.
+        self._closing = False
+        self._reconnect_lock = asyncio.Lock()
+        self._reconnect_task: asyncio.Task[None] | None = None
 
     @property
     def _handlers_ref(self) -> str:
@@ -87,14 +106,19 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         return self._events_table_name
 
     async def start(self) -> None:
-        """Create the connection pool, run migrations if enabled, and set up LISTEN."""
+        """Resolve the connection pool, run migrations if enabled, and set up LISTEN."""
         if self._pool is not None:
             return
-        self._pool = await asyncpg.create_pool(
-            self._dsn,
-            min_size=self._pool_min_size,
-            max_size=self._pool_max_size,
-        )
+        # Reset for re-start after a close().
+        self._closing = False
+        if self._external_ensure_pool is not None:
+            self._pool = await self._external_ensure_pool()
+        else:
+            self._pool = await asyncpg.create_pool(
+                self._dsn,
+                min_size=self._pool_min_size,
+                max_size=self._pool_max_size,
+            )
         if self._auto_migrate:
             await self.run_migrations()
         await self._setup_listener()
@@ -104,6 +128,14 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         assert self._pool is not None
         conn = cast(asyncpg.Connection, await self._pool.acquire())
         await conn.add_listener(self._notify_channel, self._on_notify)
+        # Recover from network blips / Postgres restarts.
+        try:
+            conn.add_termination_listener(self._on_listen_termination)
+        except AttributeError:
+            # asyncpg < 0.27 (or a stub during tests) may not expose this.
+            logger.debug(
+                "Connection.add_termination_listener unavailable; LISTEN reconnect disabled"
+            )
         self._listen_conn = conn
 
     def _on_notify(
@@ -124,8 +156,90 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         async with condition:
             condition.notify_all()
 
+    def _wake_all_subscribers(self) -> None:
+        """Wake every active condition so subscribe_events re-queries.
+
+        Used after a LISTEN reconnect — we may have missed NOTIFYs while the
+        listener connection was down. The polling fallback in
+        ``subscribe_events`` would catch them within ``poll_interval``; this
+        just makes recovery immediate.
+        """
+        # Snapshot to avoid mutation-during-iteration on the WeakValueDictionary.
+        for cond in list(self._conditions.values()):
+            asyncio.ensure_future(self._notify_condition(cond))
+
+    def _on_listen_termination(self, connection: asyncpg.Connection) -> None:
+        """asyncpg termination callback — schedule a reconnect.
+
+        Fires for normal close too, so we guard with ``self._closing``. The
+        callback runs on asyncpg's internal task; do real work via
+        ``ensure_future``.
+        """
+        if self._closing:
+            return
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            return  # already reconnecting
+        try:
+            self._reconnect_task = asyncio.ensure_future(self._reconnect_listener())
+        except RuntimeError:
+            # No running loop (e.g. termination during shutdown). Nothing to do.
+            logger.debug("No running loop to schedule LISTEN reconnect")
+
+    async def _reconnect_listener(self) -> None:
+        """Reconnect the LISTEN connection with bounded exponential backoff.
+
+        On success, wakes every subscribe_events consumer so they re-query
+        immediately rather than waiting for the polling fallback.
+        """
+        async with self._reconnect_lock:
+            if self._closing or self._pool is None:
+                return
+
+            logger.warning("LISTEN connection dropped; reconnecting")
+
+            # Release the dead conn back to the pool. asyncpg handles already-
+            # closed connections gracefully on release.
+            if self._listen_conn is not None:
+                try:
+                    await self._pool.release(self._listen_conn)
+                except Exception:
+                    logger.debug(
+                        "Failed to release dead listen connection", exc_info=True
+                    )
+                self._listen_conn = None
+
+            delay = _LISTEN_RECONNECT_INITIAL_DELAY
+            while not self._closing:
+                try:
+                    await self._setup_listener()
+                except Exception:
+                    logger.warning(
+                        "LISTEN reconnect attempt failed; retrying in %.1fs",
+                        delay,
+                        exc_info=True,
+                    )
+                    try:
+                        await asyncio.sleep(delay)
+                    except asyncio.CancelledError:
+                        return
+                    delay = min(delay * 2, _LISTEN_RECONNECT_MAX_DELAY)
+                    continue
+
+                logger.info("LISTEN connection re-established")
+                self._wake_all_subscribers()
+                return
+
     async def close(self) -> None:
-        """Tear down the LISTEN connection and close the pool."""
+        """Tear down the LISTEN connection and close the pool (if owned)."""
+        # Block any in-flight reconnect coroutine from re-installing the listener.
+        self._closing = True
+        if self._reconnect_task is not None and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+            try:
+                await self._reconnect_task
+            except (asyncio.CancelledError, Exception):
+                pass
+        self._reconnect_task = None
         if self._listen_conn is not None:
             try:
                 await self._listen_conn.remove_listener(
@@ -141,7 +255,8 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
                 )
             self._listen_conn = None
         if self._pool is not None:
-            await self._pool.close()
+            if self._owns_pool:
+                await self._pool.close()
             self._pool = None
 
     async def _ensure_pool(self) -> asyncpg.Pool:

--- a/packages/llama-agents-server/tests/server/test_pool.py
+++ b/packages/llama-agents-server/tests/server/test_pool.py
@@ -1,0 +1,210 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+
+import asyncpg
+import pytest
+from llama_agents.server._pool import PoolProvider
+
+
+class FakePool:
+    def __init__(self) -> None:
+        self.close_calls = 0
+        self.terminate_calls = 0
+
+    async def close(self) -> None:
+        self.close_calls += 1
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+
+
+def pool_factory(pool: FakePool) -> asyncpg.Pool:
+    return cast(asyncpg.Pool, pool)
+
+
+def create_owned_provider(
+    monkeypatch: pytest.MonkeyPatch,
+    pool: FakePool,
+    calls: list[tuple[str, int, int]] | None = None,
+) -> PoolProvider:
+    async def create_pool(
+        dsn: str,
+        *,
+        min_size: int,
+        max_size: int,
+    ) -> asyncpg.Pool:
+        if calls is not None:
+            calls.append((dsn, min_size, max_size))
+        return pool_factory(pool)
+
+    monkeypatch.setattr(asyncpg, "create_pool", create_pool)
+    return PoolProvider.create("postgresql://example/db", min_size=2, max_size=7)
+
+
+async def test_create_uses_asyncpg_create_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = FakePool()
+    calls: list[tuple[str, int, int]] = []
+
+    provider = create_owned_provider(monkeypatch, pool, calls)
+
+    assert await provider.get() is pool
+    assert calls == [("postgresql://example/db", 2, 7)]
+
+
+async def test_owned_provider_closes_cached_pool_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = FakePool()
+    provider = create_owned_provider(monkeypatch, pool)
+
+    assert await provider.get() is pool
+    await provider.close()
+    await provider.close()
+
+    assert pool.close_calls == 1
+    assert pool.terminate_calls == 0
+
+
+async def test_borrowed_provider_close_and_terminate_do_not_affect_pool() -> None:
+    pool = FakePool()
+    provider = PoolProvider.borrowed(
+        lambda: asyncio.sleep(0, result=pool_factory(pool))
+    )
+
+    assert await provider.get() is pool
+    await provider.close()
+    provider.terminate()
+
+    assert pool.close_calls == 0
+    assert pool.terminate_calls == 0
+    assert await provider.get() is pool
+
+
+async def test_owned_provider_terminates_cached_pool_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = FakePool()
+    provider = create_owned_provider(monkeypatch, pool)
+
+    assert await provider.get() is pool
+    provider.terminate()
+    provider.terminate()
+
+    assert pool.close_calls == 0
+    assert pool.terminate_calls == 1
+
+
+async def test_close_and_terminate_before_get_do_not_call_factory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, int, int]] = []
+
+    closed = create_owned_provider(monkeypatch, FakePool(), calls)
+    await closed.close()
+
+    terminated = create_owned_provider(monkeypatch, FakePool(), calls)
+    terminated.terminate()
+
+    assert calls == []
+
+
+async def test_close_after_terminate_is_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = FakePool()
+    provider = create_owned_provider(monkeypatch, pool)
+
+    assert await provider.get() is pool
+    provider.terminate()
+    await provider.close()
+
+    assert pool.close_calls == 0
+    assert pool.terminate_calls == 1
+
+
+async def test_terminate_after_close_is_safe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = FakePool()
+    provider = create_owned_provider(monkeypatch, pool)
+
+    assert await provider.get() is pool
+    await provider.close()
+    provider.terminate()
+
+    assert pool.close_calls == 1
+    assert pool.terminate_calls == 0
+
+
+async def test_get_after_close_raises() -> None:
+    provider = PoolProvider(
+        lambda: asyncio.sleep(0, result=pool_factory(FakePool())),
+        owns_pool=True,
+    )
+
+    await provider.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        await provider.get()
+
+
+async def test_get_after_terminate_raises() -> None:
+    provider = PoolProvider(
+        lambda: asyncio.sleep(0, result=pool_factory(FakePool())),
+        owns_pool=True,
+    )
+
+    provider.terminate()
+
+    with pytest.raises(RuntimeError, match="terminated"):
+        await provider.get()
+
+
+async def test_factory_exception_is_not_cached() -> None:
+    pool = FakePool()
+    calls = 0
+
+    async def factory() -> asyncpg.Pool:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("failed")
+        return pool_factory(pool)
+
+    provider = PoolProvider.borrowed(factory)
+
+    with pytest.raises(ValueError, match="failed"):
+        await provider.get()
+
+    assert await provider.get() is pool
+    assert calls == 2
+
+
+async def test_concurrent_get_invokes_factory_once() -> None:
+    pool = FakePool()
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def factory() -> asyncpg.Pool:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return pool_factory(pool)
+
+    provider = PoolProvider.borrowed(factory)
+
+    first = asyncio.create_task(provider.get())
+    await started.wait()
+    second = asyncio.create_task(provider.get())
+    release.set()
+
+    assert await asyncio.gather(first, second) == [pool, pool]
+    assert calls == 1

--- a/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
+from llama_agents.server._pool import PoolProvider
 from llama_agents.server._store.abstract_workflow_store import (
     HandlerQuery,
     PersistentHandler,
@@ -123,7 +124,7 @@ async def test_close_without_start_is_safe() -> None:
 async def test_borrowed_pool_not_closed_on_close(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """When constructed with ensure_pool, the borrowed pool is never closed."""
+    """When constructed with a borrowed provider, the borrowed pool is never closed."""
     fake_pool = MagicMock()
     fake_pool.close = MagicMock()  # would be awaited if called
     factory_calls = 0
@@ -141,7 +142,7 @@ async def test_borrowed_pool_not_closed_on_close(
 
     store = PostgresWorkflowStore(
         dsn="postgresql://localhost/test",
-        ensure_pool=factory,
+        pool=PoolProvider.borrowed(factory),
         auto_migrate=False,
     )
 

--- a/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -117,6 +118,111 @@ async def test_on_notify_wakes_condition() -> None:
 async def test_close_without_start_is_safe() -> None:
     store = PostgresWorkflowStore(dsn="postgresql://localhost/test")
     await store.close()  # Should not raise
+
+
+async def test_borrowed_pool_not_closed_on_close(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When constructed with ensure_pool, the borrowed pool is never closed."""
+    fake_pool = MagicMock()
+    fake_pool.close = MagicMock()  # would be awaited if called
+    factory_calls = 0
+
+    async def factory() -> Any:
+        nonlocal factory_calls
+        factory_calls += 1
+        return fake_pool
+
+    # _setup_listener acquires from the pool — short-circuit it for this unit test.
+    async def noop_setup_listener(self: PostgresWorkflowStore) -> None:
+        return None
+
+    monkeypatch.setattr(PostgresWorkflowStore, "_setup_listener", noop_setup_listener)
+
+    store = PostgresWorkflowStore(
+        dsn="postgresql://localhost/test",
+        ensure_pool=factory,
+        auto_migrate=False,
+    )
+
+    await store.start()
+    assert factory_calls == 1
+    assert store._pool is fake_pool
+
+    await store.close()
+    fake_pool.close.assert_not_called()
+    assert store._pool is None
+
+
+async def test_listen_termination_callback_schedules_reconnect(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the LISTEN conn drops, _on_listen_termination must schedule reconnect."""
+    reconnect_called = asyncio.Event()
+
+    async def fake_reconnect(self: PostgresWorkflowStore) -> None:
+        reconnect_called.set()
+
+    monkeypatch.setattr(PostgresWorkflowStore, "_reconnect_listener", fake_reconnect)
+
+    store = PostgresWorkflowStore(dsn="postgresql://localhost/test")
+    store._on_listen_termination(MagicMock())
+
+    await asyncio.wait_for(reconnect_called.wait(), timeout=1.0)
+
+
+async def test_listen_termination_callback_noops_when_closing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The closing flag suppresses reconnect attempts during teardown."""
+    called = False
+
+    async def fake_reconnect(self: PostgresWorkflowStore) -> None:
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(PostgresWorkflowStore, "_reconnect_listener", fake_reconnect)
+
+    store = PostgresWorkflowStore(dsn="postgresql://localhost/test")
+    store._closing = True
+    store._on_listen_termination(MagicMock())
+    await asyncio.sleep(0.01)
+    assert called is False
+
+
+async def test_reconnect_listener_wakes_subscribers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After a successful reconnect, all active subscribe_events conditions are notified."""
+
+    async def fake_setup_listener(self: PostgresWorkflowStore) -> None:
+        return None
+
+    monkeypatch.setattr(PostgresWorkflowStore, "_setup_listener", fake_setup_listener)
+
+    store = PostgresWorkflowStore(dsn="postgresql://localhost/test")
+    # Pretend the pool exists so _reconnect_listener proceeds.
+    store._pool = cast(Any, MagicMock())
+
+    # Hold strong references to the conditions; the store keeps weak refs only.
+    cond_a = store._get_or_create_condition("run-a")
+    cond_b = store._get_or_create_condition("run-b")
+
+    woken = {"a": False, "b": False}
+
+    async def waiter(name: str, cond: asyncio.Condition) -> None:
+        async with cond:
+            await cond.wait()
+            woken[name] = True
+
+    task_a = asyncio.create_task(waiter("a", cond_a))
+    task_b = asyncio.create_task(waiter("b", cond_b))
+    await asyncio.sleep(0.01)
+
+    await store._reconnect_listener()
+
+    await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=1.0)
+    assert woken == {"a": True, "b": True}
 
 
 # ── Integration tests (require Docker) ──────────────────────────────


### PR DESCRIPTION
## Summary

- DBOSRuntime now owns one lazily-created asyncpg pool and shares it with the workflow store, internal adapter, executor lease manager, and postgres persistence helpers.
- PostgresWorkflowStore and ExecutorLeaseManager use `PoolProvider`, so borrowed pools stay owned by the runtime and consumer shutdown is just `close()`.
- Runtime destroy now closes the workflow store before terminating the pool, which lets the LISTEN connection unwind without reaching into store internals.
- Pool sizing is configurable with `pool_size` / `pool_min_size`; the workflow store also reconnects LISTEN after connection drops.
- Bumps the DBOS server dependency and removes the stale appserver server upper bound.

