### PR TITLE
Polish llamactl command output

### DIFF
--- a/.changeset/llamactl-cli-polish.md
+++ b/.changeset/llamactl-cli-polish.md
@@ -1,0 +1,5 @@
+---
+"llamactl": patch
+---
+
+Polish llamactl error handling, status output, and deployment update flags

--- a/packages/llamactl/src/llama_agents/cli/app.py
+++ b/packages/llamactl/src/llama_agents/cli/app.py
@@ -5,11 +5,6 @@ from typing import Any
 import click
 from llama_agents.cli.commands.aliased_group import AliasedGroup
 from llama_agents.cli.options import global_options
-from rich import print as rprint
-from rich.console import Console
-from rich.text import Text
-
-console = Console(highlight=False)
 
 
 def print_version(ctx: click.Context, param: click.Parameter, value: Any) -> None:
@@ -21,7 +16,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: Any) -> Non
         return None
     try:
         ver = pkg_version("llamactl")
-        console.print(Text.assemble("client version: ", (ver, "green")))
+        click.echo(f"client version: {ver}")
 
         # If there is an active profile, attempt to query server version
         auth_service = service.current_auth_service()
@@ -29,29 +24,13 @@ def print_version(ctx: click.Context, param: click.Parameter, value: Any) -> Non
             try:
                 data = auth_service.fetch_server_version()
                 server_ver = data.version
-                console.print(
-                    Text.assemble(
-                        "server version: ",
-                        (
-                            server_ver or "unknown",
-                            "bright_yellow" if server_ver is None else "green",
-                        ),
-                    )
-                )
+                click.echo(f"server version: {server_ver or 'unknown'}")
             except Exception as e:
-                console.print(
-                    Text.assemble(
-                        "server version: ",
-                        ("unavailable", "bright_yellow"),
-                        (f" - {e}", "dim"),
-                    )
-                )
+                click.echo(f"server version: unavailable - {e}")
     except PackageNotFoundError:
-        rprint("[red]Package 'llamactl' not found[/red]")
-        raise click.Abort()
+        raise click.ClickException("Package 'llamactl' not found")
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
     ctx.exit()
 
 

--- a/packages/llamactl/src/llama_agents/cli/client.py
+++ b/packages/llamactl/src/llama_agents/cli/client.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, AsyncGenerator
 
 import click
 from llama_agents.cli.env_settings import LlamactlEnvSettings, read_env_settings
-from rich import print as rprint
 
 if TYPE_CHECKING:
     from llama_agents.core.client.manage_client import ControlPlaneClient, ProjectClient
@@ -161,13 +160,10 @@ def get_project_client(project_id_override: str | None = None) -> ProjectClient:
     from llama_agents.cli.config.env_service import service
 
     auth_svc = service.current_auth_service()
-    rprint("\n[bold red]No profile configured![/bold red]")
-    rprint("\nTo get started, create a profile with:")
-    if auth_svc.env.requires_auth:
-        rprint("[cyan]llamactl auth login[/cyan]")
-    else:
-        rprint("[cyan]llamactl auth token[/cyan]")
-    raise SystemExit(1)
+    command = (
+        "llamactl auth login" if auth_svc.env.requires_auth else "llamactl auth token"
+    )
+    raise click.ClickException(f"No profile configured. To get started, run: {command}")
 
 
 @asynccontextmanager

--- a/packages/llamactl/src/llama_agents/cli/commands/agentcore.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/agentcore.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 import click
+from llama_agents.cli.output import echo_status as _out
 
 from ..app import app
 from ..options import global_options
@@ -21,7 +22,7 @@ def agentcore() -> None:
 
 
 @agentcore.command("run", help="Run AgentCore server")
-def run():
+def run() -> None:
     start_app()
 
 
@@ -30,7 +31,7 @@ def run():
     help="Run AgentCore server locally with a local SQLite store (no AWS required). "
     "Send requests to POST http://localhost:8080/invocations",
 )
-def test():
+def test() -> None:
     start_app(local=True)
 
 
@@ -38,7 +39,7 @@ def test():
     "export",
     help="Export generated code to a `.agentcore` folder in the current working directory.",
 )
-def export():
+def export() -> None:
     export_generated_entrypoint_code()
 
 
@@ -92,5 +93,5 @@ def start_app(local: bool = False) -> None:
     try:
         start_app_in_target_venv(path, local=local)
     except subprocess.CalledProcessError as exc:
-        print("Failed to run agentcore, see errors above.")  # noqa
+        _out("Failed to run agentcore, see errors above.")
         raise click.exceptions.Exit(exc.returncode)

--- a/packages/llamactl/src/llama_agents/cli/commands/agentcore.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/agentcore.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 
 import click
-from llama_agents.cli.output import echo_status as _out
+from llama_agents.cli.output import status
 
 from ..app import app
 from ..options import global_options
@@ -93,5 +93,5 @@ def start_app(local: bool = False) -> None:
     try:
         start_app_in_target_venv(path, local=local)
     except subprocess.CalledProcessError as exc:
-        _out("Failed to run agentcore, see errors above.")
+        status("failed to run agentcore; see errors above")
         raise click.exceptions.Exit(exc.returncode)

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -11,9 +11,8 @@ from typing import TYPE_CHECKING
 
 import click
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
-from llama_agents.cli.output import echo_status as _out
+from llama_agents.cli.output import status, warning
 from llama_agents.cli.param_types import OrgType, ProfileType, ProjectType
-from llama_agents.cli.styles import MUTED_COL, PRIMARY_COL, WARNING
 from llama_agents.cli.utils.capabilities import probe_organizations_support
 
 from ..app import app
@@ -88,9 +87,7 @@ def create_api_key_profile(
                     "--api-key and --project are required in non-interactive mode"
                 )
             created = auth_svc.create_profile_from_token(project_id, api_key)
-            _out(
-                f"[green]Created API key profile '{created.name}' and set as current[/green]"
-            )
+            status(f"created API key profile {created.name} and set as current")
             return
 
         # Interactive mode: prompt for token (masked) and validate
@@ -98,7 +95,7 @@ def create_api_key_profile(
         org = _discover_organization(auth_svc, api_key=token_value)
         org_id_for_projects = org.org_id if org is not None else None
         if org is not None:
-            _out(f"Projects for organization [bold]{org.org_name}[/]")
+            status(f"projects for organization {org.org_name}")
         projects = _prompt_validate_api_key_and_list_projects(
             auth_svc, token_value, org_id=org_id_for_projects
         )
@@ -108,14 +105,12 @@ def create_api_key_profile(
             projects, auth_svc.env.requires_auth
         )
         if not selected_project_id:
-            _out(f"[{WARNING}]No project selected[/]")
+            status("no project selected")
             return
 
         # Create and set profile
         created = auth_svc.create_profile_from_token(selected_project_id, token_value)
-        _out(
-            f"[green]Created API key profile '{created.name}' and set as current[/green]"
-        )
+        status(f"created API key profile {created.name} and set as current")
     except click.ClickException:
         raise
     except Exception as e:
@@ -130,25 +125,19 @@ def device_login() -> None:
 
     try:
         created = _create_device_profile()
-        _out(
-            f"[green]Created login profile '{created.name}' and set as current[/green]"
-        )
+        status(f"created login profile {created.name} and set as current")
 
     except NoProjectsFoundError:
-        _out(f"[{WARNING}]⚠️ No Existing Projects - Welcome to LlamaCloud![/]")
-        _out(f"[{WARNING}]Looks like this may be your first time logging in.[/]")
-        _out(
-            f"[{WARNING}]Before you can get started, log in to https://cloud.llamaindex.ai to complete your account setup.[/]"
-        )
+        warning("no existing projects")
+        status("looks like this may be your first time logging in")
+        status("log in to https://cloud.llamaindex.ai to complete account setup")
         return
 
     except OIDCNotEnabledError as e:
-        _out(
-            f"[{WARNING}]This server does not have browser-based login (OIDC) configured.[/]"
-        )
+        warning("this server does not have browser-based login (OIDC) configured")
         if str(e):
-            _out(f"[{MUTED_COL}]Server response: {e}[/]")
-        _out("Use [cyan]llamactl auth token[/cyan] to log in with an API key instead.")
+            status(f"server response: {e}")
+        status("use llamactl auth token to log in with an API key instead")
         return
 
     except Exception as e:
@@ -166,11 +155,11 @@ def list_profiles(output: str) -> None:
         current = auth_svc.get_current_profile()
 
         if not profiles and output == "text":
-            _out(f"[{WARNING}]No profiles found[/]")
+            status("no profiles found")
             if auth_svc.env.requires_auth:
-                _out("Create one with: [cyan]llamactl auth login[/cyan]")
+                status("create one with: llamactl auth login")
             else:
-                _out("Create one with: [cyan]llamactl auth token[/cyan]")
+                status("create one with: llamactl auth token")
             return
 
         current_name = current.name if current else None
@@ -195,7 +184,7 @@ def destroy_database() -> None:
     ):
         return
     ConfigManager(init_database=False).destroy_database()
-    _out("[green]Database destroyed[/green]")
+    status("database destroyed")
 
 
 @auth.command("show-db", hidden=True)
@@ -203,7 +192,7 @@ def destroy_database() -> None:
 def config_database() -> None:
     """Config the database"""
     path = _get_service().config_manager().db_path
-    _out(f"[bold]{path}[/bold]")
+    status(path)
 
 
 @auth.command("switch")
@@ -215,11 +204,11 @@ def switch_profile(name: str | None) -> None:
     try:
         selected_auth = _select_profile(auth_svc, name)
         if not selected_auth:
-            _out(f"[{WARNING}]No profile selected[/]")
+            status("no profile selected")
             return
 
         auth_svc.set_current_profile(selected_auth.name)
-        _out(f"[green]Switched to profile '{selected_auth.name}'[/green]")
+        status(f"switched profile {selected_auth.name}")
 
     except Exception as e:
         raise click.ClickException(str(e)) from e
@@ -239,7 +228,7 @@ def delete_profile(name: str | None) -> None:
             raise click.ClickException("No profile selected")
 
         if asyncio.run(auth_svc.delete_profile(auth.name)):
-            _out(f"[green]Logged out from '{auth.name}'[/green]")
+            status(f"logged out {auth.name}")
         else:
             raise click.ClickException(f"Profile '{auth.name}' not found")
 
@@ -287,7 +276,7 @@ def list_organizations(output: str) -> None:
         auth_svc = _get_service().current_auth_service()
         if not probe_organizations_support():
             if output == "text":
-                _out(f"[{WARNING}]This server does not support organizations[/]")
+                warning("this server does not support organizations")
                 return
             # Structured outputs: emit an empty list so scripts get a
             # well-typed answer instead of an unparsable warning.
@@ -296,7 +285,7 @@ def list_organizations(output: str) -> None:
 
         organizations = _list_organizations(auth_svc)
         if not organizations and output == "text":
-            _out(f"[{WARNING}]No organizations found[/]")
+            status("no organizations found")
             return
 
         default_org = next((o.org_id for o in organizations if o.is_default), None)
@@ -344,13 +333,13 @@ def change_project(project_id: str | None, org_id: str | None) -> None:
             ):
                 raise click.ClickException(f"Project {project_id} not found")
         auth_svc.set_project(profile.name, project_id)
-        _out(f"Set active project to [bold green]{project_id}[/]")
+        status(f"switched project {project_id}")
         return
     try:
         projects = _list_projects(auth_svc)
 
         if not projects:
-            _out(f"[{WARNING}]No projects found[/]")
+            status("no projects found")
             return
 
         current_project_id = profile.project_id
@@ -383,9 +372,9 @@ def change_project(project_id: str | None, org_id: str | None) -> None:
             )
             name = selected_project.project_name if selected_project else result
             auth_svc.set_project(profile.name, result)
-            _out(f"Set active project to [bold {PRIMARY_COL}]{name}[/]")
+            status(f"switched project {name}")
         else:
-            _out(f"[{WARNING}]No project selected[/]")
+            status("no project selected")
     except click.ClickException:
         raise
     except Exception as e:
@@ -429,15 +418,13 @@ def inject_env_vars(
 
         vars = env_vars_from_profile(profile)
         if not vars:
-            _out(f"[{WARNING}]No variables to inject[/]")
+            status("no variables to inject")
             return
         env_file.parent.mkdir(parents=True, exist_ok=True)
         for key, value in vars.items():
             set_key(str(env_file), key, value)
         rel = os.path.relpath(env_file, Path.cwd())
-        _out(
-            f"[green]Wrote environment variables: {', '.join(vars.keys())} to {rel}[/green]"
-        )
+        status(f"wrote environment variables to {rel}")
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
@@ -529,7 +516,7 @@ def _create_device_profile() -> Auth:
         raise click.ClickException("No projects found for this account")
 
     if org is not None:
-        _out(f"Projects for organization [bold]{org.org_name}[/]")
+        status(f"projects for organization {org.org_name}")
 
     selected_project_id = _select_or_enter_project(projects, True)
     if not selected_project_id:
@@ -599,15 +586,15 @@ async def _run_device_authentication(base_url: str) -> DeviceOIDC:
             DeviceAuthorizationRequest(client_id=client_id, scope=scope_value),
         )
 
-        _out(
-            "[bold]complete authentication by visiting the verification URI and confirming the device:[/bold]"
+        status(
+            "complete authentication by visiting the verification URI and confirming the device:"
         )
         if da.verification_uri:
-            _out(
-                f"Verification URI: {da.verification_uri} (will open in your browser if supported)"
+            status(
+                f"verification URI: {da.verification_uri} (will open in your browser if supported)"
             )
         if da.user_code:
-            _out(f"User Code: {da.user_code} to confirm the device")
+            status(f"user code: {da.user_code} to confirm the device")
         if da.verification_uri_complete:
             try:
                 webbrowser.open(da.verification_uri_complete)
@@ -798,12 +785,12 @@ def _prompt_validate_api_key_and_list_projects(
         return _list_projects(auth_svc, api_key, org_id=org_id)
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 401:
-            _out("[red]Invalid API key. Please try again.[/red]")
+            status("invalid API key; please try again")
             return _prompt_validate_api_key_and_list_projects(
                 auth_svc, _prompt_for_api_key(), org_id=org_id
             )
         if e.response.status_code == 403:
-            _out("[red]This environment requires a valid API key.[/red]")
+            status("this environment requires a valid API key")
             return _prompt_validate_api_key_and_list_projects(
                 auth_svc, _prompt_for_api_key(), org_id=org_id
             )
@@ -862,7 +849,7 @@ def _select_profile(auth_svc: AuthService, profile_name: str | None) -> Auth | N
         profiles = auth_svc.list_profiles()
 
         if not profiles:
-            _out(f"[{WARNING}]No profiles found[/]")
+            status("no profiles found")
             return None
 
         current = auth_svc.get_current_profile()
@@ -886,5 +873,5 @@ def _select_profile(auth_svc: AuthService, profile_name: str | None) -> Auth | N
     except click.ClickException:
         raise
     except Exception as e:
-        _out(f"[red]Error loading profiles: {e}[/red]")
+        warning(f"error loading profiles: {e}")
         return None

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -11,10 +11,10 @@ from typing import TYPE_CHECKING
 
 import click
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
+from llama_agents.cli.output import echo_status as _out
 from llama_agents.cli.param_types import OrgType, ProfileType, ProjectType
 from llama_agents.cli.styles import MUTED_COL, PRIMARY_COL, WARNING
 from llama_agents.cli.utils.capabilities import probe_organizations_support
-from rich import print as rprint
 
 from ..app import app
 from ..display import AuthProfileDisplay, OrgDisplay
@@ -60,8 +60,14 @@ def auth() -> None:
 @auth.command("token")
 @global_options
 @click.option(
+    "--project",
+    "project_id",
+    help="Project ID to use for the login when creating non-interactively.",
+)
+@click.option(
     "--project-id",
-    help="Project ID to use for the login when creating non-interactively",
+    "project_id",
+    hidden=True,
 )
 @click.option(
     "--api-key",
@@ -75,14 +81,14 @@ def create_api_key_profile(
     try:
         auth_svc = _get_service().current_auth_service()
 
-        # Non-interactive mode: require both api-key and project-id
+        # Non-interactive mode: require both api-key and project.
         if not is_interactive_session():
             if not api_key or not project_id:
                 raise click.ClickException(
-                    "--api-key and --project-id are required in non-interactive mode"
+                    "--api-key and --project are required in non-interactive mode"
                 )
             created = auth_svc.create_profile_from_token(project_id, api_key)
-            rprint(
+            _out(
                 f"[green]Created API key profile '{created.name}' and set as current[/green]"
             )
             return
@@ -92,7 +98,7 @@ def create_api_key_profile(
         org = _discover_organization(auth_svc, api_key=token_value)
         org_id_for_projects = org.org_id if org is not None else None
         if org is not None:
-            rprint(f"Projects for organization [bold]{org.org_name}[/]")
+            _out(f"Projects for organization [bold]{org.org_name}[/]")
         projects = _prompt_validate_api_key_and_list_projects(
             auth_svc, token_value, org_id=org_id_for_projects
         )
@@ -102,17 +108,18 @@ def create_api_key_profile(
             projects, auth_svc.env.requires_auth
         )
         if not selected_project_id:
-            rprint(f"[{WARNING}]No project selected[/]")
+            _out(f"[{WARNING}]No project selected[/]")
             return
 
         # Create and set profile
         created = auth_svc.create_profile_from_token(selected_project_id, token_value)
-        rprint(
+        _out(
             f"[green]Created API key profile '{created.name}' and set as current[/green]"
         )
+    except click.ClickException:
+        raise
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @auth.command("login")
@@ -123,32 +130,29 @@ def device_login() -> None:
 
     try:
         created = _create_device_profile()
-        rprint(
+        _out(
             f"[green]Created login profile '{created.name}' and set as current[/green]"
         )
 
     except NoProjectsFoundError:
-        rprint(f"[{WARNING}]⚠️ No Existing Projects - Welcome to LlamaCloud![/]")
-        rprint(f"[{WARNING}]Looks like this may be your first time logging in.[/]")
-        rprint(
+        _out(f"[{WARNING}]⚠️ No Existing Projects - Welcome to LlamaCloud![/]")
+        _out(f"[{WARNING}]Looks like this may be your first time logging in.[/]")
+        _out(
             f"[{WARNING}]Before you can get started, log in to https://cloud.llamaindex.ai to complete your account setup.[/]"
         )
         return
 
     except OIDCNotEnabledError as e:
-        rprint(
+        _out(
             f"[{WARNING}]This server does not have browser-based login (OIDC) configured.[/]"
         )
         if str(e):
-            rprint(f"[{MUTED_COL}]Server response: {e}[/]")
-        rprint(
-            "Use [cyan]llamactl auth token[/cyan] to log in with an API key instead."
-        )
+            _out(f"[{MUTED_COL}]Server response: {e}[/]")
+        _out("Use [cyan]llamactl auth token[/cyan] to log in with an API key instead.")
         return
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @auth.command("list")
@@ -162,11 +166,11 @@ def list_profiles(output: str) -> None:
         current = auth_svc.get_current_profile()
 
         if not profiles and output == "text":
-            rprint(f"[{WARNING}]No profiles found[/]")
+            _out(f"[{WARNING}]No profiles found[/]")
             if auth_svc.env.requires_auth:
-                rprint("Create one with: [cyan]llamactl auth login[/cyan]")
+                _out("Create one with: [cyan]llamactl auth login[/cyan]")
             else:
-                rprint("Create one with: [cyan]llamactl auth token[/cyan]")
+                _out("Create one with: [cyan]llamactl auth token[/cyan]")
             return
 
         current_name = current.name if current else None
@@ -177,8 +181,7 @@ def list_profiles(output: str) -> None:
         render_output(displays, output)
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @auth.command("destroy", hidden=True)
@@ -192,7 +195,7 @@ def destroy_database() -> None:
     ):
         return
     ConfigManager(init_database=False).destroy_database()
-    rprint("[green]Database destroyed[/green]")
+    _out("[green]Database destroyed[/green]")
 
 
 @auth.command("show-db", hidden=True)
@@ -200,7 +203,7 @@ def destroy_database() -> None:
 def config_database() -> None:
     """Config the database"""
     path = _get_service().config_manager().db_path
-    rprint(f"[bold]{path}[/bold]")
+    _out(f"[bold]{path}[/bold]")
 
 
 @auth.command("switch")
@@ -212,15 +215,14 @@ def switch_profile(name: str | None) -> None:
     try:
         selected_auth = _select_profile(auth_svc, name)
         if not selected_auth:
-            rprint(f"[{WARNING}]No profile selected[/]")
+            _out(f"[{WARNING}]No profile selected[/]")
             return
 
         auth_svc.set_current_profile(selected_auth.name)
-        rprint(f"[green]Switched to profile '{selected_auth.name}'[/green]")
+        _out(f"[green]Switched to profile '{selected_auth.name}'[/green]")
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @auth.command("logout")
@@ -232,17 +234,17 @@ def delete_profile(name: str | None) -> None:
         auth_svc = _get_service().current_auth_service()
         auth = _select_profile(auth_svc, name)
         if not auth:
-            rprint(f"[{WARNING}]No profile selected[/]")
-            return
+            if name:
+                raise click.ClickException(f"Profile '{name}' not found")
+            raise click.ClickException("No profile selected")
 
         if asyncio.run(auth_svc.delete_profile(auth.name)):
-            rprint(f"[green]Logged out from '{auth.name}'[/green]")
+            _out(f"[green]Logged out from '{auth.name}'[/green]")
         else:
-            rprint(f"[red]Profile '{auth.name}' not found[/red]")
+            raise click.ClickException(f"Profile '{auth.name}' not found")
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 # Very simple introspection: decode current token via provider JWKS
@@ -272,8 +274,7 @@ def me() -> None:
         )
         click.echo(json.dumps(claims, indent=2, sort_keys=True))
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 # Organizations commands
@@ -286,7 +287,7 @@ def list_organizations(output: str) -> None:
         auth_svc = _get_service().current_auth_service()
         if not probe_organizations_support():
             if output == "text":
-                rprint(f"[{WARNING}]This server does not support organizations[/]")
+                _out(f"[{WARNING}]This server does not support organizations[/]")
                 return
             # Structured outputs: emit an empty list so scripts get a
             # well-typed answer instead of an unparsable warning.
@@ -295,7 +296,7 @@ def list_organizations(output: str) -> None:
 
         organizations = _list_organizations(auth_svc)
         if not organizations and output == "text":
-            rprint(f"[{WARNING}]No organizations found[/]")
+            _out(f"[{WARNING}]No organizations found[/]")
             return
 
         default_org = next((o.org_id for o in organizations if o.is_default), None)
@@ -306,8 +307,7 @@ def list_organizations(output: str) -> None:
         render_output(displays, output)
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 # Projects commands
@@ -344,13 +344,13 @@ def change_project(project_id: str | None, org_id: str | None) -> None:
             ):
                 raise click.ClickException(f"Project {project_id} not found")
         auth_svc.set_project(profile.name, project_id)
-        rprint(f"Set active project to [bold green]{project_id}[/]")
+        _out(f"Set active project to [bold green]{project_id}[/]")
         return
     try:
         projects = _list_projects(auth_svc)
 
         if not projects:
-            rprint(f"[{WARNING}]No projects found[/]")
+            _out(f"[{WARNING}]No projects found[/]")
             return
 
         current_project_id = profile.project_id
@@ -383,14 +383,13 @@ def change_project(project_id: str | None, org_id: str | None) -> None:
             )
             name = selected_project.project_name if selected_project else result
             auth_svc.set_project(profile.name, result)
-            rprint(f"Set active project to [bold {PRIMARY_COL}]{name}[/]")
+            _out(f"Set active project to [bold {PRIMARY_COL}]{name}[/]")
         else:
-            rprint(f"[{WARNING}]No project selected[/]")
+            _out(f"[{WARNING}]No project selected[/]")
     except click.ClickException:
         raise
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @auth.command("inject")
@@ -430,18 +429,17 @@ def inject_env_vars(
 
         vars = env_vars_from_profile(profile)
         if not vars:
-            rprint(f"[{WARNING}]No variables to inject[/]")
+            _out(f"[{WARNING}]No variables to inject[/]")
             return
         env_file.parent.mkdir(parents=True, exist_ok=True)
         for key, value in vars.items():
             set_key(str(env_file), key, value)
         rel = os.path.relpath(env_file, Path.cwd())
-        rprint(
+        _out(
             f"[green]Wrote environment variables: {', '.join(vars.keys())} to {rel}[/green]"
         )
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 def _auto_device_name() -> str:
@@ -531,7 +529,7 @@ def _create_device_profile() -> Auth:
         raise click.ClickException("No projects found for this account")
 
     if org is not None:
-        rprint(f"Projects for organization [bold]{org.org_name}[/]")
+        _out(f"Projects for organization [bold]{org.org_name}[/]")
 
     selected_project_id = _select_or_enter_project(projects, True)
     if not selected_project_id:
@@ -601,15 +599,15 @@ async def _run_device_authentication(base_url: str) -> DeviceOIDC:
             DeviceAuthorizationRequest(client_id=client_id, scope=scope_value),
         )
 
-        rprint(
+        _out(
             "[bold]complete authentication by visiting the verification URI and confirming the device:[/bold]"
         )
         if da.verification_uri:
-            rprint(
+            _out(
                 f"Verification URI: {da.verification_uri} (will open in your browser if supported)"
             )
         if da.user_code:
-            rprint(f"User Code: {da.user_code} to confirm the device")
+            _out(f"User Code: {da.user_code} to confirm the device")
         if da.verification_uri_complete:
             try:
                 webbrowser.open(da.verification_uri_complete)
@@ -800,12 +798,12 @@ def _prompt_validate_api_key_and_list_projects(
         return _list_projects(auth_svc, api_key, org_id=org_id)
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 401:
-            rprint("[red]Invalid API key. Please try again.[/red]")
+            _out("[red]Invalid API key. Please try again.[/red]")
             return _prompt_validate_api_key_and_list_projects(
                 auth_svc, _prompt_for_api_key(), org_id=org_id
             )
         if e.response.status_code == 403:
-            rprint("[red]This environment requires a valid API key.[/red]")
+            _out("[red]This environment requires a valid API key.[/red]")
             return _prompt_validate_api_key_and_list_projects(
                 auth_svc, _prompt_for_api_key(), org_id=org_id
             )
@@ -864,7 +862,7 @@ def _select_profile(auth_svc: AuthService, profile_name: str | None) -> Auth | N
         profiles = auth_svc.list_profiles()
 
         if not profiles:
-            rprint(f"[{WARNING}]No profiles found[/]")
+            _out(f"[{WARNING}]No profiles found[/]")
             return None
 
         current = auth_svc.get_current_profile()
@@ -888,5 +886,5 @@ def _select_profile(auth_svc: AuthService, profile_name: str | None) -> Auth | N
     except click.ClickException:
         raise
     except Exception as e:
-        rprint(f"[red]Error loading profiles: {e}[/red]")
+        _out(f"[red]Error loading profiles: {e}[/red]")
         return None

--- a/packages/llamactl/src/llama_agents/cli/commands/completion.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/completion.py
@@ -10,6 +10,7 @@ import click
 from click.shell_completion import get_completion_class
 from llama_agents.cli.app import app
 from llama_agents.cli.options import global_options
+from llama_agents.cli.output import echo_status as _out
 from llama_agents.cli.paths import (
     bash_completion_dir,
     bash_rc_path,
@@ -17,7 +18,6 @@ from llama_agents.cli.paths import (
     zsh_completion_dir,
     zsh_rc_path,
 )
-from rich import print as rprint
 
 
 @app.group(help="Shell completion helpers.", no_args_is_help=True)
@@ -79,8 +79,8 @@ def install(shell: str | None, dry_run: bool) -> None:
         _install_fish(source, dry_run)
 
     if not dry_run:
-        rprint(f"\nDetected shell: [bold]{shell}[/bold]")
-        rprint("Restart your shell or source the config to activate completions.")
+        _out(f"\nDetected shell: [bold]{shell}[/bold]")
+        _out("Restart your shell or source the config to activate completions.")
 
 
 # ---------------------------------------------------------------------------
@@ -107,12 +107,12 @@ def _install_bash(source: str, dry_run: bool) -> None:
     target = comp_dir / "llamactl"
 
     if dry_run:
-        rprint(f"Would write completion script to [cyan]{target}[/cyan]")
+        _out(f"Would write completion script to [cyan]{target}[/cyan]")
         return
 
     comp_dir.mkdir(parents=True, exist_ok=True)
     target.write_text(source)
-    rprint(f"Wrote completions to [cyan]{target}[/cyan]")
+    _out(f"Wrote completions to [cyan]{target}[/cyan]")
 
     # Ensure .bashrc sources the completion dir
     bashrc = bash_rc_path()
@@ -128,15 +128,13 @@ def _install_zsh(source: str, dry_run: bool) -> None:
     target = zfunc / "_llamactl"
 
     if dry_run:
-        rprint(f"Would write completion script to [cyan]{target}[/cyan]")
-        rprint(
-            "Would ensure [cyan]~/.zfunc[/cyan] is in fpath in [cyan]~/.zshrc[/cyan]"
-        )
+        _out(f"Would write completion script to [cyan]{target}[/cyan]")
+        _out("Would ensure [cyan]~/.zfunc[/cyan] is in fpath in [cyan]~/.zshrc[/cyan]")
         return
 
     zfunc.mkdir(parents=True, exist_ok=True)
     target.write_text(source)
-    rprint(f"Wrote completions to [cyan]{target}[/cyan]")
+    _out(f"Wrote completions to [cyan]{target}[/cyan]")
 
     zshrc = zsh_rc_path()
     _ensure_zsh_fpath(zshrc, dry_run)
@@ -147,12 +145,12 @@ def _install_fish(source: str, dry_run: bool) -> None:
     target = comp_dir / "llamactl.fish"
 
     if dry_run:
-        rprint(f"Would write completion script to [cyan]{target}[/cyan]")
+        _out(f"Would write completion script to [cyan]{target}[/cyan]")
         return
 
     comp_dir.mkdir(parents=True, exist_ok=True)
     target.write_text(source)
-    rprint(f"Wrote completions to [cyan]{target}[/cyan]")
+    _out(f"Wrote completions to [cyan]{target}[/cyan]")
 
 
 def _ensure_zsh_fpath(zshrc: Path, dry_run: bool) -> None:
@@ -168,12 +166,12 @@ def _ensure_zsh_fpath(zshrc: Path, dry_run: bool) -> None:
 
     if dry_run:
         for action in actions:
-            rprint(f"Would update [cyan]{zshrc}[/cyan]: {action}")
+            _out(f"Would update [cyan]{zshrc}[/cyan]: {action}")
         return
 
     zshrc.write_text(updated_content)
     for action in actions:
-        rprint(f"Updated [cyan]{zshrc}[/cyan]: {action}")
+        _out(f"Updated [cyan]{zshrc}[/cyan]: {action}")
 
 
 def _plan_zshrc_update(content: str) -> tuple[str, list[str]]:
@@ -292,9 +290,9 @@ def _ensure_source_line(rc_file: Path, line: str, dry_run: bool) -> None:
         content = ""
 
     if dry_run:
-        rprint(f"Would add to [cyan]{rc_file}[/cyan]: {line}")
+        _out(f"Would add to [cyan]{rc_file}[/cyan]: {line}")
         return
 
     with rc_file.open("a") as f:
         f.write(f"\n{line}  {_MARKER}\n")
-    rprint(f"Added to [cyan]{rc_file}[/cyan]: {line}")
+    _out(f"Added to [cyan]{rc_file}[/cyan]: {line}")

--- a/packages/llamactl/src/llama_agents/cli/commands/completion.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/completion.py
@@ -10,7 +10,7 @@ import click
 from click.shell_completion import get_completion_class
 from llama_agents.cli.app import app
 from llama_agents.cli.options import global_options
-from llama_agents.cli.output import echo_status as _out
+from llama_agents.cli.output import status
 from llama_agents.cli.paths import (
     bash_completion_dir,
     bash_rc_path,
@@ -79,8 +79,8 @@ def install(shell: str | None, dry_run: bool) -> None:
         _install_fish(source, dry_run)
 
     if not dry_run:
-        _out(f"\nDetected shell: [bold]{shell}[/bold]")
-        _out("Restart your shell or source the config to activate completions.")
+        status(f"detected shell {shell}")
+        status("restart your shell or source the config to activate completions")
 
 
 # ---------------------------------------------------------------------------
@@ -107,12 +107,12 @@ def _install_bash(source: str, dry_run: bool) -> None:
     target = comp_dir / "llamactl"
 
     if dry_run:
-        _out(f"Would write completion script to [cyan]{target}[/cyan]")
+        status(f"would write completion script to {target}")
         return
 
     comp_dir.mkdir(parents=True, exist_ok=True)
     target.write_text(source)
-    _out(f"Wrote completions to [cyan]{target}[/cyan]")
+    status(f"wrote completions to {target}")
 
     # Ensure .bashrc sources the completion dir
     bashrc = bash_rc_path()
@@ -128,13 +128,13 @@ def _install_zsh(source: str, dry_run: bool) -> None:
     target = zfunc / "_llamactl"
 
     if dry_run:
-        _out(f"Would write completion script to [cyan]{target}[/cyan]")
-        _out("Would ensure [cyan]~/.zfunc[/cyan] is in fpath in [cyan]~/.zshrc[/cyan]")
+        status(f"would write completion script to {target}")
+        status("would ensure ~/.zfunc is in fpath in ~/.zshrc")
         return
 
     zfunc.mkdir(parents=True, exist_ok=True)
     target.write_text(source)
-    _out(f"Wrote completions to [cyan]{target}[/cyan]")
+    status(f"wrote completions to {target}")
 
     zshrc = zsh_rc_path()
     _ensure_zsh_fpath(zshrc, dry_run)
@@ -145,12 +145,12 @@ def _install_fish(source: str, dry_run: bool) -> None:
     target = comp_dir / "llamactl.fish"
 
     if dry_run:
-        _out(f"Would write completion script to [cyan]{target}[/cyan]")
+        status(f"would write completion script to {target}")
         return
 
     comp_dir.mkdir(parents=True, exist_ok=True)
     target.write_text(source)
-    _out(f"Wrote completions to [cyan]{target}[/cyan]")
+    status(f"wrote completions to {target}")
 
 
 def _ensure_zsh_fpath(zshrc: Path, dry_run: bool) -> None:
@@ -166,12 +166,12 @@ def _ensure_zsh_fpath(zshrc: Path, dry_run: bool) -> None:
 
     if dry_run:
         for action in actions:
-            _out(f"Would update [cyan]{zshrc}[/cyan]: {action}")
+            status(f"would update {zshrc}: {action}")
         return
 
     zshrc.write_text(updated_content)
     for action in actions:
-        _out(f"Updated [cyan]{zshrc}[/cyan]: {action}")
+        status(f"updated {zshrc}: {action}")
 
 
 def _plan_zshrc_update(content: str) -> tuple[str, list[str]]:
@@ -290,9 +290,9 @@ def _ensure_source_line(rc_file: Path, line: str, dry_run: bool) -> None:
         content = ""
 
     if dry_run:
-        _out(f"Would add to [cyan]{rc_file}[/cyan]: {line}")
+        status(f"would update {rc_file}: add {line}")
         return
 
     with rc_file.open("a") as f:
         f.write(f"\n{line}  {_MARKER}\n")
-    _out(f"Added to [cyan]{rc_file}[/cyan]: {line}")
+    status(f"updated {rc_file}: add {line}")

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -21,7 +21,6 @@ from llama_agents.cli.interactive import (
     select_or_exit,
 )
 from llama_agents.cli.param_types import DeploymentType, GitShaType
-from llama_agents.cli.styles import WARNING
 from llama_agents.core.git.git_util import is_git_repo
 from llama_agents.core.schema import LogEvent
 from llama_agents.core.schema.deployments import (
@@ -32,9 +31,9 @@ from llama_agents.core.schema.deployments import (
     DeploymentUpdate,
 )
 from pydantic import ValidationError
-from rich import print as rprint
+from rich.console import Console
 
-from ..app import app, console
+from ..app import app
 from ..apply_yaml import (
     SPEC_FIELDS,
     ApplyYamlError,
@@ -71,6 +70,7 @@ from ..yaml_template import render as render_yaml_template
 
 DeploymentApplyMode = Literal["apply", "create", "update"]
 DeploymentOperationAction = Literal["create", "update"]
+err_console = Console(stderr=True, highlight=False)
 
 
 @dataclass(frozen=True)
@@ -102,6 +102,18 @@ class RepositoryValidationError(click.ClickException):
 
 def _error(path: tuple[str | int, ...], message: str) -> FieldError:
     return FieldError(path=path, message=message)
+
+
+def _warn(message: str) -> None:
+    click.secho(message, fg="yellow", err=True)
+
+
+def _success(message: str) -> None:
+    click.secho(message, fg="green", err=True)
+
+
+def _status(message: str) -> None:
+    click.echo(message, err=True)
 
 
 def _wire_path_from_loc(
@@ -430,7 +442,7 @@ def _open_deployment_yaml_editor(current_text: str) -> str | None:
 
 
 def _editor_cancelled() -> None:
-    rprint(f"[{WARNING}]Cancelled[/]")
+    _warn("Cancelled")
 
 
 def _editor_text_unchanged(current_text: str, last_opened_text: str) -> bool:
@@ -439,17 +451,17 @@ def _editor_text_unchanged(current_text: str, last_opened_text: str) -> bool:
 
 def _editor_noop(mode: DeploymentApplyMode) -> None:
     if mode == "create":
-        rprint(f"[{WARNING}]No changes saved; fill in the YAML before creating[/]")
+        _warn("No changes saved; fill in the YAML before creating")
     else:
-        rprint(f"[{WARNING}]No changes saved[/]")
+        _warn("No changes saved")
 
 
 def _editor_empty() -> None:
-    rprint(f"[{WARNING}]No deployment YAML saved; nothing applied[/]")
+    _warn("No deployment YAML saved; nothing applied")
 
 
 def _editor_comments_only() -> None:
-    rprint(f"[{WARNING}]No deployment fields saved; add YAML fields and run again[/]")
+    _warn("No deployment fields saved; add YAML fields and run again")
 
 
 def _edit_deployment_yaml_loop(
@@ -554,9 +566,7 @@ def _do_get(
             deployments = asyncio.run(client.list_deployments())
 
             if not deployments and mode == "text":
-                rprint(
-                    f"[{WARNING}]No deployments found for project {client.project_id}[/]"
-                )
+                _warn(f"No deployments found for project {client.project_id}")
                 return
 
             displays = [DeploymentDisplay.from_response(d) for d in deployments]
@@ -575,8 +585,7 @@ def _do_get(
             e, deployment_id=deployment_id, project_id=effective_project
         )
         message = friendly if friendly is not None else str(e)
-        rprint(f"[red]Error: {message}[/red]")
-        raise click.Abort()
+        raise click.ClickException(message) from e
 
 
 @deployments.command("get")
@@ -696,16 +705,13 @@ def configure_git_remote_cmd(deployment_id: str | None, project: str | None) -> 
             git_url, client.api_key, client.project_id, deployment_id
         )
 
-        rprint(
-            f"[green]Configured git remote '{remote_name}' for {deployment_id}[/green]"
-        )
-        rprint(f"Push with: [cyan]git push {remote_name}[/cyan]")
+        _success(f"Configured git remote '{remote_name}' for {deployment_id}")
+        _status(f"Push with: git push {remote_name}")
 
     except click.ClickException:
         raise
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @deployments.command("delete")
@@ -715,13 +721,13 @@ def configure_git_remote_cmd(deployment_id: str | None, project: str | None) -> 
     "-f",
     "--filename",
     default=None,
-    type=click.File("r"),
+    type=click.Path(allow_dash=True, exists=True, dir_okay=False, path_type=str),
     help="Path to YAML file; name is read from the file. Mutually exclusive with positional ID.",
 )
 @project_option
 def delete_deployment(
     deployment_id: str | None,
-    filename: click.utils.LazyFile | None,
+    filename: str | None,
     project: str | None,
 ) -> None:
     """Delete a deployment"""
@@ -732,7 +738,7 @@ def delete_deployment(
 
     if filename is not None:
         try:
-            deployment_id = parse_delete_yaml_name(filename.read())
+            deployment_id = parse_delete_yaml_name(_read_apply_input(filename))
         except ApplyYamlError as exc:
             raise click.ClickException(str(exc)) from exc
 
@@ -742,11 +748,10 @@ def delete_deployment(
         client = get_project_client(project_id_override=project)
 
         asyncio.run(client.delete_deployment(deployment_id))
-        rprint(f"[green]Deleted deployment: {deployment_id}[/green]")
+        _success(f"Deleted deployment: {deployment_id}")
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 def _apply_push(
@@ -765,7 +770,7 @@ def _apply_push(
         git_url, client.api_key, client.project_id, deployment_id
     )
     local_ref, target_ref = internal_push_refspec(git_ref)
-    with console.status("pushing code..."):
+    with err_console.status("pushing code..."):
         push_result = push_to_remote(
             remote_name, local_ref=local_ref, target_ref=target_ref
         )
@@ -790,7 +795,6 @@ def _apply_push_after_save(
     try:
         _apply_push(client, deployment_id, git_ref)
     except PushFailedError as exc:
-        click.echo(str(exc.message), err=True)
         raise PushFailedError(
             f"{exc.message}\n"
             "re-run `llamactl deployments apply -f <file>` to retry the push"
@@ -942,9 +946,9 @@ async def _execute_deployment_operation(
         push_before_save = False
 
     if desired_is_push and not is_git_repo():
-        rprint(
-            f"[{WARNING}]Not in a git repo — skipping push, "
-            "server will resolve from last pushed code[/]"
+        _warn(
+            "Not in a git repo — skipping push, "
+            "server will resolve from last pushed code"
         )
         desired_is_push = False
         push_before_save = False
@@ -957,16 +961,16 @@ async def _execute_deployment_operation(
             display.spec.git_ref or existing.git_ref,
         )
         response = await client.update_deployment(display.name, operation.payload)
-        click.echo(f"updated {response.id}")
+        _status(f"updated {response.id}")
     elif operation.action == "update":
         assert display.name is not None
         response = await client.update_deployment(display.name, operation.payload)
-        click.echo(f"updated {response.id}")
+        _status(f"updated {response.id}")
         if desired_is_push:
             _apply_push_after_save(client, response.id, display.spec.git_ref)
     else:
         response = await client.create_deployment(operation.payload)
-        click.echo(f"created {response.id}")
+        _status(f"created {response.id}")
         if desired_is_push:
             _apply_push_after_save(client, response.id, display.spec.git_ref)
 
@@ -1103,7 +1107,7 @@ def apply_deployment(
                 sort_keys=False,
             )
         )
-        click.echo(verdict)
+        _status(verdict)
         return
 
     try:
@@ -1177,8 +1181,7 @@ def edit_deployment(
             e, deployment_id=deployment_id, project_id=effective_project
         )
         message = friendly if friendly is not None else str(e)
-        rprint(f"[red]Error: {message}[/red]")
-        raise click.Abort()
+        raise click.ClickException(message) from e
 
 
 def _push_internal_for_update(
@@ -1192,9 +1195,9 @@ def _push_internal_for_update(
     server can resolve the ref to a fresh SHA.
     """
     if not is_git_repo():
-        rprint(
-            f"[{WARNING}]Not in a git repo — skipping push, "
-            "server will resolve from last pushed code[/]"
+        _warn(
+            "Not in a git repo — skipping push, "
+            "server will resolve from last pushed code"
         )
         return
 
@@ -1203,16 +1206,16 @@ def _push_internal_for_update(
         git_url, client.api_key, client.project_id, deployment_id
     )
     local_ref, target_ref = internal_push_refspec(git_ref)
-    with console.status("Pushing code..."):
+    with err_console.status("Pushing code..."):
         push_result = push_to_remote(
             remote_name, local_ref=local_ref, target_ref=target_ref
         )
     if push_result.returncode != 0:
         stderr = push_result.stderr.decode(errors="replace").strip()
-        rprint(f"[{WARNING}]Push failed: {stderr}[/]")
-        rprint(
-            f"[{WARNING}]Continuing with update using last pushed code. "
-            f"To debug, try: llamactl deployments configure-git-remote {deployment_id}[/]"
+        _warn(f"Push failed: {stderr}")
+        _warn(
+            "Continuing with update using last pushed code. "
+            f"To debug, try: llamactl deployments configure-git-remote {deployment_id}"
         )
 
 
@@ -1224,13 +1227,20 @@ def _push_internal_for_update(
     help="Reference branch, tag, or commit SHA for the deployment. If not provided, the current reference and latest commit on it will be used.",
     default=None,
 )
+@click.option(
+    "--no-push",
+    is_flag=True,
+    default=False,
+    help="Skip pushing local code for internal-repo deployments.",
+)
 @project_option
 def refresh_deployment(
     deployment_id: str | None,
     git_ref: str | None,
+    no_push: bool,
     project: str | None,
 ) -> None:
-    """Update the deployment, pulling the latest code from it's branch"""
+    """Update the deployment, pulling the latest code from its branch."""
     deployment_id = _require_deployment_id(deployment_id, "update", project)
     try:
         # Single asyncio.run with one client: reusing a ProjectClient across
@@ -1240,14 +1250,14 @@ def refresh_deployment(
             async with project_client_context(project_id_override=project) as client:
                 current = await client.get_deployment(deployment_id)
                 effective_git_ref = git_ref or current.git_ref
-                if current.repo_url == INTERNAL_CODE_REPO_SCHEME:
+                if current.repo_url == INTERNAL_CODE_REPO_SCHEME and not no_push:
                     _push_internal_for_update(
                         deployment_id,
                         effective_git_ref,
                         client=client,
                     )
                 # Re-resolves the branch to the latest commit SHA on the server.
-                with console.status(f"Refreshing {current.display_name}..."):
+                with err_console.status(f"Refreshing {current.display_name}..."):
                     updated = await client.update_deployment(
                         deployment_id,
                         DeploymentUpdate(git_ref=effective_git_ref),
@@ -1262,13 +1272,12 @@ def refresh_deployment(
         new_short = short_sha(new_git_sha) if new_git_sha else "-"
 
         if old_git_sha == new_git_sha:
-            rprint(f"No changes: already at {new_short}")
+            _status(f"No changes: already at {new_short}")
         else:
-            rprint(f"Updated: {old_short} → {new_short}")
+            _status(f"Updated: {old_short} → {new_short}")
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @deployments.command("history")
@@ -1297,14 +1306,13 @@ def show_history(
         )
 
         if not items_sorted and output == "text":
-            rprint(f"No history recorded for {deployment_id}")
+            _status(f"No history recorded for {deployment_id}")
             return
 
         displays = [ReleaseDisplay.from_response(item) for item in items_sorted]
         render_output(displays, output)
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @deployments.command("rollback")
@@ -1365,12 +1373,11 @@ def rollback(
 
         updated = asyncio.run(_do_rollback())
         new_short = short_sha(updated.git_sha) if updated.git_sha else "-"
-        rprint(f"[green]Rollback initiated[/green]: {deployment_id} → {new_short}")
+        _success(f"Rollback initiated: {deployment_id} → {new_short}")
     except click.ClickException:
         raise
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @deployments.command("logs")
@@ -1449,8 +1456,7 @@ def deployment_logs(
         # Clean exit on Ctrl-C; no traceback.
         return
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
     if events_seen == 0 and not follow:
         click.echo("no logs available yet", err=True)

--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -20,6 +20,7 @@ from llama_agents.cli.interactive import (
     require_or_list_choices,
     select_or_exit,
 )
+from llama_agents.cli.output import status, warning
 from llama_agents.cli.param_types import DeploymentType, GitShaType
 from llama_agents.core.git.git_util import is_git_repo
 from llama_agents.core.schema import LogEvent
@@ -31,7 +32,6 @@ from llama_agents.core.schema.deployments import (
     DeploymentUpdate,
 )
 from pydantic import ValidationError
-from rich.console import Console
 
 from ..app import app
 from ..apply_yaml import (
@@ -70,7 +70,6 @@ from ..yaml_template import render as render_yaml_template
 
 DeploymentApplyMode = Literal["apply", "create", "update"]
 DeploymentOperationAction = Literal["create", "update"]
-err_console = Console(stderr=True, highlight=False)
 
 
 @dataclass(frozen=True)
@@ -102,18 +101,6 @@ class RepositoryValidationError(click.ClickException):
 
 def _error(path: tuple[str | int, ...], message: str) -> FieldError:
     return FieldError(path=path, message=message)
-
-
-def _warn(message: str) -> None:
-    click.secho(message, fg="yellow", err=True)
-
-
-def _success(message: str) -> None:
-    click.secho(message, fg="green", err=True)
-
-
-def _status(message: str) -> None:
-    click.echo(message, err=True)
 
 
 def _wire_path_from_loc(
@@ -442,7 +429,7 @@ def _open_deployment_yaml_editor(current_text: str) -> str | None:
 
 
 def _editor_cancelled() -> None:
-    _warn("Cancelled")
+    status("cancelled")
 
 
 def _editor_text_unchanged(current_text: str, last_opened_text: str) -> bool:
@@ -451,17 +438,17 @@ def _editor_text_unchanged(current_text: str, last_opened_text: str) -> bool:
 
 def _editor_noop(mode: DeploymentApplyMode) -> None:
     if mode == "create":
-        _warn("No changes saved; fill in the YAML before creating")
+        status("no changes saved; fill in the YAML before creating")
     else:
-        _warn("No changes saved")
+        status("no changes saved")
 
 
 def _editor_empty() -> None:
-    _warn("No deployment YAML saved; nothing applied")
+    status("no deployment YAML saved; nothing applied")
 
 
 def _editor_comments_only() -> None:
-    _warn("No deployment fields saved; add YAML fields and run again")
+    status("no deployment fields saved; add YAML fields and run again")
 
 
 def _edit_deployment_yaml_loop(
@@ -566,7 +553,7 @@ def _do_get(
             deployments = asyncio.run(client.list_deployments())
 
             if not deployments and mode == "text":
-                _warn(f"No deployments found for project {client.project_id}")
+                status(f"no deployments found for project {client.project_id}")
                 return
 
             displays = [DeploymentDisplay.from_response(d) for d in deployments]
@@ -705,8 +692,8 @@ def configure_git_remote_cmd(deployment_id: str | None, project: str | None) -> 
             git_url, client.api_key, client.project_id, deployment_id
         )
 
-        _success(f"Configured git remote '{remote_name}' for {deployment_id}")
-        _status(f"Push with: git push {remote_name}")
+        status(f"configured git remote {remote_name} for {deployment_id}")
+        status(f"push with: git push {remote_name}")
 
     except click.ClickException:
         raise
@@ -748,7 +735,7 @@ def delete_deployment(
         client = get_project_client(project_id_override=project)
 
         asyncio.run(client.delete_deployment(deployment_id))
-        _success(f"Deleted deployment: {deployment_id}")
+        status(f"deleted {deployment_id}")
 
     except Exception as e:
         raise click.ClickException(str(e)) from e
@@ -770,12 +757,14 @@ def _apply_push(
         git_url, client.api_key, client.project_id, deployment_id
     )
     local_ref, target_ref = internal_push_refspec(git_ref)
-    with err_console.status("pushing code..."):
-        push_result = push_to_remote(
-            remote_name, local_ref=local_ref, target_ref=target_ref
-        )
+    status("pushing code")
+    push_result = push_to_remote(
+        remote_name, local_ref=local_ref, target_ref=target_ref
+    )
     if push_result.returncode != 0:
-        stderr = push_result.stderr.decode(errors="replace").strip()
+        stderr = " ".join(
+            push_result.stderr.decode(errors="replace").strip().splitlines()
+        )
         raise PushFailedError(
             f"push failed: {stderr}\n"
             f"To debug, try: llamactl deployments configure-git-remote {deployment_id}"
@@ -946,10 +935,7 @@ async def _execute_deployment_operation(
         push_before_save = False
 
     if desired_is_push and not is_git_repo():
-        _warn(
-            "Not in a git repo — skipping push, "
-            "server will resolve from last pushed code"
-        )
+        warning("not in a git repo; skipping push, server will use last pushed code")
         desired_is_push = False
         push_before_save = False
 
@@ -961,16 +947,16 @@ async def _execute_deployment_operation(
             display.spec.git_ref or existing.git_ref,
         )
         response = await client.update_deployment(display.name, operation.payload)
-        _status(f"updated {response.id}")
+        status(f"updated {response.id}")
     elif operation.action == "update":
         assert display.name is not None
         response = await client.update_deployment(display.name, operation.payload)
-        _status(f"updated {response.id}")
+        status(f"updated {response.id}")
         if desired_is_push:
             _apply_push_after_save(client, response.id, display.spec.git_ref)
     else:
         response = await client.create_deployment(operation.payload)
-        _status(f"created {response.id}")
+        status(f"created {response.id}")
         if desired_is_push:
             _apply_push_after_save(client, response.id, display.spec.git_ref)
 
@@ -1107,7 +1093,7 @@ def apply_deployment(
                 sort_keys=False,
             )
         )
-        _status(verdict)
+        status(verdict)
         return
 
     try:
@@ -1195,10 +1181,7 @@ def _push_internal_for_update(
     server can resolve the ref to a fresh SHA.
     """
     if not is_git_repo():
-        _warn(
-            "Not in a git repo — skipping push, "
-            "server will resolve from last pushed code"
-        )
+        warning("not in a git repo; skipping push, server will use last pushed code")
         return
 
     git_url = get_deployment_git_url(client.base_url, deployment_id)
@@ -1206,16 +1189,18 @@ def _push_internal_for_update(
         git_url, client.api_key, client.project_id, deployment_id
     )
     local_ref, target_ref = internal_push_refspec(git_ref)
-    with err_console.status("Pushing code..."):
-        push_result = push_to_remote(
-            remote_name, local_ref=local_ref, target_ref=target_ref
-        )
+    status("pushing code")
+    push_result = push_to_remote(
+        remote_name, local_ref=local_ref, target_ref=target_ref
+    )
     if push_result.returncode != 0:
-        stderr = push_result.stderr.decode(errors="replace").strip()
-        _warn(f"Push failed: {stderr}")
-        _warn(
-            "Continuing with update using last pushed code. "
-            f"To debug, try: llamactl deployments configure-git-remote {deployment_id}"
+        stderr = " ".join(
+            push_result.stderr.decode(errors="replace").strip().splitlines()
+        )
+        warning(f"push failed: {stderr}")
+        warning(
+            "continuing with update using last pushed code; "
+            f"run llamactl deployments configure-git-remote {deployment_id} to debug"
         )
 
 
@@ -1257,11 +1242,11 @@ def refresh_deployment(
                         client=client,
                     )
                 # Re-resolves the branch to the latest commit SHA on the server.
-                with err_console.status(f"Refreshing {current.display_name}..."):
-                    updated = await client.update_deployment(
-                        deployment_id,
-                        DeploymentUpdate(git_ref=effective_git_ref),
-                    )
+                status(f"refreshing {deployment_id}")
+                updated = await client.update_deployment(
+                    deployment_id,
+                    DeploymentUpdate(git_ref=effective_git_ref),
+                )
                 return current, updated
 
         current_deployment, updated_deployment = asyncio.run(_do_update())
@@ -1272,9 +1257,9 @@ def refresh_deployment(
         new_short = short_sha(new_git_sha) if new_git_sha else "-"
 
         if old_git_sha == new_git_sha:
-            _status(f"No changes: already at {new_short}")
+            status(f"no changes {deployment_id} already at {new_short}")
         else:
-            _status(f"Updated: {old_short} → {new_short}")
+            status(f"updated {deployment_id} {old_short} -> {new_short}")
 
     except Exception as e:
         raise click.ClickException(str(e)) from e
@@ -1306,7 +1291,7 @@ def show_history(
         )
 
         if not items_sorted and output == "text":
-            _status(f"No history recorded for {deployment_id}")
+            status(f"no history {deployment_id}")
             return
 
         displays = [ReleaseDisplay.from_response(item) for item in items_sorted]
@@ -1373,7 +1358,7 @@ def rollback(
 
         updated = asyncio.run(_do_rollback())
         new_short = short_sha(updated.git_sha) if updated.git_sha else "-"
-        _success(f"Rollback initiated: {deployment_id} → {new_short}")
+        status(f"rolled back {deployment_id} to {new_short}")
     except click.ClickException:
         raise
     except Exception as e:

--- a/packages/llamactl/src/llama_agents/cli/commands/dev.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/dev.py
@@ -15,9 +15,9 @@ from llama_agents.cli.commands.serve import (
     serve as serve_command,
 )
 from llama_agents.cli.options import global_options
+from llama_agents.cli.output import echo_status as _out
 from llama_agents.core.config import DEFAULT_DEPLOYMENT_FILE_PATH
 from llama_agents.core.deployment_config import DeploymentConfig
-from rich import print as rprint
 
 from ..app import app
 
@@ -86,11 +86,11 @@ def validate_command(deployment_file: Path, validate_env: bool) -> None:
             skip_env_validation=skip_env_validation,
         )
     except subprocess.CalledProcessError as exc:
-        rprint("[red]Workflow validation failed. See errors above.[/red]")
+        _out("[red]Workflow validation failed. See errors above.[/red]")
         raise Exit(exc.returncode)
 
     _print_connection_summary()
-    rprint(f"[green]Validated workflows in {config_dir} successfully.[/green]")
+    _out(f"[green]Validated workflows in {config_dir} successfully.[/green]")
 
 
 @dev.command(
@@ -121,8 +121,9 @@ def export_json_graph_command(
 ) -> None:
     """Export the configured workflows to a JSON document that may be used for graph visualization."""
     if not deployment_file.exists():
-        rprint(f"[red]Deployment file '{deployment_file}' does not exist[/red]")
-        raise click.Abort()
+        raise click.ClickException(
+            f"Deployment file '{deployment_file}' does not exist"
+        )
 
     _ensure_project_layout(
         deployment_file, command_name="llamactl dev export-json-graph"
@@ -147,9 +148,9 @@ def export_json_graph_command(
             output=output,
         )
     except subprocess.CalledProcessError as exc:
-        rprint("[red]Workflow JSON graph export failed. See errors above.[/red]")
+        _out("[red]Workflow JSON graph export failed. See errors above.[/red]")
         raise Exit(exc.returncode)
-    rprint(f"[green]Exported workflow JSON graph to {output}[/green]")
+    _out(f"[green]Exported workflow JSON graph to {output}[/green]")
 
 
 @dev.command(
@@ -197,26 +198,21 @@ def run_command(deployment_file: Path, no_auth: bool, cmd: tuple[str, ...]) -> N
     except (Exit, Abort, SystemExit, click.ClickException):
         raise
     except FileNotFoundError as exc:
-        rprint(f"[red]Command not found: {exc.filename}[/red]")
-        raise click.Abort()
+        raise click.ClickException(f"Command not found: {exc.filename}") from exc
     except Exception as exc:  # pragma: no cover - unexpected errors reported to user
-        rprint(f"[red]Failed to run command: {exc}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(exc)) from exc
 
 
 def _ensure_project_layout(deployment_file: Path, *, command_name: str) -> Path:
     if not deployment_file.exists():
-        rprint(f"[red]Deployment file '{deployment_file}' not found[/red]")
-        raise click.Abort()
+        raise click.ClickException(f"Deployment file '{deployment_file}' not found")
 
     config_dir = deployment_file if deployment_file.is_dir() else deployment_file.parent
     if not (config_dir / "pyproject.toml").exists():
-        rprint(
-            "[red]No pyproject.toml found at[/red] "
-            f"[bold]{config_dir}[/bold].\n"
+        raise click.ClickException(
+            f"No pyproject.toml found at {config_dir}.\n"
             f"Add a pyproject.toml to your project and re-run '{command_name}'."
         )
-        raise click.Abort()
     return config_dir
 
 

--- a/packages/llamactl/src/llama_agents/cli/commands/dev.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/dev.py
@@ -15,7 +15,7 @@ from llama_agents.cli.commands.serve import (
     serve as serve_command,
 )
 from llama_agents.cli.options import global_options
-from llama_agents.cli.output import echo_status as _out
+from llama_agents.cli.output import status
 from llama_agents.core.config import DEFAULT_DEPLOYMENT_FILE_PATH
 from llama_agents.core.deployment_config import DeploymentConfig
 
@@ -86,11 +86,11 @@ def validate_command(deployment_file: Path, validate_env: bool) -> None:
             skip_env_validation=skip_env_validation,
         )
     except subprocess.CalledProcessError as exc:
-        _out("[red]Workflow validation failed. See errors above.[/red]")
+        status("workflow validation failed; see errors above")
         raise Exit(exc.returncode)
 
     _print_connection_summary()
-    _out(f"[green]Validated workflows in {config_dir} successfully.[/green]")
+    status(f"validated workflows in {config_dir}")
 
 
 @dev.command(
@@ -148,9 +148,9 @@ def export_json_graph_command(
             output=output,
         )
     except subprocess.CalledProcessError as exc:
-        _out("[red]Workflow JSON graph export failed. See errors above.[/red]")
+        status("workflow JSON graph export failed; see errors above")
         raise Exit(exc.returncode)
-    _out(f"[green]Exported workflow JSON graph to {output}[/green]")
+    status(f"exported workflow JSON graph to {output}")
 
 
 @dev.command(

--- a/packages/llamactl/src/llama_agents/cli/commands/env.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/env.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING
 import click
 from llama_agents.cli.config.schema import Environment
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
+from llama_agents.cli.output import echo_status as _out
 from llama_agents.cli.param_types import EnvironmentType
 from llama_agents.cli.styles import WARNING
 from packaging import version as packaging_version
-from rich import print as rprint
 
 from ..display import EnvDisplay
 from ..options import global_options, output_option, render_output
@@ -50,7 +50,7 @@ def list_environments_cmd(output: str) -> None:
         current_env = service.get_current_environment()
 
         if not envs and output == "text":
-            rprint(f"[{WARNING}]No environments found[/]")
+            _out(f"[{WARNING}]No environments found[/]")
             return
 
         current_url = current_env.api_url if current_env else None
@@ -59,8 +59,7 @@ def list_environments_cmd(output: str) -> None:
         ]
         render_output(displays, output)
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @env_group.command("add")
@@ -81,7 +80,7 @@ def add_environment_cmd(api_url: str | None) -> None:
                 show_default=current_env is not None,
             )
             if not entered:
-                rprint(f"[{WARNING}]No environment entered[/]")
+                _out(f"[{WARNING}]No environment entered[/]")
                 return
             api_url = entered.strip()
 
@@ -90,15 +89,14 @@ def add_environment_cmd(api_url: str | None) -> None:
         api_url = api_url.rstrip("/")
         env = service.probe_environment(api_url)
         service.create_or_update_environment(env)
-        rprint(
+        _out(
             f"[green]Added environment[/green] {env.api_url} (requires_auth={env.requires_auth}, min_llamactl_version={env.min_llamactl_version or '-'})."
         )
         _maybe_warn_min_version(env.min_llamactl_version)
     except click.ClickException:
         raise
     except Exception as e:
-        rprint(f"[red]Failed to add environment: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @env_group.command("delete")
@@ -121,14 +119,13 @@ def delete_environment_cmd(api_url: str | None) -> None:
         deleted = service.delete_environment(api_url)
         if not deleted:
             raise click.ClickException(f"Environment '{api_url}' not found")
-        rprint(
+        _out(
             f"[green]Deleted environment[/green] {api_url} and all associated profiles"
         )
     except click.ClickException:
         raise
     except Exception as e:
-        rprint(f"[red]Failed to delete environment: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 @env_group.command("switch")
@@ -154,16 +151,15 @@ def switch_environment_cmd(api_url: str | None) -> None:
         try:
             env = service.auto_update_env(env)
         except Exception as e:
-            rprint(f"[{WARNING}]Failed to resolve environment: {e}[/]")
+            _out(f"[{WARNING}]Failed to resolve environment: {e}[/]")
             return
         service.current_auth_service().select_any_profile()
-        rprint(f"[green]Switched to environment[/green] {env.api_url}")
+        _out(f"[green]Switched to environment[/green] {env.api_url}")
         _maybe_warn_min_version(env.min_llamactl_version)
     except click.ClickException:
         raise
     except Exception as e:
-        rprint(f"[red]Failed to switch environment: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 def _get_cli_version() -> str | None:
@@ -181,7 +177,7 @@ def _maybe_warn_min_version(min_required: str | None) -> None:
         return
     try:
         if packaging_version.parse(current) < packaging_version.parse(min_required):
-            rprint(
+            _out(
                 f"[{WARNING}]Warning:[/] This environment requires llamactl >= [bold]{min_required}[/bold], you have [bold]{current}[/bold]."
             )
     except Exception:

--- a/packages/llamactl/src/llama_agents/cli/commands/env.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/env.py
@@ -6,9 +6,8 @@ from typing import TYPE_CHECKING
 import click
 from llama_agents.cli.config.schema import Environment
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
-from llama_agents.cli.output import echo_status as _out
+from llama_agents.cli.output import status, warning
 from llama_agents.cli.param_types import EnvironmentType
-from llama_agents.cli.styles import WARNING
 from packaging import version as packaging_version
 
 from ..display import EnvDisplay
@@ -50,7 +49,7 @@ def list_environments_cmd(output: str) -> None:
         current_env = service.get_current_environment()
 
         if not envs and output == "text":
-            _out(f"[{WARNING}]No environments found[/]")
+            status("no environments found")
             return
 
         current_url = current_env.api_url if current_env else None
@@ -80,7 +79,7 @@ def add_environment_cmd(api_url: str | None) -> None:
                 show_default=current_env is not None,
             )
             if not entered:
-                _out(f"[{WARNING}]No environment entered[/]")
+                status("no environment entered")
                 return
             api_url = entered.strip()
 
@@ -89,8 +88,9 @@ def add_environment_cmd(api_url: str | None) -> None:
         api_url = api_url.rstrip("/")
         env = service.probe_environment(api_url)
         service.create_or_update_environment(env)
-        _out(
-            f"[green]Added environment[/green] {env.api_url} (requires_auth={env.requires_auth}, min_llamactl_version={env.min_llamactl_version or '-'})."
+        requires_auth = str(env.requires_auth).lower()
+        status(
+            f"added environment {env.api_url} requires_auth={requires_auth} min_llamactl_version={env.min_llamactl_version or '-'}"
         )
         _maybe_warn_min_version(env.min_llamactl_version)
     except click.ClickException:
@@ -119,9 +119,7 @@ def delete_environment_cmd(api_url: str | None) -> None:
         deleted = service.delete_environment(api_url)
         if not deleted:
             raise click.ClickException(f"Environment '{api_url}' not found")
-        _out(
-            f"[green]Deleted environment[/green] {api_url} and all associated profiles"
-        )
+        status(f"deleted environment {api_url} and associated profiles")
     except click.ClickException:
         raise
     except Exception as e:
@@ -151,10 +149,10 @@ def switch_environment_cmd(api_url: str | None) -> None:
         try:
             env = service.auto_update_env(env)
         except Exception as e:
-            _out(f"[{WARNING}]Failed to resolve environment: {e}[/]")
+            warning(f"failed to resolve environment: {e}")
             return
         service.current_auth_service().select_any_profile()
-        _out(f"[green]Switched to environment[/green] {env.api_url}")
+        status(f"switched environment {env.api_url}")
         _maybe_warn_min_version(env.min_llamactl_version)
     except click.ClickException:
         raise
@@ -177,8 +175,8 @@ def _maybe_warn_min_version(min_required: str | None) -> None:
         return
     try:
         if packaging_version.parse(current) < packaging_version.parse(min_required):
-            _out(
-                f"[{WARNING}]Warning:[/] This environment requires llamactl >= [bold]{min_required}[/bold], you have [bold]{current}[/bold]."
+            warning(
+                f"this environment requires llamactl >= {min_required}; you have {current}"
             )
     except Exception:
         # If packaging is not available or parsing fails, skip strict comparison

--- a/packages/llamactl/src/llama_agents/cli/commands/init.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/init.py
@@ -10,6 +10,7 @@ from click.exceptions import Exit
 from llama_agents.cli.app import app
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
 from llama_agents.cli.options import global_options
+from llama_agents.cli.output import echo_status as _out
 from llama_agents.cli.param_types import TemplateType
 from llama_agents.cli.templates import (
     ALL_TEMPLATES,
@@ -17,7 +18,6 @@ from llama_agents.cli.templates import (
     UI_TEMPLATES,
     TemplateOption,
 )
-from rich import print as rprint
 
 _ClickPath = getattr(click, "Path")
 
@@ -76,14 +76,14 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
         has_git = False
 
     if not has_git:
-        rprint(
+        _out(
             "git is required to initialize a template. Make sure you have it installed and available in your PATH."
         )
         raise Exit(1)
 
     if template is None:
         if interactive:
-            rprint(
+            _out(
                 "[bold]Select a template to start from.[/bold] Either with javascript frontend UI, or just a python workflow that can be used as an API."
             )
         template = (
@@ -111,14 +111,14 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
             else:
                 return
         else:
-            rprint(f"[yellow]No directory provided. Defaulting to {template}[/]")
+            _out(f"[yellow]No directory provided. Defaulting to {template}[/]")
             dir = Path(template)
 
     resolved_template: TemplateOption | None = next(
         (o for o in ALL_TEMPLATES if o.id == template), None
     )
     if resolved_template is None:
-        rprint(f"Template {template} not found")
+        _out(f"Template {template} not found")
         raise Exit(1)
     if dir.exists():
         is_ok = force or (
@@ -126,7 +126,7 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
         )
 
         if not is_ok:
-            rprint(
+            _out(
                 f"[yellow]Try again with another directory or pass --force to overwrite the existing directory '{str(dir)}'[/]"
             )
             raise Exit(1)
@@ -175,7 +175,7 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
 
             if inside_existing_repo:
                 # Do not create a nested repo; user likely wants this within the parent repo
-                rprint(
+                _out(
                     "[yellow]Detected an existing Git repository in a parent directory; skipping git initialization for this app.[/]"
                 )
                 # Treat as initialized for purposes of what instructions to show later
@@ -207,50 +207,50 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
                     elif isinstance(e, FileNotFoundError):
                         err_msg = "git executable not found"
 
-                    rprint("")
-                    rprint("⚠️  [bold]Skipping git initialization due to an error.[/]")
+                    _out("")
+                    _out("⚠️  [bold]Skipping git initialization due to an error.[/]")
                     if err_msg:
-                        rprint(f"    {err_msg}")
-                    rprint("    You can initialize it manually:")
-                    rprint(
+                        _out(f"    {err_msg}")
+                    _out("    You can initialize it manually:")
+                    _out(
                         "      git init && git add . && git commit -m 'Initial commit'"
                     )
-                    rprint("")
+                    _out("")
     finally:
         os.chdir(original_cwd)
 
     # If git is not available at all, let the user know how to proceed
     if not has_git:
-        rprint("")
-        rprint("⚠️  [bold]Skipping git initialization due to an error.[/]")
-        rprint("    git executable not found")
-        rprint("    You can initialize it manually:")
-        rprint("      git init && git add . && git commit -m 'Initial commit'")
-        rprint("")
+        _out("")
+        _out("⚠️  [bold]Skipping git initialization due to an error.[/]")
+        _out("    git executable not found")
+        _out("    You can initialize it manually:")
+        _out("      git init && git add . && git commit -m 'Initial commit'")
+        _out("")
 
-    rprint(
+    _out(
         f"Successfully created [blue]{dir}[/] using the [blue]{resolved_template.name}[/] template! 🎉 🦙 💾"
     )
-    rprint("")
-    rprint("[bold]To run locally:[/]")
-    rprint(f"    [orange3]cd[/] {dir}")
-    rprint("    [orange3]uvx[/] llamactl serve")
-    rprint("")
-    rprint("[bold]To deploy:[/]")
+    _out("")
+    _out("[bold]To run locally:[/]")
+    _out(f"    [orange3]cd[/] {dir}")
+    _out("    [orange3]uvx[/] llamactl serve")
+    _out("")
+    _out("[bold]To deploy:[/]")
     # Only show manual git init steps if repository failed to initialize earlier
     if not git_initialized:
-        rprint("    [orange3]git[/] init")
-        rprint("    [orange3]git[/] add .")
-        rprint("    [orange3]git[/] commit -m 'Initial commit'")
-        rprint("")
-    rprint("[dim](Create a new repo and add it as a remote)[/]")
-    rprint("")
-    rprint("    [orange3]git[/] remote add origin <your-repo-url>")
-    rprint("    [orange3]git[/] push -u origin main")
-    rprint("")
-    # rprint("  [orange3]uvx[/] llamactl login")
-    rprint("    [orange3]uvx[/] llamactl deploy create")
-    rprint("")
+        _out("    [orange3]git[/] init")
+        _out("    [orange3]git[/] add .")
+        _out("    [orange3]git[/] commit -m 'Initial commit'")
+        _out("")
+    _out("[dim](Create a new repo and add it as a remote)[/]")
+    _out("")
+    _out("    [orange3]git[/] remote add origin <your-repo-url>")
+    _out("    [orange3]git[/] push -u origin main")
+    _out("")
+    # _out("  [orange3]uvx[/] llamactl login")
+    _out("    [orange3]uvx[/] llamactl deploy create")
+    _out("")
 
 
 def _update() -> None:
@@ -266,7 +266,7 @@ def _update() -> None:
             quiet=True,
         )
     except Exception as e:  # scoped to copier errors; type opaque here
-        rprint(f"{e}")
+        _out(f"{e}")
         raise Exit(1)
 
     # Check git status and warn about conflicts
@@ -292,12 +292,12 @@ def _update() -> None:
                     modified_files.append(filename)
 
             if conflicted_files:
-                rprint("")
-                rprint("⚠️  [bold]Files with conflicts detected:[/]")
+                _out("")
+                _out("⚠️  [bold]Files with conflicts detected:[/]")
                 for file in conflicted_files:
-                    rprint(f"    {file}")
-                rprint("")
-                rprint(
+                    _out(f"    {file}")
+                _out("")
+                _out(
                     "Please manually resolve conflicts with a merge editor before proceeding."
                 )
 

--- a/packages/llamactl/src/llama_agents/cli/commands/init.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/init.py
@@ -10,7 +10,7 @@ from click.exceptions import Exit
 from llama_agents.cli.app import app
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
 from llama_agents.cli.options import global_options
-from llama_agents.cli.output import echo_status as _out
+from llama_agents.cli.output import status, warning
 from llama_agents.cli.param_types import TemplateType
 from llama_agents.cli.templates import (
     ALL_TEMPLATES,
@@ -76,15 +76,15 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
         has_git = False
 
     if not has_git:
-        _out(
+        status(
             "git is required to initialize a template. Make sure you have it installed and available in your PATH."
         )
         raise Exit(1)
 
     if template is None:
         if interactive:
-            _out(
-                "[bold]Select a template to start from.[/bold] Either with javascript frontend UI, or just a python workflow that can be used as an API."
+            status(
+                "select a template to start from. either with javascript frontend UI, or just a python workflow that can be used as an API."
             )
         template = (
             select_or_exit(
@@ -111,14 +111,14 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
             else:
                 return
         else:
-            _out(f"[yellow]No directory provided. Defaulting to {template}[/]")
+            status(f"no directory provided; defaulting to {template}")
             dir = Path(template)
 
     resolved_template: TemplateOption | None = next(
         (o for o in ALL_TEMPLATES if o.id == template), None
     )
     if resolved_template is None:
-        _out(f"Template {template} not found")
+        status(f"template {template} not found")
         raise Exit(1)
     if dir.exists():
         is_ok = force or (
@@ -126,8 +126,8 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
         )
 
         if not is_ok:
-            _out(
-                f"[yellow]Try again with another directory or pass --force to overwrite the existing directory '{str(dir)}'[/]"
+            status(
+                f"try again with another directory or pass --force to overwrite the existing directory {str(dir)}"
             )
             raise Exit(1)
         else:
@@ -175,8 +175,8 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
 
             if inside_existing_repo:
                 # Do not create a nested repo; user likely wants this within the parent repo
-                _out(
-                    "[yellow]Detected an existing Git repository in a parent directory; skipping git initialization for this app.[/]"
+                warning(
+                    "skipping git initialization: existing Git repository in a parent directory"
                 )
                 # Treat as initialized for purposes of what instructions to show later
                 git_initialized = True
@@ -207,50 +207,46 @@ def _create(template: str | None, dir: Path | None, force: bool) -> None:
                     elif isinstance(e, FileNotFoundError):
                         err_msg = "git executable not found"
 
-                    _out("")
-                    _out("⚠️  [bold]Skipping git initialization due to an error.[/]")
+                    status("")
+                    warning(f"skipping git initialization: {err_msg or 'git error'}")
                     if err_msg:
-                        _out(f"    {err_msg}")
-                    _out("    You can initialize it manually:")
-                    _out(
+                        status(f"    {err_msg}")
+                    status("    You can initialize it manually:")
+                    status(
                         "      git init && git add . && git commit -m 'Initial commit'"
                     )
-                    _out("")
+                    status("")
     finally:
         os.chdir(original_cwd)
 
     # If git is not available at all, let the user know how to proceed
     if not has_git:
-        _out("")
-        _out("⚠️  [bold]Skipping git initialization due to an error.[/]")
-        _out("    git executable not found")
-        _out("    You can initialize it manually:")
-        _out("      git init && git add . && git commit -m 'Initial commit'")
-        _out("")
+        status("")
+        warning("skipping git initialization: git executable not found")
+        status("    You can initialize it manually:")
+        status("      git init && git add . && git commit -m 'Initial commit'")
+        status("")
 
-    _out(
-        f"Successfully created [blue]{dir}[/] using the [blue]{resolved_template.name}[/] template! 🎉 🦙 💾"
-    )
-    _out("")
-    _out("[bold]To run locally:[/]")
-    _out(f"    [orange3]cd[/] {dir}")
-    _out("    [orange3]uvx[/] llamactl serve")
-    _out("")
-    _out("[bold]To deploy:[/]")
+    status(f"created {dir} using the {resolved_template.name} template")
+    status("")
+    status("to run locally:")
+    status(f"    cd {dir}")
+    status("    uvx llamactl serve")
+    status("")
+    status("to deploy:")
     # Only show manual git init steps if repository failed to initialize earlier
     if not git_initialized:
-        _out("    [orange3]git[/] init")
-        _out("    [orange3]git[/] add .")
-        _out("    [orange3]git[/] commit -m 'Initial commit'")
-        _out("")
-    _out("[dim](Create a new repo and add it as a remote)[/]")
-    _out("")
-    _out("    [orange3]git[/] remote add origin <your-repo-url>")
-    _out("    [orange3]git[/] push -u origin main")
-    _out("")
-    # _out("  [orange3]uvx[/] llamactl login")
-    _out("    [orange3]uvx[/] llamactl deploy create")
-    _out("")
+        status("    git init")
+        status("    git add .")
+        status("    git commit -m 'Initial commit'")
+        status("")
+    status("(Create a new repo and add it as a remote)")
+    status("")
+    status("    git remote add origin <your-repo-url>")
+    status("    git push -u origin main")
+    status("")
+    status("    uvx llamactl deploy create")
+    status("")
 
 
 def _update() -> None:
@@ -266,7 +262,7 @@ def _update() -> None:
             quiet=True,
         )
     except Exception as e:  # scoped to copier errors; type opaque here
-        _out(f"{e}")
+        status(f"{e}")
         raise Exit(1)
 
     # Check git status and warn about conflicts
@@ -283,21 +279,21 @@ def _update() -> None:
             modified_files = []
 
             for line in result.stdout.strip().split("\n"):
-                status = line[:2]
+                git_status = line[:2]
                 filename = line[3:]
 
-                if "UU" in status or "AA" in status or "DD" in status:
+                if "UU" in git_status or "AA" in git_status or "DD" in git_status:
                     conflicted_files.append(filename)
-                elif status.strip():
+                elif git_status.strip():
                     modified_files.append(filename)
 
             if conflicted_files:
-                _out("")
-                _out("⚠️  [bold]Files with conflicts detected:[/]")
+                status("")
+                warning("files with conflicts detected:")
                 for file in conflicted_files:
-                    _out(f"    {file}")
-                _out("")
-                _out(
+                    status(f"    {file}")
+                status("")
+                status(
                     "Please manually resolve conflicts with a merge editor before proceeding."
                 )
 

--- a/packages/llamactl/src/llama_agents/cli/commands/pkg.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/pkg.py
@@ -10,7 +10,6 @@ from llama_agents.cli.pkg import (
 from llama_agents.core.deployment_config import (
     read_deployment_config_from_git_root_or_cwd,
 )
-from rich import print as rprint
 
 from ..app import app
 
@@ -55,33 +54,28 @@ def create_container_file(
 
 def _check_deployment_config(deployment_file: Path) -> Path:
     if not deployment_file.exists():
-        rprint(f"[red]Deployment file '{deployment_file}' not found[/red]")
-        raise click.Abort()
+        raise click.ClickException(f"Deployment file '{deployment_file}' not found")
 
     # Early check: appserver requires a pyproject.toml in the config directory
     config_dir = deployment_file if deployment_file.is_dir() else deployment_file.parent
     if not (config_dir / "pyproject.toml").exists():
-        rprint(
-            "[red]No pyproject.toml found at[/red] "
-            f"[bold]{config_dir}[/bold].\n"
+        raise click.ClickException(
+            f"No pyproject.toml found at {config_dir}.\n"
             "Add a pyproject.toml to your project and re-run 'llamactl serve'."
         )
-        raise click.Abort()
 
     try:
         config = read_deployment_config_from_git_root_or_cwd(
             Path.cwd(), deployment_file
         )
     except Exception:
-        rprint(
-            "[red]Error: Could not read a deployment config. This doesn't appear to be a valid llama-deploy project.[/red]"
+        raise click.ClickException(
+            "Could not read a deployment config. This doesn't appear to be a valid llama-deploy project."
         )
-        raise click.Abort()
     if config.ui:
-        rprint(
-            "[bold red]Containerized UI builds are currently not supported. Please remove the UI configuration from your deployment file if you wish to proceed.[/]"
+        raise click.ClickException(
+            "Containerized UI builds are currently not supported. Please remove the UI configuration from your deployment file if you wish to proceed."
         )
-        raise click.Abort()
     return config_dir
 
 
@@ -107,16 +101,14 @@ def _create_file_for_container(
     dockerfile_content = build_dockerfile_content(python_version, port)
 
     if Path(output_file).exists() and not overwrite:
-        rprint(
-            f"[red bold]Error: {output_file} already exists. If you wish to overwrite the file, pass `--overwrite` as a flag to the command.[/]"
+        raise click.ClickException(
+            f"{output_file} already exists. If you wish to overwrite the file, pass `--overwrite` as a flag to the command."
         )
-        raise click.Abort()
     with open(output_file, "w") as f:
         f.write(dockerfile_content)
     if Path(dockerignore_path).exists() and not overwrite:
-        rprint(
-            f"[red bold]Error: {dockerignore_path} already exists. If you wish to overwrite the file, pass `--overwrite` as a flag to the command.[/]"
+        raise click.ClickException(
+            f"{dockerignore_path} already exists. If you wish to overwrite the file, pass `--overwrite` as a flag to the command."
         )
-        raise click.Abort()
     with open(dockerignore_path, "w") as f:
         f.write(dockerignore_content)

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -12,6 +12,7 @@ from llama_agents.cli.commands.auth import validate_authenticated_profile
 from llama_agents.cli.env_settings import read_env_settings
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
 from llama_agents.cli.options import native_tls_option
+from llama_agents.cli.output import echo_status as _out
 from llama_agents.cli.styles import WARNING
 from llama_agents.cli.utils.capabilities import probe_organizations_support
 from llama_agents.cli.utils.redact import redact_api_key
@@ -20,7 +21,6 @@ from llama_agents.core.deployment_config import (
     read_deployment_config_from_git_root_or_cwd,
 )
 from llama_agents.core.schema.projects import OrgSummary, ProjectSummary
-from rich import print as rprint
 
 from ..app import app
 
@@ -99,18 +99,15 @@ def serve(
 ) -> None:
     """Run llama_deploy API Server in the foreground. Reads the deployment configuration from the current directory. Can optionally specify a deployment file path."""
     if not deployment_file.exists():
-        rprint(f"[red]Deployment file '{deployment_file}' not found[/red]")
-        raise click.Abort()
+        raise click.ClickException(f"Deployment file '{deployment_file}' not found")
 
     # Early check: appserver requires a pyproject.toml in the config directory
     config_dir = deployment_file if deployment_file.is_dir() else deployment_file.parent
     if not (config_dir / "pyproject.toml").exists():
-        rprint(
-            "[red]No pyproject.toml found at[/red] "
-            f"[bold]{config_dir}[/bold].\n"
+        raise click.ClickException(
+            f"No pyproject.toml found at {config_dir}.\n"
             "Add a pyproject.toml to your project and re-run 'llamactl serve'."
         )
-        raise click.Abort()
 
     try:
         # Pre-check: if the template requires llama cloud access, ensure credentials
@@ -161,8 +158,7 @@ def serve(
         logger.debug("Shutting down...")
 
     except Exception as e:
-        rprint(f"[red]Error: {e}[/red]")
-        raise click.Abort()
+        raise click.ClickException(str(e)) from e
 
 
 def _set_env_vars_from_profile(profile: Auth) -> None:
@@ -231,10 +227,9 @@ def _maybe_inject_llama_cloud_credentials(
             Path.cwd(), deployment_file
         )
     except Exception:
-        rprint(
-            "[red]Error: Could not read a deployment config. This doesn't appear to be a valid llama-deploy project.[/red]"
+        raise click.ClickException(
+            "Could not read a deployment config. This doesn't appear to be a valid llama-deploy project."
         )
-        raise click.Abort()
 
     if not config.llama_cloud and not require_cloud:
         return
@@ -259,7 +254,7 @@ def _maybe_inject_llama_cloud_credentials(
 
     env = service.get_current_environment()
     if not env.requires_auth:
-        rprint(
+        _out(
             f"[{WARNING}]Warning: This app requires Llama Cloud authentication, and no LLAMA_CLOUD_API_KEY is present. The app may not work.[/]"
         )
         return
@@ -281,13 +276,13 @@ def _maybe_inject_llama_cloud_credentials(
             if authed.api_key:
                 _set_env_vars_from_profile(authed)
                 return
-        rprint(
+        _out(
             f"[{WARNING}]Warning: No Llama Cloud credentials configured. The app may not work.[/]"
         )
         return
 
     # Non-interactive session
-    rprint(
+    _out(
         f"[{WARNING}]Warning: LLAMA_CLOUD_API_KEY is not set and no logged-in profile was found. The app may not work.[/]"
     )
 
@@ -328,7 +323,7 @@ def _maybe_select_project_for_env_key() -> None:
             return
 
         if org is not None:
-            rprint(f"Projects for organization [bold]{org.org_name}[/]")
+            _out(f"Projects for organization [bold]{org.org_name}[/]")
 
         # Multiple: prompt selection
         current_project_id = settings.llama_agents_project_id
@@ -366,6 +361,6 @@ def _print_connection_summary() -> None:
     redacted = redact_api_key(api_key)
     env_text = base_url or "-"
     proj_text = project_id or "-"
-    rprint(
+    _out(
         f"Connecting to environment: [bold]{env_text}[/], project: [bold]{proj_text}[/], api key: [bold]{redacted}[/]"
     )

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -12,8 +12,7 @@ from llama_agents.cli.commands.auth import validate_authenticated_profile
 from llama_agents.cli.env_settings import read_env_settings
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
 from llama_agents.cli.options import native_tls_option
-from llama_agents.cli.output import echo_status as _out
-from llama_agents.cli.styles import WARNING
+from llama_agents.cli.output import status, warning
 from llama_agents.cli.utils.capabilities import probe_organizations_support
 from llama_agents.cli.utils.redact import redact_api_key
 from llama_agents.core.config import DEFAULT_DEPLOYMENT_FILE_PATH
@@ -254,8 +253,8 @@ def _maybe_inject_llama_cloud_credentials(
 
     env = service.get_current_environment()
     if not env.requires_auth:
-        _out(
-            f"[{WARNING}]Warning: This app requires Llama Cloud authentication, and no LLAMA_CLOUD_API_KEY is present. The app may not work.[/]"
+        warning(
+            "LLAMA_CLOUD_API_KEY is not set and no logged-in profile was found; the app may not work"
         )
         return
 
@@ -276,14 +275,14 @@ def _maybe_inject_llama_cloud_credentials(
             if authed.api_key:
                 _set_env_vars_from_profile(authed)
                 return
-        _out(
-            f"[{WARNING}]Warning: No Llama Cloud credentials configured. The app may not work.[/]"
+        warning(
+            "LLAMA_CLOUD_API_KEY is not set and no logged-in profile was found; the app may not work"
         )
         return
 
     # Non-interactive session
-    _out(
-        f"[{WARNING}]Warning: LLAMA_CLOUD_API_KEY is not set and no logged-in profile was found. The app may not work.[/]"
+    warning(
+        "LLAMA_CLOUD_API_KEY is not set and no logged-in profile was found; the app may not work"
     )
 
 
@@ -323,7 +322,7 @@ def _maybe_select_project_for_env_key() -> None:
             return
 
         if org is not None:
-            _out(f"Projects for organization [bold]{org.org_name}[/]")
+            status(f"projects for organization {org.org_name}")
 
         # Multiple: prompt selection
         current_project_id = settings.llama_agents_project_id
@@ -361,6 +360,6 @@ def _print_connection_summary() -> None:
     redacted = redact_api_key(api_key)
     env_text = base_url or "-"
     proj_text = project_id or "-"
-    _out(
-        f"Connecting to environment: [bold]{env_text}[/], project: [bold]{proj_text}[/], api key: [bold]{redacted}[/]"
+    status(
+        f"connecting to environment {env_text}, project {proj_text}, api key {redacted}"
     )

--- a/packages/llamactl/src/llama_agents/cli/env.py
+++ b/packages/llamactl/src/llama_agents/cli/env.py
@@ -4,8 +4,7 @@ from io import StringIO
 from typing import Dict
 
 from dotenv import dotenv_values
-from llama_agents.cli.styles import WARNING
-from rich import print as rprint
+from llama_agents.cli.output import echo_status as _out
 
 
 def load_env_secrets_from_string(env_content: str) -> Dict[str, str]:
@@ -26,7 +25,5 @@ def load_env_secrets_from_string(env_content: str) -> Dict[str, str]:
         # Filter out None values and convert to strings
         return {k: str(v) for k, v in secrets.items() if v is not None}
     except Exception as e:
-        rprint(
-            f"[{WARNING}]Warning: Could not parse environment variables from string: {e}[/]"
-        )
+        _out(f"Warning: Could not parse environment variables from string: {e}")
         return {}

--- a/packages/llamactl/src/llama_agents/cli/env.py
+++ b/packages/llamactl/src/llama_agents/cli/env.py
@@ -4,7 +4,7 @@ from io import StringIO
 from typing import Dict
 
 from dotenv import dotenv_values
-from llama_agents.cli.output import echo_status as _out
+from llama_agents.cli.output import warning
 
 
 def load_env_secrets_from_string(env_content: str) -> Dict[str, str]:
@@ -25,5 +25,5 @@ def load_env_secrets_from_string(env_content: str) -> Dict[str, str]:
         # Filter out None values and convert to strings
         return {k: str(v) for k, v in secrets.items() if v is not None}
     except Exception as e:
-        _out(f"Warning: Could not parse environment variables from string: {e}")
+        warning(f"could not parse environment variables from string: {e}")
         return {}

--- a/packages/llamactl/src/llama_agents/cli/output.py
+++ b/packages/llamactl/src/llama_agents/cli/output.py
@@ -2,15 +2,16 @@
 # Copyright (c) 2026 LlamaIndex Inc.
 from __future__ import annotations
 
-import re
 from typing import Any
 
 import click
 
-_RICH_TAG_RE = re.compile(r"\[/?[a-zA-Z0-9_ #=/.-]+\]")
+
+def status(message: Any = "", *, nl: bool = True) -> None:
+    """Write human-facing CLI status text to stderr."""
+    click.echo(str(message), err=True, nl=nl)
 
 
-def echo_status(message: Any = "", **kwargs: Any) -> None:
-    """Write human-facing CLI status text to stderr without Rich markup."""
-    kwargs.setdefault("err", True)
-    click.echo(_RICH_TAG_RE.sub("", str(message)), **kwargs)
+def warning(message: Any, *, nl: bool = True) -> None:
+    """Write a human-facing CLI warning to stderr."""
+    status(f"warning: {message}", nl=nl)

--- a/packages/llamactl/src/llama_agents/cli/output.py
+++ b/packages/llamactl/src/llama_agents/cli/output.py
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import click
+
+_RICH_TAG_RE = re.compile(r"\[/?[a-zA-Z0-9_ #=/.-]+\]")
+
+
+def echo_status(message: Any = "", **kwargs: Any) -> None:
+    """Write human-facing CLI status text to stderr without Rich markup."""
+    kwargs.setdefault("err", True)
+    click.echo(_RICH_TAG_RE.sub("", str(message)), **kwargs)

--- a/packages/llamactl/tests/test_auth_cli.py
+++ b/packages/llamactl/tests/test_auth_cli.py
@@ -89,7 +89,7 @@ def test_auth_list_profiles_no_profiles() -> None:
         mock_service.current_auth_service.return_value = mock_auth_svc
         result = runner.invoke(app, ["auth", "list"])
         assert result.exit_code == 0
-        assert "No profiles found" in result.output
+        assert "no profiles found" in result.output
 
 
 def test_auth_switch_profile_success_and_missing() -> None:
@@ -112,7 +112,7 @@ def test_auth_switch_profile_success_and_missing() -> None:
         mock_service2.current_auth_service.return_value = MagicMock()
         result = runner.invoke(app, ["auth", "switch", "doesnt-exist"])
         assert result.exit_code == 0
-        assert "No profile selected" in result.output
+        assert "no profile selected" in result.output
 
 
 def test_auth_logout_existing() -> None:

--- a/packages/llamactl/tests/test_auth_cli.py
+++ b/packages/llamactl/tests/test_auth_cli.py
@@ -17,12 +17,40 @@ def test_auth_create_api_key_profile_non_interactive_validation() -> None:
         result = runner.invoke(app, ["auth", "token"])
     assert result.exit_code != 0
     assert (
-        "--api-key and --project-id are required in non-interactive mode"
-        in result.output
+        "--api-key and --project are required in non-interactive mode" in result.output
     )
 
 
 def test_auth_create_api_key_profile_non_interactive_success() -> None:
+    runner = CliRunner()
+    with (
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+        patch(
+            "llama_agents.cli.commands.auth.is_interactive_session", return_value=False
+        ),
+    ):
+        mock_auth_svc = MagicMock()
+        mock_auth_svc.create_profile_from_token.return_value = SimpleNamespace(
+            name="prof"
+        )
+        mock_service.current_auth_service.return_value = mock_auth_svc
+
+        result = runner.invoke(
+            app,
+            [
+                "auth",
+                "token",
+                "--project",
+                "p",
+                "--api-key",
+                "key",
+            ],
+        )
+        assert result.exit_code == 0
+        mock_auth_svc.create_profile_from_token.assert_called_once_with("p", "key")
+
+
+def test_auth_create_api_key_profile_project_id_alias() -> None:
     runner = CliRunner()
     with (
         patch("llama_agents.cli.config.env_service.service") as mock_service,
@@ -47,8 +75,9 @@ def test_auth_create_api_key_profile_non_interactive_success() -> None:
                 "key",
             ],
         )
-        assert result.exit_code == 0
-        mock_auth_svc.create_profile_from_token.assert_called_once_with("p", "key")
+
+    assert result.exit_code == 0
+    mock_auth_svc.create_profile_from_token.assert_called_once_with("p", "key")
 
 
 def test_auth_list_profiles_no_profiles() -> None:
@@ -108,8 +137,8 @@ def test_auth_logout_missing() -> None:
     ):
         mock_service2.current_auth_service.return_value = MagicMock()
         result = runner.invoke(app, ["auth", "logout", "missing"])
-        assert result.exit_code == 0
-        assert "No profile selected" in result.output
+        assert result.exit_code != 0
+        assert "Profile 'missing' not found" in result.output
 
 
 def test_auth_project_non_interactive_lists_options_and_hints() -> None:

--- a/packages/llamactl/tests/test_commands_core.py
+++ b/packages/llamactl/tests/test_commands_core.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import MagicMock, patch
 
+import click
 import llama_agents.cli.client as client_module
 import llama_agents.cli.config.env_service as env_service
 import pytest
@@ -104,7 +105,7 @@ def test_client_requires_valid_profile() -> None:
         mock_auth_svc = MagicMock()
         mock_auth_svc.get_current_profile.return_value = None
         mock_service.current_auth_service.return_value = mock_auth_svc
-        with pytest.raises(SystemExit):
+        with pytest.raises(click.ClickException, match="No profile configured"):
             get_project_client()
 
 
@@ -199,13 +200,11 @@ def test_incomplete_env_var_project_client_without_profile_warns_and_exits(
     set_llama_cloud_env(monkeypatch, api_key="env-api-key")
     _set_current_profile(monkeypatch, None)
 
-    with pytest.raises(SystemExit) as exc_info:
+    with pytest.raises(click.ClickException, match="No profile configured"):
         get_project_client()
 
     captured = capsys.readouterr()
-    assert exc_info.value.code == 1
     assert PARTIAL_ENV_WARNING in captured.err
-    assert "No profile configured" in captured.out
 
 
 def test_env_var_project_override_wins_over_env_project_id(

--- a/packages/llamactl/tests/test_completion_commands.py
+++ b/packages/llamactl/tests/test_completion_commands.py
@@ -63,7 +63,7 @@ def test_completion_install_dry_run() -> None:
         app, ["completion", "install", "--shell", "zsh", "--dry-run"]
     )
     assert result.exit_code == 0
-    assert "Would write" in result.output
+    assert "would write completion script" in result.output
 
 
 def test_completion_install_dry_run_bash() -> None:
@@ -72,7 +72,7 @@ def test_completion_install_dry_run_bash() -> None:
         app, ["completion", "install", "--shell", "bash", "--dry-run"]
     )
     assert result.exit_code == 0
-    assert "Would write" in result.output
+    assert "would write completion script" in result.output
 
 
 def test_completion_install_dry_run_fish() -> None:
@@ -81,7 +81,7 @@ def test_completion_install_dry_run_fish() -> None:
         app, ["completion", "install", "--shell", "fish", "--dry-run"]
     )
     assert result.exit_code == 0
-    assert "Would write" in result.output
+    assert "would write completion script" in result.output
 
 
 def test_completion_install_zsh_repairs_ordered_completion_block(

--- a/packages/llamactl/tests/test_deployments_apply_cmd.py
+++ b/packages/llamactl/tests/test_deployments_apply_cmd.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import httpx
 import llama_agents.cli.config.env_service as env_service
 import pytest
+import yaml
 from click.testing import CliRunner
 from conftest import (
     make_deployment,
@@ -276,6 +277,11 @@ def test_apply_dry_run_named(patched_auth: Any, tmp_path: Any) -> None:
     client.get_deployment.assert_not_called()
     client.create_deployment.assert_not_called()
     client.update_deployment.assert_not_called()
+    assert "would upsert" not in result.stdout
+    assert "would upsert deployment 'new-app'" in result.stderr
+    assert (
+        yaml.safe_load(result.stdout)["repo_url"] == "https://github.com/example/repo"
+    )
     assert "would" in result.output.lower()
     assert "upsert" in result.output.lower()
 
@@ -741,6 +747,8 @@ def test_delete_from_file(patched_auth: Any, tmp_path: Any) -> None:
         result = runner.invoke(app, ["deployments", "delete", "-f", str(f)])
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert "Deleted deployment: doomed-app" in result.stderr
     client.delete_deployment.assert_called_once()
     call_args = client.delete_deployment.call_args
     assert call_args[0][0] == "doomed-app"
@@ -795,6 +803,8 @@ def test_delete_reads_stdin(patched_auth: Any) -> None:
         )
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert "Deleted deployment: stdin-app" in result.stderr
     client.delete_deployment.assert_called_once()
     call_args = client.delete_deployment.call_args
     assert call_args[0][0] == "stdin-app"
@@ -1000,6 +1010,7 @@ def test_apply_push_mode_update_does_push_then_save(
         result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
     assert "updated my-app" in result.output
     mock_push.assert_called_once()
     client.update_deployment.assert_called_once()
@@ -1058,6 +1069,7 @@ def test_apply_external_to_push_mode_does_save_then_push(
         result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
     assert "updated my-app" in result.output
     client.update_deployment.assert_called_once()
     mock_push.assert_called_once()
@@ -1076,6 +1088,7 @@ def test_apply_push_to_external_does_save_only(
         result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
     assert "updated my-app" in result.output
     mock_push.assert_not_called()
 
@@ -1094,6 +1107,7 @@ def test_apply_internal_scheme_roundtrip_pushes(
         result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
     assert "updated my-app" in result.output
     mock_push.assert_called_once()
     client.validate_repository.assert_not_called()
@@ -1117,6 +1131,8 @@ def test_apply_internal_scheme_skips_push_when_not_in_git_repo(
         result = runner.invoke(app, ["deployments", "apply", "-f", str(f)])
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert "Not in a git repo" in result.stderr
     assert "updated my-app" in result.output
     # Push should be skipped entirely.
     mock_push.assert_not_called()

--- a/packages/llamactl/tests/test_deployments_apply_cmd.py
+++ b/packages/llamactl/tests/test_deployments_apply_cmd.py
@@ -748,7 +748,7 @@ def test_delete_from_file(patched_auth: Any, tmp_path: Any) -> None:
 
     assert result.exit_code == 0, result.output
     assert result.stdout == ""
-    assert "Deleted deployment: doomed-app" in result.stderr
+    assert "deleted doomed-app" in result.stderr
     client.delete_deployment.assert_called_once()
     call_args = client.delete_deployment.call_args
     assert call_args[0][0] == "doomed-app"
@@ -804,7 +804,7 @@ def test_delete_reads_stdin(patched_auth: Any) -> None:
 
     assert result.exit_code == 0, result.output
     assert result.stdout == ""
-    assert "Deleted deployment: stdin-app" in result.stderr
+    assert "deleted stdin-app" in result.stderr
     client.delete_deployment.assert_called_once()
     call_args = client.delete_deployment.call_args
     assert call_args[0][0] == "stdin-app"
@@ -1132,7 +1132,10 @@ def test_apply_internal_scheme_skips_push_when_not_in_git_repo(
 
     assert result.exit_code == 0, result.output
     assert result.stdout == ""
-    assert "Not in a git repo" in result.stderr
+    assert (
+        "warning: not in a git repo; skipping push, server will use last pushed code"
+        in result.stderr
+    )
     assert "updated my-app" in result.output
     # Push should be skipped entirely.
     mock_push.assert_not_called()

--- a/packages/llamactl/tests/test_deployments_update.py
+++ b/packages/llamactl/tests/test_deployments_update.py
@@ -6,7 +6,7 @@ The headline regression here: ``deployments update <id>`` for an internal-code
 deployment used to call ``asyncio.run`` twice with the same ``ProjectClient``.
 The shared httpx pool was bound to the first (closed) event loop, and the
 second run raised ``RuntimeError: Event loop is closed`` — surfacing in CI as
-``Error: Event loop is closed`` after the "Continuing with update using last
+``Error: Event loop is closed`` after the "continuing with update using last
 pushed code" fallback when the internal git mirror returned a transient 500.
 """
 
@@ -62,7 +62,8 @@ def test_deployments_update_external_repo(patched_auth: Any) -> None:
         result = runner.invoke(app, ["deployments", "update", "my-app"])
     assert result.exit_code == 0, result.output
     assert result.stdout == ""
-    assert "Updated:" in result.stderr
+    assert "refreshing my-app" in result.stderr
+    assert "updated my-app aaaaaaa -> bbbbbbb" in result.stderr
     client.get_deployment.assert_called_once()
     client.update_deployment.assert_called_once()
 
@@ -113,8 +114,8 @@ def test_deployments_update_internal_repo_push_failure_does_not_abort(
 
     assert result.exit_code == 0, result.output
     assert result.stdout == ""
-    assert "Push failed:" in result.stderr
-    assert "Continuing with update using last pushed code" in result.stderr
+    assert "warning: push failed:" in result.stderr
+    assert "warning: continuing with update using last pushed code" in result.stderr
     assert "Event loop is closed" not in result.output
     client.get_deployment.assert_called_once()
     client.update_deployment.assert_called_once()
@@ -144,7 +145,8 @@ def test_deployments_update_no_push_skips_internal_git_push(
 
     assert result.exit_code == 0, result.output
     assert result.stdout == ""
-    assert "Updated:" in result.stderr
+    assert "refreshing my-app" in result.stderr
+    assert "updated my-app aaaaaaa -> bbbbbbb" in result.stderr
     is_git_repo.assert_not_called()
     configure_git_remote.assert_not_called()
     push_to_remote.assert_not_called()

--- a/packages/llamactl/tests/test_deployments_update.py
+++ b/packages/llamactl/tests/test_deployments_update.py
@@ -61,6 +61,8 @@ def test_deployments_update_external_repo(patched_auth: Any) -> None:
     with patch_project_client(client):
         result = runner.invoke(app, ["deployments", "update", "my-app"])
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert "Updated:" in result.stderr
     client.get_deployment.assert_called_once()
     client.update_deployment.assert_called_once()
 
@@ -110,6 +112,41 @@ def test_deployments_update_internal_repo_push_failure_does_not_abort(
         result = runner.invoke(app, ["deployments", "update", "my-app"])
 
     assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert "Push failed:" in result.stderr
+    assert "Continuing with update using last pushed code" in result.stderr
     assert "Event loop is closed" not in result.output
+    client.get_deployment.assert_called_once()
+    client.update_deployment.assert_called_once()
+
+
+def test_deployments_update_no_push_skips_internal_git_push(
+    patched_auth: Any,
+) -> None:
+    runner = CliRunner()
+    current = make_deployment(
+        "my-app", repo_url=INTERNAL_CODE_REPO_SCHEME, git_sha="a" * 40
+    )
+    updated = make_deployment(
+        "my-app", repo_url=INTERNAL_CODE_REPO_SCHEME, git_sha="b" * 40
+    )
+    client = _client_mock(current, updated)
+
+    with (
+        patch_project_client(client),
+        patch("llama_agents.cli.commands.deployment.is_git_repo") as is_git_repo,
+        patch("llama_agents.cli.commands.deployment.push_to_remote") as push_to_remote,
+        patch(
+            "llama_agents.cli.commands.deployment.configure_git_remote"
+        ) as configure_git_remote,
+    ):
+        result = runner.invoke(app, ["deployments", "update", "my-app", "--no-push"])
+
+    assert result.exit_code == 0, result.output
+    assert result.stdout == ""
+    assert "Updated:" in result.stderr
+    is_git_repo.assert_not_called()
+    configure_git_remote.assert_not_called()
+    push_to_remote.assert_not_called()
     client.get_deployment.assert_called_once()
     client.update_deployment.assert_called_once()

--- a/packages/llamactl/tests/test_dev_commands.py
+++ b/packages/llamactl/tests/test_dev_commands.py
@@ -125,7 +125,7 @@ def test_dev_validate_reports_failures(
 
     result = runner.invoke(app, ["dev", "validate", str(tmp_path)])
     assert result.exit_code != 0
-    assert "Workflow validation failed" in result.output
+    assert "workflow validation failed; see errors above" in result.output
 
 
 @dataclass
@@ -427,7 +427,7 @@ def test_export_json_graph_reports_failures(
 
     result = runner.invoke(app, ["dev", "export-json-graph"])
     assert result.exit_code != 0, result.output
-    assert "Workflow JSON graph export failed" in result.output
+    assert "workflow JSON graph export failed; see errors above" in result.output
 
 
 def test_export_json_graph_deployment_file_not_exist(

--- a/packages/llamactl/tests/test_init_command.py
+++ b/packages/llamactl/tests/test_init_command.py
@@ -203,7 +203,7 @@ def test_init_handles_git_init_failure_gracefully(tmp_path: Path) -> None:
 
         assert result.exit_code == 0, result.output
         assert target_dir.exists()
-        assert "Skipping git initialization" in result.output
+        assert "warning: skipping git initialization" in result.output
         mock_scaffold.assert_called_once()
 
 
@@ -257,7 +257,10 @@ def test_init_skips_git_init_when_inside_parent_repo(tmp_path: Path) -> None:
 
         assert result.exit_code == 0, result.output
         assert target_dir.exists()
-        assert "Detected an existing Git repository" in result.output
+        assert (
+            "warning: skipping git initialization: existing Git repository"
+            in result.output
+        )
 
 
 def test_copy_scaffold(tmp_path: Path) -> None:
@@ -342,7 +345,7 @@ def test_init_non_interactive_defaults_directory(tmp_path: Path) -> None:
             assert result.exit_code == 0, result.output
             # Should default to template name
             assert (tmp_path / "basic-ui").exists()
-            assert "Defaulting to basic-ui" in result.output
+            assert "no directory provided; defaulting to basic-ui" in result.output
         finally:
             os.chdir(original_cwd)
 

--- a/packages/llamactl/tests/test_pkg.py
+++ b/packages/llamactl/tests/test_pkg.py
@@ -101,7 +101,7 @@ def test__check_deployment_config(
         assert str(conf_dir) == str(tmp_path)
         with open(tmp_path / "pyproject.toml", "w") as f:
             f.write(pyproject_toml_with_ui)
-        with pytest.raises(click.Abort):
+        with pytest.raises(click.ClickException):
             _check_deployment_config(tmp_path)
     except Exception as e:
         raise e
@@ -129,9 +129,7 @@ def test__create_file_for_container(
         assert (tmp_path / "Dockerfile").read_text(encoding="utf-8") == dockerfile
         content = (tmp_path / ".dockerignore").read_text()
         assert DEFAULT_DOCKER_IGNORE in content
-        with pytest.raises(
-            click.Abort
-        ):  # without --overwrite, this raises an exception
+        with pytest.raises(click.ClickException):
             _create_file_for_container(
                 output_file="Dockerfile",
                 deployment_file=tmp_path,

--- a/packages/llamactl/tests/test_serve_llama_cloud.py
+++ b/packages/llamactl/tests/test_serve_llama_cloud.py
@@ -281,6 +281,6 @@ def test_warns_non_interactive_without_key(
         assert os.environ.get("LLAMA_CLOUD_API_KEY") is None
         # Warning present
         assert (
-            "Warning: LLAMA_CLOUD_API_KEY is not set" in res.output
-            or "Warning: No Llama Cloud credentials" in res.output
+            "warning: LLAMA_CLOUD_API_KEY is not set and no logged-in profile was found; the app may not work"
+            in res.output
         )


### PR DESCRIPTION
`llamactl` now uses one user-facing error path (`click.ClickException`) and keeps human status messages on stderr. Structured output, templates, and logs stay on stdout.

Status output is plain text now: no Rich tags, no color helpers, no spinners, and warnings use the same `warning:` prefix. Mutating commands use the same lowercase verb shape (`created`, `updated`, `deleted`, `rolled back`) across deployments, auth, env, completion, dev, serve, and init.

`auth token` accepts `--project` with `--project-id` kept as a compatibility alias, `delete -f` uses the same filename handling as apply/create/edit, and `deployments update --no-push` can refresh an internal-code deployment without pushing local code first.
