### PR TITLE
docs: refresh llamactl docs

### DIFF
--- a/architecture-docs/overall-architecture.md
+++ b/architecture-docs/overall-architecture.md
@@ -88,11 +88,16 @@ directory = "./ui"
 ```bash
 llamactl auth env switch https://api.cloud.llamaindex.ai
 llamactl auth login
-llamactl auth token
+llamactl auth token --project <PROJECT_ID>
 llamactl auth logout
-llamactl deployment create
-llamactl deployment list
-llamactl deployment get <id>
+llamactl deployments template > deployment.yaml
+llamactl deployments apply -f deployment.yaml
+llamactl deployments create
+llamactl deployments get
+llamactl deployments get NAME
+llamactl deployments edit NAME
+llamactl deployments update NAME
+llamactl deployments logs NAME --follow
 ```
 
 ## Component Interaction Flow

--- a/architecture-docs/quick-reference.md
+++ b/architecture-docs/quick-reference.md
@@ -75,11 +75,16 @@ directory = "./ui"
 ```bash
 llamactl auth env list              # List environments
 llamactl auth env switch <URL>      # Switch current environment
-llamactl auth token                 # Create/select profile via API key
-llamactl deployment create          # Create new deployment
-llamactl deployment list            # List deployments
-llamactl deployment get <id>        # Get deployment details
-llamactl deployment delete <id>     # Delete deployment
+llamactl auth token --project <PROJECT_ID>  # Create/select profile via API key
+llamactl deployments template > deployment.yaml  # Generate apply YAML
+llamactl deployments apply -f deployment.yaml    # Create or update from YAML
+llamactl deployments create          # Create new deployment in $EDITOR
+llamactl deployments get             # List deployments
+llamactl deployments get NAME        # Get deployment details
+llamactl deployments edit NAME       # Edit deployment in $EDITOR
+llamactl deployments update NAME     # Deploy latest code for current git ref
+llamactl deployments logs NAME --follow  # Stream deployment logs
+llamactl deployments delete NAME     # Delete deployment
 ```
 
 ### Commands Reference

--- a/architecture-docs/quick-reference.md
+++ b/architecture-docs/quick-reference.md
@@ -82,7 +82,7 @@ llamactl deployments create          # Create new deployment in $EDITOR
 llamactl deployments get             # List deployments
 llamactl deployments get NAME        # Get deployment details
 llamactl deployments edit NAME       # Edit deployment in $EDITOR
-llamactl deployments update NAME     # Deploy latest code for current git ref
+llamactl deployments update NAME     # Re-resolve current git ref and release it
 llamactl deployments logs NAME --follow  # Stream deployment logs
 llamactl deployments delete NAME     # Delete deployment
 ```

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth-env.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth-env.md
@@ -14,9 +14,9 @@ llamactl auth env [COMMAND] [options]
 Commands:
 
 - `list`: List known environments and mark the current one
-- `add <API_URL> [--interactive/--no-interactive]`: Probe the server and upsert the environment
-- `switch [API_URL] [--interactive/--no-interactive]`: Select the current environment (prompts if omitted)
-- `delete [API_URL] [--interactive/--no-interactive]`: Remove an environment and its associated profiles
+- `add <API_URL>`: Probe the server and upsert the environment
+- `switch [API_URL]`: Select the current environment
+- `delete [API_URL]`: Remove an environment and its associated profiles
 
 Notes:
 
@@ -39,7 +39,7 @@ Shows a table of environments with API URL, whether auth is required, and the cu
 llamactl auth env add <API_URL>
 ```
 
-Probes the server at `<API_URL>` and stores discovered settings. Interactive mode can prompt for the URL.
+Probes the server at `<API_URL>` and stores discovered settings.
 
 ### Switch
 
@@ -47,7 +47,7 @@ Probes the server at `<API_URL>` and stores discovered settings. Interactive mod
 llamactl auth env switch [API_URL]
 ```
 
-Sets the current environment. If omitted in interactive mode, you’ll be prompted to select one.
+Sets the current environment. If `API_URL` is omitted in a TTY, choose from known environments. Scripts should pass `API_URL`.
 
 ### Delete
 

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth.md
@@ -13,35 +13,36 @@ llamactl auth [COMMAND] [options]
 
 Commands:
 
-- `token [--project PROJECT] [--api-key KEY] [--interactive/--no-interactive]`: Create profile from API key; validates token and selects a project
+- `token [--project PROJECT] [--api-key KEY]`: Create profile from API key; validates token and selects a project
 - `login`: Login via web browser (OIDC device flow) and create a profile
 - `list`: List login profiles in the current environment
-- `switch [NAME] [--interactive/--no-interactive]`: Set currently logged in user/token
-- `logout [NAME] [--interactive/--no-interactive]`: Delete a login and its local data
+- `switch [NAME]`: Set currently logged in user/token
+- `logout [NAME]`: Delete a login and its local data
 - `organizations [-o text|json|yaml|wide]`: List organizations available to the current profile
-- `project [PROJECT_ID] [--org ORG_ID] [--interactive/--no-interactive]`: Change the active project for the current profile
+- `project [PROJECT_ID] [--org ORG_ID]`: Change the active project for the current profile
 - `inject [--env-file PATH]`: Write profile credentials to a `.env` file
 
 Notes:
 
 - Profiles are filtered by the current environment (`llamactl auth env switch`).
-- Non-interactive `token` requires both `--api-key` and `--project`.
+- `auth token` creates a profile without prompts when both `--api-key` and `--project` are supplied.
 
 ## Commands
 
 ### Token
 
 ```bash
-llamactl auth token [--project PROJECT] [--api-key KEY] [--interactive/--no-interactive]
+llamactl auth token [--project PROJECT] [--api-key KEY]
 ```
 
-- Interactive: Prompts for API key (masked), validates it by listing projects, then lets you choose a project. Creates an auto‑named profile and sets it current.
-- Non‑interactive: Requires both `--api-key` and `--project`.
+Without flags, prompts for an API key, validates it by listing projects, then lets you choose a project. Creates an auto‑named profile and sets it current.
+
+With both `--api-key` and `--project`, creates the profile without prompts.
 
 Example:
 
 ```bash
-llamactl auth token --api-key llx-... --project your-project-id --no-interactive
+llamactl auth token --api-key llx-... --project your-project-id
 ```
 
 ### Login
@@ -63,15 +64,15 @@ Shows a table of profiles for the current environment with name and active proje
 ### Switch
 
 ```bash
-llamactl auth switch [NAME] [--interactive/--no-interactive]
+llamactl auth switch [NAME]
 ```
 
-Set the current profile. If `NAME` is omitted in interactive mode, you will be prompted to select one.
+Set the current profile. If `NAME` is omitted in a TTY, choose from the available profiles. Scripts should pass `NAME`.
 
 ### Logout
 
 ```bash
-llamactl auth logout [NAME] [--interactive/--no-interactive]
+llamactl auth logout [NAME]
 ```
 
 Delete a profile. If the deleted profile is current, the current selection is cleared.
@@ -94,17 +95,17 @@ llamactl auth organizations -o json
 ### Project
 
 ```bash
-llamactl auth project [PROJECT_ID] [--org ORG_ID] [--interactive/--no-interactive]
+llamactl auth project [PROJECT_ID] [--org ORG_ID]
 ```
 
-Change the active project for the current profile. In interactive mode, select from server projects. In environments that don't require auth, you can also enter a project ID.
+Change the active project for the current profile. If `PROJECT_ID` is omitted in a TTY, choose from server projects. In environments that don't require auth, you can also enter a project ID.
 
 - `--org ORG_ID`: Scope project lookup to an organization.
 
 ### Inject
 
 ```bash
-llamactl auth inject [--env-file PATH] [--interactive/--no-interactive]
+llamactl auth inject [--env-file PATH]
 ```
 
 Write `LLAMA_CLOUD_API_KEY`, `LLAMA_CLOUD_BASE_URL`, and `LLAMA_AGENTS_PROJECT_ID` from the current profile into a `.env` file. Creates the file if it doesn't exist; overwrites existing values.

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth.md
@@ -13,29 +13,36 @@ llamactl auth [COMMAND] [options]
 
 Commands:
 
-- `token [--project-id ID] [--api-key KEY] [--interactive/--no-interactive]`: Create profile from API key; validates token and selects a project
+- `token [--project PROJECT] [--api-key KEY] [--interactive/--no-interactive]`: Create profile from API key; validates token and selects a project
 - `login`: Login via web browser (OIDC device flow) and create a profile
 - `list`: List login profiles in the current environment
 - `switch [NAME] [--interactive/--no-interactive]`: Set currently logged in user/token
 - `logout [NAME] [--interactive/--no-interactive]`: Delete a login and its local data
-- `project [PROJECT_ID] [--interactive/--no-interactive]`: Change the active project for the current profile
+- `organizations [-o text|json|yaml|wide]`: List organizations available to the current profile
+- `project [PROJECT_ID] [--org ORG_ID] [--interactive/--no-interactive]`: Change the active project for the current profile
 - `inject [--env-file PATH]`: Write profile credentials to a `.env` file
 
 Notes:
 
 - Profiles are filtered by the current environment (`llamactl auth env switch`).
-- Non-interactive `token` requires both `--api-key` and `--project-id`.
+- Non-interactive `token` requires both `--api-key` and `--project`.
 
 ## Commands
 
 ### Token
 
 ```bash
-llamactl auth token [--project-id ID] [--api-key KEY] [--interactive/--no-interactive]
+llamactl auth token [--project PROJECT] [--api-key KEY] [--interactive/--no-interactive]
 ```
 
 - Interactive: Prompts for API key (masked), validates it by listing projects, then lets you choose a project. Creates an auto‑named profile and sets it current.
-- Non‑interactive: Requires both `--api-key` and `--project-id`.
+- Non‑interactive: Requires both `--api-key` and `--project`.
+
+Example:
+
+```bash
+llamactl auth token --api-key llx-... --project your-project-id --no-interactive
+```
 
 ### Login
 
@@ -69,13 +76,30 @@ llamactl auth logout [NAME] [--interactive/--no-interactive]
 
 Delete a profile. If the deleted profile is current, the current selection is cleared.
 
+### Organizations
+
+```bash
+llamactl auth organizations [-o text|json|yaml|wide]
+```
+
+List organizations available to the current profile. Text output marks the default organization.
+
+Examples:
+
+```bash
+llamactl auth organizations
+llamactl auth organizations -o json
+```
+
 ### Project
 
 ```bash
-llamactl auth project [PROJECT_ID] [--interactive/--no-interactive]
+llamactl auth project [PROJECT_ID] [--org ORG_ID] [--interactive/--no-interactive]
 ```
 
 Change the active project for the current profile. In interactive mode, select from server projects. In environments that don't require auth, you can also enter a project ID.
+
+- `--org ORG_ID`: Scope project lookup to an organization.
 
 ### Inject
 
@@ -107,7 +131,7 @@ Example:
 ```bash
 export LLAMA_CLOUD_API_KEY="llx-..."
 export LLAMA_AGENTS_PROJECT_ID="your-project-id"
-llamactl deployments list
+llamactl deployments get
 ```
 
 Or generate a `.env` from your current profile with [`llamactl auth inject`](#inject).

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-deployments.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-deployments.md
@@ -3,7 +3,9 @@ title: deployments
 sidebar:
   order: 103
 ---
-Deploy your app to the cloud and manage existing deployments. These commands operate on the project configured in your profile.
+Deploy your app to LlamaCloud and manage existing deployments.
+
+Deployment names are the stable ids shown in the `NAME` column. Commands use the active profile's project by default. Pass `--project PROJECT` on API-backed commands to override it for one command.
 
 ## Usage
 
@@ -13,68 +15,261 @@ llamactl deployments [COMMAND] [options]
 
 Commands:
 
-- `list`: List deployments for the configured project
-- `get [DEPLOYMENT_ID] [--non-interactive]`: Show details; opens a live monitor unless `--non-interactive`
-- `create`: Interactively create a new deployment
-- `edit [DEPLOYMENT_ID]`: Interactively edit a deployment
-- `delete [DEPLOYMENT_ID] [--confirm]`: Delete a deployment; `--confirm` skips the prompt
-- `update [DEPLOYMENT_ID]`: Pull latest code from the configured branch and redeploy
+- `get [NAME]`: List deployments, or show one deployment
+- `create`: Create a deployment from an editor or YAML file
+- `edit [NAME]`: Edit a deployment in your editor, or update from a YAML file
+- `apply -f FILE`: Create or update a deployment from YAML
+- `template`: Print a YAML scaffold for a new deployment
+- `delete NAME`: Delete a deployment
+- `delete -f FILE`: Delete the deployment named in a YAML file
+- `update NAME`: Redeploy at the latest commit
+- `history NAME`: Show release history
+- `rollback NAME`: Roll back to an earlier git SHA
+- `logs NAME`: Fetch or stream deployment logs
+- `configure-git-remote NAME`: Configure the push-mode git remote
 
 Notes:
 
-- If `DEPLOYMENT_ID` is omitted, you’ll be prompted to select one.
-- All commands accept global options (profile, host, etc.).
+- `-o json` and `-o yaml` are for scripts. Status messages go to stderr; structured data goes to stdout.
+- `-f -` reads YAML from stdin on commands that accept `-f`.
+- `repo_url: ""` in apply YAML means push the current local working tree. Use `--no-push` when you want to save deployment config without pushing code.
 
 ## Commands
-
-### List
-
-```bash
-llamactl deployments list
-```
-
-Shows a table of deployments with name, id, status, repo, deployment file, git ref, and secrets summary.
 
 ### Get
 
 ```bash
-llamactl deployments get [DEPLOYMENT_ID] [--non-interactive]
+llamactl deployments get [NAME] [-o text|json|yaml|wide|template] [--project PROJECT]
 ```
 
-- Default behavior opens a live monitor with status and streaming logs.
-- Use `--non-interactive` to print details to the console instead of opening the monitor.
+With no `NAME`, lists deployments in the active project. With `NAME`, prints one deployment.
 
-### Create (interactive)
+Output modes:
+
+- `text`: Default table output
+- `wide`: Table output with less common columns
+- `json`: Machine-readable JSON
+- `yaml`: Machine-readable YAML
+- `template`: Apply-shaped YAML for one deployment only
+
+Examples:
+
+```bash
+llamactl deployments get
+llamactl deployments get invoice-agent -o yaml
+llamactl deployments get invoice-agent -o template > deployment.yaml
+```
+
+### Create
+
+```bash
+llamactl deployments create [-f FILE] [--no-push] [--project PROJECT]
+```
+
+Without `-f`, opens `$EDITOR` with a commented YAML scaffold. Save and close the file to create the deployment.
+
+With `-f FILE`, creates from YAML without opening an editor. Use `-f -` to read from stdin.
+
+Flags:
+
+- `-f, --filename FILE`: YAML file, or `-` for stdin
+- `--no-push`: Skip pushing local code for push-mode deployments
+- `--project PROJECT`: Override the active project
+
+Examples:
 
 ```bash
 llamactl deployments create
+llamactl deployments create -f deployment.yaml
+llamactl deployments create -f - < deployment.yaml
+llamactl deployments create --no-push
 ```
 
-Starts an interactive flow to create a deployment. You can provide values like repository, branch, deployment file path, and secrets. (Flags such as `--repo-url`, `--name`, `--deployment-file-path`, `--git-ref`, `--personal-access-token` exist but creation is currently interactive.)
-
-### Edit (interactive)
+### Edit
 
 ```bash
-llamactl deployments edit [DEPLOYMENT_ID]
+llamactl deployments edit [NAME] [-f FILE] [--no-push] [--project PROJECT]
 ```
 
-Opens an interactive form to update deployment settings.
+Without `-f`, fetches the deployment, renders editable YAML, and opens `$EDITOR`. If `NAME` is omitted in an interactive terminal, `llamactl` asks you to pick a deployment.
+
+With `-f FILE`, updates from YAML without opening an editor. If `NAME` is omitted, the YAML must include top-level `name`.
+
+Flags:
+
+- `-f, --filename FILE`: YAML file, or `-` for stdin
+- `--no-push`: Skip pushing local code for push-mode deployments
+- `--project PROJECT`: Override the active project
+
+Examples:
+
+```bash
+llamactl deployments edit invoice-agent
+llamactl deployments edit invoice-agent -f deployment.yaml
+llamactl deployments edit -f deployment.yaml
+```
+
+### Apply
+
+```bash
+llamactl deployments apply -f FILE [--dry-run] [--no-push] [--annotate-on-error] [--project PROJECT]
+```
+
+Applies deployment YAML declaratively. If the top-level `name` exists, `apply` updates that deployment. If it does not exist, `apply` creates it. YAML produced by `deployments template` or `deployments get NAME -o template` is ready for this command.
+
+`${VAR}` references are resolved from the process environment at apply time. Masked secret values from read output are ignored so round-tripping a deployment does not overwrite existing secrets with placeholders.
+
+Flags:
+
+- `-f, --filename FILE`: Required YAML file, or `-` for stdin
+- `--dry-run`: Validate and print the resolved payload without changing the deployment
+- `--no-push`: Skip pushing local code for push-mode deployments
+- `--annotate-on-error`: Write validation errors back into the YAML as comments
+- `--project PROJECT`: Override the active project
+
+Examples:
+
+```bash
+llamactl deployments template > deployment.yaml
+llamactl deployments apply -f deployment.yaml
+llamactl deployments apply -f deployment.yaml --dry-run
+llamactl deployments apply -f deployment.yaml --annotate-on-error
+llamactl deployments get invoice-agent -o template | llamactl deployments apply -f -
+```
+
+### Template
+
+```bash
+llamactl deployments template
+```
+
+Prints a commented YAML scaffold for a new deployment. This command is offline and does not require auth. It uses local context when available, such as the current git remote, current branch, deployment config path, and secret names.
+
+Example:
+
+```bash
+llamactl deployments template > deployment.yaml
+```
 
 ### Delete
 
 ```bash
-llamactl deployments delete [DEPLOYMENT_ID] [--confirm]
+llamactl deployments delete NAME [--project PROJECT]
+llamactl deployments delete -f FILE [--project PROJECT]
 ```
 
-Deletes a deployment. Without `--confirm`, you’ll be asked to confirm.
+Deletes a deployment immediately. Pass `NAME` directly, or pass `-f FILE` to read the deployment name from YAML.
+
+Flags:
+
+- `-f, --filename FILE`: YAML file containing top-level `name`
+- `--project PROJECT`: Override the active project
+
+Examples:
+
+```bash
+llamactl deployments delete invoice-agent
+llamactl deployments delete -f deployment.yaml
+```
 
 ### Update
 
 ```bash
-llamactl deployments update [DEPLOYMENT_ID]
+llamactl deployments update NAME [--git-ref REF] [--no-push] [--project PROJECT]
 ```
 
-Refreshes the deployment to the latest commit on the configured branch and shows the resulting Git SHA change.
+Redeploys using the latest commit for the deployment's configured git ref. Use `--git-ref` to switch to a branch, tag, or commit. For push-mode deployments, local code is pushed first unless `--no-push` is set.
+
+Flags:
+
+- `--git-ref REF`: Branch, tag, or commit SHA to deploy
+- `--no-push`: Skip pushing local code for push-mode deployments
+- `--project PROJECT`: Override the active project
+
+Examples:
+
+```bash
+llamactl deployments update invoice-agent
+llamactl deployments update invoice-agent --git-ref release-2026-05
+llamactl deployments update invoice-agent --no-push
+```
+
+### History
+
+```bash
+llamactl deployments history NAME [-o text|json|yaml|wide] [--project PROJECT]
+```
+
+Shows release history for a deployment, newest first.
+
+Examples:
+
+```bash
+llamactl deployments history invoice-agent
+llamactl deployments history invoice-agent -o yaml
+```
+
+### Rollback
+
+```bash
+llamactl deployments rollback NAME [--git-sha SHA] [--project PROJECT]
+```
+
+Rolls a deployment back to a previous git SHA. In an interactive terminal, omit `--git-sha` to pick from release history. In non-interactive runs, pass `--git-sha`.
+
+Flags:
+
+- `--git-sha SHA`: Git SHA to roll back to
+- `--project PROJECT`: Override the active project
+
+Examples:
+
+```bash
+llamactl deployments history invoice-agent
+llamactl deployments rollback invoice-agent --git-sha 3f2a1c9
+llamactl deployments rollback invoice-agent
+```
+
+### Logs
+
+```bash
+llamactl deployments logs NAME [--follow] [--json] [--tail N] [--since-seconds N] [--include-init-containers] [--project PROJECT]
+```
+
+Fetches recent deployment logs and exits. Use `--follow` to keep streaming.
+
+Flags:
+
+- `--follow, -f`: Stream until interrupted
+- `--json`: Emit one JSON log event per line
+- `--tail N`: Number of log lines to fetch initially
+- `--since-seconds N`: Only return logs newer than this many seconds
+- `--include-init-containers`: Include init container logs
+- `--project PROJECT`: Override the active project
+
+Examples:
+
+```bash
+llamactl deployments logs invoice-agent
+llamactl deployments logs invoice-agent --follow
+llamactl deployments logs invoice-agent --tail 50 --since-seconds 3600
+llamactl deployments logs invoice-agent --json
+```
+
+### Configure Git Remote
+
+```bash
+llamactl deployments configure-git-remote NAME [--project PROJECT]
+```
+
+Configures an authenticated git remote for a push-mode deployment. The remote is named `llamaagents-NAME`.
+
+Examples:
+
+```bash
+llamactl deployments configure-git-remote invoice-agent
+git push llamaagents-invoice-agent
+```
 
 ## See also
 

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-deployments.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-deployments.md
@@ -91,7 +91,7 @@ llamactl deployments create --no-push
 llamactl deployments edit [NAME] [-f FILE] [--no-push] [--project PROJECT]
 ```
 
-Without `-f`, fetches the deployment, renders editable YAML, and opens `$EDITOR`. If `NAME` is omitted in an interactive terminal, `llamactl` asks you to pick a deployment.
+Without `-f`, fetches the deployment, renders editable YAML, and opens `$EDITOR`. If `NAME` is omitted in a TTY, choose from existing deployments. Scripts should pass `NAME`.
 
 With `-f FILE`, updates from YAML without opening an editor. If `NAME` is omitted, the YAML must include top-level `name`.
 
@@ -217,7 +217,7 @@ llamactl deployments history invoice-agent -o yaml
 llamactl deployments rollback NAME [--git-sha SHA] [--project PROJECT]
 ```
 
-Rolls a deployment back to a previous git SHA. In an interactive terminal, omit `--git-sha` to pick from release history. In non-interactive runs, pass `--git-sha`.
+Rolls a deployment back to a previous git SHA. In a TTY, omit `--git-sha` to choose from release history. Scripts should pass `--git-sha`.
 
 Flags:
 

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-deployments.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-deployments.md
@@ -22,7 +22,7 @@ Commands:
 - `template`: Print a YAML scaffold for a new deployment
 - `delete NAME`: Delete a deployment
 - `delete -f FILE`: Delete the deployment named in a YAML file
-- `update NAME`: Redeploy at the latest commit
+- `update NAME`: Resolve a git ref again and start a new release
 - `history NAME`: Show release history
 - `rollback NAME`: Roll back to an earlier git SHA
 - `logs NAME`: Fetch or stream deployment logs
@@ -32,7 +32,7 @@ Notes:
 
 - `-o json` and `-o yaml` are for scripts. Status messages go to stderr; structured data goes to stdout.
 - `-f -` reads YAML from stdin on commands that accept `-f`.
-- `repo_url: ""` in apply YAML means push the current local working tree. Use `--no-push` when you want to save deployment config without pushing code.
+- `repo_url: ""` in apply YAML means push the current local working tree. Push-capable deployment mutations support `--no-push` when you have already pushed separately or want the server to use the revision it can already resolve.
 
 ## Commands
 
@@ -178,12 +178,14 @@ llamactl deployments delete -f deployment.yaml
 llamactl deployments update NAME [--git-ref REF] [--no-push] [--project PROJECT]
 ```
 
-Redeploys using the latest commit for the deployment's configured git ref. Use `--git-ref` to switch to a branch, tag, or commit. For push-mode deployments, local code is pushed first unless `--no-push` is set.
+Resolves the deployment's configured git ref again and starts a new release from the resulting commit. Use `--git-ref` to switch to a branch, tag, or commit before resolving.
+
+For push-mode deployments, `update` mirrors local code before resolving the ref. Use `--no-push` if you already pushed separately or want to redeploy the revision already available to the server.
 
 Flags:
 
 - `--git-ref REF`: Branch, tag, or commit SHA to deploy
-- `--no-push`: Skip pushing local code for push-mode deployments
+- `--no-push`: Skip mirroring local code for push-mode deployments
 - `--project PROJECT`: Override the active project
 
 Examples:

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-init.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-init.md
@@ -14,15 +14,14 @@ llamactl init --update
 
 ## Templates
 
-- basic-ui: A basic starter workflow with a React Vite UI
-- extraction-review: Extraction Agent with Review UI (Llama Cloud integration; review/correct extracted results)
+Run `llamactl init` without `--template` to open the template picker. The picker shows both UI templates and headless workflow templates.
 
-If omitted, you will be prompted to choose interactively.
+Use `--template <id>` when you already know which template you want. Template IDs can change as templates are added or renamed, so use the picker or the [Agent Templates](/python/llamaagents/llamactl/agent-templates/) page for the current list.
 
 ## Options
 
 - `--update`: Update the current app to the latest template version. Ignores other options.
-- `--template <id>`: Template to use (`basic-ui`, `extraction-review`).
+- `--template <id>`: Template to use.
 - `--dir <path>`: Directory to create the new app in. Defaults to the template name.
 - `--force`: Overwrite the directory if it already exists.
 
@@ -30,27 +29,31 @@ If omitted, you will be prompted to choose interactively.
 
 - Copies the selected template into the target directory using [`copier`](https://copier.readthedocs.io/en/stable/)
 - Adds assistant docs: `AGENTS.md` and symlinks `CLAUDE.md`/`GEMINI.md`
-- initializes a Git repository if `git` is available
+- Initializes a Git repository if `git` is available
 - Prints next steps to run locally and deploy
 
 ## Examples
 
-- Interactive flow:
+Open the template picker:
+
 ```bash
 llamactl init
 ```
 
-- Non‑interactive creation:
+Create from a known template:
+
 ```bash
-llamactl init --template basic-ui --dir my-app
+llamactl init --template <template-id> --dir my-app
 ```
 
-- Overwrite an existing directory:
+Overwrite an existing directory:
+
 ```bash
-llamactl init --template basic-ui --dir ./basic-ui --force
+llamactl init --template <template-id> --dir ./my-app --force
 ```
 
-- Update an existing app to the latest template:
+Update an existing app to the latest template:
+
 ```bash
 llamactl init --update
 ```

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-serve.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-serve.md
@@ -23,12 +23,18 @@ llamactl serve [DEPLOYMENT_FILE] [options]
 - `--preview`: Build the UI to static files and serve them (production‑like)
 - `--port <int>`: Port for the API server
 - `--ui-port <int>`: Port for the UI proxy in dev
+- `--log-level <DEBUG|INFO|WARNING|ERROR|CRITICAL>`: Log level for the API server
+- `--log-format <console|json>`: Log format for the API server
+- `--persistence <memory|local|cloud>`: Persistence mode for the workflow server. Defaults to local persistence.
+- `--local-persistence-path <path>`: SQLite database path for local persistence
+- `--host <host>`: Host for the API server. Defaults to `127.0.0.1`; use `0.0.0.0` to accept remote connections.
 
 ## Behavior
 
 - Prepares the server environment (installs dependencies unless `--no-install`)
 - In dev mode (default), proxies your UI dev server and reloads on change
 - In preview mode, builds the UI to static files and serves them without a proxy
+- Uses local workflow persistence by default; `--persistence cloud` stores workflow state in LlamaCloud
 
 ### Credential injection
 

--- a/docs/src/content/docs/llamaagents/llamactl/cd-with-github-actions.md
+++ b/docs/src/content/docs/llamaagents/llamactl/cd-with-github-actions.md
@@ -7,26 +7,39 @@ sidebar:
 Cloud deployments of LlamaAgents are now in beta preview and broadly available for feedback. You can try them out locally or deploy to LlamaCloud and send us feedback with the in-app button.
 :::
 
-As described in the [Getting Started](/python/llamaagents/llamactl/getting-started) guide, deploying a LlamaAgent to LlamaCloud requires connecting it to a `git` source (specifically, GitHub).
+Use `llamactl deployments apply -f` in GitHub Actions when you want a deployment spec in source control and an automated update on every push.
 
-However, when you push changes to GitHub, they are not automatically applied to your LlamaAgent. To keep your deployment in sync with your `git` reference, you must manually run `llamactl deployments update`.
+## Required Secrets and Variables
 
-This manual approach provides fine-grained control over when changes to your production branch are deployed, but it may not fit every workflow.
+`llamactl` can authenticate from environment variables, so CI does not need a stored profile:
 
-If you prefer to automate the process using continuous deployment, you can use the `run-llama/llamactl-deploy` GitHub Action.
+- `LLAMA_CLOUD_API_KEY`: store as a GitHub Actions secret.
+- `LLAMA_AGENTS_PROJECT_ID`: store as a GitHub Actions variable or secret.
 
-To use this action, you’ll need:
+If you deploy to a non-default LlamaCloud environment, also set `LLAMA_CLOUD_BASE_URL`.
 
-- A LlamaCloud API key
-- The Project ID associated with your LlamaAgent deployment
-- The ID of the deployed LlamaAgent
+## Deployment Spec
 
-Optionally, you can specify a `git` reference for the deployment (such as a commit SHA or branch name).
-
-Here’s an example workflow configuration:
+Keep a deployment spec in your repository, for example `deployment.yaml`:
 
 ```yaml
-name: Update LlamaAgent Deployment
+name: my-agent
+spec:
+  repo_url: https://github.com/${GITHUB_REPOSITORY}
+  deployment_file_path: "."
+  git_ref: ${GITHUB_SHA}
+  secrets:
+    OPENAI_API_KEY: ${OPENAI_API_KEY}
+```
+
+`deployments apply` resolves `${VAR}` references from the process environment before sending the deployment to LlamaCloud. That lets the same file use GitHub-provided values like `GITHUB_SHA` and secrets injected by the workflow.
+
+Use a stable `name` if the workflow should update the same deployment every run. If `name` is omitted and the spec uses `generate_name`, each apply can create a new deployment.
+
+## Workflow Example
+
+```yaml
+name: Deploy LlamaAgents app
 
 on:
   push:
@@ -34,18 +47,28 @@ on:
       - main
 
 jobs:
-  update-deployment:
+  deploy:
     runs-on: ubuntu-latest
+    env:
+      LLAMA_CLOUD_API_KEY: ${{ secrets.LLAMA_CLOUD_API_KEY }}
+      LLAMA_AGENTS_PROJECT_ID: ${{ vars.LLAMA_AGENTS_PROJECT_ID }}
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Update deployment
-        uses: run-llama/llamactl-deploy@v0.1.0
-        with:
-          llama-cloud-api-key: ${{ secrets.LLAMA_CLOUD_API_KEY }}
-          llama-cloud-project-id: ${{ secrets.LLAMA_CLOUD_PROJECT_ID }}
-          deployment-id: "your-deployment-id"
-          git-reference: ${{ github.sha }} # optional
+      - name: Apply deployment
+        run: uvx llamactl deployments apply -f deployment.yaml --annotate-on-error
 ```
 
-You can find the reference for this GitHub Action in the [dedicated repository](https://github.com/run-llama/llamactl-deploy).
+`--annotate-on-error` writes validation and API errors back into the YAML input so the Actions log points at the field that failed. The command exits non-zero on failure.
+
+## Capturing Status Output
+
+`llamactl` keeps machine-readable output on stdout and status messages on stderr. If a workflow parses status text from `deployments apply`, capture stderr explicitly:
+
+```bash
+status="$(uvx llamactl deployments apply -f deployment.yaml --annotate-on-error 2>&1 >/dev/null)"
+printf '%s\n' "$status"
+```
+
+Prefer a stable `name` in `deployment.yaml` over parsing the status message when downstream steps need the deployment name.

--- a/docs/src/content/docs/llamaagents/llamactl/configuration-reference.md
+++ b/docs/src/content/docs/llamaagents/llamactl/configuration-reference.md
@@ -35,7 +35,7 @@ llama_cloud = true
 ```
 
 When this is set:
-- During development, `llamactl` prompts you to log in to LlamaCloud if you're not already. After that, it injects `LLAMA_CLOUD_API_KEY`, `LLAMA_CLOUD_PROJECT_ID`, and `LLAMA_CLOUD_BASE_URL` into your Python server process and JavaScript build.
+- During development, `llamactl` uses environment variable auth or the active profile, then injects `LLAMA_CLOUD_API_KEY`, `LLAMA_AGENTS_PROJECT_ID`, and `LLAMA_CLOUD_BASE_URL` into your Python server process and JavaScript build.
 - When deployed, LlamaCloud automatically injects a dedicated API key into the Python process. The frontend process receives a short-lived session cookie specific to each user visiting the application. Therefore, configure the project ID on the frontend API client so that LlamaCloud API requests from the frontend and backend are scoped to the same project ID.
 
 ### `.env` files

--- a/docs/src/content/docs/llamaagents/llamactl/getting-started.md
+++ b/docs/src/content/docs/llamaagents/llamactl/getting-started.md
@@ -196,7 +196,7 @@ Use `-o json` or `-o yaml` with `deployments get` when another tool needs struct
 
 ## Update a Deployment
 
-If the deployment tracks a branch, update it to the latest commit on that branch:
+If the deployment tracks a branch, re-resolve that branch and start a new release from the latest commit:
 
 ```bash
 llamactl deployments update NAME
@@ -206,6 +206,12 @@ To point at a specific branch, tag, or commit:
 
 ```bash
 llamactl deployments update NAME --git-ref main
+```
+
+For push-mode deployments, `update` pushes local code before resolving the ref. If you have already pushed separately, use `--no-push`:
+
+```bash
+llamactl deployments update NAME --no-push
 ```
 
 To edit the deployment spec in your editor:

--- a/docs/src/content/docs/llamaagents/llamactl/getting-started.md
+++ b/docs/src/content/docs/llamaagents/llamactl/getting-started.md
@@ -9,76 +9,94 @@ Cloud deployments of LlamaAgents are now in beta preview and broadly available f
 
 ## Getting Started with `llamactl`
 
-LlamaAgents uses the [`llamactl` CLI for development](https://pypi.org/project/llamactl/). `llamactl` bootstraps an application server that manages running and persisting your workflows, and a control plane for managing cloud deployments of applications. It has some system pre-requisites that must be installed in order to work:
+`llamactl` is the local development and deployment CLI for LlamaAgents. It can scaffold an app, run the app server locally, and manage cloud deployments from your terminal.
 
 :::tip[Prefer a UI?]
-You can also deploy starter templates directly from the LlamaCloud dashboard—no CLI or dependencies required. See [Click-to-Deploy from LlamaCloud](/python/llamaagents/llamactl/click-to-deploy).
+You can also deploy starter templates directly from the LlamaCloud dashboard. See [Click-to-Deploy from LlamaCloud](/python/llamaagents/llamactl/click-to-deploy).
 :::
 
-- Make sure you have [`uv`](https://docs.astral.sh/uv/getting-started/installation/) installed. `uv` is a Python package manager and build tool. `llamactl` integrates with it in order to quickly manage your project's build and dependencies.
-- Windows support is experimental (as of version `0.3.14`) and requires some adjustments to run `llamactl` without issues: see [our dedicated guide](https://github.com/run-llama/llamactl-windows) on the topic. For a better user experience, it is still advisable to use WSL2 (e.g., Ubuntu) and follow the Linux instructions. See [Install WSL](https://learn.microsoft.com/windows/wsl/install).
-- Likewise, Node.js is required for UI development. For macOS and Linux, we recommend installing Node via [`nvm`](https://github.com/nvm-sh/nvm) to manage versions. You can use your node package manager of choice (`npm`, `pnpm`, or `yarn`). For Windows, we recommend using [Chocolatey](https://community.chocolatey.org/packages/nodejs) for the installation process.
-- Ensure `git` is installed:
-  - macOS: [Install via Xcode Command Line Tools](https://git-scm.com/download/mac) or Homebrew (`brew install git`)
-  - Linux: Follow your distro instructions: [git-scm.com/download/linux](https://git-scm.com/download/linux)
-  - Windows: use [Chocolatey](https://community.chocolatey.org/packages/git.install)
+Before you start:
 
+- Install [`uv`](https://docs.astral.sh/uv/getting-started/installation/). `llamactl` uses it to manage Python environments and project dependencies.
+- Install `git`. Cloud deployments are built from source repositories.
+- Install Node.js if you are using a template with a frontend. For macOS and Linux, we recommend [`nvm`](https://github.com/nvm-sh/nvm). For Windows, we recommend [Chocolatey](https://community.chocolatey.org/packages/nodejs).
+- Windows support is experimental. For the best experience, use WSL2. If you run directly on Windows, see [the Windows guide](https://github.com/run-llama/llamactl-windows).
 
 ## Install
 
-Choose one:
+Install `llamactl` with `pip`:
 
-- Try without installing:
+```bash
+pip install llamactl
+```
+
+Or run it on demand with `uvx`:
+
 ```bash
 uvx llamactl --help
 ```
 
-- Install globally (recommended):
+If you use `uvx`, replace `llamactl` with `uvx llamactl` in the commands below.
+
+## Authenticate
+
+Log in with your browser:
+
 ```bash
-uv tool install -U llamactl
-llamactl --help
+llamactl auth login
 ```
+
+If browser login is not available, use an API key and project ID:
+
+```bash
+llamactl auth token --api-key "$LLAMA_CLOUD_API_KEY" --project "$LLAMA_AGENTS_PROJECT_ID"
+```
+
+For CI or other non-interactive environments, you can skip the stored profile and set environment variables instead:
+
+```bash
+export LLAMA_CLOUD_API_KEY="llx-..."
+export LLAMA_AGENTS_PROJECT_ID="project-id"
+```
+
+See [`llamactl auth`](/python/llamaagents/llamactl-reference/commands-auth) and [`llamactl auth env`](/python/llamaagents/llamactl-reference/commands-auth-env) for profile and environment commands.
 
 ## Initialize a Project
 
-`llamactl` includes starter templates for both full‑stack UI apps, and headless (API only) workflows. Pick a template and customize it.
-
-:::warning
-Since llamactl uses symlinks when initializing, you might run into some permission issues with Windows. We advise you to activate Developer Settings using `start ms-settings:developers` before running `llamactl init`.
-:::
+Create a new LlamaAgents project:
 
 ```bash
 llamactl init
 ```
 
-This will prompt for some details, and create a Python module that contains LlamaIndex workflows, plus an optional UI you can serve as a static frontend.
+`llamactl init` opens a template picker and writes a project scaffold. Templates may include Python workflows only, or a Python app plus a frontend UI.
 
-:::info
-When you run `llamactl init`, the scaffold also includes AI assistant-facing docs: `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`. These contain quick references and instructions for using LlamaIndex libraries to assist coding. These files are optional and safe to customize or remove — they do not affect your builds, runtime, or deployments.
+:::warning
+`llamactl init` uses symlinks. On Windows, enable Developer Mode with `start ms-settings:developers` before running the command.
 :::
 
-Application configuration is managed within your project's `pyproject.toml`, where you can define Python workflow instances that should be served, environment details, and configuration for how the UI should be built. See the [Deployment Config Reference](/python/llamaagents/llamactl/configuration-reference) for details on all configurable fields.
+:::info
+The scaffold may include assistant-facing files such as `AGENTS.md`, `CLAUDE.md`, and `GEMINI.md`. They are optional and do not affect builds, runtime, or deployments.
+:::
 
-## Develop and Run Locally
+Application configuration lives in your project's `pyproject.toml`, or in `llama_agents.yaml` / `llama_agents.toml`. See the [Deployment Config Reference](/python/llamaagents/llamactl/configuration-reference) for the schema.
 
-Once you have a project, you can run the dev server for your application:
+## Run Locally
+
+From the project directory, start the local development server:
 
 ```bash
 llamactl serve
 ```
 
-`llamactl serve` will
+`llamactl serve` installs dependencies, reads the workflows configured for the app, serves them as an API, and proxies the frontend development server when the app has a UI.
 
-1. Install all required dependencies
-2. Read the workflows configured in your app’s `pyproject.toml` and serve them as an API
-3. Start up and proxy the frontend development server, so you can seamlessly write a full stack application.
-
-For example, with the following configuration, the app will be served at `http://localhost:4501/deployments/my-package`. Make a `POST` request to `/deployments/my-package/workflows/my-workflow/run` to trigger the workflow in `src/my_package/my_workflow.py`.
+For example, this configuration serves `my-workflow` under the local deployment named `my-package`:
 
 ```toml
 [project]
 name = "my-package"
-# ...
+
 [tool.llamaagents.workflows]
 my-workflow = "my_package.my_workflow:workflow"
 
@@ -88,61 +106,123 @@ directory = "ui"
 
 ```py
 # src/my_package/my_workflow.py
-# from workflows import ...
-# ...
 workflow = MyWorkflow()
 ```
 
-At this point, you can get to coding. The development server will detect changes as you save files. It will even resume in-progress workflows!
+The local API is available at `http://localhost:4501/deployments/my-package`. To run the workflow, make a `POST` request to `/deployments/my-package/workflows/my-workflow/run`.
 
-For more information about CLI flags available, see [`llamactl serve`](/python/llamaagents/llamactl-reference/commands-serve).
-
-For a more detailed reference on how to define and expose workflows, see [Workflows & App Server API](/python/llamaagents/llamactl/workflow-api).
+For flags, see [`llamactl serve`](/python/llamaagents/llamactl-reference/commands-serve). For workflow API details, see [Workflows & App Server API](/python/llamaagents/llamactl/workflow-api).
 
 ## Create a Cloud Deployment
 
-LlamaAgents applications can be rapidly deployed just by pointing to a source git repository. With the provided repository configuration, LlamaCloud will clone, build, and serve your app. It can even access GitHub private repositories by installing the [GitHub app](https://github.com/apps/llama-deploy).
-
-Example:
+Cloud deployments are built from a Git repository. Commit and push your project first:
 
 ```bash
 git remote add origin https://github.com/org/repo
 git add -A
-git commit -m 'Set up new app'
+git commit -m "Set up LlamaAgents app"
 git push -u origin main
 ```
 
-Then, create a deployment:
+Then create the deployment:
 
 ```bash
 llamactl deployments create
 ```
 
-:::info
-The first time you run this, you'll be prompted to log into LlamaCloud.
+`deployments create` opens a YAML deployment spec in your `$EDITOR`. Review the detected repository, deployment config path, Git ref, and secrets. Save and close the file to create the deployment.
 
-Username/password sign-in is not yet supported. If you do not have a supported social sign-in provider, you can use token-based authentication via `llamactl auth token`. See [`llamactl auth`](/python/llamaagents/llamactl-reference/commands-auth) for details.
-:::
+For non-interactive creation, pass a file:
 
-This will open an interactive Terminal UI (TUI). You can tab through fields, or even point and click with your mouse if your terminal supports it. All required fields should be automatically detected from your environment, but can be customized:
+```bash
+llamactl deployments create -f deployment.yaml
+```
 
-- Name: Human‑readable and URL‑safe; appears in your deployment URL
-- Git repository: Public HTTP or private GitHub (install the GitHub app for private repos)
-- Git branch: Branch to pull and build from (use `llamactl deployments update` to roll forward). This can also be a tag or a git commit.
-- Secrets: Pre‑filled from your local `.env`; edit as needed. These cannot be read again after creation.
+Private GitHub repositories require LlamaCloud to have repository access. If access is missing, `llamactl` will return an error with the next step.
 
-When you save, LlamaAgents will verify that it has access to your repository (and prompt you to install the GitHub app if not)
+## Declarative Deployments
 
-After creation, the TUI will show deployment status and logs.
-- You can later use `llamactl deployments get` to view again.
-- You can add secrets or change branches with `llamactl deployments edit`.
-- If you update your source repo, run `llamactl deployments update` to roll a new version. If you are interested in automating the deployment updates with GitHub Actions, you can read the [Continuous Deployment guide](/python/llamaagents/llamactl/cd-with-github-actions/)
+For repeatable deploys, generate an apply-shaped deployment spec:
 
-## Alternative Ways to Deploy
+```bash
+llamactl deployments template > deployment.yaml
+```
 
-If you prefer a self-hosted deployments, `llamactl` has utilities to export your workflows to container files, so that you can easily build images and deploy your agent workflow anywhere.
+Edit the file, then apply it:
 
-Read more about this in the [`pkg` command reference](/python/llamaagents/llamactl-reference/commands-pkg/).
+```bash
+llamactl deployments apply -f deployment.yaml
+```
+
+`apply` creates the deployment when it does not exist and updates it when it does. Secret values can reference local environment variables:
+
+```yaml
+name: my-agent
+spec:
+  repo_url: https://github.com/org/repo
+  deployment_file_path: "."
+  git_ref: main
+  secrets:
+    OPENAI_API_KEY: ${OPENAI_API_KEY}
+```
+
+Run a dry run before changing cloud state:
+
+```bash
+llamactl deployments apply -f deployment.yaml --dry-run
+```
+
+## Inspect and Stream Logs
+
+List deployments in the active project:
+
+```bash
+llamactl deployments get
+```
+
+Fetch one deployment:
+
+```bash
+llamactl deployments get NAME
+```
+
+Stream logs:
+
+```bash
+llamactl deployments logs NAME --follow
+```
+
+Use `-o json` or `-o yaml` with `deployments get` when another tool needs structured output.
+
+## Update a Deployment
+
+If the deployment tracks a branch, update it to the latest commit on that branch:
+
+```bash
+llamactl deployments update NAME
+```
+
+To point at a specific branch, tag, or commit:
+
+```bash
+llamactl deployments update NAME --git-ref main
+```
+
+To edit the deployment spec in your editor:
+
+```bash
+llamactl deployments edit NAME
+```
+
+Or keep the spec in version control and re-apply it:
+
+```bash
+llamactl deployments apply -f deployment.yaml
+```
+
+## Package for Self-Hosted Deployments
+
+If you prefer to build and deploy containers yourself, use `llamactl pkg` to generate container files for your app. See the [`pkg` command reference](/python/llamaagents/llamactl-reference/commands-pkg/).
 
 ---
 

--- a/docs/src/content/docs/llamaagents/llamactl/getting-started.md
+++ b/docs/src/content/docs/llamaagents/llamactl/getting-started.md
@@ -24,19 +24,17 @@ Before you start:
 
 ## Install
 
-Install `llamactl` with `pip`:
+Install `llamactl` globally with `uv`:
 
 ```bash
-pip install llamactl
+uv tool install -U llamactl
 ```
 
-Or run it on demand with `uvx`:
+Or pin it to a project:
 
 ```bash
-uvx llamactl --help
+uv add --dev llamactl
 ```
-
-If you use `uvx`, replace `llamactl` with `uvx llamactl` in the commands below.
 
 ## Authenticate
 

--- a/packages/llamactl/README.md
+++ b/packages/llamactl/README.md
@@ -1,9 +1,8 @@
 # llamactl
 
+`llamactl` is the CLI for developing LlamaAgents apps locally and managing their LlamaCloud deployments.
 
-A command-line interface for managing LlamaDeploy projects and deployments.
-
-For an end-to-end introduction, see [Getting started with LlamaAgents](https://developers.llamaindex.ai/python/cloud/llamaagents/getting-started).
+For the full guide, see the [LlamaAgents `llamactl` docs](https://developers.llamaindex.ai/python/llamaagents/llamactl/getting-started/).
 
 ## Installation
 
@@ -13,89 +12,99 @@ Install from PyPI:
 pip install llamactl
 ```
 
-Or using uv:
+Or run without installing:
 
 ```bash
-uv add llamactl
+uvx llamactl --help
 ```
 
 ## Quick Start
 
-1. **Configure your profile**: Set up connection to your LlamaDeploy control plane
-   ```bash
-   llamactl profile configure
-   ```
+Create or select an auth profile:
 
-2. **Check health**: Verify connection to the control plane
-   ```bash
-   llamactl health
-   ```
+```bash
+llamactl auth login
+```
 
-3. **Create a project**: Initialize a new deployment project
-   ```bash
-   llamactl project create my-project
-   ```
+If browser login is not available, use an API key:
 
-4. **Deploy**: Deploy your project to the control plane
-   ```bash
-   llamactl deployment create my-deployment --project-name my-project
-   ```
+```bash
+llamactl auth token --api-key "$LLAMA_CLOUD_API_KEY" --project "$LLAMA_AGENTS_PROJECT_ID"
+```
 
-## Commands
+Scaffold and run an app:
 
-### Profile Management
-- `llamactl profile configure` - Configure connection to control plane
-- `llamactl profile show` - Show current profile configuration
-- `llamactl profile list` - List all configured profiles
+```bash
+llamactl init
+cd my-app
+llamactl serve
+```
 
-### Project Management
-- `llamactl project create <name>` - Create a new project
-- `llamactl project list` - List all projects
-- `llamactl project show <name>` - Show project details
-- `llamactl project delete <name>` - Delete a project
+Create a cloud deployment:
 
-### Deployment Management
-- `llamactl deployment create <name>` - Create a new deployment
-- `llamactl deployment list` - List all deployments
-- `llamactl deployment show <name>` - Show deployment details
-- `llamactl deployment delete <name>` - Delete a deployment
-- `llamactl deployment logs <name>` - View deployment logs
+```bash
+llamactl deployments create
+```
 
-### Health & Status
-- `llamactl health` - Check control plane health
-- `llamactl serve` - Start local development server
+Inspect it and stream logs:
+
+```bash
+llamactl deployments get
+llamactl deployments get NAME
+llamactl deployments logs NAME --follow
+```
+
+For declarative deployments:
+
+```bash
+llamactl deployments template > deployment.yaml
+llamactl deployments apply -f deployment.yaml
+```
+
+## Command Groups
+
+- `llamactl auth`: log in, create API-key profiles, switch profiles, select projects, and list organizations.
+- `llamactl auth env`: list, add, inspect, and switch LlamaCloud API environments.
+- `llamactl deployments`: create, apply, edit, update, inspect, delete, roll back, and stream deployment logs.
+- `llamactl init`: create a new LlamaAgents project from a starter template.
+- `llamactl serve`: run the local app server and optional frontend dev server.
+- `llamactl pkg`: generate container build files for self-hosted deployments.
+- `llamactl completion`: generate or install shell completions.
+- `llamactl agentcore`: run or export AgentCore apps.
 
 ## Configuration
 
-llamactl stores configuration in your home directory at `~/.llamactl/`.
+`llamactl auth login` and `llamactl auth token` create local auth profiles. A profile stores the active API environment, project, and credential used by deployment commands.
 
-### Profile Configuration
-Profiles allow you to manage multiple control plane connections:
+For CI and other non-interactive environments, set env vars instead of using a profile:
 
 ```bash
-# Configure default profile
-llamactl profile configure
-
-# Configure named profile
-llamactl profile configure --profile production
-
-# Use specific profile for commands
-llamactl --profile production deployment list
+export LLAMA_CLOUD_API_KEY="llx-..."
+export LLAMA_AGENTS_PROJECT_ID="project-id"
 ```
 
-## Development
+`LLAMA_CLOUD_BASE_URL` can point the CLI at a non-default environment. When both `LLAMA_CLOUD_API_KEY` and `LLAMA_AGENTS_PROJECT_ID` are set, env var auth takes precedence over the stored profile for cloud commands. Many commands also accept `--project` to override the active project for that invocation.
 
-This CLI is part of the LlamaDeploy ecosystem. For development setup:
+## Shell Completion
 
-1. Clone the repository
-2. Install dependencies: `uv sync`
-3. Run tests: `uv run pytest`
+Install completions for your current shell:
+
+```bash
+llamactl completion install
+```
+
+Or print a completion script:
+
+```bash
+llamactl completion generate zsh
+```
 
 ## Requirements
 
 - Python 3.12+
-- Access to a LlamaDeploy control plane
+- `uv` for project dependency management
+- `git` for cloud deployments
 
 ## License
 
-This project is licensed under the MIT License.
+MIT

--- a/packages/llamactl/README.md
+++ b/packages/llamactl/README.md
@@ -6,16 +6,16 @@ For the full guide, see the [LlamaAgents `llamactl` docs](https://developers.lla
 
 ## Installation
 
-Install from PyPI:
+Install globally with `uv`:
 
 ```bash
-pip install llamactl
+uv tool install -U llamactl
 ```
 
-Or run without installing:
+Or pin it to a project:
 
 ```bash
-uvx llamactl --help
+uv add --dev llamactl
 ```
 
 ## Quick Start

--- a/packages/llamactl/src/llama_agents/cli/commands/init.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/init.py
@@ -245,7 +245,7 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
     status("    git remote add origin <your-repo-url>")
     status("    git push -u origin main")
     status("")
-    status("    uvx llamactl deploy create")
+    status("    uvx llamactl deployments create")
     status("")
 
 

--- a/packages/llamactl/tests/test_init_command.py
+++ b/packages/llamactl/tests/test_init_command.py
@@ -91,6 +91,8 @@ def test_init_create_with_flags_calls_copier_and_git(tmp_path: Path) -> None:
         calls = [" ".join(call_args.args[0]) for call_args in mock_subproc.mock_calls]
         assert any(cmd.startswith("git --version") for cmd in calls)
         assert target_dir.exists()
+        assert "uvx llamactl deployments create" in result.output
+        assert "uvx llamactl deploy create" not in result.output
         # Symlinks to AGENTS.md should be created by the init flow
         claude_link = target_dir / "CLAUDE.md"
         gemini_link = target_dir / "GEMINI.md"


### PR DESCRIPTION
The `llamactl` docs were still describing the old prompt/TUI deployment flow and singular command names. This rewrites the command reference, getting-started guide, CI guide, and package README around the plural `deployments` surface.

Covers editor-based create/edit, declarative `template`/`apply`, logs/history/rollback, env-var auth for CI, and the stdout/stderr split for scripts. The generated `llamactl init` next steps now point at `deployments create` too, so the scaffolded app output matches the docs.