### PR TITLE
Add opt-in workflow pressure diagnostics

### DIFF
--- a/.changeset/workflow-pressure-diagnostics.md
+++ b/.changeset/workflow-pressure-diagnostics.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-server": minor
+---
+
+Add opt-in workflow pressure diagnostics.

--- a/packages/llama-agents-server/README.md
+++ b/packages/llama-agents-server/README.md
@@ -51,6 +51,37 @@ llama-agents-server my_server.py
 - Human-in-the-loop support for interactive workflows
 - Persistence with built-in SQLite store (or bring your own via `AbstractWorkflowStore`)
 
+## Pressure Diagnostics
+
+Pressure diagnostics are opt-in instrumentation for incident debugging. They
+record workflow step intervals alongside event-loop lag and process RSS
+threshold events, then emit structured log records through
+`llama_agents.server.diagnostics.pressure`.
+
+```python
+from llama_agents.server import PressureDiagnosticsConfig, WorkflowServer
+
+server = WorkflowServer(
+    diagnostics=PressureDiagnosticsConfig(
+        enabled=True,
+        sample_interval=1.0,
+        event_loop_lag_threshold_ms=250,
+        memory_rss_threshold_mb=3000,
+        memory_growth_threshold_mb=500,
+        memory_growth_window_seconds=60,
+        capture_lag_stacks=True,
+    )
+)
+```
+
+Example log payloads include `memory_rss_threshold_exceeded`,
+`memory_growth_threshold_exceeded`, and
+`event_loop_lag_threshold_exceeded`. Each pressure event includes the active or
+overlapping workflow intervals at the time of the sample. Treat those intervals
+as temporal context, not proof that a step caused memory growth or lag. Pair
+these logs with process profilers such as py-spy or Memray when an incident
+needs allocation or CPU attribution.
+
 ## Client
 
 Use [`llama-agents-client`](https://pypi.org/project/llama-agents-client/) to interact with deployed servers programmatically.

--- a/packages/llama-agents-server/pyproject.toml
+++ b/packages/llama-agents-server/pyproject.toml
@@ -28,7 +28,8 @@ dependencies = [
   "llama-agents-client>=0.2.0",
   "starlette>=0.39.0",
   "uvicorn>=0.32.0",
-  "httpx>=0.27.0"
+  "httpx>=0.27.0",
+  "psutil>=5.9.0"
 ]
 
 [project.optional-dependencies]

--- a/packages/llama-agents-server/src/llama_agents/server/__init__.py
+++ b/packages/llama-agents-server/src/llama_agents/server/__init__.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
 
+from ._diagnostics import PressureDiagnosticsConfig, PressureDiagnosticsRecorder
 from ._store.abstract_workflow_store import (
     AbstractWorkflowStore,
     HandlerQuery,
@@ -16,6 +17,8 @@ __all__ = [
     "AbstractWorkflowStore",
     "HandlerQuery",
     "PersistentHandler",
+    "PressureDiagnosticsConfig",
+    "PressureDiagnosticsRecorder",
     "WorkflowServer",
     "MemoryWorkflowStore",
     "SqliteWorkflowStore",

--- a/packages/llama-agents-server/src/llama_agents/server/_diagnostics/__init__.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_diagnostics/__init__.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+from .pressure import (
+    PressureDiagnosticsConfig,
+    PressureDiagnosticsDecorator,
+    PressureDiagnosticsRecorder,
+)
+
+__all__ = [
+    "PressureDiagnosticsConfig",
+    "PressureDiagnosticsDecorator",
+    "PressureDiagnosticsRecorder",
+]

--- a/packages/llama-agents-server/src/llama_agents/server/_diagnostics/pressure.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_diagnostics/pressure.py
@@ -1,0 +1,694 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+import threading
+import time
+import traceback
+from collections import deque
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+import psutil
+from typing_extensions import override
+from workflows.context.serializers import BaseSerializer
+from workflows.events import Event, StartEvent, StepState, StepStateChanged
+from workflows.runtime.runtime_decorators import (
+    BaseExternalRunAdapterDecorator,
+    BaseInternalRunAdapterDecorator,
+    BaseRuntimeDecorator,
+)
+from workflows.runtime.types.internal_state import BrokerState
+from workflows.runtime.types.plugin import (
+    ExternalRunAdapter,
+    InternalRunAdapter,
+    Runtime,
+)
+from workflows.workflow import Workflow
+
+pressure_logger = logging.getLogger("llama_agents.server.diagnostics.pressure")
+
+MB = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class PressureDiagnosticsConfig:
+    """Configuration for opt-in workflow pressure diagnostics."""
+
+    enabled: bool = False
+    sample_interval: float = 1.0
+    event_loop_lag_threshold_ms: float | None = 250.0
+    memory_rss_threshold_mb: float | None = None
+    memory_growth_threshold_mb: float | None = None
+    memory_growth_window_seconds: float = 60.0
+    capture_lag_stacks: bool = False
+    lag_stack_max_frames: int = 40
+    max_events: int = 500
+    event_ttl_seconds: float | None = 3600.0
+    activity_buffer_size: int = 1000
+    memory_sample_buffer_size: int = 300
+    max_active_intervals_in_event: int = 25
+    warning_rate_limit_seconds: float = 30.0
+
+    def __post_init__(self) -> None:
+        if self.sample_interval <= 0:
+            raise ValueError("sample_interval must be greater than 0")
+        if self.memory_growth_window_seconds <= 0:
+            raise ValueError("memory_growth_window_seconds must be greater than 0")
+        if self.max_events <= 0:
+            raise ValueError("max_events must be greater than 0")
+        if self.activity_buffer_size <= 0:
+            raise ValueError("activity_buffer_size must be greater than 0")
+        if self.memory_sample_buffer_size <= 0:
+            raise ValueError("memory_sample_buffer_size must be greater than 0")
+        if self.max_active_intervals_in_event <= 0:
+            raise ValueError("max_active_intervals_in_event must be greater than 0")
+        if self.warning_rate_limit_seconds < 0:
+            raise ValueError("warning_rate_limit_seconds must be non-negative")
+
+
+@dataclass(frozen=True)
+class _ActivityInterval:
+    run_id: str
+    workflow_name: str | None
+    step_name: str
+    worker_id: str
+    input_event_name: str
+    started_at: str
+    started_monotonic: float
+    output_event_name: str | None = None
+    ended_at: str | None = None
+    ended_monotonic: float | None = None
+    duration_seconds: float | None = None
+    finish_reason: str | None = None
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.run_id, self.step_name, self.worker_id)
+
+    def as_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class _MemorySample:
+    timestamp: str
+    monotonic: float
+    rss_bytes: int
+    rss_mb: float
+
+    def as_payload(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class PressureDiagnosticsRecorder:
+    """Process-local recorder and sampler for workflow pressure diagnostics."""
+
+    def __init__(
+        self,
+        config: PressureDiagnosticsConfig,
+        *,
+        monotonic_clock: Callable[[], float] = time.monotonic,
+        wall_clock: Callable[[], datetime] | None = None,
+        rss_sampler: Callable[[], int] | None = None,
+        logger: logging.Logger = pressure_logger,
+    ) -> None:
+        self.config = config
+        self._clock = monotonic_clock
+        self._wall_clock = wall_clock or (lambda: datetime.now(timezone.utc))
+        self._rss_sampler = rss_sampler or (lambda: psutil.Process().memory_info().rss)
+        self._logger = logger
+        self._pid = os.getpid()
+        self._lock = threading.RLock()
+        self._events: deque[dict[str, Any]] = deque(maxlen=config.max_events)
+        self._active_intervals: dict[tuple[str, str, str], _ActivityInterval] = {}
+        self._completed_intervals: deque[_ActivityInterval] = deque(
+            maxlen=config.activity_buffer_size
+        )
+        self._memory_samples: deque[_MemorySample] = deque(
+            maxlen=config.memory_sample_buffer_size
+        )
+        self._run_workflow_names: dict[str, str] = {}
+        self._subscribers: list[Callable[[dict[str, Any]], None]] = []
+        self._sampler_task: asyncio.Task[None] | None = None
+        self._watchdog_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._loop_thread_id: int | None = None
+        self._last_heartbeat_monotonic: float | None = None
+        self._last_warning_monotonic: dict[str, float] = {}
+        self._is_started = False
+
+    @property
+    def is_started(self) -> bool:
+        return self._is_started
+
+    async def start(self) -> None:
+        if self._is_started or not self.config.enabled:
+            return
+        self._is_started = True
+        self._stop_event.clear()
+        self._loop_thread_id = threading.get_ident()
+        self._last_heartbeat_monotonic = self._clock()
+        self._sampler_task = asyncio.create_task(
+            self._sample_loop(), name="pressure-diagnostics-sampler"
+        )
+        if self.config.event_loop_lag_threshold_ms is not None:
+            self._watchdog_thread = threading.Thread(
+                target=self._watchdog_loop,
+                name="pressure-diagnostics-watchdog",
+                daemon=True,
+            )
+            self._watchdog_thread.start()
+
+    async def stop(self) -> None:
+        if not self._is_started:
+            return
+        self._is_started = False
+        self._stop_event.set()
+        task = self._sampler_task
+        self._sampler_task = None
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        thread = self._watchdog_thread
+        self._watchdog_thread = None
+        if thread is not None:
+            thread.join(timeout=max(1.0, self.config.sample_interval * 2))
+        self.finish_run_intervals("*", reason="recorder_stopped")
+
+    def subscribe(
+        self, callback: Callable[[dict[str, Any]], None]
+    ) -> Callable[[], None]:
+        with self._lock:
+            self._subscribers.append(callback)
+
+        def unsubscribe() -> None:
+            with self._lock:
+                if callback in self._subscribers:
+                    self._subscribers.remove(callback)
+
+        return unsubscribe
+
+    def record_run_start(self, run_id: str, workflow_name: str) -> None:
+        with self._lock:
+            self._run_workflow_names[run_id] = workflow_name
+
+    def record_run_end(self, run_id: str, *, reason: str = "run_ended") -> None:
+        self.finish_run_intervals(run_id, reason=reason)
+        with self._lock:
+            self._run_workflow_names.pop(run_id, None)
+
+    def record_step_state(self, run_id: str, event: StepStateChanged) -> None:
+        if event.step_state == StepState.RUNNING:
+            self.record_step_start(
+                run_id=run_id,
+                workflow_name=self._workflow_name_for_run(run_id),
+                step_name=event.name,
+                worker_id=event.worker_id,
+                input_event_name=event.input_event_name,
+            )
+        elif event.step_state == StepState.NOT_RUNNING:
+            self.record_step_end(
+                run_id=run_id,
+                step_name=event.name,
+                worker_id=event.worker_id,
+                output_event_name=event.output_event_name,
+            )
+
+    def record_step_start(
+        self,
+        *,
+        run_id: str,
+        workflow_name: str | None,
+        step_name: str,
+        worker_id: str,
+        input_event_name: str,
+    ) -> None:
+        now = self._clock()
+        interval = _ActivityInterval(
+            run_id=run_id,
+            workflow_name=workflow_name,
+            step_name=step_name,
+            worker_id=worker_id,
+            input_event_name=input_event_name,
+            started_at=self._timestamp(),
+            started_monotonic=now,
+        )
+        key = interval.key
+        with self._lock:
+            replaced = self._active_intervals.pop(key, None)
+            if replaced is not None:
+                self._completed_intervals.append(
+                    self._finish_interval(
+                        replaced, now=now, reason="replaced_by_new_start"
+                    )
+                )
+            self._active_intervals[key] = interval
+        self._record_event(
+            "workflow_step_interval_started",
+            interval.as_payload(),
+            level=logging.DEBUG,
+        )
+
+    def record_step_end(
+        self,
+        *,
+        run_id: str,
+        step_name: str,
+        worker_id: str,
+        output_event_name: str | None = None,
+        reason: str = "step_not_running",
+    ) -> None:
+        key = (run_id, step_name, worker_id)
+        now = self._clock()
+        with self._lock:
+            interval = self._active_intervals.pop(key, None)
+            if interval is None:
+                return
+            finished = self._finish_interval(
+                interval,
+                now=now,
+                reason=reason,
+                output_event_name=output_event_name,
+            )
+            self._completed_intervals.append(finished)
+        self._record_event(
+            "workflow_step_interval_finished",
+            finished.as_payload(),
+            level=logging.DEBUG,
+        )
+
+    def finish_run_intervals(self, run_id: str, *, reason: str) -> None:
+        now = self._clock()
+        finished: list[_ActivityInterval] = []
+        with self._lock:
+            for key, interval in list(self._active_intervals.items()):
+                if run_id != "*" and interval.run_id != run_id:
+                    continue
+                self._active_intervals.pop(key, None)
+                completed = self._finish_interval(interval, now=now, reason=reason)
+                self._completed_intervals.append(completed)
+                finished.append(completed)
+        for interval in finished:
+            self._record_event(
+                "workflow_step_interval_finished",
+                interval.as_payload(),
+                level=logging.DEBUG,
+            )
+
+    def record_pressure_event(self, event_type: str, payload: dict[str, Any]) -> None:
+        self._record_event(event_type, payload, level=logging.WARNING)
+
+    def sample_memory_once(self) -> _MemorySample:
+        return self.record_memory_sample()
+
+    def record_memory_sample(self, rss_bytes: int | None = None) -> _MemorySample:
+        rss = rss_bytes if rss_bytes is not None else self._rss_sampler()
+        sample = _MemorySample(
+            timestamp=self._timestamp(),
+            monotonic=self._clock(),
+            rss_bytes=rss,
+            rss_mb=round(rss / MB, 3),
+        )
+        with self._lock:
+            self._memory_samples.append(sample)
+        self._check_memory_thresholds(sample)
+        return sample
+
+    def record_event_loop_lag(
+        self, lag_ms: float, stack_frames: list[str] | None = None
+    ) -> None:
+        threshold_ms = self.config.event_loop_lag_threshold_ms
+        if threshold_ms is not None and lag_ms < threshold_ms:
+            return
+        frames = stack_frames or []
+        if self.config.capture_lag_stacks:
+            frames = frames[: self.config.lag_stack_max_frames]
+        else:
+            frames = []
+        active = self._active_intervals_payload()
+        payload = {
+            "lag_ms": lag_ms,
+            "threshold_ms": threshold_ms,
+            "active_interval_count": active["count"],
+            "active_intervals": active["items"],
+            "active_intervals_truncated": active["truncated"],
+            "stack_frames": frames,
+            "stack_captured": bool(frames),
+        }
+        self._record_event(
+            "event_loop_lag_threshold_exceeded",
+            payload,
+            level=logging.WARNING,
+        )
+
+    def record_lag(
+        self,
+        lag_seconds: float,
+        *,
+        source: str,
+        stack_frames: list[str] | None = None,
+    ) -> None:
+        threshold_ms = self.config.event_loop_lag_threshold_ms
+        lag_ms = round(lag_seconds * 1000, 3)
+        if threshold_ms is None or lag_ms < threshold_ms:
+            return
+        if not self._can_emit_warning("event_loop_lag_threshold_exceeded"):
+            return
+        frames = stack_frames or []
+        if self.config.capture_lag_stacks:
+            frames = frames[: self.config.lag_stack_max_frames]
+        else:
+            frames = []
+        active = self._active_intervals_payload()
+        self._record_event(
+            "event_loop_lag_threshold_exceeded",
+            {
+                "lag_ms": lag_ms,
+                "threshold_ms": threshold_ms,
+                "source": source,
+                "active_interval_count": active["count"],
+                "active_intervals": active["items"],
+                "active_intervals_truncated": active["truncated"],
+                "stack_frames": frames,
+                "stack_captured": bool(frames),
+            },
+            level=logging.WARNING,
+        )
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            samples = list(self._memory_samples)
+            active = [
+                interval.as_payload() for interval in self._active_intervals.values()
+            ]
+            return {
+                "pid": self._pid,
+                "is_started": self._is_started,
+                "active_interval_count": len(active),
+                "active_intervals": active[: self.config.max_active_intervals_in_event],
+                "active_intervals_truncated": max(
+                    0, len(active) - self.config.max_active_intervals_in_event
+                ),
+                "latest_memory_sample": samples[-1].as_payload() if samples else None,
+                "recent_event_count": len(self._events),
+            }
+
+    def recent_events(self, limit: int | None = None) -> list[dict[str, Any]]:
+        self._prune_events()
+        with self._lock:
+            events = list(self._events)
+        if limit is None:
+            return events
+        return events[-limit:]
+
+    def memory_samples(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [sample.as_payload() for sample in self._memory_samples]
+
+    def overlapping_intervals(
+        self, start_monotonic: float, end_monotonic: float
+    ) -> list[dict[str, Any]]:
+        with self._lock:
+            intervals = list(self._completed_intervals) + list(
+                self._active_intervals.values()
+            )
+        overlapping = [
+            interval.as_payload()
+            for interval in intervals
+            if interval.started_monotonic <= end_monotonic
+            and (
+                interval.ended_monotonic is None
+                or interval.ended_monotonic >= start_monotonic
+            )
+        ]
+        return overlapping[: self.config.max_active_intervals_in_event]
+
+    async def _sample_loop(self) -> None:
+        expected = self._clock() + self.config.sample_interval
+        while True:
+            await asyncio.sleep(self.config.sample_interval)
+            now = self._clock()
+            lag_seconds = max(0.0, now - expected)
+            self._last_heartbeat_monotonic = now
+            self.record_lag(lag_seconds, source="heartbeat")
+            self.record_memory_sample()
+            expected = now + self.config.sample_interval
+
+    def _watchdog_loop(self) -> None:
+        threshold = (self.config.event_loop_lag_threshold_ms or 0) / 1000
+        poll_interval = min(self.config.sample_interval, max(0.05, threshold / 2))
+        while not self._stop_event.wait(poll_interval):
+            last = self._last_heartbeat_monotonic
+            if last is None:
+                continue
+            lag_seconds = self._clock() - last - self.config.sample_interval
+            if lag_seconds < threshold:
+                continue
+            stack_frames = None
+            if self.config.capture_lag_stacks:
+                stack_frames = self._capture_loop_stack()
+            self.record_lag(lag_seconds, source="watchdog", stack_frames=stack_frames)
+
+    def _capture_loop_stack(self) -> list[str]:
+        if self._loop_thread_id is None:
+            return []
+        frame = sys._current_frames().get(self._loop_thread_id)
+        if frame is None:
+            return []
+        formatted = traceback.format_stack(frame)
+        return formatted[-self.config.lag_stack_max_frames :]
+
+    def _check_memory_thresholds(self, sample: _MemorySample) -> None:
+        threshold_mb = self.config.memory_rss_threshold_mb
+        if threshold_mb is not None and sample.rss_mb >= threshold_mb:
+            if self._can_emit_warning("memory_rss_threshold_exceeded"):
+                active = self._active_intervals_payload()
+                self._record_event(
+                    "memory_rss_threshold_exceeded",
+                    {
+                        "rss_bytes": sample.rss_bytes,
+                        "rss_mb": sample.rss_mb,
+                        "threshold_mb": threshold_mb,
+                        "sample": sample.as_payload(),
+                        "active_interval_count": active["count"],
+                        "active_intervals": active["items"],
+                        "active_intervals_truncated": active["truncated"],
+                    },
+                    level=logging.WARNING,
+                )
+
+        growth_threshold_mb = self.config.memory_growth_threshold_mb
+        if growth_threshold_mb is None:
+            return
+        window_start = sample.monotonic - self.config.memory_growth_window_seconds
+        with self._lock:
+            candidates = [
+                s for s in self._memory_samples if s.monotonic >= window_start
+            ]
+        if not candidates:
+            return
+        baseline = candidates[0]
+        growth_mb = sample.rss_mb - baseline.rss_mb
+        if growth_mb < growth_threshold_mb:
+            return
+        if not self._can_emit_warning("memory_growth_threshold_exceeded"):
+            return
+        overlapping = self.overlapping_intervals(baseline.monotonic, sample.monotonic)
+        self._record_event(
+            "memory_growth_threshold_exceeded",
+            {
+                "growth_mb": round(growth_mb, 3),
+                "threshold_mb": growth_threshold_mb,
+                "window_seconds": self.config.memory_growth_window_seconds,
+                "baseline_sample": baseline.as_payload(),
+                "current_sample": sample.as_payload(),
+                "overlapping_interval_count": len(overlapping),
+                "overlapping_intervals": overlapping,
+            },
+            level=logging.WARNING,
+        )
+
+    def _record_event(
+        self,
+        event_type: str,
+        payload: dict[str, Any],
+        *,
+        level: int,
+    ) -> None:
+        event = {
+            "event_type": event_type,
+            "timestamp": self._timestamp(),
+            "monotonic": self._clock(),
+            "pid": self._pid,
+            **payload,
+        }
+        self._prune_events()
+        with self._lock:
+            self._events.append(event)
+            subscribers = list(self._subscribers)
+        self._logger.log(
+            level,
+            event_type,
+            extra={
+                "pressure_event_type": event_type,
+                "pressure_event": event,
+            },
+        )
+        for subscriber in subscribers:
+            subscriber(event)
+
+    def _active_intervals_payload(self) -> dict[str, Any]:
+        with self._lock:
+            active = [
+                interval.as_payload() for interval in self._active_intervals.values()
+            ]
+        cap = self.config.max_active_intervals_in_event
+        return {
+            "count": len(active),
+            "items": active[:cap],
+            "truncated": max(0, len(active) - cap),
+        }
+
+    def _can_emit_warning(self, event_type: str) -> bool:
+        now = self._clock()
+        with self._lock:
+            last = self._last_warning_monotonic.get(event_type)
+            if last is not None and now - last < self.config.warning_rate_limit_seconds:
+                return False
+            self._last_warning_monotonic[event_type] = now
+        return True
+
+    def _prune_events(self) -> None:
+        ttl = self.config.event_ttl_seconds
+        if ttl is None:
+            return
+        cutoff = self._clock() - ttl
+        with self._lock:
+            while self._events and self._events[0]["monotonic"] < cutoff:
+                self._events.popleft()
+
+    def _workflow_name_for_run(self, run_id: str) -> str | None:
+        with self._lock:
+            return self._run_workflow_names.get(run_id)
+
+    def _finish_interval(
+        self,
+        interval: _ActivityInterval,
+        *,
+        now: float,
+        reason: str,
+        output_event_name: str | None = None,
+    ) -> _ActivityInterval:
+        return _ActivityInterval(
+            run_id=interval.run_id,
+            workflow_name=interval.workflow_name,
+            step_name=interval.step_name,
+            worker_id=interval.worker_id,
+            input_event_name=interval.input_event_name,
+            started_at=interval.started_at,
+            started_monotonic=interval.started_monotonic,
+            output_event_name=output_event_name,
+            ended_at=self._timestamp(),
+            ended_monotonic=now,
+            duration_seconds=round(now - interval.started_monotonic, 6),
+            finish_reason=reason,
+        )
+
+    def _timestamp(self) -> str:
+        return self._wall_clock().isoformat()
+
+
+class _PressureDiagnosticsInternalRunAdapter(BaseInternalRunAdapterDecorator):
+    def __init__(
+        self,
+        decorated: InternalRunAdapter,
+        recorder: PressureDiagnosticsRecorder,
+    ) -> None:
+        super().__init__(decorated)
+        self._recorder = recorder
+
+    @override
+    async def write_to_event_stream(self, event: Event) -> None:
+        if isinstance(event, StepStateChanged):
+            self._recorder.record_step_state(self.run_id, event)
+        await super().write_to_event_stream(event)
+
+    @override
+    async def close(self) -> None:
+        try:
+            await super().close()
+        finally:
+            self._recorder.record_run_end(self.run_id, reason="internal_adapter_closed")
+
+
+class _PressureDiagnosticsExternalRunAdapter(BaseExternalRunAdapterDecorator):
+    def __init__(
+        self,
+        decorated: ExternalRunAdapter,
+        recorder: PressureDiagnosticsRecorder,
+    ) -> None:
+        super().__init__(decorated)
+        self._recorder = recorder
+
+    @override
+    async def close(self) -> None:
+        try:
+            await super().close()
+        finally:
+            self._recorder.record_run_end(self.run_id, reason="external_adapter_closed")
+
+    @override
+    async def cancel(self) -> None:
+        try:
+            await super().cancel()
+        finally:
+            self._recorder.finish_run_intervals(self.run_id, reason="external_cancel")
+
+
+class PressureDiagnosticsDecorator(BaseRuntimeDecorator):
+    """Runtime decorator that records workflow activity for pressure diagnostics."""
+
+    def __init__(
+        self,
+        decorated: Runtime,
+        recorder: PressureDiagnosticsRecorder,
+    ) -> None:
+        super().__init__(decorated)
+        self._recorder = recorder
+
+    @override
+    def run_workflow(
+        self,
+        run_id: str,
+        workflow: Workflow,
+        init_state: BrokerState,
+        start_event: StartEvent | None = None,
+        serialized_state: dict[str, Any] | None = None,
+        serializer: BaseSerializer | None = None,
+    ) -> ExternalRunAdapter:
+        self._recorder.record_run_start(run_id, workflow.workflow_name)
+        adapter = super().run_workflow(
+            run_id,
+            workflow,
+            init_state,
+            start_event=start_event,
+            serialized_state=serialized_state,
+            serializer=serializer,
+        )
+        return _PressureDiagnosticsExternalRunAdapter(adapter, self._recorder)
+
+    @override
+    def get_internal_adapter(self, workflow: Workflow) -> InternalRunAdapter:
+        inner = self._decorated.get_internal_adapter(workflow)
+        return _PressureDiagnosticsInternalRunAdapter(inner, self._recorder)

--- a/packages/llama-agents-server/src/llama_agents/server/server.py
+++ b/packages/llama-agents-server/src/llama_agents/server/server.py
@@ -9,6 +9,11 @@ from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator
 
 import uvicorn
+from llama_agents.server._diagnostics import (
+    PressureDiagnosticsConfig,
+    PressureDiagnosticsDecorator,
+    PressureDiagnosticsRecorder,
+)
 from llama_agents.server._runtime.idle_release_runtime import IdleReleaseDecorator
 from llama_agents.server._runtime.persistence_runtime import PersistenceDecorator
 from llama_agents.server._runtime.server_runtime import ServerRuntimeDecorator
@@ -67,6 +72,7 @@ class WorkflowServer:
         idle_timeout: float = 60.0,
         sse_heartbeat_interval: float | None = 25.0,
         accept_context_api: bool = False,
+        diagnostics: PressureDiagnosticsConfig | None = None,
     ):
         """Create a new workflow server.
 
@@ -100,7 +106,14 @@ class WorkflowServer:
                 bodies. Defaults to ``False``. Context deserialization can
                 instantiate arbitrary Pydantic objects via ``importlib``, so
                 only enable this on trusted networks.
+            diagnostics: Optional pressure diagnostics configuration. Diagnostics
+                are disabled by default and only start sampler tasks when this
+                is provided with ``enabled=True``.
         """
+        self.diagnostics = (
+            diagnostics if diagnostics is not None else PressureDiagnosticsConfig()
+        )
+        self.pressure_diagnostics_recorder: PressureDiagnosticsRecorder | None = None
         self._workflow_store = (
             workflow_store if workflow_store is not None else MemoryWorkflowStore()
         )
@@ -113,6 +126,13 @@ class WorkflowServer:
                 idle_timeout=idle_timeout,
             )
         )
+        if self.diagnostics.enabled:
+            self.pressure_diagnostics_recorder = PressureDiagnosticsRecorder(
+                self.diagnostics
+            )
+            inner = PressureDiagnosticsDecorator(
+                inner, self.pressure_diagnostics_recorder
+            )
         self._runtime: ServerRuntimeDecorator = ServerRuntimeDecorator(
             inner,
             store=self._workflow_store,
@@ -178,8 +198,15 @@ class WorkflowServer:
         Idle workflows are not resumed - they remain released and will be
         loaded on-demand when events arrive for them.
         """
-        await self._service.start()
-        return self
+        if self.pressure_diagnostics_recorder is not None:
+            await self.pressure_diagnostics_recorder.start()
+        try:
+            await self._service.start()
+            return self
+        except Exception:
+            if self.pressure_diagnostics_recorder is not None:
+                await self.pressure_diagnostics_recorder.stop()
+            raise
 
     @asynccontextmanager
     async def contextmanager(self) -> AsyncGenerator[WorkflowServer, None]:
@@ -192,7 +219,11 @@ class WorkflowServer:
 
     async def stop(self) -> None:
         """Gracefully shut down all running workflow handlers."""
-        await self._service.stop()
+        try:
+            await self._service.stop()
+        finally:
+            if self.pressure_diagnostics_recorder is not None:
+                await self.pressure_diagnostics_recorder.stop()
 
     # ------------------------------------------------------------------
     # Serve

--- a/packages/llama-agents-server/tests/server/test_pressure_diagnostics.py
+++ b/packages/llama-agents-server/tests/server/test_pressure_diagnostics.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from llama_agents.server import (
+    MemoryWorkflowStore,
+    PressureDiagnosticsConfig,
+    WorkflowServer,
+)
+from llama_agents.server._diagnostics.pressure import PressureDiagnosticsRecorder
+from server_test_fixtures import wait_for_passing  # type: ignore[import]
+from workflows import Workflow, step
+from workflows.events import StartEvent, StopEvent
+
+
+def _get_field(value: Any, name: str) -> Any:
+    if isinstance(value, dict):
+        return value[name]
+    return getattr(value, name)
+
+
+def _get_optional_field(value: Any, name: str, default: Any = None) -> Any:
+    if isinstance(value, dict):
+        return value.get(name, default)
+    return getattr(value, name, default)
+
+
+def _event_type(event: Any) -> str:
+    return str(
+        _get_optional_field(
+            event,
+            "event_type",
+            _get_optional_field(event, "type", _get_optional_field(event, "kind")),
+        )
+    )
+
+
+def _payload(event: Any) -> dict[str, Any]:
+    payload = _get_optional_field(event, "payload", event)
+    if isinstance(payload, dict):
+        return payload
+    return payload.model_dump(mode="python")
+
+
+def _make_recorder(
+    *,
+    config: PressureDiagnosticsConfig | None = None,
+    rss_values_mb: Sequence[float] = (),
+) -> tuple[PressureDiagnosticsRecorder, Callable[[float], None]]:
+    now = 0.0
+    rss_iter = iter(rss_values_mb)
+    last_rss_mb = 0.0
+
+    def monotonic_clock() -> float:
+        return now
+
+    def wall_clock() -> datetime:
+        return datetime.fromtimestamp(now, tz=timezone.utc)
+
+    def rss_sampler() -> int:
+        nonlocal last_rss_mb
+        last_rss_mb = next(rss_iter, last_rss_mb)
+        return int(last_rss_mb * 1024 * 1024)
+
+    def advance(seconds: float) -> None:
+        nonlocal now
+        now += seconds
+
+    recorder = PressureDiagnosticsRecorder(
+        config=config or PressureDiagnosticsConfig(enabled=True),
+        monotonic_clock=monotonic_clock,
+        wall_clock=wall_clock,
+        rss_sampler=rss_sampler,
+    )
+    return recorder, advance
+
+
+def test_pressure_diagnostics_config_export_and_default_disabled() -> None:
+    config = PressureDiagnosticsConfig()
+
+    assert config.enabled is False
+
+    disabled_server = WorkflowServer()
+    assert disabled_server.diagnostics == config
+    assert disabled_server.pressure_diagnostics_recorder is None
+
+    enabled_server = WorkflowServer(
+        diagnostics=PressureDiagnosticsConfig(enabled=True, sample_interval=0.01)
+    )
+    assert enabled_server.diagnostics.enabled is True
+    assert enabled_server.pressure_diagnostics_recorder is not None
+
+
+def test_pressure_recorder_ring_buffer_snapshot_and_interval_overlap(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    recorder, advance = _make_recorder(
+        config=PressureDiagnosticsConfig(enabled=True, max_events=3)
+    )
+
+    advance(1.0)
+    recorder.record_step_start(
+        run_id="run-a",
+        workflow_name="workflow-a",
+        step_name="first",
+        worker_id="0",
+        input_event_name="StartEvent",
+    )
+    advance(2.0)
+    recorder.record_step_start(
+        run_id="run-b",
+        workflow_name="workflow-b",
+        step_name="second",
+        worker_id="1",
+        input_event_name="StartEvent",
+    )
+    advance(1.0)
+    recorder.record_step_end(
+        run_id="run-a",
+        step_name="first",
+        worker_id="0",
+        output_event_name="StopEvent",
+    )
+
+    for sequence in range(5):
+        recorder.record_pressure_event(
+            event_type="synthetic_pressure_event",
+            payload={"sequence": sequence},
+        )
+
+    assert any(
+        getattr(record, "pressure_event_type", None) == "synthetic_pressure_event"
+        and getattr(record, "pressure_event", {})["sequence"] == 4
+        for record in caplog.records
+    )
+
+    recent_events = recorder.recent_events()
+    assert [_payload(event)["sequence"] for event in recent_events] == [2, 3, 4]
+
+    snapshot = recorder.snapshot()
+    active_intervals = _get_field(snapshot, "active_intervals")
+    assert len(active_intervals) == 1
+    assert _get_field(active_intervals[0], "run_id") == "run-b"
+    assert _get_field(active_intervals[0], "step_name") == "second"
+
+    overlapping_intervals = recorder.overlapping_intervals(
+        start_monotonic=2.5,
+        end_monotonic=4.5,
+    )
+    assert {_get_field(interval, "run_id") for interval in overlapping_intervals} == {
+        "run-a",
+        "run-b",
+    }
+
+
+def test_pressure_recorder_tracks_concurrent_workers_separately() -> None:
+    recorder, _advance = _make_recorder()
+
+    for worker_id in ("0", "1"):
+        recorder.record_step_start(
+            run_id="run-a",
+            workflow_name="workflow-a",
+            step_name="parallel",
+            worker_id=worker_id,
+            input_event_name="StartEvent",
+        )
+
+    active_intervals = recorder.snapshot()["active_intervals"]
+    assert {
+        (_get_field(interval, "step_name"), _get_field(interval, "worker_id"))
+        for interval in active_intervals
+    } == {("parallel", "0"), ("parallel", "1")}
+
+    recorder.record_run_end("run-a", reason="cancelled")
+
+    assert recorder.snapshot()["active_intervals"] == []
+    finished = [
+        event
+        for event in recorder.recent_events()
+        if _event_type(event) == "workflow_step_interval_finished"
+    ]
+    assert {_payload(event)["finish_reason"] for event in finished} == {"cancelled"}
+
+
+def test_pressure_recorder_memory_threshold_and_growth_with_injected_sampler() -> None:
+    recorder, advance = _make_recorder(
+        config=PressureDiagnosticsConfig(
+            enabled=True,
+            memory_rss_threshold_mb=140,
+            memory_growth_threshold_mb=40,
+            memory_growth_window_seconds=10,
+        ),
+        rss_values_mb=[100, 150, 171],
+    )
+    recorder.record_step_start(
+        run_id="memory-run",
+        workflow_name="memory-workflow",
+        step_name="allocate",
+        worker_id="0",
+        input_event_name="StartEvent",
+    )
+
+    recorder.sample_memory_once()
+    advance(5.0)
+    recorder.sample_memory_once()
+    advance(5.0)
+    recorder.sample_memory_once()
+
+    events = recorder.recent_events()
+    event_types = {_event_type(event) for event in events}
+    assert "memory_rss_threshold_exceeded" in event_types
+    assert "memory_growth_threshold_exceeded" in event_types
+
+    growth_event = next(
+        event
+        for event in events
+        if _event_type(event) == "memory_growth_threshold_exceeded"
+    )
+    growth_payload = _payload(growth_event)
+    assert growth_payload["growth_mb"] >= 40
+    assert growth_payload["window_seconds"] == 10
+    assert growth_payload["overlapping_interval_count"] == 1
+
+
+def test_pressure_recorder_lag_threshold_uses_active_intervals() -> None:
+    recorder, _advance = _make_recorder(
+        config=PressureDiagnosticsConfig(
+            enabled=True,
+            event_loop_lag_threshold_ms=25,
+            capture_lag_stacks=True,
+            lag_stack_max_frames=2,
+        )
+    )
+    recorder.record_step_start(
+        run_id="lag-run",
+        workflow_name="lag-workflow",
+        step_name="block",
+        worker_id="0",
+        input_event_name="StartEvent",
+    )
+
+    recorder.record_event_loop_lag(
+        lag_ms=30,
+        stack_frames=["workflow.py:10 in block", "runtime.py:20 in tick", "extra"],
+    )
+
+    lag_event = next(
+        event
+        for event in recorder.recent_events()
+        if _event_type(event) == "event_loop_lag_threshold_exceeded"
+    )
+    lag_payload = _payload(lag_event)
+    assert lag_payload["lag_ms"] == 30
+    assert lag_payload["active_interval_count"] == 1
+    assert lag_payload["active_intervals"][0]["run_id"] == "lag-run"
+    assert lag_payload["stack_frames"] == [
+        "workflow.py:10 in block",
+        "runtime.py:20 in tick",
+    ]
+
+
+class DiagnosticWorkflow(Workflow):
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="done")
+
+
+async def test_workflow_server_pressure_diagnostics_record_step_intervals() -> None:
+    server = WorkflowServer(
+        workflow_store=MemoryWorkflowStore(),
+        diagnostics=PressureDiagnosticsConfig(enabled=True, sample_interval=0.01),
+    )
+    workflow = DiagnosticWorkflow()
+    server.add_workflow("diagnostic", workflow)
+
+    async with server.contextmanager():
+        handler = await server._service.start_workflow(workflow, "diagnostic-handler")
+        completed = await server._service.await_workflow(handler)
+
+        assert completed.status == "completed"
+
+        async def interval_events_were_recorded() -> list[Any]:
+            recorder = server.pressure_diagnostics_recorder
+            assert recorder is not None
+            events = recorder.recent_events()
+            event_types = {_event_type(event) for event in events}
+            assert "workflow_step_interval_started" in event_types
+            assert "workflow_step_interval_finished" in event_types
+            return events
+
+        events = await wait_for_passing(interval_events_were_recorded)
+
+    interval_events = [
+        event
+        for event in events
+        if _event_type(event)
+        in {"workflow_step_interval_started", "workflow_step_interval_finished"}
+    ]
+    assert {_payload(event)["workflow_name"] for event in interval_events} == {
+        "diagnostic"
+    }
+    assert {_payload(event)["step_name"] for event in interval_events} == {"start"}

--- a/uv.lock
+++ b/uv.lock
@@ -2605,6 +2605,7 @@ dependencies = [
     { name = "httpx" },
     { name = "llama-agents-client" },
     { name = "llama-index-workflows" },
+    { name = "psutil" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -2635,6 +2636,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "llama-agents-client", editable = "packages/llama-agents-client" },
     { name = "llama-index-workflows", editable = "packages/llama-index-workflows" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "starlette", specifier = ">=0.39.0" },
     { name = "uvicorn", specifier = ">=0.32.0" },
 ]
@@ -4193,6 +4195,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/f5/65d838092fd01c44d16037953fd4c2cc851e783de9b8f02b27ec4ffd906f/protobuf-6.33.5-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:8afa18e1d6d20af15b417e728e9f60f3aa108ee76f23c3b2c07a2c3b546d3afd", size = 339411, upload-time = "2026-01-29T21:51:27.446Z" },
     { url = "https://files.pythonhosted.org/packages/9b/53/a9443aa3ca9ba8724fdfa02dd1887c1bcd8e89556b715cfbacca6b63dbec/protobuf-6.33.5-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:cbf16ba3350fb7b889fca858fb215967792dc125b35c7976ca4818bee3521cf0", size = 323465, upload-time = "2026-01-29T21:51:28.925Z" },
     { url = "https://files.pythonhosted.org/packages/57/bf/2086963c69bdac3d7cff1cc7ff79b8ce5ea0bec6797a017e1be338a46248/protobuf-6.33.5-py3-none-any.whl", hash = "sha256:69915a973dd0f60f31a08b8318b73eab2bd6a392c79184b3612226b0a3f8ec02", size = 170687, upload-time = "2026-01-29T21:51:32.557Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Workflow pressure is hard to debug from process metrics alone. This adds opt-in instrumentation in `llama-agents-server` that records workflow step intervals next to event-loop lag and RSS threshold events, without adding routes or starting background sampling by default.

- Adds `PressureDiagnosticsConfig` and a process-local recorder, then decorates default or custom runtimes only when diagnostics are enabled.
- Tracks step start/finish intervals from `StepStateChanged`, with cleanup on close/cancel and bounded snapshot/recent-event APIs for a later debugger route.
- Samples RSS and event-loop lag with rate-limited structured logs, optional loop stack capture, and overlap-based interval payloads.
- Documents enablement and adds recorder/runtime tests.

Tests:
- `uv run dev -p llama-agents-server -- tests/server/test_pressure_diagnostics.py -q`
- `uv run dev -p server`
- `uv run ty check packages/llama-agents-server/src packages/llama-agents-server/tests/server/test_pressure_diagnostics.py`
- `uv run ruff check packages/llama-agents-server/src/llama_agents/server packages/llama-agents-server/tests/server/test_pressure_diagnostics.py`
- `uv run pre-commit run -a` fails in existing repo-wide type hooks on unresolved optional imports outside this server change (`bedrock_agentcore`, `cryptography`, `llamactl`/`textual`).