### PR TITLE
llamactl: deployments apply -f

### DIFF
--- a/.changeset/llamactl-deployments-apply.md
+++ b/.changeset/llamactl-deployments-apply.md
@@ -1,0 +1,5 @@
+---
+"llamactl": minor
+---
+
+Add `llamactl deployments apply -f` and `delete -f` for declarative deployment management

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,13 @@ We use **pytest** with idiomatic pytest patterns. Follow these guidelines:
   ```
 - Comments are useful, but avoid fluff.
 - Import etiquette
-  - **Never use inline imports**
-  - **Never use `if TYPE_CHECKING` imports**
-  - Exceptions to these rules are made only when there are A) Acceptable circular imports or B) real startup performance issues
-  - When an inline import is warranted, it **must** carry a short comment explaining the deferral reason (which cycle it breaks, or what startup cost it avoids). No naked inline imports.
-  - **Put the inline import at the chokepoint, not in the leaf.** When a cycle exists, defer the import in the high-level module that orchestrates things (e.g. `workflow.py`), not via a `TYPE_CHECKING` / late-import hack in the low-level module the cycle passes through. The low-level module stays clean; the high-level module owns the deferral with a one-line rationale. Example: `workflows/workflow.py` imports `workflows.representation.validate` inline inside `_validate_graph_structure` because the `representation` package transitively imports `Workflow`; the leaf modules under `representation/` keep their normal top-level imports.
+  - **Do not use inline imports.** This is the default rule. Do not move imports into functions just to make an edit work quickly, avoid a top-level import conflict, or silence a linter/type checker.
+  - Inline imports are allowed only for two accepted conditions: circular import chokepoints and known startup-time deferrals.
+  - Circular import deferrals must have a well-defined chokepoint that owns the inline import burden. Prefer the high-level orchestration module that closes the loop, such as `workflow.py`; keep low-level leaf modules on normal top-level imports.
+  - Startup-time deferrals are only acceptable for known, measured import costs on latency-sensitive surfaces, such as fast CLI startup. Do not invent new startup deferrals casually.
+  - If a change appears to need a new inline import, first look for a normal top-level import, a better module boundary, or an existing chokepoint. Treat adding an inline import as a design exception, not a convenience.
+  - When an inline import is truly warranted, it must carry a short comment explaining the deferral reason: which cycle it breaks, or what startup cost it avoids. No naked inline imports.
+  - Put inline imports at the very beginning of the function that uses them, before other executable logic.
+  - `if TYPE_CHECKING` imports may only be used alongside one of the accepted inline-import patterns above, so the runtime import stays deferred while annotations remain typed.
+  - Do not wrap deferred-only types in string annotations. Use `from __future__ import annotations` instead.
 - Only add `__init__.py` `__all__` exports when a file is legitimately needed for public library consumption. Module level imports should not be used internally. For the most part you should never do this unless explicitly requested to do so

--- a/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
+++ b/packages/llama-agents-core/src/llama_agents/core/schema/deployments.py
@@ -287,8 +287,7 @@ class DeploymentUpdate(Base):
     """
     Patch-style update model for deployments.
 
-    Fields not included in the request will remain unchanged.
-    Fields explicitly set to None will clear/delete the field value.
+    Fields set to None remain unchanged.
 
     For secrets: provide a dict where string values add/update secrets
     and null values remove secrets.

--- a/packages/llamactl/src/llama_agents/cli/apply_yaml.py
+++ b/packages/llamactl/src/llama_agents/cli/apply_yaml.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""YAML parsing for ``llamactl deployments apply -f``.
+
+Pure parsing + validation — no network, no client calls.  Takes YAML text,
+resolves ``${VAR}`` environment variables, strips ``********`` mask sentinels,
+and validates against :class:`DeploymentDisplay`.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+import yaml
+from llama_agents.cli.display import DeploymentDisplay, DeploymentSpec
+from pydantic import ValidationError
+
+_ENV_VAR_RE = re.compile(r"\$\{([^}]+)\}")
+
+
+class ApplyYamlError(Exception):
+    """Base error for YAML apply parsing/validation failures."""
+
+
+class UnresolvedEnvVarsError(ApplyYamlError):
+    """Raised when ``${VAR}`` references cannot be resolved."""
+
+    def __init__(self, unresolved: list[str]) -> None:
+        self.unresolved = unresolved
+        super().__init__(
+            f"unresolved environment variables: {', '.join(sorted(unresolved))}"
+        )
+
+
+_ENV_STRING_SPEC_FIELDS = (
+    "repo_url",
+    "deployment_file_path",
+    "git_ref",
+    "appserver_version",
+    "personal_access_token",
+)
+
+
+def _resolve_string(text: str, unresolved: list[str]) -> str:
+    def _replacer(match: re.Match[str]) -> str:
+        var = match.group(1)
+        env_val = os.environ.get(var)
+        if env_val is None:
+            unresolved.append(var)
+            return match.group(0)  # leave ${VAR} as-is
+        return env_val
+
+    return _ENV_VAR_RE.sub(_replacer, text)
+
+
+def _resolve_spec_env_vars(spec: DeploymentSpec) -> DeploymentSpec:
+    unresolved: list[str] = []
+    updates: dict[str, Any] = {}
+
+    for field in _ENV_STRING_SPEC_FIELDS:
+        value = getattr(spec, field)
+        if isinstance(value, str):
+            updates[field] = _resolve_string(value, unresolved)
+
+    if spec.secrets is not None:
+        updates["secrets"] = {
+            name: _resolve_string(value, unresolved)
+            if isinstance(value, str)
+            else value
+            for name, value in spec.secrets.items()
+        }
+
+    if unresolved:
+        raise UnresolvedEnvVarsError(unresolved)
+    return spec.model_copy(update=updates)
+
+
+def _load_yaml_mapping(text: str) -> dict[str, Any]:
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise ApplyYamlError(f"invalid YAML: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ApplyYamlError(
+            f"expected a YAML mapping at the top level, got {type(raw).__name__}"
+        )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Main parse entry point
+# ---------------------------------------------------------------------------
+
+
+def parse_apply_yaml(text: str) -> DeploymentDisplay:
+    """Parse YAML apply input into a validated :class:`DeploymentDisplay`.
+
+    1. ``yaml.safe_load`` → dict.
+    2. Drop ``status`` (round-trip artifact from ``get -o yaml``).
+    3. Validate against :class:`DeploymentDisplay` (pydantic handles
+       ``extra="forbid"`` rejection for typos / excluded fields).
+    4. Resolve ``${VAR}`` env vars in typed string fields under ``spec``.
+    5. Strip ``********`` mask sentinels from ``spec.secrets`` and
+       ``spec.personal_access_token``.
+    6. Wrap :class:`~pydantic.ValidationError` into :class:`ApplyYamlError`.
+    """
+    raw = _load_yaml_mapping(text)
+
+    # Drop read-only status block.
+    raw.pop("status", None)
+
+    try:
+        display = DeploymentDisplay.model_validate(raw)
+    except ValidationError as exc:
+        raise ApplyYamlError(str(exc)) from exc
+
+    display = display.model_copy(update={"spec": _resolve_spec_env_vars(display.spec)})
+    return display.without_mask_sentinels()
+
+
+# ---------------------------------------------------------------------------
+# Lightweight delete helper
+# ---------------------------------------------------------------------------
+
+
+def parse_delete_yaml_name(text: str) -> str:
+    """Extract the ``name`` field from YAML for a delete operation.
+
+    No env resolution, no model validation — just pull the top-level
+    ``name`` string.
+    """
+    raw = _load_yaml_mapping(text)
+
+    name = raw.get("name")
+    if name is None:
+        raise ApplyYamlError("missing required field: name")
+    if not isinstance(name, str):
+        raise ApplyYamlError(f"name must be a string, got {type(name).__name__}")
+    return name

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -6,14 +6,18 @@ A deployment points the control plane at your Git repository and deployment file
 git ref, reads the config, and runs your app.
 """
 
+from __future__ import annotations
+
 import asyncio
-import subprocess
 from pathlib import Path
 
 import click
+import yaml
 from llama_agents.cli.commands.auth import validate_authenticated_profile
+from llama_agents.core.client.manage_client import ProjectClient
 from llama_agents.cli.param_types import DeploymentType, GitShaType
 from llama_agents.cli.styles import WARNING
+from llama_agents.core.git.git_util import is_git_repo
 from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import (
     INTERNAL_CODE_REPO_SCHEME,
@@ -24,6 +28,11 @@ from llama_agents.core.schema.deployments import (
 from rich import print as rprint
 
 from ..app import app, console
+from ..apply_yaml import (
+    ApplyYamlError,
+    parse_apply_yaml,
+    parse_delete_yaml_name,
+)
 from ..client import get_project_client, project_client_context
 from ..display import (
     PUSH_MODE_REPO_URL,
@@ -51,7 +60,6 @@ from ..utils.git_push import (
     push_to_remote,
 )
 from ..yaml_template import render as render_yaml_template
-
 
 @app.group(
     help="Deploy your app to the cloud.",
@@ -304,12 +312,7 @@ def configure_git_remote_cmd(
     """
     validate_authenticated_profile(interactive)
     try:
-        result = subprocess.run(
-            ["git", "rev-parse", "--git-dir"],
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
+        if not is_git_repo():
             raise click.ClickException("Not a git repository")
 
         deployment_id = select_deployment(
@@ -341,16 +344,37 @@ def configure_git_remote_cmd(
 @deployments.command("delete")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@click.option(
+    "-f",
+    "--filename",
+    default=None,
+    type=click.File("r"),
+    help="Path to YAML file; name is read from the file. Mutually exclusive with positional ID.",
+)
 @project_option
 @interactive_option
 def delete_deployment(
-    deployment_id: str | None, interactive: bool, project: str | None
+    deployment_id: str | None,
+    filename: click.utils.LazyFile | None,
+    interactive: bool,
+    project: str | None,
 ) -> None:
     """Delete a deployment"""
     # Keep this import local: the helper imports `questionary`, which import-time
     # profiling showed is a noticeable CLI startup cost. Avoid other local
     # imports unless instrumentation shows they are slow.
     from ..interactive_prompts.utils import confirm_action
+
+    if filename is not None and deployment_id is not None:
+        raise click.ClickException(
+            "--filename and deployment ID are mutually exclusive"
+        )
+
+    if filename is not None:
+        try:
+            deployment_id = parse_delete_yaml_name(filename.read())
+        except ApplyYamlError as exc:
+            raise click.ClickException(str(exc)) from exc
 
     validate_authenticated_profile(interactive)
     try:
@@ -374,6 +398,232 @@ def delete_deployment(
     except Exception as e:
         rprint(f"[red]Error: {e}[/red]")
         raise click.Abort()
+
+
+def _apply_push(
+    client: ProjectClient,
+    deployment_id: str,
+    git_ref: str | None,
+) -> None:
+    """Push local code to the deployment's internal bare repo.
+
+    Used in the push-then-save flow (existing push-mode → push-mode update)
+    and also called by ``_apply_push_after_save`` for the save-then-push flow.
+    Raises ``click.ClickException`` on failure.
+    """
+    api_key = get_api_key()
+    git_url = get_deployment_git_url(client.base_url, deployment_id)
+    remote_name = configure_git_remote(
+        git_url, api_key, client.project_id, deployment_id
+    )
+    local_ref, target_ref = internal_push_refspec(git_ref)
+    with console.status("pushing code..."):
+        push_result = push_to_remote(
+            remote_name, local_ref=local_ref, target_ref=target_ref
+        )
+    if push_result.returncode != 0:
+        stderr = push_result.stderr.decode(errors="replace").strip()
+        raise click.ClickException(
+            f"push failed: {stderr}\n"
+            f"To debug, try: llamactl deployments configure-git-remote {deployment_id}"
+        )
+
+
+def _apply_push_after_save(
+    client: ProjectClient,
+    deployment_id: str,
+    git_ref: str | None,
+) -> None:
+    """Push after a successful create/update (bootstrap push).
+
+    On push failure the save already succeeded, so the error message includes
+    a recovery hint. Raises ``click.ClickException`` on failure.
+    """
+    try:
+        _apply_push(client, deployment_id, git_ref)
+    except click.ClickException as exc:
+        click.echo(str(exc.message), err=True)
+        raise click.ClickException(
+            "re-run `llamactl deployments apply -f <file>` to retry the push"
+        ) from exc
+
+
+async def _apply_deployment_from_yaml(
+    client: ProjectClient, display: DeploymentDisplay, *, no_push: bool = False
+) -> None:
+    # Deferred: llamactl startup budget avoids importing httpx at module level.
+    import httpx
+
+    existing: DeploymentResponse | None = None
+    is_update = False
+
+    try:
+        if display.name is not None:
+            try:
+                existing = await client.get_deployment(display.name)
+                is_update = True
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 404:
+                    if display.generate_name is None:
+                        raise click.ClickException(
+                            "deployment not found and no generate_name provided "
+                            "for create"
+                        ) from exc
+                else:
+                    raise
+        elif not display.generate_name:
+            raise click.ClickException(
+                "YAML must include top-level 'name' or 'generate_name'"
+            )
+
+        # Pre-flight validate-repository (skipped for push-mode, dry-run,
+        # and when repo_url is unset on the update path).
+        repo_url = display.spec.repo_url
+        skip_validation = (
+            repo_url is None
+            or repo_url == ""
+            or repo_url == INTERNAL_CODE_REPO_SCHEME
+            or (is_update and "repo_url" not in display.spec.model_fields_set)
+        )
+        if not skip_validation:
+            assert repo_url is not None  # guarded by skip_validation
+            vr = await client.validate_repository(
+                repo_url=repo_url,
+                deployment_id=existing.id if existing else None,
+                pat=display.spec.personal_access_token,
+            )
+            if not vr.accessible:
+                raise click.ClickException(vr.message)
+
+        # Push ordering matrix:
+        #   (no deployment, push)    -> save then push (bootstrap)
+        #   (push, push)             -> push then save (bare repo must hold
+        #                              new ref before update resolves git_ref)
+        #   (external, push)         -> save then push (switch into push mode)
+        #   (*, external)            -> save only
+        #   (*, same-as-current)     -> save only (repo_url omitted in YAML)
+        current_is_push = (
+            existing is not None and existing.repo_url == INTERNAL_CODE_REPO_SCHEME
+        )
+        if "repo_url" not in display.spec.model_fields_set:
+            desired_is_push = current_is_push
+        elif (
+            display.spec.repo_url == ""
+            or display.spec.repo_url == INTERNAL_CODE_REPO_SCHEME
+        ):
+            desired_is_push = True
+        else:
+            desired_is_push = False
+
+        push_before_save = current_is_push and desired_is_push
+
+        if desired_is_push and no_push:
+            desired_is_push = False
+            push_before_save = False
+
+        if desired_is_push and not is_git_repo():
+            rprint(
+                f"[{WARNING}]Not in a git repo — skipping push, "
+                "server will resolve from last pushed code[/]"
+            )
+            desired_is_push = False
+            push_before_save = False
+
+        # Execute: translate, optionally push, and call the API.
+        if push_before_save:
+            assert existing is not None and display.name is not None
+            _apply_push(
+                client,
+                existing.id,
+                display.spec.git_ref or existing.git_ref,
+            )
+            payload = display.to_update_payload()
+            response = await client.update_deployment(display.name, payload)
+            click.echo(f"updated {response.id}")
+        elif is_update:
+            assert display.name is not None
+            payload = display.to_update_payload()
+            response = await client.update_deployment(display.name, payload)
+            click.echo(f"updated {response.id}")
+            if desired_is_push:
+                _apply_push_after_save(client, response.id, display.spec.git_ref)
+        else:
+            payload = display.to_create_payload()
+            response = await client.create_deployment(payload)
+            click.echo(f"created {response.id}")
+            if desired_is_push:
+                _apply_push_after_save(client, response.id, display.spec.git_ref)
+
+    except click.ClickException:
+        raise
+    except httpx.HTTPStatusError:
+        raise
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+@deployments.command("apply")
+@global_options
+@click.option(
+    "-f",
+    "--filename",
+    required=True,
+    type=click.File("r"),
+    help="Path to YAML file, or '-' for stdin.",
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    default=False,
+    help="Validate and print the resolved payload without making API calls.",
+)
+@click.option(
+    "--no-push",
+    is_flag=True,
+    default=False,
+    help="Skip pushing local code even when the deployment uses push-mode.",
+)
+@project_option
+def apply_deployment(
+    filename: click.utils.LazyFile,
+    dry_run: bool,
+    no_push: bool,
+    project: str | None,
+) -> None:
+    """Apply a deployment from a YAML file.
+
+    Creates the deployment if it doesn't exist, or updates it if it does.
+    Reads the file (or stdin with ``-f -``), resolves ``${VAR}`` references
+    from the environment, and issues the appropriate API call.
+    """
+    text = filename.read()
+    try:
+        display = parse_apply_yaml(text)
+    except ApplyYamlError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    if dry_run:
+        if display.name:
+            verdict = f"would upsert deployment '{display.name}'"
+        elif display.generate_name:
+            verdict = f"would create deployment '{display.generate_name}'"
+        else:
+            raise click.ClickException(
+                "YAML must include top-level 'name' or 'generate_name'"
+            )
+
+        click.echo(
+            yaml.safe_dump(
+                display.spec.as_redacted().model_dump(mode="json", exclude_unset=True),
+                sort_keys=False,
+            )
+        )
+        click.echo(verdict)
+        return
+
+    validate_authenticated_profile(interactive=False)
+    client = get_project_client(project_id_override=project)
+    asyncio.run(_apply_deployment_from_yaml(client, display, no_push=no_push))
 
 
 @deployments.command("edit")
@@ -431,9 +681,7 @@ def _push_internal_for_update(
     This ensures the S3-stored bare repo has the latest commits so the
     server can resolve the ref to a fresh SHA.
     """
-    # Check we're in a git repo
-    result = subprocess.run(["git", "rev-parse", "--git-dir"], capture_output=True)
-    if result.returncode != 0:
+    if not is_git_repo():
         rprint(
             f"[{WARNING}]Not in a git repo — skipping push, "
             "server will resolve from last pushed code[/]"

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -10,11 +10,11 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 
 import click
 import yaml
 from llama_agents.cli.commands.auth import validate_authenticated_profile
-from llama_agents.core.client.manage_client import ProjectClient
 from llama_agents.cli.param_types import DeploymentType, GitShaType
 from llama_agents.cli.styles import WARNING
 from llama_agents.core.git.git_util import is_git_repo
@@ -60,6 +60,7 @@ from ..utils.git_push import (
     push_to_remote,
 )
 from ..yaml_template import render as render_yaml_template
+
 
 @app.group(
     help="Deploy your app to the cloud.",
@@ -401,7 +402,7 @@ def delete_deployment(
 
 
 def _apply_push(
-    client: ProjectClient,
+    client: Any,
     deployment_id: str,
     git_ref: str | None,
 ) -> None:
@@ -430,7 +431,7 @@ def _apply_push(
 
 
 def _apply_push_after_save(
-    client: ProjectClient,
+    client: Any,
     deployment_id: str,
     git_ref: str | None,
 ) -> None:
@@ -449,7 +450,7 @@ def _apply_push_after_save(
 
 
 async def _apply_deployment_from_yaml(
-    client: ProjectClient, display: DeploymentDisplay, *, no_push: bool = False
+    client: Any, display: DeploymentDisplay, *, no_push: bool = False
 ) -> None:
     # Deferred: llamactl startup budget avoids importing httpx at module level.
     import httpx

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -29,7 +29,9 @@ from typing import Any, Callable, Literal, Union, get_args, get_origin
 
 from llama_agents.cli.render import format_iso_z, gh_short, short_sha, star_marker
 from llama_agents.core.schema.deployments import (
+    DeploymentCreate,
     DeploymentResponse,
+    DeploymentUpdate,
     LlamaDeploymentPhase,
     ReleaseHistoryItem,
 )
@@ -248,9 +250,10 @@ class DeploymentSpec(BaseModel):
         str | None,
         Column("REPO", format=gh_short, default="-"),
         Doc(
-            '"" = push your local working tree on apply.\n'
-            '"internal://" = reuse a previously-pushed working tree.\n'
-            "https://… = remote git URL (GitHub, GitLab, etc.)."
+            '"" = push your local working tree (use for new deployments).\n'
+            '"internal://" = push your local working tree (use for existing deployments).\n'
+            "https://… = remote git URL (GitHub, GitLab, etc.).\n"
+            "Omit to keep the current value without pushing."
         ),
     ] = None
     deployment_file_path: Annotated[
@@ -284,6 +287,18 @@ class DeploymentSpec(BaseModel):
         str | None,
         TrailingDoc("private-repo access (GitHub PAT, GitLab access token)"),
     ] = None
+
+    def as_redacted(self) -> DeploymentSpec:
+        """Return a copy with secret values masked for display-only output."""
+        updates: dict[str, Any] = {}
+        if self.secrets is not None:
+            updates["secrets"] = {
+                name: None if value is None else SECRET_MASK
+                for name, value in self.secrets.items()
+            }
+        if self.personal_access_token is not None:
+            updates["personal_access_token"] = SECRET_MASK
+        return self.model_copy(update=updates)
 
 
 class DeploymentStatus(BaseModel):
@@ -384,6 +399,75 @@ class DeploymentDisplay(BaseModel):
         if self.status is not None:
             data["status"] = self.status.model_dump(mode="json")
         return data
+
+    def without_mask_sentinels(self) -> DeploymentDisplay:
+        """Return a copy with apply-unsafe mask sentinel values removed."""
+        spec_data = self.spec.model_dump(mode="json", exclude_unset=True)
+        stripped_spec = strip_masks(spec_data)
+        if stripped_spec == spec_data:
+            return self
+
+        data = self.model_dump(mode="json", exclude_unset=True)
+        data["spec"] = stripped_spec
+        return DeploymentDisplay.model_validate(data)
+
+    def to_create_payload(self) -> DeploymentCreate:
+        """Translate this display model into the create wire model."""
+        spec = self.spec
+
+        if spec.suspended is not None:
+            raise ValueError(
+                "cannot create a deployment as suspended; "
+                "create it first, then update with --suspended"
+            )
+
+        if spec.secrets is not None:
+            none_keys = [k for k, v in spec.secrets.items() if v is None]
+            if none_keys:
+                raise ValueError(
+                    f"cannot delete secrets on create "
+                    f"(null values for: {', '.join(sorted(none_keys))})"
+                )
+            secrets = {k: v for k, v in spec.secrets.items() if v is not None}
+        else:
+            secrets = None
+
+        if self.generate_name is None:
+            raise ValueError("generate_name is required on create")
+
+        return DeploymentCreate(
+            id=self.name,
+            display_name=self.generate_name,
+            repo_url=spec.repo_url if spec.repo_url is not None else "",
+            deployment_file_path=spec.deployment_file_path,
+            git_ref=spec.git_ref,
+            appserver_version=spec.appserver_version,
+            personal_access_token=spec.personal_access_token,
+            secrets=secrets,
+        )
+
+    def to_update_payload(self) -> DeploymentUpdate:
+        """Translate this display model into the patch-style update wire model."""
+        spec = self.spec
+
+        # PAT semantics:
+        #   explicit null in YAML  -> "" on wire (delete sentinel)
+        #   string value           -> set as given
+        #   not present            -> None (unchanged by the patch model)
+        pat = spec.personal_access_token
+        if "personal_access_token" in spec.model_fields_set and pat is None:
+            pat = ""
+
+        return DeploymentUpdate(
+            display_name=self.generate_name,
+            repo_url=spec.repo_url,
+            deployment_file_path=spec.deployment_file_path,
+            git_ref=spec.git_ref,
+            personal_access_token=pat,
+            secrets=spec.secrets,
+            appserver_version=spec.appserver_version,
+            suspended=spec.suspended,
+        )
 
 
 class ReleaseDisplay(BaseModel):

--- a/packages/llamactl/src/llama_agents/cli/options.py
+++ b/packages/llamactl/src/llama_agents/cli/options.py
@@ -4,6 +4,7 @@ import os
 from typing import Any, Callable, ParamSpec, TypeVar
 
 import click
+import yaml
 from llama_agents.cli.interactive_prompts.session_utils import is_interactive_session
 from llama_agents.cli.param_types import ProjectType
 from pydantic import BaseModel
@@ -56,7 +57,7 @@ def output_option(f: Callable[P, R]) -> Callable[P, R]:
 def output_option_with_template(f: Callable[P, R]) -> Callable[P, R]:
     """Variant of :func:`output_option` that adds the ``template`` choice.
 
-    ``template`` emits the apply-shaped YAML scaffold (annotated with ``#!``
+    ``template`` emits the apply-shaped YAML scaffold (annotated with ``##``
     docs, suitable for ``llamactl deployments apply -f``). It only makes sense
     on a single-row read (``deployments get <name>``) and is opted-in per
     command rather than advertised on every ``-o``-bearing command.
@@ -161,10 +162,6 @@ def render_output(
         click.echo(json.dumps(_to_json_safe(payload), indent=2))
         return
     if mode == "yaml":
-        # Defer pyyaml import: it's a measurable chunk of CLI startup and
-        # only paid for by the (rare) `-o yaml` path.
-        import yaml
-
         click.echo(yaml.safe_dump(_to_json_safe(payload), sort_keys=False))
         return
 

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -240,11 +240,8 @@ def _trailing_doc(info: FieldInfo | None) -> str | None:
 
 
 def _required_docs(docs: tuple[str, ...]) -> tuple[str, ...]:
-    """Prefix required state onto the first doc line, or emit a fallback."""
-    if not docs:
-        return ("REQUIRED.",)
-    first, *rest = docs
-    return (f"REQUIRED. {first}", *rest)
+    """Insert a REQUIRED marker above the existing doc lines."""
+    return ("REQUIRED.", *docs)
 
 
 def _one_line(value: str | None) -> str | None:

--- a/packages/llamactl/tests/test_apply_yaml.py
+++ b/packages/llamactl/tests/test_apply_yaml.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``cli.apply_yaml`` — YAML parsing for ``deployments apply -f``."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from llama_agents.cli.apply_yaml import (
+    ApplyYamlError,
+    UnresolvedEnvVarsError,
+    parse_apply_yaml,
+    parse_delete_yaml_name,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+MINIMAL_YAML = textwrap.dedent("""\
+    name: my-app
+    spec:
+      repo_url: https://github.com/example/repo
+""")
+
+
+def _yaml_with_spec(**spec_fields: object) -> str:
+    """Build a minimal YAML doc with arbitrary spec fields."""
+    lines = ["name: my-app", "spec:"]
+    for k, v in spec_fields.items():
+        lines.append(f"  {k}: {v}")
+    return "\n".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# parse_apply_yaml — basics
+# ---------------------------------------------------------------------------
+
+
+def test_parse_basic_name_and_repo() -> None:
+    display = parse_apply_yaml(MINIMAL_YAML)
+    assert display.name == "my-app"
+    assert display.spec.repo_url == "https://github.com/example/repo"
+
+
+def test_parse_drops_status_key() -> None:
+    """Round-trip from ``get -o yaml`` includes ``status``; parse strips it."""
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+        status:
+          phase: Running
+          project_id: proj_default
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.name == "my-app"
+    assert display.status is None
+
+
+def test_parse_unknown_spec_field_raises() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          image_tag: latest
+    """)
+    with pytest.raises(ApplyYamlError, match="image_tag"):
+        parse_apply_yaml(doc)
+
+
+def test_parse_unknown_spec_field_rebuild_raises() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          rebuild: true
+    """)
+    with pytest.raises(ApplyYamlError, match="rebuild"):
+        parse_apply_yaml(doc)
+
+
+# ---------------------------------------------------------------------------
+# Environment variable resolution
+# ---------------------------------------------------------------------------
+
+
+def test_env_var_resolves(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MY_REPO", "https://github.com/resolved/repo")
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: ${MY_REPO}
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.spec.repo_url == "https://github.com/resolved/repo"
+
+
+def test_env_var_multiple_in_one_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("HOST", "example.com")
+    monkeypatch.setenv("PORT", "8080")
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://${HOST}:${PORT}/repo
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.spec.repo_url == "https://example.com:8080/repo"
+
+
+def test_env_var_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MISSING_VAR", raising=False)
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: ${MISSING_VAR}
+    """)
+    with pytest.raises(UnresolvedEnvVarsError) as exc_info:
+        parse_apply_yaml(doc)
+    assert "MISSING_VAR" in exc_info.value.unresolved
+
+
+def test_env_var_multiple_missing_listed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AAA", raising=False)
+    monkeypatch.delenv("BBB", raising=False)
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: ${AAA}/${BBB}
+    """)
+    with pytest.raises(UnresolvedEnvVarsError) as exc_info:
+        parse_apply_yaml(doc)
+    assert "AAA" in exc_info.value.unresolved
+    assert "BBB" in exc_info.value.unresolved
+
+
+def test_env_var_in_unknown_field_is_not_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MISSING_VAR", raising=False)
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          image_tag: ${MISSING_VAR}
+    """)
+    with pytest.raises(ApplyYamlError, match="image_tag"):
+        parse_apply_yaml(doc)
+
+
+def test_env_var_in_non_string_field_is_not_resolved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MISSING_VAR", raising=False)
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          suspended: ${MISSING_VAR}
+    """)
+    with pytest.raises(ApplyYamlError, match="suspended"):
+        parse_apply_yaml(doc)
+
+
+def test_env_var_in_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SECRET_VAL", "s3cret")
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          secrets:
+            MY_SECRET: ${SECRET_VAL}
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.spec.secrets is not None
+    assert display.spec.secrets["MY_SECRET"] == "s3cret"
+
+
+# ---------------------------------------------------------------------------
+# Mask passthrough (strip SECRET_MASK values)
+# ---------------------------------------------------------------------------
+
+
+def test_mask_pat_stripped() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          personal_access_token: "********"
+    """)
+    display = parse_apply_yaml(doc)
+    # Masked PAT is stripped — field not set on the model.
+    assert "personal_access_token" not in display.spec.model_fields_set
+
+
+def test_mask_secret_entry_stripped() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          secrets:
+            FOO: "********"
+    """)
+    display = parse_apply_yaml(doc)
+    # All entries masked → secrets key itself dropped.
+    assert display.spec.secrets is None or "FOO" not in display.spec.secrets
+
+
+def test_mask_partial_secrets() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          secrets:
+            FOO: "********"
+            BAR: real-value
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.spec.secrets is not None
+    assert "FOO" not in display.spec.secrets
+    assert display.spec.secrets["BAR"] == "real-value"
+
+
+# ---------------------------------------------------------------------------
+# Null handling
+# ---------------------------------------------------------------------------
+
+
+def test_null_pat_preserved() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          personal_access_token: null
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.spec.personal_access_token is None
+    assert "personal_access_token" in display.spec.model_fields_set
+
+
+def test_null_secret_value_preserved() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          secrets:
+            FOO: null
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.spec.secrets is not None
+    assert display.spec.secrets["FOO"] is None
+
+
+# ---------------------------------------------------------------------------
+# generate_name
+# ---------------------------------------------------------------------------
+
+
+def test_generate_name_snake_case() -> None:
+    doc = textwrap.dedent("""\
+        generate_name: my-slug
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    display = parse_apply_yaml(doc)
+    assert display.generate_name == "my-slug"
+
+
+# ---------------------------------------------------------------------------
+# parse_delete_yaml_name
+# ---------------------------------------------------------------------------
+
+
+def test_delete_returns_name() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    assert parse_delete_yaml_name(doc) == "my-app"
+
+
+def test_delete_missing_name_raises() -> None:
+    doc = textwrap.dedent("""\
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    with pytest.raises(ApplyYamlError):
+        parse_delete_yaml_name(doc)
+
+
+def test_delete_non_string_name_raises() -> None:
+    doc = textwrap.dedent("""\
+        name: 42
+    """)
+    with pytest.raises(ApplyYamlError):
+        parse_delete_yaml_name(doc)
+
+
+def test_delete_ignores_other_fields_no_env_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No env resolution or model validation happens."""
+    monkeypatch.delenv("MISSING", raising=False)
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: ${MISSING}
+          bogus_field: whatever
+    """)
+    # Should succeed — only name is inspected.
+    assert parse_delete_yaml_name(doc) == "my-app"
+
+
+# ---------------------------------------------------------------------------
+# Schema validation error messages
+# ---------------------------------------------------------------------------
+
+
+def test_validation_error_includes_spec_prefix() -> None:
+    doc = textwrap.dedent("""\
+        name: my-app
+        spec:
+          repo_url: https://github.com/example/repo
+          bogus: nope
+    """)
+    with pytest.raises(ApplyYamlError, match="spec"):
+        parse_apply_yaml(doc)

--- a/packages/llamactl/tests/test_deployments_apply_cmd.py
+++ b/packages/llamactl/tests/test_deployments_apply_cmd.py
@@ -1,0 +1,694 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for ``deployments apply -f`` and ``delete -f`` CLI commands."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import textwrap
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+from conftest import make_deployment, patch_project_client
+from llama_agents.cli.app import app
+from llama_agents.core.schema.deployments import DeploymentResponse
+from llama_agents.core.schema.git_validation import RepositoryValidationResponse
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _http_404(deployment_id: str = "unknown") -> httpx.HTTPStatusError:
+    request = httpx.Request(
+        "GET", f"http://test/api/v1beta1/deployments/{deployment_id}"
+    )
+    response = httpx.Response(404, request=request, text='{"detail":"not found"}')
+    return httpx.HTTPStatusError("HTTP 404", request=request, response=response)
+
+
+def _http_409() -> httpx.HTTPStatusError:
+    request = httpx.Request("POST", "http://test/api/v1beta1/deployments")
+    response = httpx.Response(
+        409, request=request, text='{"detail":"conflict: deployment already exists"}'
+    )
+    return httpx.HTTPStatusError("HTTP 409", request=request, response=response)
+
+
+def _apply_client_mock(
+    *,
+    existing: DeploymentResponse | None = None,
+    created: DeploymentResponse | None = None,
+    validate_accessible: bool = True,
+) -> MagicMock:
+    """Mock client for apply tests."""
+    client = MagicMock()
+    client.project_id = "proj_default"
+    client.base_url = "http://test:8011"
+
+    if existing:
+
+        async def _get(
+            deployment_id: str, include_events: bool = False
+        ) -> DeploymentResponse:
+            if deployment_id == existing.id:
+                return existing
+            raise _http_404(deployment_id)
+
+        client.get_deployment = AsyncMock(side_effect=_get)
+    else:
+        client.get_deployment = AsyncMock(
+            side_effect=lambda *a, **kw: (_ for _ in ()).throw(_http_404())
+        )
+
+    if created:
+        client.create_deployment = AsyncMock(return_value=created)
+    else:
+        client.create_deployment = AsyncMock(return_value=make_deployment("new-app"))
+
+    client.update_deployment = AsyncMock(
+        return_value=existing or make_deployment("my-app")
+    )
+
+    async def _validate(
+        repo_url: str,
+        deployment_id: str | None = None,
+        pat: str | None = None,
+    ) -> RepositoryValidationResponse:
+        return RepositoryValidationResponse(
+            accessible=validate_accessible,
+            message="ok" if validate_accessible else "repo not found",
+        )
+
+    client.validate_repository = AsyncMock(side_effect=_validate)
+    client.delete_deployment = AsyncMock()
+
+    return client
+
+
+MINIMAL_CREATE_YAML = textwrap.dedent("""\
+    name: new-app
+    generate_name: New App
+    spec:
+      repo_url: https://github.com/example/repo
+""")
+
+MINIMAL_UPDATE_YAML = textwrap.dedent("""\
+    name: my-app
+    spec:
+      git_ref: v2
+""")
+
+
+def test_apply_creates_when_not_found(patched_auth: Any, tmp_path: Any) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(MINIMAL_CREATE_YAML)
+
+    client = _apply_client_mock(created=make_deployment("new-app"))
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.create_deployment.assert_called_once()
+    assert "created" in result.output.lower()
+    assert "new-app" in result.output
+
+
+def test_apply_updates_when_exists(patched_auth: Any, tmp_path: Any) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(MINIMAL_UPDATE_YAML)
+
+    existing = make_deployment("my-app")
+    client = _apply_client_mock(existing=existing)
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.update_deployment.assert_called_once()
+    call_args = client.update_deployment.call_args
+    assert call_args[0][0] == "my-app"
+    assert "updated" in result.output.lower()
+    assert "my-app" in result.output
+
+
+def test_apply_update_uses_one_event_loop(patched_auth: Any, tmp_path: Any) -> None:
+    loop: asyncio.AbstractEventLoop | None = None
+
+    def check_loop() -> None:
+        nonlocal loop
+        running = asyncio.get_running_loop()
+        if loop is None:
+            loop = running
+        elif running is not loop:
+            raise RuntimeError("Event loop is closed")
+
+    async def get_deployment(deployment_id: str) -> DeploymentResponse:
+        check_loop()
+        return make_deployment(deployment_id)
+
+    async def update_deployment(deployment_id: str, payload: Any) -> DeploymentResponse:
+        check_loop()
+        return make_deployment(deployment_id)
+
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(MINIMAL_UPDATE_YAML)
+
+    client = MagicMock()
+    client.project_id = "proj_default"
+    client.base_url = "http://test:8011"
+    client.get_deployment = AsyncMock(side_effect=get_deployment)
+    client.update_deployment = AsyncMock(side_effect=update_deployment)
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.update_deployment.assert_called_once()
+    assert "updated" in result.output.lower()
+
+
+def test_apply_reads_stdin(patched_auth: Any) -> None:
+    runner = CliRunner()
+    client = _apply_client_mock(created=make_deployment("new-app"))
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "apply", "-f", "-"],
+            input=MINIMAL_CREATE_YAML,
+        )
+
+    assert result.exit_code == 0, result.output
+    client.create_deployment.assert_called_once()
+    assert "new-app" in result.output
+
+
+def test_apply_generate_name_only(patched_auth: Any, tmp_path: Any) -> None:
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        generate_name: My App
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    server_returned = make_deployment("my-app-xyz", display_name="My App")
+    client = _apply_client_mock(created=server_returned)
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.create_deployment.assert_called_once()
+    create_payload = client.create_deployment.call_args[0][0]
+    assert create_payload.id is None
+    # The server-assigned id should appear in output.
+    assert "my-app-xyz" in result.output
+
+
+def test_apply_409_surfaces_error(patched_auth: Any, tmp_path: Any) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(MINIMAL_CREATE_YAML)
+
+    client = _apply_client_mock()
+    client.create_deployment = AsyncMock(side_effect=_http_409())
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code != 0
+    # HTTPStatusError is re-raised directly; the 409 info surfaces either
+    # in output (if Click wraps it) or in the exception object.
+    assert "409" in result.output or (
+        result.exception is not None and "409" in str(result.exception)
+    )
+
+
+def test_apply_dry_run_named(patched_auth: Any, tmp_path: Any) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(MINIMAL_CREATE_YAML)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+    client.update_deployment.assert_not_called()
+    assert "would" in result.output.lower()
+    assert "upsert" in result.output.lower()
+
+
+def test_apply_dry_run_generate_name_only(patched_auth: Any, tmp_path: Any) -> None:
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        generate_name: My App
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+    assert "would" in result.output.lower()
+    assert "create" in result.output.lower()
+
+
+def test_apply_dry_run_masks_resolved_secret_values(
+    patched_auth: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("API_KEY_FOR_DRY_RUN", "sk-test-secret")
+    monkeypatch.setenv("PAT_FOR_DRY_RUN", "ghp-test-secret")
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        generate_name: My App
+        spec:
+          repo_url: https://github.com/example/repo
+          secrets:
+            API_KEY: ${API_KEY_FOR_DRY_RUN}
+            DELETE_ME: null
+          personal_access_token: ${PAT_FOR_DRY_RUN}
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f), "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    client.create_deployment.assert_not_called()
+    assert "sk-test-secret" not in result.output
+    assert "ghp-test-secret" not in result.output
+    assert "API_KEY: '********'" in result.output
+    assert "DELETE_ME: null" in result.output
+    assert "personal_access_token: '********'" in result.output
+
+
+def test_apply_no_name_no_generate_name_errors(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code != 0
+    output_lower = result.output.lower()
+    assert "name" in output_lower or "generate_name" in output_lower
+
+
+def test_apply_name_without_generate_name_404_errors(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        name: new-app
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()  # get_deployment raises 404
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code != 0
+    assert "generate_name" in result.output.lower()
+
+
+def test_apply_validate_repository_blocks_create(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(MINIMAL_CREATE_YAML)
+
+    client = _apply_client_mock(validate_accessible=False)
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code != 0
+    client.create_deployment.assert_not_called()
+
+
+def test_apply_push_mode_skips_validate_repository(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        generate_name: My App
+        spec:
+          repo_url: ""
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()
+    with patch_project_client(client), _patched_git_push():
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.validate_repository.assert_not_called()
+
+
+def test_apply_env_var_resolves(
+    patched_auth: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("MY_REPO_URL", "https://github.com/env-resolved/repo")
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        name: env-app
+        generate_name: Env App
+        spec:
+          repo_url: ${MY_REPO_URL}
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock(
+        created=make_deployment(
+            "env-app", repo_url="https://github.com/env-resolved/repo"
+        )
+    )
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    # The resolved URL should have been passed to the client.
+    create_payload = client.create_deployment.call_args[0][0]
+    assert create_payload.repo_url == "https://github.com/env-resolved/repo"
+
+
+def test_apply_unresolved_env_var_errors(
+    patched_auth: Any, tmp_path: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("NONEXISTENT_VAR_FOR_TEST", raising=False)
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        name: env-app
+        generate_name: Env App
+        spec:
+          repo_url: ${NONEXISTENT_VAR_FOR_TEST}
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code != 0
+    assert "NONEXISTENT_VAR_FOR_TEST" in result.output
+
+
+def test_delete_from_file(patched_auth: Any, tmp_path: Any) -> None:
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        name: doomed-app
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(
+            app, ["deployments", "delete", "-f", str(f), "--no-interactive"]
+        )
+
+    assert result.exit_code == 0, result.output
+    client.delete_deployment.assert_called_once()
+    call_args = client.delete_deployment.call_args
+    assert call_args[0][0] == "doomed-app"
+
+
+def test_delete_file_and_positional_mutually_exclusive(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    runner = CliRunner()
+    yaml_text = "name: my-app\nspec: {}\n"
+    f = tmp_path / "deploy.yaml"
+    f.write_text(yaml_text)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "delete", "my-app", "-f", str(f), "--no-interactive"],
+        )
+
+    assert result.exit_code != 0
+    assert "mutually exclusive" in result.output.lower()
+
+
+def test_delete_reads_stdin(patched_auth: Any) -> None:
+    runner = CliRunner()
+    yaml_text = textwrap.dedent("""\
+        name: stdin-app
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
+
+    client = _apply_client_mock()
+    with patch_project_client(client):
+        result = runner.invoke(
+            app,
+            ["deployments", "delete", "-f", "-", "--no-interactive"],
+            input=yaml_text,
+        )
+
+    assert result.exit_code == 0, result.output
+    client.delete_deployment.assert_called_once()
+    call_args = client.delete_deployment.call_args
+    assert call_args[0][0] == "stdin-app"
+
+
+def _push_mode_client(
+    *,
+    existing_repo_url: str = "internal://",
+    deployment_id: str = "my-app",
+) -> MagicMock:
+    """Client mock for a push-mode deployment."""
+    existing = make_deployment(deployment_id, repo_url=existing_repo_url)
+    client = _apply_client_mock(existing=existing)
+    client.update_deployment = AsyncMock(return_value=existing)
+    return client
+
+
+_DEPLOY_CMD = "llama_agents.cli.commands.deployment"
+
+
+@contextmanager
+def _patched_git_push(
+    *, returncode: int = 0, stderr: bytes = b""
+) -> Generator[MagicMock, None, None]:
+    """Patch the three git-push helpers so push-mode tests don't hit real git.
+
+    Yields the ``push_to_remote`` mock for assertions.
+    """
+    with (
+        patch(f"{_DEPLOY_CMD}.configure_git_remote", return_value="llamaagents-test"),
+        patch(
+            f"{_DEPLOY_CMD}.push_to_remote",
+            return_value=subprocess.CompletedProcess([], returncode, stderr=stderr),
+        ) as mock_push,
+        patch(f"{_DEPLOY_CMD}.get_api_key", return_value="test-key"),
+    ):
+        yield mock_push
+
+
+def test_apply_push_mode_create_does_save_then_push(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """Create with repo_url="" → save first (POST), then push."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("generate_name: My App\nspec:\n  repo_url: ''\n  git_ref: main\n")
+
+    client = _apply_client_mock()
+    with patch_project_client(client), _patched_git_push() as mock_push:
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    assert "created new-app" in result.output
+    client.create_deployment.assert_called_once()
+    mock_push.assert_called_once()
+
+
+def test_apply_push_mode_update_does_push_then_save(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """Existing push-mode + desired push-mode → push first, then save."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  git_ref: feature-branch\n")
+
+    client = _push_mode_client()
+    with patch_project_client(client), _patched_git_push() as mock_push:
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    assert "updated my-app" in result.output
+    mock_push.assert_called_once()
+    client.update_deployment.assert_called_once()
+
+
+def test_apply_push_then_save_push_failure_aborts(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """Push-then-save: if push fails, update must NOT be called."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  git_ref: main\n")
+
+    client = _push_mode_client()
+    with (
+        patch_project_client(client),
+        _patched_git_push(returncode=1, stderr=b"push rejected"),
+    ):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code != 0
+    assert "push failed" in result.output.lower() or "push rejected" in result.output
+    client.update_deployment.assert_not_called()
+
+
+def test_apply_save_then_push_push_failure_shows_recovery(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """Save-then-push: if push fails after save, show recovery hint."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("generate_name: My App\nspec:\n  repo_url: ''\n")
+
+    client = _apply_client_mock()
+    with (
+        patch_project_client(client),
+        _patched_git_push(returncode=1, stderr=b"auth failed"),
+    ):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code != 0
+    assert "created new-app" in result.output
+    assert "re-run" in result.output.lower()
+
+
+def test_apply_external_to_push_mode_does_save_then_push(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """Switching from external repo to push-mode → save then push."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  repo_url: ''\n")
+
+    client = _push_mode_client(existing_repo_url="https://github.com/org/repo")
+    with patch_project_client(client), _patched_git_push() as mock_push:
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    assert "updated my-app" in result.output
+    client.update_deployment.assert_called_once()
+    mock_push.assert_called_once()
+
+
+def test_apply_push_to_external_does_save_only(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """Switching from push-mode to external → save only, no push."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  repo_url: https://github.com/org/new-repo\n")
+
+    client = _push_mode_client()
+    with patch_project_client(client), _patched_git_push() as mock_push:
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    assert "updated my-app" in result.output
+    mock_push.assert_not_called()
+
+
+def test_apply_internal_scheme_roundtrip_pushes(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """``get -o template`` emits ``repo_url: internal://``; re-applying that
+    YAML should treat it as push-mode and push-then-save."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  repo_url: 'internal://'\n  git_ref: main\n")
+
+    client = _push_mode_client()
+    with patch_project_client(client), _patched_git_push() as mock_push:
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    assert "updated my-app" in result.output
+    mock_push.assert_called_once()
+    client.validate_repository.assert_not_called()
+
+
+def test_apply_internal_scheme_skips_push_when_not_in_git_repo(
+    patched_auth: Any, tmp_path: Any
+) -> None:
+    """When not in a git repo, push-mode apply should skip the push
+    and still succeed (spec-only update)."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  suspended: true\n")
+
+    client = _push_mode_client()
+    with (
+        patch_project_client(client),
+        _patched_git_push() as mock_push,
+        patch(f"{_DEPLOY_CMD}.is_git_repo", return_value=False),
+    ):
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    assert "updated my-app" in result.output
+    # Push should be skipped entirely.
+    mock_push.assert_not_called()
+    # The update should still go through.
+    client.update_deployment.assert_called_once()
+
+
+def test_apply_no_push_skips_push(patched_auth: Any, tmp_path: Any) -> None:
+    """``--no-push`` suppresses the git push even when the deployment is
+    push-mode and cwd is a valid git repo."""
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  git_ref: feature-branch\n")
+
+    client = _push_mode_client()
+    with patch_project_client(client), _patched_git_push() as mock_push:
+        result = runner.invoke(app, ["deployments", "apply", "-f", str(f), "--no-push"])
+
+    assert result.exit_code == 0, result.output
+    assert "updated my-app" in result.output
+    mock_push.assert_not_called()
+    client.update_deployment.assert_called_once()

--- a/packages/llamactl/tests/test_deployments_template_cmd.py
+++ b/packages/llamactl/tests/test_deployments_template_cmd.py
@@ -153,9 +153,7 @@ def test_template_outside_git_repo_emits_compact_head_and_required_tildes(
     # ``name`` and ``generate_name`` are commented-out (server defaults the id).
     assert "  repo_url: ~" in out
     repo_idx = out.index("  repo_url: ~")
-    assert (
-        '  ## REQUIRED. "" = push your local working tree on apply.' in out[:repo_idx]
-    )
+    assert "  ## REQUIRED.\n" in out[:repo_idx]
     assert "## Required — set before `apply`." not in out
 
     # Top-level identity tier: both keys commented-out, cwd-derived defaults.

--- a/packages/llamactl/tests/test_deployments_update.py
+++ b/packages/llamactl/tests/test_deployments_update.py
@@ -92,11 +92,7 @@ def test_deployments_update_internal_repo_push_failure_does_not_abort(
 
     with (
         patch_project_client(client),
-        # ``git rev-parse --git-dir`` succeeds — we're "in a repo".
-        patch(
-            "llama_agents.cli.commands.deployment.subprocess.run",
-            return_value=_completed_process(returncode=0, stdout=b".git\n"),
-        ),
+        patch("llama_agents.cli.commands.deployment.is_git_repo", return_value=True),
         patch(
             "llama_agents.cli.commands.deployment.configure_git_remote",
             return_value="llamaagents-my-app",

--- a/packages/llamactl/tests/test_display.py
+++ b/packages/llamactl/tests/test_display.py
@@ -14,7 +14,40 @@ from llama_agents.cli.display import (
     DeploymentSpec,
     DeploymentStatus,
 )
+from llama_agents.core.schema.deployments import DeploymentCreate, DeploymentUpdate
 from pydantic import ValidationError
+
+_CREATE_SPEC_FIELDS = frozenset(
+    {
+        "repo_url",
+        "deployment_file_path",
+        "git_ref",
+        "appserver_version",
+        "secrets",
+        "personal_access_token",
+    }
+)
+_UPDATE_SPEC_FIELDS = frozenset(
+    {
+        "repo_url",
+        "deployment_file_path",
+        "git_ref",
+        "appserver_version",
+        "suspended",
+        "secrets",
+        "personal_access_token",
+    }
+)
+_HANDLED_SPEC_FIELDS = _CREATE_SPEC_FIELDS | _UPDATE_SPEC_FIELDS
+_SERVICE_UPDATE_FIELDS = frozenset(
+    {
+        "git_sha",
+        "static_assets_path",
+        "image_tag",
+        "bump_to_latest_appserver",
+        "rebuild",
+    }
+)
 
 
 def test_from_response_translates_spec_fields() -> None:
@@ -89,6 +122,181 @@ def test_from_response_pat_masking() -> None:
     response = make_deployment("my-app", has_personal_access_token=False)
     display = DeploymentDisplay.from_response(response)
     assert display.spec.personal_access_token is None
+
+
+def test_spec_as_redacted_masks_secret_values() -> None:
+    spec = DeploymentSpec(
+        repo_url="https://github.com/example/repo",
+        secrets={"API_KEY": "sk-test", "DELETE_ME": None},
+        personal_access_token="ghp-test",
+    )
+
+    data = spec.as_redacted().model_dump(mode="json", exclude_unset=True)
+
+    assert data == {
+        "repo_url": "https://github.com/example/repo",
+        "secrets": {"API_KEY": SECRET_MASK, "DELETE_ME": None},
+        "personal_access_token": SECRET_MASK,
+    }
+
+
+def test_without_mask_sentinels_removes_apply_unsafe_masks() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(
+            repo_url="https://github.com/example/repo",
+            secrets={"REAL": "value", "MASKED": SECRET_MASK},
+            personal_access_token=SECRET_MASK,
+        ),
+    )
+
+    stripped = display.without_mask_sentinels()
+
+    assert stripped.spec.secrets == {"REAL": "value"}
+    assert "personal_access_token" not in stripped.spec.model_fields_set
+
+
+def test_all_deployment_spec_fields_have_apply_semantics() -> None:
+    assert set(DeploymentSpec.model_fields) == _HANDLED_SPEC_FIELDS
+
+
+def test_create_payload_mapping_matches_wire_model_boundary() -> None:
+    assert _CREATE_SPEC_FIELDS == set(DeploymentCreate.model_fields) - {
+        "id",
+        "display_name",
+    }
+
+
+def test_update_payload_mapping_matches_wire_model_boundary() -> None:
+    assert _UPDATE_SPEC_FIELDS == (
+        set(DeploymentUpdate.model_fields) - {"display_name"} - _SERVICE_UPDATE_FIELDS
+    )
+
+
+def test_to_create_payload_with_name_sets_id() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        generate_name="My App",
+        spec=DeploymentSpec(repo_url="https://github.com/example/repo"),
+    )
+
+    payload = display.to_create_payload()
+
+    assert payload.id == "my-app"
+    assert payload.display_name == "My App"
+
+
+def test_to_create_payload_without_name_uses_generate_name() -> None:
+    display = DeploymentDisplay(
+        generate_name="My App",
+        spec=DeploymentSpec(repo_url="https://github.com/example/repo"),
+    )
+
+    payload = display.to_create_payload()
+
+    assert payload.id is None
+    assert payload.display_name == "My App"
+
+
+def test_to_create_payload_without_generate_name_raises() -> None:
+    display = DeploymentDisplay(
+        spec=DeploymentSpec(repo_url="https://github.com/example/repo"),
+    )
+
+    with pytest.raises(ValueError, match="generate_name"):
+        display.to_create_payload()
+
+
+def test_to_create_payload_suspended_raises() -> None:
+    display = DeploymentDisplay(
+        generate_name="My App",
+        spec=DeploymentSpec(
+            repo_url="https://github.com/example/repo",
+            suspended=True,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="suspended"):
+        display.to_create_payload()
+
+
+def test_to_create_payload_secrets_with_null_value_raises() -> None:
+    display = DeploymentDisplay(
+        generate_name="My App",
+        spec=DeploymentSpec(
+            repo_url="https://github.com/example/repo",
+            secrets={"FOO": None},
+        ),
+    )
+
+    with pytest.raises(ValueError, match="null values"):
+        display.to_create_payload()
+
+
+def test_to_create_payload_unset_fields_default() -> None:
+    display = DeploymentDisplay(
+        generate_name="My App",
+        spec=DeploymentSpec(repo_url="https://github.com/example/repo"),
+    )
+
+    payload = display.to_create_payload()
+
+    assert payload.git_ref is None
+
+
+def test_to_create_payload_empty_repo_url_passthrough() -> None:
+    display = DeploymentDisplay(
+        generate_name="My App",
+        spec=DeploymentSpec(repo_url=""),
+    )
+
+    payload = display.to_create_payload()
+
+    assert payload.repo_url == ""
+
+
+def test_to_update_payload_unset_fields_remain_none() -> None:
+    display = DeploymentDisplay(name="my-app", spec=DeploymentSpec(git_ref="v2"))
+
+    payload = display.to_update_payload()
+
+    assert payload.git_ref == "v2"
+    assert payload.repo_url is None
+
+
+def test_to_update_payload_null_pat_becomes_delete_sentinel() -> None:
+    display = DeploymentDisplay(
+        name="my-app", spec=DeploymentSpec(personal_access_token=None)
+    )
+
+    payload = display.to_update_payload()
+
+    assert payload.personal_access_token == ""
+
+
+def test_to_update_payload_secrets_null_values_preserved() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(secrets={"FOO": None, "BAR": "new-value"}),
+    )
+
+    payload = display.to_update_payload()
+
+    assert payload.secrets is not None
+    assert payload.secrets["FOO"] is None
+    assert payload.secrets["BAR"] == "new-value"
+
+
+def test_to_update_payload_generate_name_maps_to_display_name() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        generate_name="New Name",
+        spec=DeploymentSpec(repo_url="https://github.com/example/repo"),
+    )
+
+    payload = display.to_update_payload()
+
+    assert payload.display_name == "New Name"
 
 
 def test_to_output_dict_omits_empty_spec_fields() -> None:

--- a/packages/llamactl/tests/test_yaml_template.py
+++ b/packages/llamactl/tests/test_yaml_template.py
@@ -64,7 +64,7 @@ def test_render_emits_name_and_spec_in_declaration_order() -> None:
 def test_render_attaches_doc_marker_text_above_each_set_field() -> None:
     out = render(_full_display())
     assert "## Stable id for the deployment" in out
-    assert '## "" = push your local working tree on apply.' in out
+    assert '## "" = push your local working tree (use for new deployments).' in out
 
 
 def test_render_omits_generate_name_when_not_scaffolded() -> None:
@@ -120,7 +120,7 @@ def test_render_partial_spec_emits_unset_fields_as_commented_examples() -> None:
     assert git_ref_line == "  # git_ref: main"
 
 
-def test_render_required_unset_prefixes_first_doc_line() -> None:
+def test_render_required_unset_puts_marker_on_own_line() -> None:
     display = DeploymentDisplay(
         name="my-app",
         spec=DeploymentSpec(),
@@ -128,10 +128,10 @@ def test_render_required_unset_prefixes_first_doc_line() -> None:
     out = render(display, required=("repo_url",))
     assert "  repo_url: ~" in out
     repo_idx = out.index("  repo_url: ~")
-    assert (
-        '  ## REQUIRED. "" = push your local working tree on apply.' in out[:repo_idx]
-    )
-    assert "## Required — set before `apply`." not in out
+    before = out[:repo_idx]
+    # REQUIRED is on its own line, not concatenated with the first doc line.
+    assert "  ## REQUIRED.\n" in before
+    assert '  ## "" = push your local working tree (use for new deployments).' in before
 
 
 def test_render_unset_top_level_name_is_commented() -> None:
@@ -214,7 +214,7 @@ def test_render_doc_and_trailing_doc_emit_separately() -> None:
     marker renders on another field's scalar line."""
     out = render(_full_display())
     head = out.split("repo_url:", 1)[0]
-    assert '  ## "" = push your local working tree on apply.' in head
+    assert '  ## "" = push your local working tree (use for new deployments).' in head
     deploy_path_line = next(
         line for line in out.splitlines() if line.startswith("  deployment_file_path:")
     )


### PR DESCRIPTION
Adds file-driven deployment apply and delete.

`deployments apply -f` uses the same shape emitted by `deployments get -o yaml` and `deployments template`, so the workflow is render YAML, edit it, apply it back. The parser resolves `${VAR}` references locally, ignores existing `********` mask sentinels on round-trip, and treats `null` secret values as deletes.

Apply is a client-side upsert. The CLI checks whether the deployment exists, validates external repo URLs before save, then creates or updates. Push-mode is part of the same path: `repo_url: ""` means push the current working tree to the internal repo, with the ordering chosen so the server can resolve `git_ref` against the right commits.

`deployments delete -f` reads the top-level `name` from the same YAML shape and deletes that deployment. The file flag is mutually exclusive with the positional deployment arg.