### PR TITLE
Stabilize async test readiness

### DIFF
--- a/packages/llama-agents-core/src/llama_agents/core/iter_utils.py
+++ b/packages/llama-agents-core/src/llama_agents/core/iter_utils.py
@@ -87,6 +87,7 @@ async def merge_generators(
                 return_when=asyncio.FIRST_COMPLETED,
             )
 
+            completed_results: list[tuple[int, T]] = []
             for finished in done:
                 # Locate which generator this task belonged to
                 task_index: int | None = None
@@ -117,21 +118,19 @@ async def merge_generators(
                     exception_to_raise = exc
                     break
                 else:
-                    # Remove the finished task before yielding
-                    next_item_tasks.pop(task_index, None)
-                    yield value
-                    # Schedule the next item fetch for this generator
-                    active_gen: AsyncGenerator[T, None] | None = active_generators.get(
-                        task_index
-                    )
-                    if active_gen is not None:
-                        next_item_tasks[task_index] = asyncio.create_task(
-                            anext(active_gen)
-                        )
-            # If we are configured to stop on first completion and observed one,
-            # exit the outer loop to perform cleanup in the finally block.
+                    completed_results.append((task_index, value))
             if stopped_on_first_completion:
                 break
+            for task_index, value in completed_results:
+                # Remove the finished task before yielding
+                next_item_tasks.pop(task_index, None)
+                yield value
+                # Schedule the next item fetch for this generator
+                active_gen: AsyncGenerator[T, None] | None = active_generators.get(
+                    task_index
+                )
+                if active_gen is not None:
+                    next_item_tasks[task_index] = asyncio.create_task(anext(active_gen))
     finally:
         # Ensure we do not leak tasks or open generators
         for task in next_item_tasks.values():

--- a/packages/llama-agents-core/tests/test_iter_utils.py
+++ b/packages/llama-agents-core/tests/test_iter_utils.py
@@ -1,5 +1,10 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
 import asyncio
-from typing import AsyncGenerator, List
+from collections.abc import AsyncGenerator, Collection
 
 import pytest
 from llama_agents.core.iter_utils import (
@@ -9,11 +14,19 @@ from llama_agents.core.iter_utils import (
 
 
 async def _gen_with_delays(
-    values: List[str], delays: List[float]
+    values: list[str], delays: list[float]
 ) -> AsyncGenerator[str, None]:
     for value, delay in zip(values, delays):
         if delay:
             await asyncio.sleep(delay)
+        yield value
+
+
+async def _gen_with_gates(
+    values: list[str], gates: list[asyncio.Event]
+) -> AsyncGenerator[str, None]:
+    for value, gate in zip(values, gates):
+        await gate.wait()
         yield value
 
 
@@ -26,25 +39,48 @@ async def _gen_raises(after_items: int = 0) -> AsyncGenerator[str, None]:
     raise RuntimeError("boom")
 
 
-async def _gen_slow_with_close_flag(flag: asyncio.Event) -> AsyncGenerator[str, None]:
+async def _gen_with_close_flag(
+    flag: asyncio.Event, gate: asyncio.Event
+) -> AsyncGenerator[str, None]:
     try:
-        i = 0
-        while True:
-            await asyncio.sleep(0.05)
-            i += 1
-            yield f"slow-{i}"
+        await gate.wait()
+        yield "slow-1"
     finally:
         flag.set()
 
 
+async def _wait_for_count(values: Collection[object], expected_count: int) -> None:
+    for _ in range(100):
+        if len(values) == expected_count:
+            return
+        await asyncio.sleep(0)
+    raise AssertionError(f"expected {expected_count} items, got {values}")
+
+
 @pytest.mark.asyncio
 async def test_merge_generators_interleaves_in_arrival_order() -> None:
-    g1 = _gen_with_delays(["a", "c"], [0.01, 0.04])  # emits at ~0.01 and ~0.05
-    g2 = _gen_with_delays(["b", "d"], [0.02, 0.06])  # emits at ~0.02 and ~0.08
+    gate_a = asyncio.Event()
+    gate_b = asyncio.Event()
+    gate_c = asyncio.Event()
+    gate_d = asyncio.Event()
+    g1 = _gen_with_gates(["a", "c"], [gate_a, gate_c])
+    g2 = _gen_with_gates(["b", "d"], [gate_b, gate_d])
 
-    merged: List[str] = []
-    async for item in merge_generators(g1, g2):
-        merged.append(item)
+    merged: list[str] = []
+
+    async def collect() -> None:
+        async for item in merge_generators(g1, g2):
+            merged.append(item)
+
+    task = asyncio.create_task(collect())
+    gate_a.set()
+    await _wait_for_count(merged, 1)
+    gate_b.set()
+    await _wait_for_count(merged, 2)
+    gate_c.set()
+    await _wait_for_count(merged, 3)
+    gate_d.set()
+    await task
 
     assert merged == ["a", "b", "c", "d"]
 
@@ -54,7 +90,7 @@ async def test_merge_generators_propagates_exception_immediately() -> None:
     g_ok = _gen_with_delays(["x", "y"], [0.0, 0.1])
     g_err = _gen_raises(after_items=1)
 
-    items: List[str] = []
+    items: list[str] = []
     with pytest.raises(RuntimeError, match="boom"):
         async for item in merge_generators(g_ok, g_err):
             items.append(item)
@@ -67,12 +103,23 @@ async def test_merge_generators_propagates_exception_immediately() -> None:
 @pytest.mark.asyncio
 async def test_merge_generators_stop_on_first_completion_cancels_others() -> None:
     closed_event = asyncio.Event()
-    g_slow = _gen_slow_with_close_flag(closed_event)
-    g_fast = _gen_with_delays(["done"], [0.01])  # completes quickly
+    slow_gate = asyncio.Event()
+    fast_gate = asyncio.Event()
+    g_slow = _gen_with_close_flag(closed_event, slow_gate)
+    g_fast = _gen_with_gates(["done"], [fast_gate])
 
-    collected: List[str] = []
-    async for item in merge_generators(g_slow, g_fast, stop_on_first_completion=True):
-        collected.append(item)
+    collected: list[str] = []
+
+    async def collect() -> None:
+        async for item in merge_generators(
+            g_slow, g_fast, stop_on_first_completion=True
+        ):
+            collected.append(item)
+
+    task = asyncio.create_task(collect())
+    fast_gate.set()
+    await _wait_for_count(collected, 1)
+    await task
 
     # Only the fast item should be seen deterministically
     assert collected == ["done"]
@@ -93,7 +140,7 @@ async def test_debounced_sorted_prefix_sorts_then_passthrough() -> None:
             await asyncio.sleep(0.01)
             yield value
 
-    output: List[int] = []
+    output: list[int] = []
     async for item in debounced_sorted_prefix(
         inner(), key=lambda x: x, debounce_seconds=0.05, max_window_seconds=0.1
     ):

--- a/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/server_test_utils.py
+++ b/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/server_test_utils.py
@@ -9,10 +9,11 @@ import asyncio
 import socket
 import time
 from contextlib import asynccontextmanager
-from typing import AsyncGenerator, Awaitable, Callable, TypeVar
+from typing import AsyncGenerator, Awaitable, Callable, Literal, TypeVar
 
 import httpx
 import uvicorn
+from llama_agents.client.client import WorkflowClient
 from llama_agents.server import WorkflowServer
 from workflows import Context, Workflow, step
 from workflows.events import (
@@ -44,6 +45,37 @@ async def wait_for_passing(
     if last_exception:
         raise last_exception
     raise TimeoutError(f"Timed out after {max_duration}s")
+
+
+async def wait_for_requested_external_event_stream(
+    client: WorkflowClient,
+    handler_id: str,
+    *,
+    label: str,
+    max_duration: float = 5.0,
+) -> int | Literal["now"]:
+    async def wait_for_prompt() -> int | Literal["now"]:
+        stream = client.get_workflow_events(handler_id)
+        try:
+            async for ev in stream:
+                event = ev.load_event([RequestedExternalEvent])
+                if isinstance(event, RequestedExternalEvent):
+                    return stream.last_sequence
+        finally:
+            await stream.aclose()
+
+        raise AssertionError(
+            f"{label}: event stream ended before RequestedExternalEvent "
+            f"for handler {handler_id}"
+        )
+
+    try:
+        return await asyncio.wait_for(wait_for_prompt(), timeout=max_duration)
+    except TimeoutError as exc:
+        raise AssertionError(
+            f"{label}: timed out waiting for RequestedExternalEvent "
+            f"for handler {handler_id}"
+        ) from exc
 
 
 # -- Shared workflow definitions --

--- a/packages/llama-agents-integration-tests/tests/test_server_http_matrix.py
+++ b/packages/llama-agents-integration-tests/tests/test_server_http_matrix.py
@@ -20,11 +20,11 @@ from llama_agents.server import MemoryWorkflowStore, SqliteWorkflowStore, Workfl
 from llama_agents_integration_tests.server_test_utils import (
     ExternalEvent,
     InteractiveWorkflow,
-    RequestedExternalEvent,
     SimpleTestWorkflow,
     StreamingWorkflow,
     live_server,
     wait_for_passing,
+    wait_for_requested_external_event_stream,
 )
 from testcontainers.postgres import PostgresContainer
 from workflows import Context, Workflow, step
@@ -240,15 +240,11 @@ async def test_streaming_and_interactive(
     started = await client.run_workflow_nowait("InteractiveWorkflow")
     handler_id = started.handler_id
 
-    saw_prompt = False
-    async for ev in client.get_workflow_events(handler_id):
-        event = ev.load_event()
-        if isinstance(event, RequestedExternalEvent):
-            saw_prompt = True
-            sent = await client.send_event(handler_id, ExternalEvent(response="pong"))
-            assert sent.status == "sent"
-            break
-    assert saw_prompt
+    await wait_for_requested_external_event_stream(
+        client, handler_id, label=type(server._workflow_store).__name__
+    )
+    sent = await client.send_event(handler_id, ExternalEvent(response="pong"))
+    assert sent.status == "sent"
 
     async def check_completed() -> str:
         handler = await client.get_handler(handler_id)
@@ -271,20 +267,16 @@ async def test_reconnect_stream(
     started = await client.run_workflow_nowait("InteractiveWorkflow")
     handler_id = started.handler_id
 
-    saw_prompt = False
-    events_before = 0
-    async for ev in client.get_workflow_events(handler_id):
-        events_before += 1
-        event = ev.load_event()
-        if isinstance(event, RequestedExternalEvent):
-            saw_prompt = True
-            break
-    assert saw_prompt
+    prompt_cursor = await wait_for_requested_external_event_stream(
+        client, handler_id, label=type(server._workflow_store).__name__
+    )
 
     stop_seen = asyncio.Event()
 
     async def consume_again() -> None:
-        async for ev in client.get_workflow_events(handler_id):
+        async for ev in client.get_workflow_events(
+            handler_id, after_sequence=prompt_cursor
+        ):
             event = ev.load_event()
             if isinstance(event, StopEvent):
                 stop_seen.set()

--- a/packages/llama-agents-integration-tests/tests/test_server_store_matrix.py
+++ b/packages/llama-agents-integration-tests/tests/test_server_store_matrix.py
@@ -25,12 +25,12 @@ from llama_agents_integration_tests.postgres import get_asyncpg_dsn
 from llama_agents_integration_tests.server_test_utils import (
     ExternalEvent,
     InteractiveWorkflow,
-    RequestedExternalEvent,
     SimpleTestWorkflow,
     StreamEvent,
     StreamingWorkflow,
     live_server,
     wait_for_passing,
+    wait_for_requested_external_event_stream,
 )
 from workflows import Workflow, step
 from workflows.events import StartEvent, StopEvent
@@ -162,21 +162,20 @@ async def test_sse_event_streaming(
 async def test_send_external_event(
     server_with_store: tuple[str, WorkflowServer, str],
 ) -> None:
-    base_url, _server, _store_type = server_with_store
+    base_url, _server, store_type = server_with_store
     client = WorkflowClient(base_url=base_url)
     started = await client.run_workflow_nowait("interactive")
     handler_id = started.handler_id
 
-    async for ev in client.get_workflow_events(handler_id):
-        event = ev.load_event([RequestedExternalEvent])
-        if isinstance(event, RequestedExternalEvent):
-            sent = await client.send_event(handler_id, ExternalEvent(response="pong"))
-            assert sent.status == "sent"
-            break
+    await wait_for_requested_external_event_stream(client, handler_id, label=store_type)
+    sent = await client.send_event(handler_id, ExternalEvent(response="pong"))
+    assert sent.status == "sent"
 
     async def check_completed() -> None:
         data = await client.get_handler(handler_id)
-        assert data.status == "completed"
+        assert data.status == "completed", (
+            f"{store_type}: handler {handler_id} did not complete after external event"
+        )
         assert data.result is not None
         assert data.result.value.get("result") == "received: pong"
 
@@ -374,11 +373,9 @@ async def test_server_restart_resumes_workflow(
         started = await client.run_workflow_nowait("interactive")
         handler_id = started.handler_id
 
-        # Wait for the workflow to reach the waiting state
-        async for ev in client.get_workflow_events(handler_id):
-            event = ev.load_event([RequestedExternalEvent])
-            if isinstance(event, RequestedExternalEvent):
-                break
+        await wait_for_requested_external_event_stream(
+            client, handler_id, label="durable-restart"
+        )
 
     # Restart with same store - workflow should resume
     async with live_server(durable_server_factory) as (base_url2, _server2):

--- a/packages/llama-agents-server/tests/server/server_test_fixtures.py
+++ b/packages/llama-agents-server/tests/server/server_test_fixtures.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
 
+from __future__ import annotations
 
 import asyncio
 import socket
@@ -12,7 +13,13 @@ from typing import AsyncGenerator, Awaitable, Callable, TypeVar
 import httpx
 import pytest
 import uvicorn
-from llama_agents.server import MemoryWorkflowStore, SqliteWorkflowStore, WorkflowServer
+from llama_agents.server import (
+    AbstractWorkflowStore,
+    HandlerQuery,
+    MemoryWorkflowStore,
+    SqliteWorkflowStore,
+    WorkflowServer,
+)
 from workflows import Context, Workflow, step
 from workflows.events import (
     Event,
@@ -52,6 +59,39 @@ async def wait_for_passing(
         raise TimeoutError(
             f"Function {func_name} timed out after {max_duration} seconds"
         )
+
+
+async def wait_for_requested_external_event(
+    store: AbstractWorkflowStore,
+    handler_id: str,
+    *,
+    event_type: str = "RequestedExternalEvent",
+    max_duration: float = 2.0,
+    interval: float = 0.01,
+) -> str:
+    async def event_was_persisted() -> str:
+        handlers = await store.query(HandlerQuery(handler_id_in=[handler_id]))
+        assert len(handlers) == 1
+        handler = handlers[0]
+        assert handler.run_id is not None
+
+        events = await store.query_events(handler.run_id)
+        if any(
+            event.event.type == event_type or event_type in (event.event.types or [])
+            for event in events
+        ):
+            return handler.run_id
+
+        assert handler.status == "running", (
+            f"handler {handler_id} reached {handler.status} before {event_type}"
+        )
+        raise AssertionError(f"{event_type} not persisted for handler {handler_id}")
+
+    return await wait_for_passing(
+        event_was_persisted,
+        max_duration=max_duration,
+        interval=interval,
+    )
 
 
 @asynccontextmanager

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -20,6 +20,7 @@ from llama_agents_integration_tests.fake_agent_data import (
     FakeAgentDataBackend,
     create_agent_data_store,
 )
+from server_test_fixtures import wait_for_passing  # type: ignore[import]
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import DictState
 from workflows.events import Event, StopEvent
@@ -64,6 +65,39 @@ def make_envelope(
     if event is None:
         event = Event(data=f"seq-{seq_label}")
     return EventEnvelopeWithMetadata.from_event(event, include_qualified_name=False)
+
+
+async def _subscribe_and_collect(
+    store: AgentDataStore,
+    run_id: str,
+    after_sequence: int = -1,
+) -> tuple[list[StoredEvent], asyncio.Task[None]]:
+    collected: list[StoredEvent] = []
+    existing_queue_count = len(store._subscriber_queues.get(run_id, ()))
+
+    async def consumer() -> None:
+        async for event in store.subscribe_events(
+            run_id, after_sequence=after_sequence
+        ):
+            collected.append(event)
+
+    task = asyncio.create_task(consumer())
+
+    async def registered() -> None:
+        assert len(store._subscriber_queues.get(run_id, ())) > existing_queue_count
+
+    await wait_for_passing(registered, max_duration=2.0, interval=0.01)
+    return collected, task
+
+
+async def _wait_collected_count(
+    collected: list[StoredEvent],
+    expected: int,
+) -> None:
+    async def check() -> None:
+        assert len(collected) == expected
+
+    await wait_for_passing(check, max_duration=2.0, interval=0.01)
 
 
 # ---------------------------------------------------------------------------
@@ -331,14 +365,7 @@ async def test_events_isolated_by_run_id(store: AgentDataStore) -> None:
 
 @pytest.mark.asyncio
 async def test_subscribe_events_receives_appended(store: AgentDataStore) -> None:
-    collected: list[StoredEvent] = []
-
-    async def consumer() -> None:
-        async for event in store.subscribe_events("run-1"):
-            collected.append(event)
-
-    task = asyncio.create_task(consumer())
-    await asyncio.sleep(0.01)
+    collected, task = await _subscribe_and_collect(store, "run-1")
 
     await store.append_event("run-1", make_envelope(seq_label=0))
     await store.append_event("run-1", make_envelope(seq_label=1))
@@ -351,14 +378,7 @@ async def test_subscribe_events_receives_appended(store: AgentDataStore) -> None
 
 @pytest.mark.asyncio
 async def test_subscribe_events_terminates_on_stop(store: AgentDataStore) -> None:
-    collected: list[StoredEvent] = []
-
-    async def consumer() -> None:
-        async for event in store.subscribe_events("run-1"):
-            collected.append(event)
-
-    task = asyncio.create_task(consumer())
-    await asyncio.sleep(0.01)
+    collected, task = await _subscribe_and_collect(store, "run-1")
 
     await store.append_event("run-1", make_envelope(seq_label=0))
     await store.append_event("run-1", make_envelope(event=StopEvent(data="done")))
@@ -386,14 +406,7 @@ async def test_subscribe_events_with_after_sequence(store: AgentDataStore) -> No
     for i in range(3):
         await store.append_event("run-1", make_envelope(seq_label=i))
 
-    collected: list[StoredEvent] = []
-
-    async def consumer() -> None:
-        async for event in store.subscribe_events("run-1", after_sequence=1):
-            collected.append(event)
-
-    task = asyncio.create_task(consumer())
-    await asyncio.sleep(0.01)
+    collected, task = await _subscribe_and_collect(store, "run-1", after_sequence=1)
 
     await store.append_event("run-1", make_envelope(event=StopEvent(data="done")))
 
@@ -569,20 +582,8 @@ async def test_agent_data_client_reuses_http_client(store: AgentDataStore) -> No
 async def test_subscribe_events_multiple_concurrent_subscribers(
     store: AgentDataStore,
 ) -> None:
-    collected_a: list[StoredEvent] = []
-    collected_b: list[StoredEvent] = []
-
-    async def consumer_a() -> None:
-        async for event in store.subscribe_events("run-1"):
-            collected_a.append(event)
-
-    async def consumer_b() -> None:
-        async for event in store.subscribe_events("run-1"):
-            collected_b.append(event)
-
-    task_a = asyncio.create_task(consumer_a())
-    task_b = asyncio.create_task(consumer_b())
-    await asyncio.sleep(0.01)
+    collected_a, task_a = await _subscribe_and_collect(store, "run-1")
+    collected_b, task_b = await _subscribe_and_collect(store, "run-1")
 
     await store.append_event("run-1", make_envelope(seq_label=0))
     await store.append_event("run-1", make_envelope(seq_label=1))
@@ -603,14 +604,7 @@ async def test_subscribe_events_backfill_and_live(store: AgentDataStore) -> None
     await store.append_event("run-1", make_envelope(seq_label=0))
     await store.append_event("run-1", make_envelope(seq_label=1))
 
-    collected: list[StoredEvent] = []
-
-    async def consumer() -> None:
-        async for event in store.subscribe_events("run-1", after_sequence=-1):
-            collected.append(event)
-
-    task = asyncio.create_task(consumer())
-    await asyncio.sleep(0.01)
+    collected, task = await _subscribe_and_collect(store, "run-1", after_sequence=-1)
 
     # Append live events after subscriber is listening
     await store.append_event("run-1", make_envelope(seq_label=2))
@@ -631,22 +625,14 @@ async def test_subscribe_events_backfill_and_live(store: AgentDataStore) -> None
 async def test_events_fire_and_forget_during_streaming(
     store: AgentDataStore, backend: FakeAgentDataBackend
 ) -> None:
-    collected: list[StoredEvent] = []
-
-    async def consumer() -> None:
-        async for event in store.subscribe_events("run-1"):
-            collected.append(event)
-
-    task = asyncio.create_task(consumer())
-    await asyncio.sleep(0.01)
+    collected, task = await _subscribe_and_collect(store, "run-1")
 
     # Append several non-terminal events (fire-and-forget)
     for i in range(5):
         await store.append_event("run-1", make_envelope(seq_label=i))
 
     # Subscriber receives events immediately via in-memory queue
-    await asyncio.sleep(0.01)
-    assert len(collected) == 5
+    await _wait_collected_count(collected, 5)
 
     # Terminal event gathers all pending writes
     await store.append_event("run-1", make_envelope(event=StopEvent(data="done")))
@@ -745,14 +731,7 @@ async def test_persist_error_does_not_block_in_memory_delivery(
     store: AgentDataStore, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """In-memory subscribers receive events even when HTTP persistence fails."""
-    collected: list[StoredEvent] = []
-
-    async def consumer() -> None:
-        async for event in store.subscribe_events("run-1"):
-            collected.append(event)
-
-    task = asyncio.create_task(consumer())
-    await asyncio.sleep(0.01)
+    collected, task = await _subscribe_and_collect(store, "run-1")
 
     # Make client.create raise to simulate persistence failure
     original_create = store._client.create
@@ -766,11 +745,9 @@ async def test_persist_error_does_not_block_in_memory_delivery(
 
     await store.append_event("run-1", make_envelope(seq_label=0))
     await store.append_event("run-1", make_envelope(seq_label=1))
-    # Let the consumer task process queue items
-    await asyncio.sleep(0.01)
 
     # Subscriber should still receive events via in-memory queue
-    assert len(collected) == 2
+    await _wait_collected_count(collected, 2)
 
     # The failed tasks are still pending — _regroup_events would raise
     with pytest.raises(RuntimeError, match="simulated API failure"):

--- a/packages/llama-agents-server/tests/server/test_durable_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_durable_runtime.py
@@ -86,15 +86,16 @@ async def wait_handler_idle(
     handler_id: str,
     max_duration: float = 5.0,
     interval: float = 0.05,
-) -> None:
+) -> PersistentHandler:
     """Wait until a handler has idle_since set."""
 
-    async def check() -> None:
+    async def check() -> PersistentHandler:
         found = await store.query(HandlerQuery(handler_id_in=[handler_id]))
         assert len(found) == 1
         assert found[0].idle_since is not None
+        return found[0]
 
-    await wait_for_passing(check, max_duration=max_duration, interval=interval)
+    return await wait_for_passing(check, max_duration=max_duration, interval=interval)
 
 
 async def wait_run_released(
@@ -107,6 +108,36 @@ async def wait_run_released(
 
     async def check() -> None:
         assert run_id not in idle_release._active_run_ids
+
+    await wait_for_passing(check, max_duration=max_duration, interval=interval)
+
+
+async def wait_handler_idle_and_released(
+    store: AbstractWorkflowStore,
+    handler_id: str,
+    idle_release: IdleReleaseDecorator,
+    run_id: str,
+    max_duration: float = 5.0,
+) -> PersistentHandler:
+    """Wait for the durable idle marker before asserting memory release."""
+    handler = await wait_handler_idle(store, handler_id, max_duration=max_duration)
+    await wait_run_released(idle_release, run_id, max_duration=max_duration)
+    return handler
+
+
+async def wait_state_value(
+    store: AbstractWorkflowStore,
+    run_id: str,
+    key: str,
+    expected: object,
+    max_duration: float = 5.0,
+    interval: float = 0.05,
+) -> None:
+    """Wait until the run state store contains the expected value."""
+
+    async def check() -> None:
+        state_store = store.create_state_store(run_id)
+        assert await state_store.get(key) == expected
 
     await wait_for_passing(check, max_duration=max_duration, interval=interval)
 
@@ -133,15 +164,12 @@ async def test_idle_handler_released_from_memory(
 
         idle_release = _get_idle_release(server)
 
-        await wait_run_released(idle_release, run_id)
-
-        # Should still exist in store with status running
-        persisted = await memory_store.query(
-            HandlerQuery(handler_id_in=["idle-release-1"])
+        handler = await wait_handler_idle_and_released(
+            memory_store, "idle-release-1", idle_release, run_id
         )
-        assert len(persisted) == 1
-        assert persisted[0].status == "running"
-        assert persisted[0].idle_since is not None
+
+        # Should still exist in store with status running.
+        assert handler.status == "running"
 
 
 @pytest.mark.asyncio
@@ -161,8 +189,9 @@ async def test_released_handler_reloaded_on_event(
 
         idle_release = _get_idle_release(server)
 
-        # Wait for release
-        await wait_run_released(idle_release, run_id)
+        await wait_handler_idle_and_released(
+            memory_store, "reload-test-1", idle_release, run_id
+        )
 
         # Send event to wake it up
         await server._service.send_event(
@@ -192,12 +221,12 @@ async def test_idle_since_cleared_on_reload(
 
         idle_release = _get_idle_release(server)
 
-        # Wait for release
-        await wait_run_released(idle_release, run_id)
+        handler = await wait_handler_idle_and_released(
+            memory_store, "idle-clear-1", idle_release, run_id
+        )
 
         # Verify idle_since is set
-        found = await memory_store.query(HandlerQuery(handler_id_in=["idle-clear-1"]))
-        assert found[0].idle_since is not None
+        assert handler.idle_since is not None
 
         # Send event to trigger reload
         await server._service.send_event(
@@ -415,7 +444,6 @@ async def test_on_server_start_ignores_idle_handlers(
         idle_release = _get_idle_release(server)
         persistence = _get_persistence(server)
 
-        # Give the resume task time to run
         async def resume_done() -> None:
             assert persistence.resume_task is not None
             assert persistence.resume_task.done()
@@ -437,9 +465,12 @@ async def test_destroy_cancels_resume_task(
         assert persistence.resume_task is not None
 
     # After contextmanager exits, destroy() was called.
-    # Give the event loop a chance to finalize the cancellation.
-    await asyncio.sleep(0.05)
-    assert persistence.resume_task.cancelled() or persistence.resume_task.done()
+    async def resume_task_stopped() -> None:
+        resume_task = persistence.resume_task
+        assert resume_task is not None
+        assert resume_task.cancelled() or resume_task.done()
+
+    await wait_for_passing(resume_task_stopped, max_duration=2.0, interval=0.01)
 
 
 @pytest.mark.asyncio
@@ -461,9 +492,11 @@ async def test_destroy_aborts_active_runs(
 
         await wait_for_passing(run_is_active, max_duration=2.0, interval=0.01)
 
-    # After exit, active runs should be cleared
-    await asyncio.sleep(0.05)
-    assert len(idle_release._active_run_ids) == 0
+    # After exit, active runs should be cleared.
+    async def active_runs_cleared() -> None:
+        assert len(idle_release._active_run_ids) == 0
+
+    await wait_for_passing(active_runs_cleared, max_duration=2.0, interval=0.01)
 
 
 @pytest.mark.asyncio
@@ -560,8 +593,11 @@ async def test_workflow_cancelled_after_all_retries_fail(
     server.add_workflow("test", simple_test_workflow)
     # Use instant retries with only 2 attempts
     server._runtime._persistence_backoff = [0, 0]
+    fail_count = 0
 
     async def always_fail(*args: object, **kwargs: object) -> None:
+        nonlocal fail_count
+        fail_count += 1
         raise RuntimeError("permanent store failure")
 
     memory_store.update_handler_status = always_fail  # type: ignore[assignment]
@@ -569,8 +605,10 @@ async def test_workflow_cancelled_after_all_retries_fail(
     async with server.contextmanager():
         await server._service.start_workflow(simple_test_workflow, "retry-fail-1")
 
-        # Give the workflow time to run and fail through retries
-        await asyncio.sleep(0.5)
+        async def retries_exhausted() -> None:
+            assert fail_count > 2
+
+        await wait_for_passing(retries_exhausted, max_duration=2.0, interval=0.01)
 
         # The handler should NOT have reached "completed" status
         found = await memory_store.query(HandlerQuery(handler_id_in=["retry-fail-1"]))
@@ -870,7 +908,7 @@ async def test_multistep_hitl_broker_state_survives_restart(
     ].run_id
     assert run_id is not None
     state_store = sqlite_store.create_state_store(run_id)
-    assert await state_store.get("step") == "waiting_for_human_1"
+    await wait_state_value(sqlite_store, run_id, "step", "waiting_for_human_1")
     assert await state_store.get("step1_value") == "step1_complete"
 
     # Phase 2: Restart server, send first human input, let it reach second wait
@@ -935,7 +973,7 @@ async def test_multistep_hitl_multiple_restarts_at_same_wait_point(
     assert run_id is not None
 
     # Restart server 3 times without sending any events - state should be preserved
-    for i in range(3):
+    for _ in range(3):
         server_n = _make_server()
 
         async with server_n.contextmanager():
@@ -948,14 +986,12 @@ async def test_multistep_hitl_multiple_restarts_at_same_wait_point(
 
             await wait_for_passing(resume_done, max_duration=2.0, interval=0.05)
 
-            # Handler should still be idle (not resumed by _on_server_start)
-            found = await sqlite_store.query(HandlerQuery(handler_id_in=[handler_id]))
-            assert found[0].status == "running"
-            assert found[0].idle_since is not None
+            # Handler should still be idle (not resumed by _on_server_start).
+            handler = await wait_handler_idle(sqlite_store, handler_id)
+            assert handler.status == "running"
 
     # State should still be intact after multiple restarts
-    ss = sqlite_store.create_state_store(run_id)
-    assert await ss.get("step") == "waiting_for_human_1"
+    await wait_state_value(sqlite_store, run_id, "step", "waiting_for_human_1")
 
     # Now actually send the events and complete the workflow
     server_final = _make_server()
@@ -1028,8 +1064,9 @@ async def test_concurrent_send_event_to_idle_handler(
 
         idle_release = _get_idle_release(server)
 
-        # Wait for release to idle
-        await wait_run_released(idle_release, run_id)
+        await wait_handler_idle_and_released(
+            memory_store, "concurrent-1", idle_release, run_id
+        )
 
         # Fire two send_event calls concurrently
         results = await asyncio.gather(
@@ -1084,8 +1121,9 @@ async def test_failed_workflow_after_reload(
 
         idle_release = _get_idle_release(server)
 
-        # Wait for handler to become idle (waiting for FailAfterWaitEvent)
-        await wait_run_released(idle_release, run_id)
+        await wait_handler_idle_and_released(
+            memory_store, "fail-reload-1", idle_release, run_id
+        )
 
         # Send error event to trigger RuntimeError in the workflow
         await server._service.send_event(
@@ -1150,11 +1188,10 @@ async def test_counter_state_persists_across_idle_reload(
         assert run_id is not None
 
         idle_release = _get_idle_release(server)
-        await wait_run_released(idle_release, run_id)
+        await wait_handler_idle_and_released(store, handler_id, idle_release, run_id)
 
         # Verify count=1 after the start step
-        state_store = store.create_state_store(run_id)
-        assert await state_store.get("count") == 1
+        await wait_state_value(store, run_id, "count", 1)
 
         # Send event to reload and increment again
         await server._service.send_event(handler_id, IncrementEvent())

--- a/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
@@ -14,6 +14,7 @@ from llama_agents.server._store.abstract_workflow_store import (
     Status,
 )
 from llama_agents.server._store.postgres_workflow_store import PostgresWorkflowStore
+from server_test_fixtures import wait_for_passing  # type: ignore[import]
 from workflows.events import Event, StopEvent
 
 
@@ -97,15 +98,19 @@ async def test_on_notify_wakes_condition() -> None:
     condition = store._get_or_create_condition("run-1")
 
     woken = False
+    waiting = asyncio.Event()
 
     async def waiter() -> None:
         nonlocal woken
         async with condition:
+            waiting.set()
             await condition.wait()
             woken = True
 
     task = asyncio.create_task(waiter())
-    await asyncio.sleep(0.01)
+    await waiting.wait()
+    async with condition:
+        pass
 
     # Simulate the NOTIFY callback
     store._on_notify(MagicMock(), 0, "wf_events", "run-1")
@@ -191,25 +196,24 @@ async def test_integration_subscribe_events(postgres_dsn: str) -> None:
 
         run_id = "pg-run-sub"
 
-        async def append_events() -> None:
-            await asyncio.sleep(0.05)
-            await store.append_event(run_id, _make_event())
-            await asyncio.sleep(0.05)
-            await store.append_event(run_id, _make_event())
-            await asyncio.sleep(0.05)
-            await store.append_event(run_id, _make_stop_event())
-
         async def subscribe() -> list[object]:
             collected = []
             async for event in store.subscribe_events(run_id):
                 collected.append(event)
             return collected
 
-        append_task = asyncio.create_task(append_events())
         subscribe_task = asyncio.create_task(subscribe())
 
+        async def subscribed() -> None:
+            assert run_id in store._conditions
+
+        await wait_for_passing(subscribed, max_duration=2.0, interval=0.01)
+
+        await store.append_event(run_id, _make_event())
+        await store.append_event(run_id, _make_event())
+        await store.append_event(run_id, _make_stop_event())
+
         collected = await asyncio.wait_for(subscribe_task, timeout=5.0)
-        await append_task
 
         assert len(collected) == 3
     finally:

--- a/packages/llama-agents-server/tests/server/test_server_endpoints.py
+++ b/packages/llama-agents-server/tests/server/test_server_endpoints.py
@@ -23,6 +23,7 @@ from llama_index_instrumentation.dispatcher import active_instrument_tags
 from server_test_fixtures import (
     ExternalEvent,  # type: ignore[import]
     wait_for_passing,  # type: ignore[import]
+    wait_for_requested_external_event,  # type: ignore[import]
 )
 from workflows import Context, step
 
@@ -452,12 +453,13 @@ async def test_get_workflow_result_error(
     assert "handler_id" in data
     handler_id = data["handler_id"]
 
-    await asyncio.sleep(0.1)
-
     # get result
-    response = await client.get(f"/handlers/{handler_id}")
-    assert response.status_code == 500
-    data = response.json()
+    async def _wait_failed() -> dict[str, Any]:
+        response = await client.get(f"/handlers/{handler_id}")
+        assert response.status_code == 500
+        return response.json()
+
+    data = await wait_for_passing(_wait_failed)
     assert "error" in data
     assert "Test error" in data["error"]
     assert data["status"] == "failed"
@@ -881,14 +883,15 @@ async def test_get_handlers_filters_multiple_status_params(
 
 
 @pytest.mark.asyncio
-async def test_post_event_to_running_workflow(client: AsyncClient) -> None:
+async def test_post_event_to_running_workflow(
+    client: AsyncClient, server: WorkflowServer
+) -> None:
     # Start an interactive workflow
     response = await client.post("/workflows/interactive/run-nowait", json={})
     assert response.status_code == 200
     handler_id = response.json()["handler_id"]
 
-    # Wait a bit for workflow to start
-    await asyncio.sleep(0.1)
+    await wait_for_requested_external_event(server._service.store, handler_id)
 
     serializer = JsonSerializer()
     event = ExternalEvent(response="Hello from test")
@@ -908,15 +911,14 @@ async def test_post_event_to_running_workflow(client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_post_event_simple_schema_to_running_workflow(
-    client: AsyncClient,
+    client: AsyncClient, server: WorkflowServer
 ) -> None:
     # Start an interactive workflow
     response = await client.post("/workflows/interactive/run-nowait", json={})
     assert response.status_code == 200
     handler_id = response.json()["handler_id"]
 
-    # Wait a bit for workflow to start
-    await asyncio.sleep(0.1)
+    await wait_for_requested_external_event(server._service.store, handler_id)
 
     # Send the event using type/data dict format
     event_str = '{"type": "ExternalEvent", "data": {"response": "Hello from test"}}'
@@ -933,7 +935,7 @@ async def test_post_event_simple_schema_to_running_workflow(
 
 @pytest.mark.asyncio
 async def test_post_event_with_discriminators_to_running_workflow(
-    client: AsyncClient,
+    client: AsyncClient, server: WorkflowServer
 ) -> None:
     """Test posting event using JSON serializer dict format with discriminators."""
     # Start an interactive workflow
@@ -941,8 +943,7 @@ async def test_post_event_with_discriminators_to_running_workflow(
     assert response.status_code == 200
     handler_id = response.json()["handler_id"]
 
-    # Wait a bit for workflow to start
-    await asyncio.sleep(0.1)
+    await wait_for_requested_external_event(server._service.store, handler_id)
 
     # Send event as a dict with discriminators (not as a string)
     # This is the format returned by JsonSerializer().serialize_value()
@@ -1062,7 +1063,9 @@ async def test_post_event_missing_event_data(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_handler_datetime_fields_progress(client: AsyncClient) -> None:
+async def test_handler_datetime_fields_progress(
+    client: AsyncClient, server: WorkflowServer
+) -> None:
     # Start interactive workflow which waits for an external event
     response = await client.post("/workflows/interactive/run-nowait", json={})
     assert response.status_code == 200
@@ -1078,8 +1081,9 @@ async def test_handler_datetime_fields_progress(client: AsyncClient) -> None:
     assert started_at_1 <= updated_at_1
     assert item["completed_at"] is None
 
+    await wait_for_requested_external_event(server._service.store, handler_id)
+
     # Send an external event to progress the workflow and update timestamps
-    await asyncio.sleep(0.01)
     serializer = JsonSerializer()
     event = ExternalEvent(response="ts-check")
     event_str = serializer.serialize(event)
@@ -1339,8 +1343,7 @@ async def test_stream_events_after_sequence_now_receives_future_events(
         start_resp = await client.post("/workflows/interactive/run-nowait", json={})
         handler_id = start_resp.json()["handler_id"]
 
-        # Wait until some events are stored (at least the internal dispatch)
-        await asyncio.sleep(0.1)
+        await wait_for_requested_external_event(store, handler_id)
 
         # Count events currently in the store
         found = await store.query(HandlerQuery(handler_id_in=[handler_id]))

--- a/packages/llama-agents-server/tests/server/test_workflow_service.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_service.py
@@ -17,6 +17,7 @@ from server_test_fixtures import (  # type: ignore[import]
     ErrorWorkflow,
     ExternalEvent,
     wait_for_passing,
+    wait_for_requested_external_event,
 )
 from workflows import Workflow
 
@@ -229,21 +230,9 @@ async def test_send_event_happy_path(
     )
 
     async with server.contextmanager():
-        handler_data = await server._service.start_workflow(
-            interactive_workflow, "send-hp-1"
-        )
+        await server._service.start_workflow(interactive_workflow, "send-hp-1")
 
-        # Wait for the workflow to emit the InputRequiredEvent (meaning it's waiting)
-        run_id = handler_data.run_id
-        assert run_id is not None
-
-        async def handler_emitted_input_required() -> None:
-            events = await memory_store.query_events(run_id)
-            assert any(e.event.type == "RequestedExternalEvent" for e in events)
-
-        await wait_for_passing(
-            handler_emitted_input_required, max_duration=2.0, interval=0.01
-        )
+        await wait_for_requested_external_event(memory_store, "send-hp-1")
 
         await server._service.send_event("send-hp-1", ExternalEvent(response="pong"))
 

--- a/packages/llama-agents-server/tests/server/test_workflow_store_events.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_store_events.py
@@ -18,6 +18,7 @@ from llama_agents_integration_tests.fake_agent_data import (
     FakeAgentDataBackend,
     create_agent_data_store,
 )
+from server_test_fixtures import wait_for_passing  # type: ignore[import]
 from workflows.events import (
     Event,
     StopEvent,
@@ -60,17 +61,34 @@ async def _subscribe_and_collect(
 ) -> tuple[list[StoredEvent], asyncio.Task[None]]:
     """Subscribe to events, returning the collected list and the consumer task."""
     collected: list[StoredEvent] = []
-    started = asyncio.Event()
 
     async def consumer() -> None:
-        started.set()
         kwargs = {} if after_sequence is None else {"after_sequence": after_sequence}
         async for event in store.subscribe_events(run_id, **kwargs):
             collected.append(event)
 
+    subscriber_queues = getattr(store, "_subscriber_queues", None)
+    existing_queue_count = (
+        len(subscriber_queues.get(run_id, ()))
+        if subscriber_queues is not None
+        else None
+    )
     task = asyncio.create_task(consumer())
-    await started.wait()
-    await asyncio.sleep(0.01)
+
+    async def registered() -> None:
+        conditions = getattr(store, "_conditions", None)
+        if conditions is not None:
+            assert run_id in conditions
+            return
+
+        if subscriber_queues is not None:
+            assert existing_queue_count is not None
+            assert len(subscriber_queues.get(run_id, ())) > existing_queue_count
+            return
+
+        raise AssertionError("store does not expose subscription registration state")
+
+    await wait_for_passing(registered, max_duration=2.0, interval=0.01)
     return collected, task
 
 

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop.py
@@ -878,7 +878,7 @@ async def test_control_loop_stop_before_delay_uses_upcoming_sleep(
 ) -> None:
     """Test that stop_before_delay stops before the next sleep crosses the limit."""
     test_plugin, _ = test_plugin_with_time_machine
-    retry_delay = 0.01
+    retry_delay = 0.2
 
     class AlwaysFailsWorkflow(Workflow):
         attempt_count = 0
@@ -886,7 +886,7 @@ async def test_control_loop_stop_before_delay_uses_upcoming_sleep(
         @step(
             retry_policy=retry_policy(
                 wait=wait_fixed(retry_delay),
-                stop=stop_before_delay(0.03),
+                stop=stop_before_delay(0.6),
             )
         )
         async def always_fails(self, ev: StartEvent) -> StopEvent:

--- a/packages/llama-index-workflows/tests/test_workflow_internal_events.py
+++ b/packages/llama-index-workflows/tests/test_workflow_internal_events.py
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
 import asyncio
 
 import pytest
@@ -58,17 +63,27 @@ class ExampleWorkflowDictState(Workflow):
 
 
 class ExampleWorkflowMultiWorkers(Workflow):
+    def __init__(self) -> None:
+        super().__init__()
+        self._running_event_ids: set[str] = set()
+        self._all_workers_running = asyncio.Event()
+
     @step
     async def first_step(self, ev: StartEvent, ctx: Context) -> SomeEvent | None:
-        for _ in range(10):
-            ctx.send_event(SomeEvent(data=ev.message))
+        for i in range(10):
+            ctx.send_event(SomeEvent(data=str(i)))
         return None
 
     @step(num_workers=10)
-    async def second_step(self, ev: SomeEvent, ctx: Context) -> StopEvent:
-        # allow for each worker to process each event
-        await asyncio.sleep(0.1)
-        return StopEvent(result=ev.data)
+    async def second_step(self, ev: SomeEvent, ctx: Context) -> StopEvent | None:
+        self._running_event_ids.add(ev.data)
+        if len(self._running_event_ids) == 10:
+            self._all_workers_running.set()
+
+        await self._all_workers_running.wait()
+        if ev.data == "9":
+            return StopEvent(result=ev.data)
+        return None
 
 
 @pytest.fixture()

--- a/packages/llamactl/tests/textual/test_deployment_form.py
+++ b/packages/llamactl/tests/textual/test_deployment_form.py
@@ -1,7 +1,13 @@
-from collections.abc import Generator
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Generator
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import AsyncIterator
+from typing import Any, AsyncIterator, Protocol, TypeVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -32,7 +38,57 @@ from llama_agents.core.schema.deployments import (
 )
 from textual.app import App, ComposeResult
 from textual.containers import Container
+from textual.css.query import NoMatches
+from textual.screen import Screen
 from textual.widgets import Input
+
+TScreen = TypeVar("TScreen", bound=Screen[Any])
+
+
+class _Pilot(Protocol):
+    async def pause(self) -> None: ...
+
+
+async def _wait_for_screen(
+    app: DeploymentEditApp,
+    pilot: _Pilot,
+    screen_type: type[TScreen],
+    *,
+    condition: Callable[[TScreen], bool] | None = None,
+    timeout: float = 3.0,
+) -> TScreen:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        await pilot.pause()
+        screen = app.screen
+        if isinstance(screen, screen_type) and (condition is None or condition(screen)):
+            return screen
+
+    screen = app.screen
+    condition_text = " and matching state" if condition is not None else ""
+    raise AssertionError(
+        f"Timed out waiting for {screen_type.__name__}{condition_text}; "
+        f"current screen is {type(screen).__name__}"
+    )
+
+
+async def _wait_for_widget(
+    app: App[Any],
+    pilot: _Pilot,
+    selector: str,
+    *,
+    timeout: float = 3.0,
+) -> None:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        await pilot.pause()
+        try:
+            app.screen.query_one(selector)
+        except NoMatches:
+            continue
+        return
+
+    raise AssertionError(f"Timed out waiting for widget {selector}")
 
 
 def test_normalize_to_http_https_basic() -> None:
@@ -574,17 +630,9 @@ async def test_deployment_edit_app_end_to_end_create(mock_client: MagicMock) -> 
 
         # Click save - proceed through validation to monitor
         await pilot.click("#save")
-        await pilot.pause()
-
-        # If validation screen was pushed, simulate success
-        if isinstance(app.screen, ValidationScreen):
-            app.screen.post_message(
-                ValidationResultMessage("https://github.com/user/test-repo", None)
-            )
-            await pilot.pause()
 
         # Should now be on monitor screen
-        assert isinstance(app.screen, MonitorScreen)
+        monitor_screen = await _wait_for_screen(app, pilot, MonitorScreen)
 
         # Verify API was called correctly
         mock_client.create_deployment.assert_called_once()
@@ -594,7 +642,7 @@ async def test_deployment_edit_app_end_to_end_create(mock_client: MagicMock) -> 
         assert call_args.repo_url == "https://github.com/user/test-repo"
 
         # Close monitor to exit app
-        app.screen.post_message(MonitorCloseMessage())
+        monitor_screen.post_message(MonitorCloseMessage())
         await pilot.pause()
 
         # App should exit with deployment response
@@ -660,17 +708,9 @@ async def test_deployment_edit_app_end_to_end_update(
 
         # Click save and proceed through validation to monitor
         await pilot.click("#save")
-        await pilot.pause()
-
-        if isinstance(app.screen, ValidationScreen):
-            # Mock successful git validation
-            app.screen.post_message(
-                ValidationResultMessage("https://github.com/user/new-repo", None)
-            )
-            await pilot.pause()
 
         # Should now be on monitor screen
-        assert isinstance(app.screen, MonitorScreen)
+        monitor_screen = await _wait_for_screen(app, pilot, MonitorScreen)
 
         # Verify API was called correctly
         mock_client.update_deployment.assert_called_once()
@@ -682,7 +722,7 @@ async def test_deployment_edit_app_end_to_end_update(
         assert update_data.appserver_version == "1.0.0"
 
         # Close monitor to exit app
-        app.screen.post_message(MonitorCloseMessage())
+        monitor_screen.post_message(MonitorCloseMessage())
         await pilot.pause()
 
         # App should exit with updated deployment
@@ -712,15 +752,13 @@ async def test_deployment_edit_app_validation_cancellation(
         repo_url_input.value = "https://github.com/user/test-repo"  # type: ignore
 
         await pilot.click("#save")
-        await pilot.pause()
 
         # Should be on validation screen
-        assert isinstance(app.screen, ValidationScreen)
-        app.screen.post_message(ValidationCancelMessage())
-        await pilot.pause()
+        validation_screen = await _wait_for_screen(app, pilot, ValidationScreen)
+        validation_screen.post_message(ValidationCancelMessage())
 
         # Should return to form screen with cleared error
-        assert isinstance(app.screen, FormScreen)
+        await _wait_for_screen(app, pilot, FormScreen)
 
         # App should still be running (not exited)
         assert app.return_value is None
@@ -762,18 +800,17 @@ async def test_deployment_edit_app_validation_with_pat_update(
         repo_url_input.value = "https://github.com/user/test-repo"  # type: ignore
 
         await pilot.click("#save")
-        await pilot.pause()
 
         # Should be on validation screen
-        assert isinstance(app.screen, ValidationScreen)
+        validation_screen = await _wait_for_screen(app, pilot, ValidationScreen)
 
         # Mock successful validation with new PAT
-        app.screen.post_message(
+        validation_screen.post_message(
             ValidationResultMessage(
                 "https://github.com/user/test-repo", "new-pat-token"
             )
         )
-        await pilot.pause()
+        monitor_screen = await _wait_for_screen(app, pilot, MonitorScreen)
 
         # Verify API was called with updated PAT
         mock_client.create_deployment.assert_called_once()
@@ -781,7 +818,7 @@ async def test_deployment_edit_app_validation_with_pat_update(
         assert call_args.personal_access_token == "new-pat-token"
 
         # Now we're on monitor; close it to exit
-        app.screen.post_message(MonitorCloseMessage())
+        monitor_screen.post_message(MonitorCloseMessage())
         await pilot.pause()
 
         # App should exit with result
@@ -828,19 +865,12 @@ async def test_deployment_edit_app_multiple_save_attempts(
         name_input.value = "test-deployment"
 
         await pilot.click("#save")
-        await pilot.pause()
 
         # Proceed through validation to monitor
-        if isinstance(app.screen, ValidationScreen):
-            app.screen.post_message(
-                ValidationResultMessage("https://github.com/user/test-repo", None)
-            )
-            await pilot.pause()
-
-        assert isinstance(app.screen, MonitorScreen)
+        monitor_screen = await _wait_for_screen(app, pilot, MonitorScreen)
 
         # Close monitor to complete
-        app.screen.post_message(MonitorCloseMessage())
+        monitor_screen.post_message(MonitorCloseMessage())
         await pilot.pause()
 
         # Should complete successfully
@@ -869,11 +899,18 @@ async def test_deployment_edit_app_end_to_end_api_error(
 
         # Click save
         await pilot.click("#save")
-        await pilot.pause()
 
         # Should return to form screen with error
-        assert isinstance(app.screen, FormScreen)
-        assert app.screen.save_error == "Error saving deployment: API connection failed"
+        form_screen = await _wait_for_screen(
+            app,
+            pilot,
+            FormScreen,
+            condition=lambda screen: screen.save_error
+            == "Error saving deployment: API connection failed",
+        )
+        assert (
+            form_screen.save_error == "Error saving deployment: API connection failed"
+        )
 
         # Verify API was called
         mock_client.create_deployment.assert_called_once()
@@ -944,7 +981,7 @@ async def test_appserver_version_selector_edit_when_different(
 
         # Change selection to installed version (1.0.0)
         version_select.value = "1.0.0"  # type: ignore
-        await pilot.pause()
+        await _wait_for_widget(app, pilot, "#save")
 
         # Repo URL is already set from existing deployment, just click save
         await pilot.click("#save")


### PR DESCRIPTION
Async tests were still using short sleeps as readiness barriers. Under package and full-suite load those sleeps were enough to reorder generators, send events before workflows were waiting, or observe Textual screens mid-transition.

- Makes `merge_generators(..., stop_on_first_completion=True)` deterministic when a completed value and an exhausted generator arrive in the same wait batch.
- Replaces timing guesses in core, workflow internal-events, server external-event, idle-release, store subscription, integration stream, and Textual tests with explicit lifecycle signals.
- Adds clearer integration stream assertions so missing prompts and post-send completion failures fail differently.

Verification:
- `uv run dev -- -m 'not docker and not llamacloud'`
- `uv run dev -p llama-agents-integration-tests -- -q tests/test_server_store_matrix.py::test_send_external_event -m docker -s -n0`
- `uv run pre-commit run -a` still fails in `basedpyright` on existing repo-wide issues in `migration_utils.py`, `_migrations.py`, and Python-version handling for type-variable defaults; formatting, ruff, ty, codespell, and toml hooks pass.