### PR TITLE
Preserve secret placeholders in get -otemplate

### DIFF
--- a/packages/llamactl/src/llama_agents/cli/commands/deployment.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/deployment.py
@@ -315,10 +315,7 @@ def _existing_deployment_template_yaml(deployment: DeploymentResponse) -> str:
 
 
 def _existing_deployment_editor_yaml(deployment: DeploymentResponse) -> str:
-    return render_yaml_template(
-        DeploymentDisplay.from_response(deployment),
-        strip_mask_sentinels=False,
-    )
+    return render_yaml_template(DeploymentDisplay.from_response(deployment))
 
 
 def _parse_deployment_yaml_text(text: str) -> DeploymentDisplay:

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -391,15 +391,14 @@ class DeploymentDisplay(BaseModel):
     def to_output_dict(self) -> dict[str, Any]:
         """Return the dict shape used for JSON/YAML rendering.
 
-        Omits fields inside ``spec`` whose value is None and strips the
-        ``SECRET_MASK`` sentinel from ``secrets`` and ``personal_access_token``
-        so a ``get | edit | apply`` round-trip can't push a literal ``********``
-        back as the value. ``generate_name`` is emitted at the top level only
+        Omits fields inside ``spec`` whose value is None.  Masked secret
+        placeholders (``********``) are preserved so the output shows which
+        secrets exist.  ``generate_name`` is emitted at the top level only
         when set. The nested ``status`` block is preserved verbatim so its
         ``warning`` key remains explicit even when ``null``.
         """
         spec_data = self.spec.model_dump(mode="json")
-        spec_data = strip_masks({k: v for k, v in spec_data.items() if v is not None})
+        spec_data = {k: v for k, v in spec_data.items() if v is not None}
         data: dict[str, Any] = {"name": self.name}
         if self.generate_name is not None:
             data["generate_name"] = self.generate_name

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -82,7 +82,7 @@ def render(
     required: Iterable[str] = (),
     name_example: str = "my-app",
     scaffold_generate_name: bool = False,
-    strip_mask_sentinels: bool = True,
+    strip_mask_sentinels: bool = False,
 ) -> str:
     """Render ``display`` as a commented apply-shaped YAML string.
 
@@ -112,10 +112,11 @@ def render(
             ``False`` (the default), the
             field is omitted entirely. Only the offline ``deployments
             template`` flow opts in; ``get -o template`` does not.
-        strip_mask_sentinels: When ``True`` (default), omit masked secret
-            values from output so template output can be piped back into
-            apply. The editor loop sets this to ``False`` so existing secret
-            names remain visible as masked entries.
+        strip_mask_sentinels: When ``True``, omit masked secret values
+            from output so they don't round-trip into apply input.  The
+            default is ``False`` — masked placeholders are preserved so
+            ``get -o template`` and the editor both show which secrets
+            exist.  Stripping happens on the apply/parse side instead.
     """
     required_set = set(required)
     out: list[str] = []

--- a/packages/llamactl/src/llama_agents/cli/yaml_template.py
+++ b/packages/llamactl/src/llama_agents/cli/yaml_template.py
@@ -29,10 +29,11 @@ Single-character strings are force-quoted so values like ``"."`` read
 unambiguously rather than hitting YAML plain-scalar edge cases.
 
 Mask sentinels (``SECRET_MASK``) inside ``secrets`` and on
-``personal_access_token`` are stripped before rendering — the same filter
-:func:`~llama_agents.cli.display.strip_masks` applies to ``-o yaml`` /
-``-o json`` output, so a ``get -o template | apply`` round-trip can't push a
-literal ``********`` back as the value.
+``personal_access_token`` are preserved in rendered output so the user can see
+which secrets exist.  Stripping happens on the apply/parse side
+(:meth:`~llama_agents.cli.display.DeploymentDisplay.without_mask_sentinels`)
+so a ``get -o template | apply`` round-trip can't push a literal ``********``
+back as the value.
 """
 
 from __future__ import annotations

--- a/packages/llamactl/tests/test_deployments_get_output.py
+++ b/packages/llamactl/tests/test_deployments_get_output.py
@@ -186,10 +186,9 @@ def test_deployments_get_single_yaml(patched_auth: Any) -> None:
     assert obj["status"]["phase"] == "Running"
 
 
-def test_deployments_get_strips_secret_mask_sentinels(patched_auth: Any) -> None:
-    """``********`` mask sentinels never reach structured output; the keys
-    drop entirely so a ``get | edit | apply`` round-trip can't push the mask
-    back as the value."""
+def test_deployments_get_preserves_secret_mask_placeholders(patched_auth: Any) -> None:
+    """Secret names are shown with masked values so the user can see which
+    secrets are configured."""
     runner = CliRunner()
     deployments = [
         make_deployment(
@@ -203,9 +202,11 @@ def test_deployments_get_strips_secret_mask_sentinels(patched_auth: Any) -> None
         result = runner.invoke(app, ["deployments", "get", "secret-app", "-o", "json"])
     assert result.exit_code == 0, result.output
     obj = json.loads(result.output)
-    assert "secrets" not in obj["spec"]
-    assert "personal_access_token" not in obj["spec"]
-    assert "********" not in result.output
+    assert obj["spec"]["secrets"] == {
+        "LLAMA_CLOUD_API_KEY": "********",
+        "OPENAI_API_KEY": "********",
+    }
+    assert obj["spec"]["personal_access_token"] == "********"
 
 
 def test_deployments_get_empty_json_is_array(patched_auth: Any) -> None:

--- a/packages/llamactl/tests/test_deployments_get_output.py
+++ b/packages/llamactl/tests/test_deployments_get_output.py
@@ -571,11 +571,11 @@ def test_deployments_get_template_single_emits_apply_shape(patched_auth: Any) ->
     assert "phase" not in out
     # Doc comments above fields.
     assert "## Stable id for the deployment" in out
-    # Masked secrets / PAT are stripped at the emit boundary — they must not
-    # round-trip as literal ``********`` values into apply input.
-    assert "********" not in out
-    assert "secrets" not in (parsed["spec"] or {})
-    assert "personal_access_token" not in (parsed["spec"] or {})
+    # Masked secrets / PAT are preserved as placeholders so the user can see
+    # which secrets exist.  Stripping happens on the apply/parse side.
+    assert "OPENAI_API_KEY" in out
+    assert parsed["spec"]["secrets"] == {"OPENAI_API_KEY": "********"}
+    assert parsed["spec"]["personal_access_token"] == "********"
 
 
 def test_deployments_get_template_does_not_scaffold_generate_name(

--- a/packages/llamactl/tests/test_display.py
+++ b/packages/llamactl/tests/test_display.py
@@ -318,21 +318,17 @@ def test_to_output_dict_keeps_explicit_status_warning_null() -> None:
     assert data["status"]["warning"] is None
 
 
-def test_to_output_dict_strips_mask_sentinels() -> None:
-    """Mask sentinels are dropped at the emit boundary so a ``get | edit |
-    apply`` round-trip can't push the literal ``********`` back as the value."""
+def test_to_output_dict_preserves_mask_placeholders() -> None:
+    """Masked secret names are preserved so JSON/YAML output shows which
+    secrets exist.  Stripping happens on the apply/parse side instead."""
     response = make_deployment(
         "my-app",
         secret_names=["KEY"],
         has_personal_access_token=True,
     )
     data = DeploymentDisplay.from_response(response).to_output_dict()
-    # ``secrets`` had only mask values → key drops entirely.
-    assert "secrets" not in data["spec"]
-    # PAT mask drops too.
-    assert "personal_access_token" not in data["spec"]
-    # And ``SECRET_MASK`` should not appear anywhere serialized.
-    assert SECRET_MASK not in repr(data)
+    assert data["spec"]["secrets"] == {"KEY": SECRET_MASK}
+    assert data["spec"]["personal_access_token"] == SECRET_MASK
 
 
 def test_to_output_dict_emits_generate_name_when_set() -> None:

--- a/packages/llamactl/tests/test_yaml_template.py
+++ b/packages/llamactl/tests/test_yaml_template.py
@@ -334,7 +334,7 @@ def test_render_strips_secret_mask_sentinels() -> None:
             secrets={"REAL": "${REAL}", "MASKED": SECRET_MASK},
         ),
     )
-    out = render(display)
+    out = render(display, strip_mask_sentinels=True)
     assert SECRET_MASK not in out
     assert "MASKED" not in out
     # The remaining real secret is still rendered.
@@ -348,7 +348,7 @@ def test_render_drops_secrets_block_when_only_masks() -> None:
             secrets={"ONLY_MASKED": SECRET_MASK},
         ),
     )
-    out = render(display)
+    out = render(display, strip_mask_sentinels=True)
     # No uncommented secrets block — falls into the unset/example branch.
     assert "  secrets:\n    ONLY_MASKED" not in out
     assert SECRET_MASK not in out
@@ -376,7 +376,7 @@ def test_render_strips_personal_access_token_mask() -> None:
         name="my-app",
         spec=DeploymentSpec(personal_access_token=SECRET_MASK),
     )
-    out = render(display)
+    out = render(display, strip_mask_sentinels=True)
     assert SECRET_MASK not in out
     # Falls through to the commented example.
     assert "  # personal_access_token:" in out


### PR DESCRIPTION
`deployments get -otemplate` was stripping `********` mask sentinels at render time, so the output hid which secrets a deployment had configured. `deployments edit` preserved them. Now both show the masked placeholders — the stripping only happens on the apply/parse side (`without_mask_sentinels()`) where it actually matters.

Change: flip the default of `strip_mask_sentinels` in `yaml_template.render()` from `True` to `False`.