### PR TITLE
llamactl: use editor loop for deployment create/edit

### DIFF
--- a/.agents/skills/llamactl-qa/SKILL.md
+++ b/.agents/skills/llamactl-qa/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llamactl-qa
-description: Plan and run a design-QA / "taste test" of llamactl changes against a real backend. Cooperatively builds a small matrix of cases worth eyeballing, runs them against a chosen backend (prod test project by default, local kind+tilt for new API contract changes), and writes a design-review report to `thoughts/shared/qa/`. Use this for changes to `llamactl` commands, output formats, auth, or control-plane API contracts. For UI/template smoke tests, use `llamactl_browser_test` instead.
+description: Plan and run a design-QA / "taste test" of llamactl changes against a real backend. Cooperatively builds a small matrix of cases worth eyeballing, runs them against a chosen backend (test environment by default, local kind+tilt for new API contract changes), and writes a design-review report to `thoughts/shared/qa/`. Use this for changes to `llamactl` commands, output formats, auth, or control-plane API contracts. For UI/template smoke tests, use `llamactl_browser_test` instead.
 ---
 
 # llamactl CLI QA
@@ -16,8 +16,8 @@ Every row in the matrix is there because we agreed it covers a real risk or desi
 Parse these from the user's invocation before doing anything else:
 
 - `--auto`, `auto`, `fully auto`, `non-chatty`, or `-f` means run autonomously. Pick the backend, draft the matrix internally, execute it, write the report, and return only the report pointer plus any blocking issue. Do not ask for backend selection or matrix confirmation.
-- In auto mode, prefer the least risky backend that still exercises the changed surface. Use offline/temp-project rows for parse/render/local-file behavior, local kind+tilt for new control-plane contracts, and prod-test only for read-only checks or explicitly safe writes.
-- Auto mode does not relax mutation rules. Any prod write still needs an explicitly designated test project. If that is missing, skip the mutating prod row and note the gap in the report instead of asking mid-run.
+- In auto mode, prefer the least risky backend that still exercises the changed surface. Use offline rows for parse/render/local-file behavior, local kind+tilt for new control-plane contracts, and a test environment for read-only checks or safe writes. **Never use production for mutating QA.** Switch to a test environment first.
+- Auto mode does not relax mutation rules. When creating deployments for QA (e.g., to test edit or delete flows), always create your own throwaway deployments rather than editing existing ones that might be important. Clean them up at the end of the run.
 
 ### What this is NOT
 
@@ -37,9 +37,9 @@ Skip when the change is fully covered by pytest, or when the failure mode is in 
 
 ## Pick a backend
 
-1. **Prod against a test project.** Default. Read-only commands, and write commands targeting a deployment in a project explicitly designated for testing. Confirm the project name with the user before running anything mutating. Pin every command with `--project <test-project-id>` so an active-profile slip can't write into a real project.
+1. **Test environment / test project.** Default for QA that creates or mutates deployments. Use a non-production environment or a dedicated test project so throwaway deployments don't pollute real workspaces. **Never run mutating QA commands against production.** When creating test deployments (to later edit/delete them as part of the QA), create them yourself rather than editing existing deployments that may be important. Pin every command with `--project <test-project-id>` so an active-profile slip can't write into the wrong project.
 2. **Local kind + tilt.** When the change is a new API contract (new endpoint, new field, new behavior on the control plane) and you need to exercise it against a control plane that actually has the change. `uv run operator/dev.py up`. See `AGENTS.md` and `operator/AGENTS.md` for setup. Local mode runs with no auth: the `http://localhost:8011` env is preconfigured; switch to it with `llamactl auth env switch http://localhost:8011` (arg is the API URL, not a name) and a `default` profile is created automatically. No tokens, no `auth login`. Before drafting the matrix, list existing deployments with `kubectl get llamadeployments -A` — there's often something already in the cluster from prior work that you can target with `--project <id>`, saving the cost of a fresh `deployments create`.
-3. **Staging.** Rarely the right answer for this skill. Use prod-test-project or local instead.
+3. **Offline only.** For changes that only affect local rendering (template output, help text, error formatting), no backend is needed at all. Run commands that don't hit the API (e.g., `deployments template`, `--help`, non-interactive error paths).
 
 Ask the user which backend before drafting the matrix. The answer changes which rows are realistic. Skip this in auto mode and choose from the rules above.
 
@@ -71,13 +71,15 @@ If a row needs to **commit** changes (e.g., to test git-state-dependent behavior
 git -C "$WORK/app" -c user.email=qa@example.com -c user.name=qa commit -am "<msg>"
 ```
 
-Don't try to make this temp project deployable to a real backend in the same run as offline QA. If a row genuinely needs a server-side deployment, target an existing one in the test project (see the next section); creating a new one from a throwaway repo couples two flows that fail independently.
+Don't try to make this temp project deployable to a real backend in the same run as offline QA. If a row needs a server-side deployment to edit or inspect, create a throwaway deployment yourself (e.g., `create -f` with a minimal YAML + `--no-push`) rather than editing an existing deployment that might be important. Clean it up with `deployments delete` at the end of the run.
 
 ## llamactl mental model
 
 The bits that matter when designing a matrix.
 
-A profile is `(env, oauth tokens, active org, active project)`. The env is a control-plane URL. `--project <id>` overrides the profile's active project for one call. `llamactl auth list` shows the stack. `llamactl auth env list` shows envs.
+**Scoping hierarchy**: environments → profiles → organizations → projects → deployments. An environment is a control-plane URL (e.g., `http://localhost:8011` for local). Each environment can have one or more profiles (authenticated identities). Each profile has an active organization, and each organization contains projects. Deployments live inside projects. `llamactl auth env list` shows environments. `llamactl auth list` shows profiles in the active environment. `llamactl auth env switch <url>` changes environment. `llamactl auth project [id]` changes the active project within the current profile.
+
+A profile is `(env, oauth tokens, active org, active project)`. `--project <id>` overrides the profile's active project for one call. Before running any QA, check `llamactl auth env list` and `llamactl auth list` to confirm you're in the right environment and project — don't assume from a previous session. There are multiple environments with deployments available for testing; use a non-production one for mutating operations.
 
 Read commands accept `-o text|json|yaml`. Text is human-facing; json/yaml are assertable. Prefer json for QA — exact-match assertions catch field-rename regressions text formatting hides.
 
@@ -98,9 +100,9 @@ Matrix row format. Note "Look for" replaces a pass-fail "Expect" — the reviewe
 
 | # | Command | Backend | Look for | Covers |
 |---|---|---|---|---|
-| 1 | `deployments get my-app -o yaml --project <test>` | prod-test | spec/status split reads cleanly; field ordering; null vs omitted; PAT presentation | new display model shape |
-| 2 | `deployments get --project <test>` | prod-test | column choices, alignment, behavior with long repo URLs | plain-table list mode |
-| 3 | `deployments get my-app --project <other-test>` vs default | prod-test | does the override actually retarget the project | `--project` override |
+| 1 | `deployments get my-app -o yaml --project <test>` | test-env | spec/status split reads cleanly; field ordering; null vs omitted; PAT presentation | new display model shape |
+| 2 | `deployments get --project <test>` | test-env | column choices, alignment, behavior with long repo URLs | plain-table list mode |
+| 3 | `deployments get my-app --project <other-test>` vs default | test-env | does the override actually retarget the project | `--project` override |
 
 If a row's "Look for" reads as "the command works", drop it. If it reads as "I'd want to eyeball this", keep it.
 
@@ -142,7 +144,7 @@ Template:
 ````
 # llamactl QA: <one-line scope>
 
-Backend: <prod-test-project | local kind | other>
+Backend: <test environment | local kind | offline | other>
 Profile: <name> (<env URL>)
 Project: <test project id/name>
 Branch: <branch>  Commit: <short sha>
@@ -227,8 +229,10 @@ The inline chat reply is one or two sentences pointing at the file. Don't restat
 ## Common gotchas
 
 - Stale profile. `llamactl auth list` first, every session. A profile pointing at last week's env produces 401s that look like a code bug.
-- Active project drift. A test that "works on my machine" can fail elsewhere because the active project differs. Pin every prod row with `--project`.
+- Active project drift. A test that "works on my machine" can fail elsewhere because the active project differs. Pin every row with `--project`.
 - Non-test project mutation. If you mutate without `--project`, the active profile decides where it lands. Always pin write commands.
+- Wrong environment for mutations. `llamactl auth env list` shows which environment is active. Never run create/edit/delete against production — switch to a test environment first. The active environment persists across sessions, so always verify before running mutating commands.
+- Editing existing deployments. Don't edit deployments you didn't create — they may be someone's real work. Create throwaway deployments for QA and delete them when done.
 - TUI/prompt risk on write commands. `deployments delete/edit/rollback` and `create` will prompt when interactive. For QA, supply every required arg or pass `--no-interactive`. Read commands (`get`, `logs`, `history`, `auth list`, `auth env list`) don't need the flag.
 - `tee` ate a row of a multi-line table once during a run. Use shell `>` redirect for QA captures, not `tee`, when you need every line preserved.
 - `serve` vs tilt. `llamactl serve` runs the appserver locally with no kubernetes. Tilt runs the full cloud stack in kind. Different scopes; pick one.

--- a/.changeset/llamactl-editor-loop.md
+++ b/.changeset/llamactl-editor-loop.md
@@ -1,0 +1,5 @@
+---
+"llamactl": minor
+---
+
+Replace deployment create and edit forms with editor-backed YAML flows

--- a/packages/llamactl/AGENTS.md
+++ b/packages/llamactl/AGENTS.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-License-Identifier: MIT
+Copyright (c) 2026 LlamaIndex Inc.
+-->
+
+# llamactl
+
+`ProjectClient` and `ControlPlaneClient` own `httpx.AsyncClient` pools. Do not
+reuse one client instance across separate `asyncio.run(...)` calls; construct a
+fresh client or keep all awaited client work in one event loop.

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -9,6 +9,8 @@ git ref, reads the config, and runs your app.
 from __future__ import annotations
 
 import asyncio
+import os
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -56,7 +58,6 @@ from ..options import (
     render_output,
 )
 from ..render import short_sha
-from ..utils.capabilities import probe_code_push_support
 from ..utils.git_push import (
     configure_git_remote,
     get_deployment_git_url,
@@ -204,6 +205,173 @@ def _handle_annotated_apply_error(
     raise click.exceptions.Exit(1)
 
 
+def _new_deployment_template_yaml() -> str:
+    ctx = gather_local_context()
+
+    cwd_name: str = Path.cwd().name
+    preferred_name: str = ctx.generate_name or cwd_name
+    secrets: dict[str, str | None] | None = None
+    if ctx.required_secret_names:
+        secrets = {name: f"${{{name}}}" for name in ctx.required_secret_names}
+
+    if ctx.is_git_repo:
+        spec = DeploymentSpec(
+            repo_url=PUSH_MODE_REPO_URL,
+            deployment_file_path=ctx.deployment_file_path,
+            git_ref=ctx.git_ref,
+            appserver_version=ctx.installed_appserver_version,
+            secrets=secrets,
+        )
+        required: tuple[str, ...] = ()
+    else:
+        spec = DeploymentSpec(
+            appserver_version=ctx.installed_appserver_version,
+            secrets=secrets,
+        )
+        required = ("repo_url",)
+
+    display = DeploymentDisplay(name=None, generate_name=preferred_name, spec=spec)
+
+    head: list[str] = [f"WARNING: {warning}" for warning in ctx.warnings]
+    if ctx.warnings:
+        head.append("")
+    head.append("Edit, then run: llamactl deployments apply -f <file>")
+    if not ctx.is_git_repo:
+        head.extend(
+            [
+                "",
+                "NOT IN A GIT REPO — set repo_url, or cd into a working tree "
+                "and re-run.",
+            ]
+        )
+
+    field_alternatives: dict[str, tuple[str, str]] = {}
+    if ctx.is_git_repo and ctx.repo_url:
+        field_alternatives["repo_url"] = (
+            ctx.repo_url,
+            "auto-detected from your git remotes",
+        )
+
+    secret_comments: dict[str, str] = {}
+    for name_ in ctx.required_secret_names:
+        if name_ in ctx.available_secrets:
+            secret_comments[name_] = "from your .env"
+        else:
+            secret_comments[name_] = "not in your .env — add it before apply"
+
+    return render_yaml_template(
+        display,
+        head=head,
+        secret_comments=secret_comments,
+        field_alternatives=field_alternatives,
+        required=required,
+        name_example=preferred_name,
+        scaffold_generate_name=True,
+    )
+
+
+def _existing_deployment_template_yaml(deployment: DeploymentResponse) -> str:
+    return render_yaml_template(DeploymentDisplay.from_response(deployment))
+
+
+def _parse_deployment_yaml_text(text: str) -> DeploymentDisplay:
+    return parse_apply_yaml(text)
+
+
+def _apply_deployment_display(
+    client: Any, display: DeploymentDisplay, *, no_push: bool = False
+) -> None:
+    asyncio.run(_apply_deployment_from_yaml(client, display, no_push=no_push))
+
+
+def _apply_deployment_yaml_text(
+    client: Any, text: str, *, no_push: bool = False
+) -> None:
+    display = _parse_deployment_yaml_text(text)
+    _apply_deployment_display(client, display, no_push=no_push)
+
+
+def _apply_deployment_yaml_file(
+    *, filename: str, project: str | None, no_push: bool
+) -> None:
+    text = _read_apply_input(filename)
+    try:
+        display = _parse_deployment_yaml_text(text)
+    except ApplyYamlError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    client = get_project_client(project_id_override=project)
+    try:
+        _apply_deployment_display(client, display, no_push=no_push)
+    except ApplyYamlError as exc:
+        raise click.ClickException(str(exc)) from exc
+
+
+def _ci_enabled() -> bool:
+    return os.environ.get("CI", "").lower() not in {"", "0", "false", "no"}
+
+
+def _requires_file_for_editor(interactive: bool) -> bool:
+    return not interactive or _ci_enabled()
+
+
+def _has_non_comment_yaml_lines(text: str) -> bool:
+    return any(
+        stripped and not stripped.startswith("#")
+        for stripped in (line.lstrip() for line in text.splitlines())
+    )
+
+
+def _editor_abort() -> None:
+    rprint(f"[{WARNING}]Cancelled[/]")
+
+
+def _edit_deployment_yaml_loop(
+    *,
+    initial_yaml: str,
+    client: Any,
+    no_push: bool,
+) -> None:
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".yaml",
+        prefix="llamactl-deployment-",
+        delete=False,
+    ) as temp:
+        temp.write(initial_yaml)
+        temp_path = Path(temp.name)
+
+    last_opened_text = initial_yaml
+    try:
+        while True:
+            click.edit(filename=str(temp_path))
+
+            if not temp_path.exists():
+                _editor_abort()
+                return
+
+            current_text = temp_path.read_text()
+            if not current_text.strip():
+                _editor_abort()
+                return
+            if current_text == last_opened_text:
+                _editor_abort()
+                return
+            if not _has_non_comment_yaml_lines(current_text):
+                _editor_abort()
+                return
+
+            try:
+                _apply_deployment_yaml_text(client, current_text, no_push=no_push)
+                return
+            except ApplyYamlError as exc:
+                annotated = annotate_yaml_with_errors(current_text, exc.errors)
+                temp_path.write_text(annotated)
+                last_opened_text = annotated
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 @app.group(
     help="Deploy your app to the cloud.",
     no_args_is_help=True,
@@ -281,7 +449,7 @@ def _do_get(
         deployment = asyncio.run(client.get_deployment(deployment_id))
         display = DeploymentDisplay.from_response(deployment)
         if mode == "template":
-            click.echo(render_yaml_template(display), nl=False)
+            click.echo(_existing_deployment_template_yaml(deployment), nl=False)
             return
         render_output(display, output)
 
@@ -341,98 +509,46 @@ def template_deployment() -> None:
     comments. Edit the output, then run ``llamactl deployments apply -f
     <file>``. Offline by design — no auth profile required.
     """
-    ctx = gather_local_context()
-
-    cwd_name: str = Path.cwd().name
-    preferred_name: str = ctx.generate_name or cwd_name
-    secrets: dict[str, str | None] | None = None
-    if ctx.required_secret_names:
-        secrets = {name: f"${{{name}}}" for name in ctx.required_secret_names}
-
-    if ctx.is_git_repo:
-        spec = DeploymentSpec(
-            repo_url=PUSH_MODE_REPO_URL,
-            deployment_file_path=ctx.deployment_file_path,
-            git_ref=ctx.git_ref,
-            appserver_version=ctx.installed_appserver_version,
-            secrets=secrets,
-        )
-        required: tuple[str, ...] = ()
-    else:
-        spec = DeploymentSpec(
-            appserver_version=ctx.installed_appserver_version,
-            secrets=secrets,
-        )
-        required = ("repo_url",)
-
-    display = DeploymentDisplay(name=None, generate_name=preferred_name, spec=spec)
-
-    head: list[str] = [f"WARNING: {warning}" for warning in ctx.warnings]
-    if ctx.warnings:
-        head.append("")
-    head.append("Edit, then run: llamactl deployments apply -f <file>")
-    if not ctx.is_git_repo:
-        head.extend(
-            [
-                "",
-                "NOT IN A GIT REPO — set repo_url, or cd into a working tree "
-                "and re-run.",
-            ]
-        )
-
-    field_alternatives: dict[str, tuple[str, str]] = {}
-    if ctx.is_git_repo and ctx.repo_url:
-        field_alternatives["repo_url"] = (
-            ctx.repo_url,
-            "auto-detected from your git remotes",
-        )
-
-    secret_comments: dict[str, str] = {}
-    for name_ in ctx.required_secret_names:
-        if name_ in ctx.available_secrets:
-            secret_comments[name_] = "from your .env"
-        else:
-            secret_comments[name_] = "not in your .env — add it before apply"
-
-    click.echo(
-        render_yaml_template(
-            display,
-            head=head,
-            secret_comments=secret_comments,
-            field_alternatives=field_alternatives,
-            required=required,
-            name_example=preferred_name,
-            scaffold_generate_name=True,
-        ),
-        nl=False,
-    )
+    click.echo(_new_deployment_template_yaml(), nl=False)
 
 
 @deployments.command("create")
 @global_options
+@click.option(
+    "-f",
+    "--filename",
+    default=None,
+    type=click.Path(allow_dash=True, exists=True, dir_okay=False, path_type=str),
+    help="Path to YAML file, or '-' for stdin.",
+)
+@click.option(
+    "--no-push",
+    is_flag=True,
+    default=False,
+    help="Skip pushing local code even when the deployment uses push-mode.",
+)
+@project_option
 @interactive_option
 def create_deployment(
+    filename: str | None,
+    no_push: bool,
+    project: str | None,
     interactive: bool,
 ) -> None:
     """Create a new deployment."""
-    validate_authenticated_profile(interactive)
-
-    if not interactive:
-        raise click.ClickException("This command requires an interactive session.")
-
-    # Keep this import local: `llamactl --help` eagerly imports command modules,
-    # and import-time profiling showed Textual adds material startup cost here.
-    # Avoid adding other local imports unless instrumentation shows they are slow.
-    from ..textual.deployment_form import create_deployment_form
-
-    deployment_form = create_deployment_form(
-        server_supports_code_push=probe_code_push_support(),
-    )
-    if deployment_form is None:
-        rprint(f"[{WARNING}]Cancelled[/]")
+    if filename is not None:
+        _apply_deployment_yaml_file(filename=filename, project=project, no_push=no_push)
         return
 
-    rprint(f"[green]Created deployment: {deployment_form.id}[/green]")
+    if _requires_file_for_editor(interactive):
+        raise click.ClickException("pass -f <file> for non-interactive create")
+
+    client = get_project_client(project_id_override=project)
+    _edit_deployment_yaml_loop(
+        initial_yaml=_new_deployment_template_yaml(),
+        client=client,
+        no_push=no_push,
+    )
 
 
 @deployments.command("configure-git-remote")
@@ -769,7 +885,7 @@ def apply_deployment(
     """
     text = _read_apply_input(filename)
     try:
-        display = parse_apply_yaml(text)
+        display = _parse_deployment_yaml_text(text)
     except ApplyYamlError as exc:
         if annotate_on_error and not dry_run:
             _handle_annotated_apply_error(
@@ -802,7 +918,7 @@ def apply_deployment(
 
     client = get_project_client(project_id_override=project)
     try:
-        asyncio.run(_apply_deployment_from_yaml(client, display, no_push=no_push))
+        _apply_deployment_display(client, display, no_push=no_push)
     except ApplyYamlError as exc:
         if annotate_on_error:
             _handle_annotated_apply_error(
@@ -816,20 +932,44 @@ def apply_deployment(
 @deployments.command("edit")
 @global_options
 @click.argument("deployment_id", required=False, type=DeploymentType())
+@click.option(
+    "-f",
+    "--filename",
+    default=None,
+    type=click.Path(allow_dash=True, exists=True, dir_okay=False, path_type=str),
+    help="Path to YAML file, or '-' for stdin.",
+)
+@click.option(
+    "--no-push",
+    is_flag=True,
+    default=False,
+    help="Skip pushing local code even when the deployment uses push-mode.",
+)
 @project_option
 @interactive_option
 def edit_deployment(
-    deployment_id: str | None, interactive: bool, project: str | None
+    deployment_id: str | None,
+    filename: str | None,
+    no_push: bool,
+    interactive: bool,
+    project: str | None,
 ) -> None:
-    """Interactively edit a deployment"""
-    # Keep this import local: `llamactl --help` eagerly imports command modules,
-    # and import-time profiling showed Textual adds material startup cost here.
-    # Avoid adding other local imports unless instrumentation shows they are slow.
-    from ..textual.deployment_form import edit_deployment_form
+    """Edit a deployment in $EDITOR."""
+    if filename is not None:
+        if deployment_id is not None:
+            raise click.ClickException(
+                "--filename and deployment ID are mutually exclusive"
+            )
+        _apply_deployment_yaml_file(filename=filename, project=project, no_push=no_push)
+        return
 
-    validate_authenticated_profile(interactive)
+    if _requires_file_for_editor(interactive):
+        raise click.ClickException("pass -f <file> for non-interactive edit")
+
+    effective_project: str | None = project
     try:
         client = get_project_client(project_id_override=project)
+        effective_project = client.project_id
 
         deployment_id = select_deployment(
             deployment_id, interactive=interactive, project_id_override=project
@@ -839,21 +979,18 @@ def edit_deployment(
             return
 
         current_deployment = asyncio.run(client.get_deployment(deployment_id))
-
-        updated_deployment = edit_deployment_form(
-            current_deployment,
-            server_supports_code_push=probe_code_push_support(),
-        )
-        if updated_deployment is None:
-            rprint(f"[{WARNING}]Cancelled[/]")
-            return
-
-        rprint(
-            f"[green]Successfully updated deployment: {updated_deployment.id}[/green]"
+        _edit_deployment_yaml_loop(
+            initial_yaml=_existing_deployment_template_yaml(current_deployment),
+            client=client,
+            no_push=no_push,
         )
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
+        friendly = friendly_http_error(
+            e, deployment_id=deployment_id, project_id=effective_project
+        )
+        message = friendly if friendly is not None else str(e)
+        rprint(f"[red]Error: {message}[/red]")
         raise click.Abort()
 
 

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -313,6 +313,13 @@ def _existing_deployment_template_yaml(deployment: DeploymentResponse) -> str:
     return render_yaml_template(DeploymentDisplay.from_response(deployment))
 
 
+def _existing_deployment_editor_yaml(deployment: DeploymentResponse) -> str:
+    return render_yaml_template(
+        DeploymentDisplay.from_response(deployment),
+        strip_mask_sentinels=False,
+    )
+
+
 def _parse_deployment_yaml_text(text: str) -> DeploymentDisplay:
     return parse_apply_yaml(text)
 
@@ -1197,7 +1204,7 @@ def edit_deployment(
             _fetch_deployment_for_editor(project=project, deployment_id=deployment_id)
         )
         _edit_deployment_yaml_loop(
-            initial_yaml=_existing_deployment_template_yaml(current_deployment),
+            initial_yaml=_existing_deployment_editor_yaml(current_deployment),
             project=project,
             no_push=no_push,
             mode="update",

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -12,7 +12,7 @@ import asyncio
 import os
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import click
 import yaml
@@ -65,6 +65,8 @@ from ..utils.git_push import (
     push_to_remote,
 )
 from ..yaml_template import render as render_yaml_template
+
+DeploymentApplyMode = Literal["apply", "create", "update"]
 
 
 class PushFailedError(click.ClickException):
@@ -205,7 +207,9 @@ def _handle_annotated_apply_error(
     raise click.exceptions.Exit(1)
 
 
-def _new_deployment_template_yaml() -> str:
+def _new_deployment_template_yaml(
+    *, action_hint: str = "Edit, then run: llamactl deployments apply -f <file>"
+) -> str:
     ctx = gather_local_context()
 
     cwd_name: str = Path.cwd().name
@@ -235,7 +239,7 @@ def _new_deployment_template_yaml() -> str:
     head: list[str] = [f"WARNING: {warning}" for warning in ctx.warnings]
     if ctx.warnings:
         head.append("")
-    head.append("Edit, then run: llamactl deployments apply -f <file>")
+    head.append(action_hint)
     if not ctx.is_git_repo:
         head.extend(
             [
@@ -279,20 +283,49 @@ def _parse_deployment_yaml_text(text: str) -> DeploymentDisplay:
 
 
 def _apply_deployment_display(
-    client: Any, display: DeploymentDisplay, *, no_push: bool = False
+    client: Any,
+    display: DeploymentDisplay,
+    *,
+    no_push: bool = False,
+    mode: DeploymentApplyMode = "apply",
+    update_target: str | None = None,
 ) -> None:
-    asyncio.run(_apply_deployment_from_yaml(client, display, no_push=no_push))
+    asyncio.run(
+        _apply_deployment_from_yaml(
+            client,
+            display,
+            no_push=no_push,
+            mode=mode,
+            update_target=update_target,
+        )
+    )
 
 
 def _apply_deployment_yaml_text(
-    client: Any, text: str, *, no_push: bool = False
+    client: Any,
+    text: str,
+    *,
+    no_push: bool = False,
+    mode: DeploymentApplyMode = "apply",
+    update_target: str | None = None,
 ) -> None:
     display = _parse_deployment_yaml_text(text)
-    _apply_deployment_display(client, display, no_push=no_push)
+    _apply_deployment_display(
+        client,
+        display,
+        no_push=no_push,
+        mode=mode,
+        update_target=update_target,
+    )
 
 
 def _apply_deployment_yaml_file(
-    *, filename: str, project: str | None, no_push: bool
+    *,
+    filename: str,
+    project: str | None,
+    no_push: bool,
+    mode: DeploymentApplyMode = "apply",
+    update_target: str | None = None,
 ) -> None:
     text = _read_apply_input(filename)
     try:
@@ -302,7 +335,13 @@ def _apply_deployment_yaml_file(
 
     client = get_project_client(project_id_override=project)
     try:
-        _apply_deployment_display(client, display, no_push=no_push)
+        _apply_deployment_display(
+            client,
+            display,
+            no_push=no_push,
+            mode=mode,
+            update_target=update_target,
+        )
     except ApplyYamlError as exc:
         raise click.ClickException(str(exc)) from exc
 
@@ -331,6 +370,8 @@ def _edit_deployment_yaml_loop(
     initial_yaml: str,
     client: Any,
     no_push: bool,
+    mode: DeploymentApplyMode,
+    update_target: str | None = None,
 ) -> None:
     with tempfile.NamedTemporaryFile(
         mode="w",
@@ -362,7 +403,13 @@ def _edit_deployment_yaml_loop(
                 return
 
             try:
-                _apply_deployment_yaml_text(client, current_text, no_push=no_push)
+                _apply_deployment_yaml_text(
+                    client,
+                    current_text,
+                    no_push=no_push,
+                    mode=mode,
+                    update_target=update_target,
+                )
                 return
             except ApplyYamlError as exc:
                 annotated = annotate_yaml_with_errors(current_text, exc.errors)
@@ -537,7 +584,12 @@ def create_deployment(
 ) -> None:
     """Create a new deployment."""
     if filename is not None:
-        _apply_deployment_yaml_file(filename=filename, project=project, no_push=no_push)
+        _apply_deployment_yaml_file(
+            filename=filename,
+            project=project,
+            no_push=no_push,
+            mode="create",
+        )
         return
 
     if _requires_file_for_editor(interactive):
@@ -545,9 +597,12 @@ def create_deployment(
 
     client = get_project_client(project_id_override=project)
     _edit_deployment_yaml_loop(
-        initial_yaml=_new_deployment_template_yaml(),
+        initial_yaml=_new_deployment_template_yaml(
+            action_hint="Edit, save, and close to create the deployment"
+        ),
         client=client,
         no_push=no_push,
+        mode="create",
     )
 
 
@@ -705,7 +760,12 @@ def _apply_push_after_save(
 
 
 async def _apply_deployment_from_yaml(
-    client: Any, display: DeploymentDisplay, *, no_push: bool = False
+    client: Any,
+    display: DeploymentDisplay,
+    *,
+    no_push: bool = False,
+    mode: DeploymentApplyMode = "apply",
+    update_target: str | None = None,
 ) -> None:
     # Deferred: llamactl startup budget avoids importing httpx at module level.
     import httpx
@@ -714,7 +774,24 @@ async def _apply_deployment_from_yaml(
     is_update = False
 
     try:
-        if display.name is not None:
+        if mode == "create":
+            is_update = False
+        elif mode == "update":
+            if update_target is None:
+                update_target = display.name
+            if update_target is None:
+                msg = "YAML must include top-level 'name' for edit"
+                raise ApplyYamlError(msg, errors=[_error(("name",), msg)])
+            if display.name is not None and display.name != update_target:
+                msg = (
+                    f"YAML name '{display.name}' does not match deployment "
+                    f"'{update_target}'"
+                )
+                raise ApplyYamlError(msg, errors=[_error(("name",), msg)])
+            display = display.model_copy(update={"name": update_target})
+            existing = await client.get_deployment(update_target)
+            is_update = True
+        elif display.name is not None:
             try:
                 existing = await client.get_deployment(display.name)
                 is_update = True
@@ -956,11 +1033,13 @@ def edit_deployment(
 ) -> None:
     """Edit a deployment in $EDITOR."""
     if filename is not None:
-        if deployment_id is not None:
-            raise click.ClickException(
-                "--filename and deployment ID are mutually exclusive"
-            )
-        _apply_deployment_yaml_file(filename=filename, project=project, no_push=no_push)
+        _apply_deployment_yaml_file(
+            filename=filename,
+            project=project,
+            no_push=no_push,
+            mode="update",
+            update_target=deployment_id,
+        )
         return
 
     if _requires_file_for_editor(interactive):
@@ -983,6 +1062,8 @@ def edit_deployment(
             initial_yaml=_existing_deployment_template_yaml(current_deployment),
             client=client,
             no_push=no_push,
+            mode="update",
+            update_target=deployment_id,
         )
 
     except Exception as e:

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import asyncio
 import os
-import tempfile
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, NoReturn
 
 import click
 import yaml
@@ -23,6 +23,7 @@ from llama_agents.core.git.git_util import is_git_repo
 from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import (
     INTERNAL_CODE_REPO_SCHEME,
+    DeploymentCreate,
     DeploymentHistoryResponse,
     DeploymentResponse,
     DeploymentUpdate,
@@ -67,6 +68,22 @@ from ..utils.git_push import (
 from ..yaml_template import render as render_yaml_template
 
 DeploymentApplyMode = Literal["apply", "create", "update"]
+DeploymentOperationAction = Literal["create", "update"]
+
+
+@dataclass(frozen=True)
+class _DeploymentIntent:
+    display: DeploymentDisplay
+    mode: DeploymentApplyMode
+    update_target: str | None = None
+
+
+@dataclass(frozen=True)
+class _ResolvedDeploymentOperation:
+    action: DeploymentOperationAction
+    display: DeploymentDisplay
+    payload: DeploymentCreate | DeploymentUpdate
+    existing: DeploymentResponse | None = None
 
 
 class PushFailedError(click.ClickException):
@@ -207,6 +224,24 @@ def _handle_annotated_apply_error(
     raise click.exceptions.Exit(1)
 
 
+def _format_apply_yaml_error(exc: ApplyYamlError) -> str:
+    if len(exc.errors) <= 1:
+        return str(exc)
+
+    lines = ["deployment YAML has errors:"]
+    for error in exc.errors:
+        if error.path:
+            path = ".".join(str(part) for part in error.path)
+            lines.append(f"- {path}: {error.message}")
+        else:
+            lines.append(f"- {error.message}")
+    return "\n".join(lines)
+
+
+def _raise_apply_yaml_click_error(exc: ApplyYamlError) -> NoReturn:
+    raise click.ClickException(_format_apply_yaml_error(exc)) from exc
+
+
 def _new_deployment_template_yaml(
     *, action_hint: str = "Edit, then run: llamactl deployments apply -f <file>"
 ) -> str:
@@ -282,37 +317,55 @@ def _parse_deployment_yaml_text(text: str) -> DeploymentDisplay:
     return parse_apply_yaml(text)
 
 
+async def _apply_deployment_intent(
+    *,
+    project: str | None,
+    intent: _DeploymentIntent,
+    no_push: bool = False,
+) -> None:
+    async with project_client_context(project_id_override=project) as client:
+        await _apply_deployment_from_yaml(
+            client,
+            intent.display,
+            no_push=no_push,
+            mode=intent.mode,
+            update_target=intent.update_target,
+        )
+
+
 def _apply_deployment_display(
-    client: Any,
     display: DeploymentDisplay,
     *,
+    project: str | None,
     no_push: bool = False,
     mode: DeploymentApplyMode = "apply",
     update_target: str | None = None,
 ) -> None:
     asyncio.run(
-        _apply_deployment_from_yaml(
-            client,
-            display,
+        _apply_deployment_intent(
+            project=project,
+            intent=_DeploymentIntent(
+                display=display,
+                mode=mode,
+                update_target=update_target,
+            ),
             no_push=no_push,
-            mode=mode,
-            update_target=update_target,
         )
     )
 
 
 def _apply_deployment_yaml_text(
-    client: Any,
     text: str,
     *,
+    project: str | None,
     no_push: bool = False,
     mode: DeploymentApplyMode = "apply",
     update_target: str | None = None,
 ) -> None:
     display = _parse_deployment_yaml_text(text)
     _apply_deployment_display(
-        client,
         display,
+        project=project,
         no_push=no_push,
         mode=mode,
         update_target=update_target,
@@ -331,19 +384,25 @@ def _apply_deployment_yaml_file(
     try:
         display = _parse_deployment_yaml_text(text)
     except ApplyYamlError as exc:
-        raise click.ClickException(str(exc)) from exc
+        _raise_apply_yaml_click_error(exc)
 
-    client = get_project_client(project_id_override=project)
     try:
         _apply_deployment_display(
-            client,
             display,
+            project=project,
             no_push=no_push,
             mode=mode,
             update_target=update_target,
         )
     except ApplyYamlError as exc:
-        raise click.ClickException(str(exc)) from exc
+        _raise_apply_yaml_click_error(exc)
+
+
+async def _fetch_deployment_for_editor(
+    *, project: str | None, deployment_id: str
+) -> tuple[str, DeploymentResponse]:
+    async with project_client_context(project_id_override=project) as client:
+        return client.project_id, await client.get_deployment(deployment_id)
 
 
 def _ci_enabled() -> bool:
@@ -361,62 +420,69 @@ def _has_non_comment_yaml_lines(text: str) -> bool:
     )
 
 
-def _editor_abort() -> None:
+def _open_deployment_yaml_editor(current_text: str) -> str | None:
+    return click.edit(text=current_text, extension=".yaml")
+
+
+def _editor_cancelled() -> None:
     rprint(f"[{WARNING}]Cancelled[/]")
+
+
+def _editor_text_unchanged(current_text: str, last_opened_text: str) -> bool:
+    return current_text.rstrip("\n") == last_opened_text.rstrip("\n")
+
+
+def _editor_noop(mode: DeploymentApplyMode) -> None:
+    if mode == "create":
+        rprint(f"[{WARNING}]No changes saved; fill in the YAML before creating[/]")
+    else:
+        rprint(f"[{WARNING}]No changes saved[/]")
+
+
+def _editor_empty() -> None:
+    rprint(f"[{WARNING}]No deployment YAML saved; nothing applied[/]")
+
+
+def _editor_comments_only() -> None:
+    rprint(f"[{WARNING}]No deployment fields saved; add YAML fields and run again[/]")
 
 
 def _edit_deployment_yaml_loop(
     *,
     initial_yaml: str,
-    client: Any,
+    project: str | None,
     no_push: bool,
     mode: DeploymentApplyMode,
     update_target: str | None = None,
 ) -> None:
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".yaml",
-        prefix="llamactl-deployment-",
-        delete=False,
-    ) as temp:
-        temp.write(initial_yaml)
-        temp_path = Path(temp.name)
-
     last_opened_text = initial_yaml
-    try:
-        while True:
-            click.edit(filename=str(temp_path))
+    while True:
+        current_text = _open_deployment_yaml_editor(last_opened_text)
 
-            if not temp_path.exists():
-                _editor_abort()
-                return
+        if current_text is None:
+            _editor_cancelled()
+            return
+        if _editor_text_unchanged(current_text, last_opened_text):
+            _editor_noop(mode)
+            return
+        if not current_text.strip():
+            _editor_empty()
+            return
+        if not _has_non_comment_yaml_lines(current_text):
+            _editor_comments_only()
+            return
 
-            current_text = temp_path.read_text()
-            if not current_text.strip():
-                _editor_abort()
-                return
-            if current_text == last_opened_text:
-                _editor_abort()
-                return
-            if not _has_non_comment_yaml_lines(current_text):
-                _editor_abort()
-                return
-
-            try:
-                _apply_deployment_yaml_text(
-                    client,
-                    current_text,
-                    no_push=no_push,
-                    mode=mode,
-                    update_target=update_target,
-                )
-                return
-            except ApplyYamlError as exc:
-                annotated = annotate_yaml_with_errors(current_text, exc.errors)
-                temp_path.write_text(annotated)
-                last_opened_text = annotated
-    finally:
-        temp_path.unlink(missing_ok=True)
+        try:
+            _apply_deployment_yaml_text(
+                current_text,
+                project=project,
+                no_push=no_push,
+                mode=mode,
+                update_target=update_target,
+            )
+            return
+        except ApplyYamlError as exc:
+            last_opened_text = annotate_yaml_with_errors(current_text, exc.errors)
 
 
 @app.group(
@@ -595,12 +661,11 @@ def create_deployment(
     if _requires_file_for_editor(interactive):
         raise click.ClickException("pass -f <file> for non-interactive create")
 
-    client = get_project_client(project_id_override=project)
     _edit_deployment_yaml_loop(
         initial_yaml=_new_deployment_template_yaml(
             action_hint="Edit, save, and close to create the deployment"
         ),
-        client=client,
+        project=project,
         no_push=no_push,
         mode="create",
     )
@@ -759,6 +824,190 @@ def _apply_push_after_save(
         ) from exc
 
 
+def _create_identity_error() -> FieldError:
+    msg = "set top-level 'name' or 'generate_name'"
+    return _error(("name",), msg)
+
+
+def _create_source_error() -> FieldError:
+    msg = 'set spec.repo_url for create (use "" for push-mode)'
+    return _error(("spec", "repo_url"), msg)
+
+
+def _normalize_create_display(display: DeploymentDisplay) -> DeploymentDisplay:
+    if display.name is not None and display.generate_name is None:
+        return display.model_copy(update={"generate_name": display.name})
+    return display
+
+
+def _validate_create_intent(display: DeploymentDisplay) -> None:
+    errors: list[FieldError] = []
+    if not display.name and not display.generate_name:
+        errors.append(_create_identity_error())
+    if "repo_url" not in display.spec.model_fields_set or display.spec.repo_url is None:
+        errors.append(_create_source_error())
+    if errors:
+        message = (
+            errors[0].message if len(errors) == 1 else "deployment YAML has errors"
+        )
+        raise ApplyYamlError(message, errors=errors)
+
+
+async def _resolve_deployment_operation(
+    client: Any,
+    intent: _DeploymentIntent,
+) -> _ResolvedDeploymentOperation:
+    # Deferred: llamactl startup budget avoids importing httpx at module level.
+    import httpx
+
+    display = intent.display
+
+    if intent.mode == "create":
+        display = _normalize_create_display(display)
+        _validate_create_intent(display)
+        return _ResolvedDeploymentOperation(
+            action="create",
+            display=display,
+            payload=display.to_create_payload(),
+        )
+
+    if intent.mode == "update":
+        update_target = intent.update_target or display.name
+        if update_target is None:
+            msg = "YAML must include top-level 'name' for edit"
+            raise ApplyYamlError(msg, errors=[_error(("name",), msg)])
+        if display.name is not None and display.name != update_target:
+            msg = (
+                f"YAML name '{display.name}' does not match deployment "
+                f"'{update_target}'"
+            )
+            raise ApplyYamlError(msg, errors=[_error(("name",), msg)])
+
+        display = display.model_copy(update={"name": update_target})
+        existing = await client.get_deployment(update_target)
+        return _ResolvedDeploymentOperation(
+            action="update",
+            display=display,
+            payload=display.to_update_payload(),
+            existing=existing,
+        )
+
+    if display.name is not None:
+        try:
+            existing = await client.get_deployment(display.name)
+            return _ResolvedDeploymentOperation(
+                action="update",
+                display=display,
+                payload=display.to_update_payload(),
+                existing=existing,
+            )
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code != 404:
+                raise
+
+    display = _normalize_create_display(display)
+    _validate_create_intent(display)
+    return _ResolvedDeploymentOperation(
+        action="create",
+        display=display,
+        payload=display.to_create_payload(),
+    )
+
+
+async def _execute_deployment_operation(
+    client: Any,
+    operation: _ResolvedDeploymentOperation,
+    *,
+    no_push: bool = False,
+) -> None:
+    display = operation.display
+    existing = operation.existing
+    is_update = operation.action == "update"
+
+    # Pre-flight validate-repository (skipped for push-mode, dry-run,
+    # and when repo_url is unset on the update path).
+    repo_url = display.spec.repo_url
+    skip_validation = (
+        repo_url is None
+        or repo_url == ""
+        or repo_url == INTERNAL_CODE_REPO_SCHEME
+        or (is_update and "repo_url" not in display.spec.model_fields_set)
+    )
+    if not skip_validation:
+        assert repo_url is not None
+        vr = await client.validate_repository(
+            repo_url=repo_url,
+            deployment_id=existing.id if existing else None,
+            pat=display.spec.personal_access_token,
+        )
+        if not vr.accessible:
+            raise RepositoryValidationError(
+                vr.message, _repository_error_path(vr.message, display)
+            )
+
+    # Push ordering matrix:
+    #   (no deployment, push)    -> save then push (bootstrap)
+    #   (push, push)             -> push then save (bare repo must hold
+    #                              new ref before update resolves git_ref)
+    #   (external, push)         -> save then push (switch into push mode)
+    #   (*, external)            -> save only
+    #   (*, same-as-current)     -> save only (repo_url omitted in YAML)
+    current_is_push = (
+        existing is not None and existing.repo_url == INTERNAL_CODE_REPO_SCHEME
+    )
+    if "repo_url" not in display.spec.model_fields_set:
+        desired_is_push = current_is_push
+    elif display.spec.repo_url in {"", INTERNAL_CODE_REPO_SCHEME}:
+        desired_is_push = True
+    else:
+        desired_is_push = False
+
+    push_before_save = current_is_push and desired_is_push
+
+    if desired_is_push and no_push:
+        desired_is_push = False
+        push_before_save = False
+
+    if desired_is_push and not is_git_repo():
+        rprint(
+            f"[{WARNING}]Not in a git repo — skipping push, "
+            "server will resolve from last pushed code[/]"
+        )
+        desired_is_push = False
+        push_before_save = False
+
+    if push_before_save:
+        assert existing is not None and display.name is not None
+        _apply_push(
+            client,
+            existing.id,
+            display.spec.git_ref or existing.git_ref,
+        )
+        response = await client.update_deployment(display.name, operation.payload)
+        click.echo(f"updated {response.id}")
+    elif operation.action == "update":
+        assert display.name is not None
+        response = await client.update_deployment(display.name, operation.payload)
+        click.echo(f"updated {response.id}")
+        if desired_is_push:
+            _apply_push_after_save(client, response.id, display.spec.git_ref)
+    else:
+        response = await client.create_deployment(operation.payload)
+        click.echo(f"created {response.id}")
+        if desired_is_push:
+            _apply_push_after_save(client, response.id, display.spec.git_ref)
+
+
+def _create_conflict_error(display: DeploymentDisplay) -> ApplyYamlError:
+    deployment_id = display.name or display.generate_name or "deployment"
+    msg = (
+        f"deployment '{deployment_id}' already exists; use "
+        "`llamactl deployments edit -f` or `llamactl deployments apply -f` "
+        "to update"
+    )
+    return ApplyYamlError(msg, errors=[_error(("name",), msg)])
+
+
 async def _apply_deployment_from_yaml(
     client: Any,
     display: DeploymentDisplay,
@@ -770,129 +1019,14 @@ async def _apply_deployment_from_yaml(
     # Deferred: llamactl startup budget avoids importing httpx at module level.
     import httpx
 
-    existing: DeploymentResponse | None = None
-    is_update = False
-
     try:
-        if mode == "create":
-            is_update = False
-        elif mode == "update":
-            if update_target is None:
-                update_target = display.name
-            if update_target is None:
-                msg = "YAML must include top-level 'name' for edit"
-                raise ApplyYamlError(msg, errors=[_error(("name",), msg)])
-            if display.name is not None and display.name != update_target:
-                msg = (
-                    f"YAML name '{display.name}' does not match deployment "
-                    f"'{update_target}'"
-                )
-                raise ApplyYamlError(msg, errors=[_error(("name",), msg)])
-            display = display.model_copy(update={"name": update_target})
-            existing = await client.get_deployment(update_target)
-            is_update = True
-        elif display.name is not None:
-            try:
-                existing = await client.get_deployment(display.name)
-                is_update = True
-            except httpx.HTTPStatusError as exc:
-                if exc.response.status_code == 404:
-                    if display.generate_name is None:
-                        msg = (
-                            "deployment not found and no generate_name "
-                            "provided for create"
-                        )
-                        raise ApplyYamlError(
-                            msg,
-                            errors=[_error(("generate_name",), msg)],
-                        ) from exc
-                else:
-                    raise
-        elif not display.generate_name:
-            msg = "YAML must include top-level 'name' or 'generate_name'"
-            raise ApplyYamlError(msg, errors=[_error(("generate_name",), msg)])
-
-        payload = (
-            display.to_update_payload() if is_update else display.to_create_payload()
+        intent = _DeploymentIntent(
+            display=display,
+            mode=mode,
+            update_target=update_target,
         )
-
-        # Pre-flight validate-repository (skipped for push-mode, dry-run,
-        # and when repo_url is unset on the update path).
-        repo_url = display.spec.repo_url
-        skip_validation = (
-            repo_url is None
-            or repo_url == ""
-            or repo_url == INTERNAL_CODE_REPO_SCHEME
-            or (is_update and "repo_url" not in display.spec.model_fields_set)
-        )
-        if not skip_validation:
-            assert repo_url is not None  # guarded by skip_validation
-            vr = await client.validate_repository(
-                repo_url=repo_url,
-                deployment_id=existing.id if existing else None,
-                pat=display.spec.personal_access_token,
-            )
-            if not vr.accessible:
-                raise RepositoryValidationError(
-                    vr.message, _repository_error_path(vr.message, display)
-                )
-
-        # Push ordering matrix:
-        #   (no deployment, push)    -> save then push (bootstrap)
-        #   (push, push)             -> push then save (bare repo must hold
-        #                              new ref before update resolves git_ref)
-        #   (external, push)         -> save then push (switch into push mode)
-        #   (*, external)            -> save only
-        #   (*, same-as-current)     -> save only (repo_url omitted in YAML)
-        current_is_push = (
-            existing is not None and existing.repo_url == INTERNAL_CODE_REPO_SCHEME
-        )
-        if "repo_url" not in display.spec.model_fields_set:
-            desired_is_push = current_is_push
-        elif (
-            display.spec.repo_url == ""
-            or display.spec.repo_url == INTERNAL_CODE_REPO_SCHEME
-        ):
-            desired_is_push = True
-        else:
-            desired_is_push = False
-
-        push_before_save = current_is_push and desired_is_push
-
-        if desired_is_push and no_push:
-            desired_is_push = False
-            push_before_save = False
-
-        if desired_is_push and not is_git_repo():
-            rprint(
-                f"[{WARNING}]Not in a git repo — skipping push, "
-                "server will resolve from last pushed code[/]"
-            )
-            desired_is_push = False
-            push_before_save = False
-
-        # Execute: translate, optionally push, and call the API.
-        if push_before_save:
-            assert existing is not None and display.name is not None
-            _apply_push(
-                client,
-                existing.id,
-                display.spec.git_ref or existing.git_ref,
-            )
-            response = await client.update_deployment(display.name, payload)
-            click.echo(f"updated {response.id}")
-        elif is_update:
-            assert display.name is not None
-            response = await client.update_deployment(display.name, payload)
-            click.echo(f"updated {response.id}")
-            if desired_is_push:
-                _apply_push_after_save(client, response.id, display.spec.git_ref)
-        else:
-            response = await client.create_deployment(payload)
-            click.echo(f"created {response.id}")
-            if desired_is_push:
-                _apply_push_after_save(client, response.id, display.spec.git_ref)
-
+        operation = await _resolve_deployment_operation(client, intent)
+        await _execute_deployment_operation(client, operation, no_push=no_push)
     except ApplyYamlError:
         raise
     except RepositoryValidationError as exc:
@@ -910,6 +1044,12 @@ async def _apply_deployment_from_yaml(
             original_error=exc,
         ) from exc
     except httpx.HTTPStatusError as exc:
+        if (
+            mode == "create"
+            and exc.response.status_code == 409
+            and display.name is not None
+        ):
+            raise _create_conflict_error(display) from exc
         raise ApplyYamlError(
             str(exc),
             errors=_http_error_to_field_errors(exc, display=display),
@@ -970,13 +1110,13 @@ def apply_deployment(
                 text=text,
                 errors=exc.errors,
             )
-        raise click.ClickException(str(exc)) from exc
+        _raise_apply_yaml_click_error(exc)
 
     if dry_run:
         try:
             _validate_dry_run_payload(display)
         except ApplyYamlError as exc:
-            raise click.ClickException(str(exc)) from exc
+            _raise_apply_yaml_click_error(exc)
 
         verdict = (
             f"would upsert deployment '{display.name}'"
@@ -993,9 +1133,8 @@ def apply_deployment(
         click.echo(verdict)
         return
 
-    client = get_project_client(project_id_override=project)
     try:
-        _apply_deployment_display(client, display, no_push=no_push)
+        _apply_deployment_display(display, project=project, no_push=no_push)
     except ApplyYamlError as exc:
         if annotate_on_error:
             _handle_annotated_apply_error(
@@ -1003,7 +1142,7 @@ def apply_deployment(
                 text=text,
                 errors=exc.errors,
             )
-        raise click.ClickException(str(exc)) from exc
+        _raise_apply_yaml_click_error(exc)
 
 
 @deployments.command("edit")
@@ -1047,9 +1186,6 @@ def edit_deployment(
 
     effective_project: str | None = project
     try:
-        client = get_project_client(project_id_override=project)
-        effective_project = client.project_id
-
         deployment_id = select_deployment(
             deployment_id, interactive=interactive, project_id_override=project
         )
@@ -1057,10 +1193,12 @@ def edit_deployment(
             rprint(f"[{WARNING}]No deployment selected[/]")
             return
 
-        current_deployment = asyncio.run(client.get_deployment(deployment_id))
+        effective_project, current_deployment = asyncio.run(
+            _fetch_deployment_for_editor(project=project, deployment_id=deployment_id)
+        )
         _edit_deployment_yaml_loop(
             initial_yaml=_existing_deployment_template_yaml(current_deployment),
-            client=client,
+            project=project,
             no_push=no_push,
             mode="update",
             update_target=deployment_id,

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -82,6 +82,7 @@ def render(
     required: Iterable[str] = (),
     name_example: str = "my-app",
     scaffold_generate_name: bool = False,
+    strip_mask_sentinels: bool = True,
 ) -> str:
     """Render ``display`` as a commented apply-shaped YAML string.
 
@@ -111,6 +112,10 @@ def render(
             ``False`` (the default), the
             field is omitted entirely. Only the offline ``deployments
             template`` flow opts in; ``get -o template`` does not.
+        strip_mask_sentinels: When ``True`` (default), omit masked secret
+            values from output so template output can be piped back into
+            apply. The editor loop sets this to ``False`` so existing secret
+            names remain visible as masked entries.
     """
     required_set = set(required)
     out: list[str] = []
@@ -137,7 +142,7 @@ def render(
     out.append("")
     out.append("spec:")
     spec_dump = display.spec.model_dump(mode="json", exclude_none=True)
-    spec_set = strip_masks(spec_dump)
+    spec_set = strip_masks(spec_dump) if strip_mask_sentinels else spec_dump
 
     for idx, (fname, finfo) in enumerate(DeploymentSpec.model_fields.items()):
         if idx > 0 and fname in {

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -55,7 +55,7 @@ _MARKER = "## "
 _TRAILING_COLUMN = 45
 _SCAFFOLD_IDENTITY_DOCS = (
     "Set 'name' for a stable id, or 'generate_name' to let the server pick a",
-    "unique id from this slug. Leave both unset → server generates from cwd.",
+    "unique id from this slug. Create needs one of these fields.",
 )
 
 # Per-field example values shown when a spec field is unset (rendered commented).

--- a/packages/llamactl/tests/conftest.py
+++ b/packages/llamactl/tests/conftest.py
@@ -8,15 +8,18 @@ SQLite DBs do not clash across processes.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import tempfile
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from llama_agents.core.schema.deployments import DeploymentResponse
+from llama_agents.core.schema.git_validation import RepositoryValidationResponse
 
 # Base temp dir for the whole session
 _TEST_HOME = tempfile.mkdtemp(prefix="llamactl_test_home_")
@@ -74,6 +77,69 @@ def make_deployment(
     }
     base.update(overrides)
     return DeploymentResponse.model_validate(base)
+
+
+def make_loop_bound_project_client(
+    *,
+    existing: DeploymentResponse | None = None,
+    created: DeploymentResponse | None = None,
+    updated: DeploymentResponse | None = None,
+    validate_accessible: bool = True,
+) -> MagicMock:
+    loop: asyncio.AbstractEventLoop | None = None
+
+    def check_loop() -> None:
+        nonlocal loop
+        running = asyncio.get_running_loop()
+        if loop is None:
+            loop = running
+        elif running is not loop:
+            raise RuntimeError("Event loop is closed")
+
+    async def get_deployment(
+        deployment_id: str, include_events: bool = False
+    ) -> DeploymentResponse:
+        check_loop()
+        if existing is not None and deployment_id == existing.id:
+            return existing
+        request = httpx.Request(
+            "GET", f"http://test/api/v1beta1/deployments/{deployment_id}"
+        )
+        response = httpx.Response(404, request=request, text='{"detail":"not found"}')
+        raise httpx.HTTPStatusError("HTTP 404", request=request, response=response)
+
+    async def validate_repository(
+        repo_url: str,
+        deployment_id: str | None = None,
+        pat: str | None = None,
+    ) -> RepositoryValidationResponse:
+        check_loop()
+        return RepositoryValidationResponse(
+            accessible=validate_accessible,
+            message="ok" if validate_accessible else "repo not found",
+        )
+
+    async def create_deployment(payload: Any) -> DeploymentResponse:
+        check_loop()
+        return created or make_deployment("new-app")
+
+    async def update_deployment(deployment_id: str, payload: Any) -> DeploymentResponse:
+        check_loop()
+        return updated or existing or make_deployment(deployment_id)
+
+    async def aclose() -> None:
+        check_loop()
+
+    client = MagicMock()
+    client.project_id = "proj_default"
+    client.base_url = "http://test:8011"
+    client.api_key = "profile-client-key"
+    client.get_deployment = AsyncMock(side_effect=get_deployment)
+    client.validate_repository = AsyncMock(side_effect=validate_repository)
+    client.create_deployment = AsyncMock(side_effect=create_deployment)
+    client.update_deployment = AsyncMock(side_effect=update_deployment)
+    client.aclose = AsyncMock(side_effect=aclose)
+    return client
 
 
 def clear_llama_cloud_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/packages/llamactl/tests/test_deployments_apply_cmd.py
+++ b/packages/llamactl/tests/test_deployments_apply_cmd.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import subprocess
 import textwrap
 from collections.abc import Generator
@@ -17,7 +16,12 @@ import httpx
 import llama_agents.cli.config.env_service as env_service
 import pytest
 from click.testing import CliRunner
-from conftest import make_deployment, patch_project_client, set_llama_cloud_env
+from conftest import (
+    make_deployment,
+    make_loop_bound_project_client,
+    patch_project_client,
+    set_llama_cloud_env,
+)
 from llama_agents.cli.app import app
 from llama_agents.core.schema.deployments import DeploymentResponse
 from llama_agents.core.schema.git_validation import RepositoryValidationResponse
@@ -190,33 +194,11 @@ def test_apply_updates_when_exists(patched_auth: Any, tmp_path: Any) -> None:
 
 
 def test_apply_update_uses_one_event_loop(patched_auth: Any, tmp_path: Any) -> None:
-    loop: asyncio.AbstractEventLoop | None = None
-
-    def check_loop() -> None:
-        nonlocal loop
-        running = asyncio.get_running_loop()
-        if loop is None:
-            loop = running
-        elif running is not loop:
-            raise RuntimeError("Event loop is closed")
-
-    async def get_deployment(deployment_id: str) -> DeploymentResponse:
-        check_loop()
-        return make_deployment(deployment_id)
-
-    async def update_deployment(deployment_id: str, payload: Any) -> DeploymentResponse:
-        check_loop()
-        return make_deployment(deployment_id)
-
     runner = CliRunner()
     f = tmp_path / "deploy.yaml"
     f.write_text(MINIMAL_UPDATE_YAML)
 
-    client = MagicMock()
-    client.project_id = "proj_default"
-    client.base_url = "http://test:8011"
-    client.get_deployment = AsyncMock(side_effect=get_deployment)
-    client.update_deployment = AsyncMock(side_effect=update_deployment)
+    client = make_loop_bound_project_client(existing=make_deployment("my-app"))
     with patch_project_client(client):
         result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
 
@@ -392,7 +374,7 @@ def test_apply_no_name_no_generate_name_errors(
     assert "name" in output_lower or "generate_name" in output_lower
 
 
-def test_apply_name_without_generate_name_404_errors(
+def test_apply_name_without_generate_name_creates_when_missing(
     patched_auth: Any, tmp_path: Any
 ) -> None:
     runner = CliRunner()
@@ -408,8 +390,11 @@ def test_apply_name_without_generate_name_404_errors(
     with patch_project_client(client):
         result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
 
-    assert result.exit_code != 0
-    assert "generate_name" in result.output.lower()
+    assert result.exit_code == 0, result.output
+    payload = client.create_deployment.call_args[0][0]
+    assert payload.id == "new-app"
+    assert payload.display_name == "new-app"
+    assert "created new-app" in result.output
 
 
 def test_apply_validate_repository_blocks_create(
@@ -585,15 +570,12 @@ def test_apply_annotate_stdin_writes_yaml_to_stdout(patched_auth: Any) -> None:
         result = runner.invoke(
             app,
             ["deployments", "apply", "-f", "-", "--annotate-on-error"],
-            input="name: new-app\nspec:\n  repo_url: https://github.com/example/repo\n",
+            input="name: new-app\nspec: {}\n",
         )
 
     assert result.exit_code == 1
-    assert (
-        "## ERROR: generate_name: deployment not found and no generate_name provided "
-        "for create"
-    ) in result.output
-    assert "generate_name" in result.output
+    assert "## ERROR: spec.repo_url: set spec.repo_url for create" in result.output
+    assert "repo_url" in result.output
 
 
 def test_apply_annotate_dry_run_is_non_mutating(

--- a/packages/llamactl/tests/test_deployments_editor_cmd.py
+++ b/packages/llamactl/tests/test_deployments_editor_cmd.py
@@ -1,0 +1,320 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for editor-backed deployment create/edit commands."""
+
+from __future__ import annotations
+
+import inspect
+import subprocess
+import textwrap
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from click.testing import CliRunner
+from conftest import make_deployment, patch_project_client
+from llama_agents.cli.app import app
+from llama_agents.cli.commands import deployment as deployment_cmd
+from llama_agents.cli.local_context import LocalContext
+from llama_agents.core.schema.deployments import DeploymentResponse
+from llama_agents.core.schema.git_validation import RepositoryValidationResponse
+
+_DEPLOY_CMD = "llama_agents.cli.commands.deployment"
+
+
+def _http_404(deployment_id: str = "unknown") -> httpx.HTTPStatusError:
+    request = httpx.Request(
+        "GET", f"http://test/api/v1beta1/deployments/{deployment_id}"
+    )
+    response = httpx.Response(404, request=request, text='{"detail":"not found"}')
+    return httpx.HTTPStatusError("HTTP 404", request=request, response=response)
+
+
+def _editor_client_mock(
+    *,
+    existing: DeploymentResponse | None = None,
+    created: DeploymentResponse | None = None,
+) -> MagicMock:
+    client = MagicMock()
+    client.project_id = "proj_default"
+    client.base_url = "http://test:8011"
+    client.api_key = "profile-client-key"
+
+    if existing is None:
+        client.get_deployment = AsyncMock(side_effect=_http_404())
+    else:
+
+        async def _get(deployment_id: str) -> DeploymentResponse:
+            if deployment_id == existing.id:
+                return existing
+            raise _http_404(deployment_id)
+
+        client.get_deployment = AsyncMock(side_effect=_get)
+
+    client.create_deployment = AsyncMock(
+        return_value=created or make_deployment("new-app")
+    )
+    client.update_deployment = AsyncMock(
+        return_value=existing or make_deployment("my-app")
+    )
+    client.validate_repository = AsyncMock(
+        return_value=RepositoryValidationResponse(accessible=True, message="ok")
+    )
+    return client
+
+
+def _patch_local_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        deployment_cmd,
+        "gather_local_context",
+        lambda: LocalContext(
+            is_git_repo=True,
+            repo_url="https://github.com/example/repo",
+            git_ref="main",
+            generate_name="scaffold-app",
+            deployment_file_path="llama_deploy.yaml",
+            installed_appserver_version="0.5.0",
+        ),
+    )
+
+
+def test_create_opens_editor_with_template_and_applies_saved_yaml(
+    patched_auth: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_local_context(monkeypatch)
+    runner = CliRunner()
+    client = _editor_client_mock(created=make_deployment("editor-app"))
+    opened_texts: list[str] = []
+
+    def _edit(filename: str) -> None:
+        path = Path(filename)
+        opened_texts.append(path.read_text())
+        path.write_text(
+            textwrap.dedent("""\
+                generate_name: Editor App
+                spec:
+                  repo_url: https://github.com/example/repo
+            """)
+        )
+
+    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+        result = runner.invoke(app, ["deployments", "create", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert len(opened_texts) == 1
+    assert "# generate_name: scaffold-app" in opened_texts[0]
+    assert 'repo_url: ""' in opened_texts[0]
+    client.create_deployment.assert_called_once()
+    assert "created editor-app" in result.output
+
+
+def test_create_file_applies_without_editor_and_threads_project_no_push(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("generate_name: File App\nspec:\n  repo_url: ''\n")
+    client = _editor_client_mock(created=make_deployment("file-app"))
+
+    with (
+        patch_project_client(client) as ctor,
+        patch(f"{_DEPLOY_CMD}.click.edit") as edit,
+        patch(f"{_DEPLOY_CMD}.is_git_repo", return_value=True),
+        patch(f"{_DEPLOY_CMD}.push_to_remote") as push,
+    ):
+        result = runner.invoke(
+            app,
+            [
+                "deployments",
+                "create",
+                "-f",
+                str(f),
+                "--project",
+                "proj_other",
+                "--no-push",
+            ],
+        )
+
+    assert result.exit_code == 0, result.output
+    edit.assert_not_called()
+    push.assert_not_called()
+    args, _ = ctor.call_args
+    assert args[1] == "proj_other"
+    client.create_deployment.assert_called_once()
+
+
+def test_edit_opens_current_template_and_updates_saved_yaml(patched_auth: Any) -> None:
+    runner = CliRunner()
+    existing = make_deployment("my-app", git_ref="main")
+    client = _editor_client_mock(existing=existing)
+    opened_texts: list[str] = []
+
+    def _edit(filename: str) -> None:
+        path = Path(filename)
+        opened_texts.append(path.read_text())
+        path.write_text(
+            textwrap.dedent("""\
+                name: my-app
+                spec:
+                  git_ref: v2
+            """)
+        )
+
+    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+        result = runner.invoke(app, ["deployments", "edit", "my-app", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert len(opened_texts) == 1
+    assert "name: my-app" in opened_texts[0]
+    assert "status:" not in opened_texts[0]
+    assert client.get_deployment.await_count == 2
+    client.update_deployment.assert_called_once()
+    assert client.update_deployment.call_args[0][0] == "my-app"
+    assert "updated my-app" in result.output
+
+
+def test_editor_parse_error_annotates_and_reopens(patched_auth: Any) -> None:
+    runner = CliRunner()
+    client = _editor_client_mock(created=make_deployment("retry-app"))
+    opened_texts: list[str] = []
+
+    def _edit(filename: str) -> None:
+        path = Path(filename)
+        opened_texts.append(path.read_text())
+        if len(opened_texts) == 1:
+            path.write_text(
+                textwrap.dedent("""\
+                    generate_name: Retry App
+                    spec:
+                      bogus: nope
+                """)
+            )
+        else:
+            assert (
+                "## ERROR: spec.bogus: Extra inputs are not permitted"
+                in path.read_text()
+            )
+            path.write_text(
+                textwrap.dedent("""\
+                    generate_name: Retry App
+                    spec:
+                      repo_url: https://github.com/example/repo
+                """)
+            )
+
+    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+        result = runner.invoke(app, ["deployments", "create", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert len(opened_texts) == 2
+    client.create_deployment.assert_called_once()
+    assert "created retry-app" in result.output
+
+
+def test_unchanged_editor_file_aborts_without_api_calls(
+    patched_auth: Any, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _patch_local_context(monkeypatch)
+    runner = CliRunner()
+    client = _editor_client_mock()
+
+    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit") as edit:
+        result = runner.invoke(app, ["deployments", "create", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    edit.assert_called_once()
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+    client.update_deployment.assert_not_called()
+    client.validate_repository.assert_not_called()
+
+
+@pytest.mark.parametrize("saved_text", ["", "# only comments\n\n  # still comments\n"])
+def test_empty_or_all_comment_editor_file_aborts_without_api_calls(
+    patched_auth: Any,
+    monkeypatch: pytest.MonkeyPatch,
+    saved_text: str,
+) -> None:
+    _patch_local_context(monkeypatch)
+    runner = CliRunner()
+    client = _editor_client_mock()
+
+    def _edit(filename: str) -> None:
+        Path(filename).write_text(saved_text)
+
+    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+        result = runner.invoke(app, ["deployments", "create", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+    client.update_deployment.assert_not_called()
+    client.validate_repository.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("argv", "message"),
+    [
+        (["deployments", "create", "--no-interactive"], "create"),
+        (["deployments", "edit", "my-app", "--no-interactive"], "edit"),
+    ],
+)
+def test_non_interactive_editor_commands_require_file(
+    argv: list[str], message: str
+) -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, argv)
+
+    assert result.exit_code != 0
+    assert f"pass -f <file> for non-interactive {message}" in result.output
+
+
+def test_ci_forces_editor_commands_to_require_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("CI", "true")
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["deployments", "edit", "my-app", "--interactive"])
+
+    assert result.exit_code != 0
+    assert "pass -f <file> for non-interactive edit" in result.output
+
+
+def test_create_edit_do_not_reference_textual_deployment_form() -> None:
+    assert deployment_cmd.create_deployment.callback is not None
+    assert deployment_cmd.edit_deployment.callback is not None
+    create_source = inspect.getsource(deployment_cmd.create_deployment.callback)
+    edit_source = inspect.getsource(deployment_cmd.edit_deployment.callback)
+
+    assert "textual.deployment_form" not in create_source
+    assert "textual.deployment_form" not in edit_source
+    assert "create_deployment_form" not in create_source
+    assert "edit_deployment_form" not in edit_source
+
+
+def test_editor_commands_do_not_import_textual_deployment_form_on_help() -> None:
+    script = textwrap.dedent(
+        """
+        import sys
+        from click.testing import CliRunner
+        from llama_agents.cli.app import app
+
+        result = CliRunner().invoke(app, ["deployments", "create", "--help"])
+        if result.exit_code != 0:
+            raise SystemExit(result.exit_code)
+        print("llama_agents.cli.textual.deployment_form" in sys.modules)
+        """
+    )
+
+    proc = subprocess.run(
+        ["python", "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "False"

--- a/packages/llamactl/tests/test_deployments_editor_cmd.py
+++ b/packages/llamactl/tests/test_deployments_editor_cmd.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import subprocess
 import textwrap
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -13,7 +15,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import pytest
 from click.testing import CliRunner
-from conftest import make_deployment, patch_project_client
+from conftest import (
+    make_deployment,
+    make_loop_bound_project_client,
+    patch_project_client,
+)
 from llama_agents.cli.app import app
 from llama_agents.cli.commands import deployment as deployment_cmd
 from llama_agents.cli.local_context import LocalContext
@@ -79,26 +85,55 @@ def _patch_local_context(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
+@contextmanager
+def _patch_yaml_editor(*responses: str | None) -> Iterator[list[str]]:
+    opened_texts: list[str] = []
+    response_iter = iter(responses)
+
+    def _open(text: str) -> str | None:
+        opened_texts.append(text)
+        try:
+            return next(response_iter)
+        except StopIteration:
+            return text
+
+    if hasattr(deployment_cmd, "_open_deployment_yaml_editor"):
+        with patch(f"{_DEPLOY_CMD}._open_deployment_yaml_editor", side_effect=_open):
+            yield opened_texts
+        return
+
+    def _edit(*args: Any, **kwargs: Any) -> str | None:
+        if "filename" in kwargs:
+            raise AssertionError(
+                "TODO: editor commands should use "
+                "_open_deployment_yaml_editor(text: str) -> str | None or "
+                "click.edit(text=..., extension='.yaml')"
+            )
+        if len(args) > 1:
+            raise AssertionError("click.edit should receive only YAML text")
+        text = kwargs.get("text", args[0] if args else None)
+        if not isinstance(text, str):
+            raise AssertionError("click.edit should receive YAML text")
+        assert kwargs.get("extension") == ".yaml"
+        return _open(text)
+
+    with patch(f"{_DEPLOY_CMD}.click.edit", side_effect=_edit):
+        yield opened_texts
+
+
 def test_create_opens_editor_with_template_and_applies_saved_yaml(
     patched_auth: Any, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     _patch_local_context(monkeypatch)
     runner = CliRunner()
     client = _editor_client_mock(created=make_deployment("editor-app"))
-    opened_texts: list[str] = []
+    saved_text = textwrap.dedent("""\
+        generate_name: Editor App
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
 
-    def _edit(filename: str) -> None:
-        path = Path(filename)
-        opened_texts.append(path.read_text())
-        path.write_text(
-            textwrap.dedent("""\
-                generate_name: Editor App
-                spec:
-                  repo_url: https://github.com/example/repo
-            """)
-        )
-
-    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+    with patch_project_client(client), _patch_yaml_editor(saved_text) as opened_texts:
         result = runner.invoke(app, ["deployments", "create", "--interactive"])
 
     assert result.exit_code == 0, result.output
@@ -157,7 +192,10 @@ def test_create_file_uses_create_intent_not_upsert(
               repo_url: https://github.com/example/repo
         """)
     )
-    client = _editor_client_mock(existing=make_deployment("existing-app"))
+    client = make_loop_bound_project_client(
+        existing=make_deployment("existing-app"),
+        created=make_deployment("existing-app"),
+    )
 
     with patch_project_client(client):
         result = runner.invoke(app, ["deployments", "create", "-f", str(f)])
@@ -168,24 +206,75 @@ def test_create_file_uses_create_intent_not_upsert(
     client.create_deployment.assert_called_once()
 
 
+def test_create_file_name_only_uses_name_as_display_name(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: explicit-app\nspec:\n  repo_url: ''\n")
+    client = _editor_client_mock(created=make_deployment("explicit-app"))
+
+    with (
+        patch_project_client(client),
+        patch(f"{_DEPLOY_CMD}.is_git_repo", return_value=False),
+    ):
+        result = runner.invoke(app, ["deployments", "create", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    payload = client.create_deployment.call_args[0][0]
+    assert payload.id == "explicit-app"
+    assert payload.display_name == "explicit-app"
+
+
+def test_create_file_reports_identity_and_source_errors_together(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("spec:\n  git_ref: main\n")
+    client = _editor_client_mock()
+
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "create", "-f", str(f)])
+
+    assert result.exit_code != 0
+    assert "set top-level 'name' or 'generate_name'" in result.output
+    assert "set spec.repo_url for create" in result.output
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+
+
+def test_create_file_uses_one_event_loop(patched_auth: Any, tmp_path: Path) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(
+        textwrap.dedent("""\
+            generate_name: File App
+            spec:
+              repo_url: https://github.com/example/repo
+        """)
+    )
+    client = make_loop_bound_project_client(created=make_deployment("file-app"))
+
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "create", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.validate_repository.assert_awaited_once()
+    client.create_deployment.assert_called_once()
+
+
 def test_edit_opens_current_template_and_updates_saved_yaml(patched_auth: Any) -> None:
     runner = CliRunner()
     existing = make_deployment("my-app", git_ref="main")
     client = _editor_client_mock(existing=existing)
-    opened_texts: list[str] = []
+    saved_text = textwrap.dedent("""\
+        name: my-app
+        spec:
+          git_ref: v2
+    """)
 
-    def _edit(filename: str) -> None:
-        path = Path(filename)
-        opened_texts.append(path.read_text())
-        path.write_text(
-            textwrap.dedent("""\
-                name: my-app
-                spec:
-                  git_ref: v2
-            """)
-        )
-
-    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+    with patch_project_client(client), _patch_yaml_editor(saved_text) as opened_texts:
         result = runner.invoke(app, ["deployments", "edit", "my-app", "--interactive"])
 
     assert result.exit_code == 0, result.output
@@ -204,7 +293,7 @@ def test_edit_file_uses_update_intent_not_create(
     runner = CliRunner()
     f = tmp_path / "deploy.yaml"
     f.write_text("name: my-app\nspec:\n  git_ref: v2\n")
-    client = _editor_client_mock(existing=make_deployment("my-app"))
+    client = make_loop_bound_project_client(existing=make_deployment("my-app"))
 
     with patch_project_client(client):
         result = runner.invoke(app, ["deployments", "edit", "-f", str(f)])
@@ -214,6 +303,36 @@ def test_edit_file_uses_update_intent_not_create(
     client.create_deployment.assert_not_called()
     client.update_deployment.assert_called_once()
     assert client.update_deployment.call_args[0][0] == "my-app"
+
+
+def test_interactive_edit_uses_separate_clients_for_fetch_and_apply(
+    patched_auth: Any,
+) -> None:
+    runner = CliRunner()
+    existing = make_deployment("my-app", git_ref="main")
+    fetch_client = make_loop_bound_project_client(existing=existing)
+    apply_client = make_loop_bound_project_client(existing=existing)
+    saved_text = textwrap.dedent("""\
+        name: my-app
+        spec:
+          git_ref: v2
+    """)
+
+    with (
+        patch(
+            "llama_agents.core.client.manage_client.ProjectClient",
+            side_effect=[fetch_client, apply_client],
+        ) as ctor,
+        _patch_yaml_editor(saved_text),
+    ):
+        result = runner.invoke(app, ["deployments", "edit", "my-app", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert ctor.call_count == 2
+    fetch_client.get_deployment.assert_awaited_once_with("my-app")
+    fetch_client.update_deployment.assert_not_called()
+    apply_client.update_deployment.assert_called_once()
+    assert apply_client.update_deployment.call_args[0][0] == "my-app"
 
 
 def test_edit_file_rejects_name_that_does_not_match_argument(
@@ -234,26 +353,40 @@ def test_edit_file_rejects_name_that_does_not_match_argument(
     client.update_deployment.assert_not_called()
 
 
+def test_edit_file_requires_name_without_argument(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("spec:\n  git_ref: v2\n")
+    client = _editor_client_mock(existing=make_deployment("my-app"))
+
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "edit", "-f", str(f)])
+
+    assert result.exit_code != 0
+    assert "top-level 'name' for edit" in result.output
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+    client.update_deployment.assert_not_called()
+
+
 def test_edit_editor_reopens_when_name_changes(patched_auth: Any) -> None:
     runner = CliRunner()
     existing = make_deployment("my-app", git_ref="main")
     client = _editor_client_mock(existing=existing)
-    opened_texts: list[str] = []
+    changed_name = "name: other-app\nspec:\n  git_ref: v2\n"
+    fixed_name = "name: my-app\nspec:\n  git_ref: v2\n"
 
-    def _edit(filename: str) -> None:
-        path = Path(filename)
-        opened_texts.append(path.read_text())
-        if len(opened_texts) == 1:
-            path.write_text("name: other-app\nspec:\n  git_ref: v2\n")
-        else:
-            assert "## ERROR: YAML name 'other-app'" in path.read_text()
-            path.write_text("name: my-app\nspec:\n  git_ref: v2\n")
-
-    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+    with (
+        patch_project_client(client),
+        _patch_yaml_editor(changed_name, fixed_name) as opened_texts,
+    ):
         result = runner.invoke(app, ["deployments", "edit", "my-app", "--interactive"])
 
     assert result.exit_code == 0, result.output
     assert len(opened_texts) == 2
+    assert "## ERROR: YAML name 'other-app'" in opened_texts[1]
     client.update_deployment.assert_called_once()
     assert client.update_deployment.call_args[0][0] == "my-app"
 
@@ -261,39 +394,46 @@ def test_edit_editor_reopens_when_name_changes(patched_auth: Any) -> None:
 def test_editor_parse_error_annotates_and_reopens(patched_auth: Any) -> None:
     runner = CliRunner()
     client = _editor_client_mock(created=make_deployment("retry-app"))
-    opened_texts: list[str] = []
+    invalid_yaml = textwrap.dedent("""\
+        generate_name: Retry App
+        spec:
+          bogus: nope
+    """)
+    valid_yaml = textwrap.dedent("""\
+        generate_name: Retry App
+        spec:
+          repo_url: https://github.com/example/repo
+    """)
 
-    def _edit(filename: str) -> None:
-        path = Path(filename)
-        opened_texts.append(path.read_text())
-        if len(opened_texts) == 1:
-            path.write_text(
-                textwrap.dedent("""\
-                    generate_name: Retry App
-                    spec:
-                      bogus: nope
-                """)
-            )
-        else:
-            assert (
-                "## ERROR: spec.bogus: Extra inputs are not permitted"
-                in path.read_text()
-            )
-            path.write_text(
-                textwrap.dedent("""\
-                    generate_name: Retry App
-                    spec:
-                      repo_url: https://github.com/example/repo
-                """)
-            )
-
-    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+    with (
+        patch_project_client(client),
+        _patch_yaml_editor(invalid_yaml, valid_yaml) as opened_texts,
+    ):
         result = runner.invoke(app, ["deployments", "create", "--interactive"])
 
     assert result.exit_code == 0, result.output
     assert len(opened_texts) == 2
+    assert "## ERROR: spec.bogus: Extra inputs are not permitted" in opened_texts[1]
     client.create_deployment.assert_called_once()
     assert "created retry-app" in result.output
+
+
+def test_editor_create_validation_annotates_all_errors(patched_auth: Any) -> None:
+    runner = CliRunner()
+    client = _editor_client_mock()
+
+    with (
+        patch_project_client(client),
+        _patch_yaml_editor("spec: {}\n", None) as opened_texts,
+    ):
+        result = runner.invoke(app, ["deployments", "create", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert len(opened_texts) == 2
+    assert "set top-level 'name' or 'generate_name'" in opened_texts[1]
+    assert "set spec.repo_url for create" in opened_texts[1]
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
 
 
 def test_unchanged_editor_file_aborts_without_api_calls(
@@ -303,11 +443,11 @@ def test_unchanged_editor_file_aborts_without_api_calls(
     runner = CliRunner()
     client = _editor_client_mock()
 
-    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit") as edit:
+    with patch_project_client(client), _patch_yaml_editor() as opened_texts:
         result = runner.invoke(app, ["deployments", "create", "--interactive"])
 
     assert result.exit_code == 0, result.output
-    edit.assert_called_once()
+    assert len(opened_texts) == 1
     client.get_deployment.assert_not_called()
     client.create_deployment.assert_not_called()
     client.update_deployment.assert_not_called()
@@ -324,10 +464,7 @@ def test_empty_or_all_comment_editor_file_aborts_without_api_calls(
     runner = CliRunner()
     client = _editor_client_mock()
 
-    def _edit(filename: str) -> None:
-        Path(filename).write_text(saved_text)
-
-    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+    with patch_project_client(client), _patch_yaml_editor(saved_text):
         result = runner.invoke(app, ["deployments", "create", "--interactive"])
 
     assert result.exit_code == 0, result.output

--- a/packages/llamactl/tests/test_deployments_editor_cmd.py
+++ b/packages/llamactl/tests/test_deployments_editor_cmd.py
@@ -287,6 +287,20 @@ def test_edit_opens_current_template_and_updates_saved_yaml(patched_auth: Any) -
     assert "updated my-app" in result.output
 
 
+def test_edit_preserves_existing_secret_names_as_masks(patched_auth: Any) -> None:
+    runner = CliRunner()
+    existing = make_deployment("my-app", secret_names=["MY_SECRET"])
+    client = _editor_client_mock(existing=existing)
+
+    with patch_project_client(client), _patch_yaml_editor(None) as opened_texts:
+        result = runner.invoke(app, ["deployments", "edit", "my-app", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert "  secrets:\n    MY_SECRET: '********'" in opened_texts[0]
+    assert "    # MY_SECRET:" not in opened_texts[0]
+    client.update_deployment.assert_not_called()
+
+
 def test_edit_file_uses_update_intent_not_create(
     patched_auth: Any, tmp_path: Path
 ) -> None:

--- a/packages/llamactl/tests/test_deployments_editor_cmd.py
+++ b/packages/llamactl/tests/test_deployments_editor_cmd.py
@@ -29,6 +29,16 @@ from llama_agents.core.schema.git_validation import RepositoryValidationResponse
 _DEPLOY_CMD = "llama_agents.cli.commands.deployment"
 
 
+@pytest.fixture(autouse=True)
+def _clear_ci_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CI=true in GitHub Actions makes editor commands require -f.
+
+    Clear it so interactive editor tests can run. The test that explicitly
+    verifies CI behavior sets CI=true via its own monkeypatch.
+    """
+    monkeypatch.delenv("CI", raising=False)
+
+
 def _http_404(deployment_id: str = "unknown") -> httpx.HTTPStatusError:
     request = httpx.Request(
         "GET", f"http://test/api/v1beta1/deployments/{deployment_id}"

--- a/packages/llamactl/tests/test_deployments_editor_cmd.py
+++ b/packages/llamactl/tests/test_deployments_editor_cmd.py
@@ -4,7 +4,6 @@
 
 from __future__ import annotations
 
-import inspect
 import subprocess
 import textwrap
 from pathlib import Path
@@ -145,6 +144,30 @@ def test_create_file_applies_without_editor_and_threads_project_no_push(
     client.create_deployment.assert_called_once()
 
 
+def test_create_file_uses_create_intent_not_upsert(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text(
+        textwrap.dedent("""\
+            name: existing-app
+            generate_name: Existing App
+            spec:
+              repo_url: https://github.com/example/repo
+        """)
+    )
+    client = _editor_client_mock(existing=make_deployment("existing-app"))
+
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "create", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.get_deployment.assert_not_called()
+    client.update_deployment.assert_not_called()
+    client.create_deployment.assert_called_once()
+
+
 def test_edit_opens_current_template_and_updates_saved_yaml(patched_auth: Any) -> None:
     runner = CliRunner()
     existing = make_deployment("my-app", git_ref="main")
@@ -173,6 +196,66 @@ def test_edit_opens_current_template_and_updates_saved_yaml(patched_auth: Any) -
     client.update_deployment.assert_called_once()
     assert client.update_deployment.call_args[0][0] == "my-app"
     assert "updated my-app" in result.output
+
+
+def test_edit_file_uses_update_intent_not_create(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: my-app\nspec:\n  git_ref: v2\n")
+    client = _editor_client_mock(existing=make_deployment("my-app"))
+
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "edit", "-f", str(f)])
+
+    assert result.exit_code == 0, result.output
+    client.get_deployment.assert_awaited_once()
+    client.create_deployment.assert_not_called()
+    client.update_deployment.assert_called_once()
+    assert client.update_deployment.call_args[0][0] == "my-app"
+
+
+def test_edit_file_rejects_name_that_does_not_match_argument(
+    patched_auth: Any, tmp_path: Path
+) -> None:
+    runner = CliRunner()
+    f = tmp_path / "deploy.yaml"
+    f.write_text("name: other-app\nspec:\n  git_ref: v2\n")
+    client = _editor_client_mock(existing=make_deployment("my-app"))
+
+    with patch_project_client(client):
+        result = runner.invoke(app, ["deployments", "edit", "my-app", "-f", str(f)])
+
+    assert result.exit_code != 0
+    assert "does not match deployment 'my-app'" in result.output
+    client.get_deployment.assert_not_called()
+    client.create_deployment.assert_not_called()
+    client.update_deployment.assert_not_called()
+
+
+def test_edit_editor_reopens_when_name_changes(patched_auth: Any) -> None:
+    runner = CliRunner()
+    existing = make_deployment("my-app", git_ref="main")
+    client = _editor_client_mock(existing=existing)
+    opened_texts: list[str] = []
+
+    def _edit(filename: str) -> None:
+        path = Path(filename)
+        opened_texts.append(path.read_text())
+        if len(opened_texts) == 1:
+            path.write_text("name: other-app\nspec:\n  git_ref: v2\n")
+        else:
+            assert "## ERROR: YAML name 'other-app'" in path.read_text()
+            path.write_text("name: my-app\nspec:\n  git_ref: v2\n")
+
+    with patch_project_client(client), patch(f"{_DEPLOY_CMD}.click.edit", _edit):
+        result = runner.invoke(app, ["deployments", "edit", "my-app", "--interactive"])
+
+    assert result.exit_code == 0, result.output
+    assert len(opened_texts) == 2
+    client.update_deployment.assert_called_once()
+    assert client.update_deployment.call_args[0][0] == "my-app"
 
 
 def test_editor_parse_error_annotates_and_reopens(patched_auth: Any) -> None:
@@ -281,18 +364,6 @@ def test_ci_forces_editor_commands_to_require_file(
 
     assert result.exit_code != 0
     assert "pass -f <file> for non-interactive edit" in result.output
-
-
-def test_create_edit_do_not_reference_textual_deployment_form() -> None:
-    assert deployment_cmd.create_deployment.callback is not None
-    assert deployment_cmd.edit_deployment.callback is not None
-    create_source = inspect.getsource(deployment_cmd.create_deployment.callback)
-    edit_source = inspect.getsource(deployment_cmd.edit_deployment.callback)
-
-    assert "textual.deployment_form" not in create_source
-    assert "textual.deployment_form" not in edit_source
-    assert "create_deployment_form" not in create_source
-    assert "edit_deployment_form" not in edit_source
 
 
 def test_editor_commands_do_not_import_textual_deployment_form_on_help() -> None:

--- a/packages/llamactl/tests/test_yaml_template.py
+++ b/packages/llamactl/tests/test_yaml_template.py
@@ -356,6 +356,21 @@ def test_render_drops_secrets_block_when_only_masks() -> None:
     assert "  # secrets:" in out
 
 
+def test_render_can_preserve_masked_secret_names_for_editor() -> None:
+    display = DeploymentDisplay(
+        name="my-app",
+        spec=DeploymentSpec(
+            secrets={"MY_SECRET": SECRET_MASK},
+            personal_access_token=SECRET_MASK,
+        ),
+    )
+
+    out = render(display, strip_mask_sentinels=False)
+
+    assert "  secrets:\n    MY_SECRET: '********'" in out
+    assert "  personal_access_token: '********'" in out
+
+
 def test_render_strips_personal_access_token_mask() -> None:
     display = DeploymentDisplay(
         name="my-app",


### PR DESCRIPTION
`deployments create` and `deployments edit` now use the same YAML/editor loop as apply. The command renders deployment YAML, sends saved text through a resolved create/update/apply operation, and runs all client calls for that operation inside one async client lifetime.

The create path is explicit: `create -f` always creates, accepts `name` as the stable id, supports `name` + `generate_name`, and reports missing identity/source fields together. `apply -f` keeps upsert-by-name behavior. Editor exits now distinguish cancel, unchanged save, empty/comment-only saves, and validation retries, so no-op editor saves no longer look like cancellation.

Edit mode keeps existing secret names visible as masked entries, so setting `MY_SECRET` round-trips as `MY_SECRET: '********'` on the next edit instead of falling back to the commented scaffold example. Public template output still strips masks so `get -o template | apply` cannot push mask sentinels back as secret values.

This also removes the create/edit Textual form dependency and keeps the YAML scaffold wording aligned with create requirements.