### PR TITLE
Restructure llamactl auth commands

### DIFF
--- a/.changeset/llamactl-auth-command-groups.md
+++ b/.changeset/llamactl-auth-command-groups.md
@@ -1,0 +1,5 @@
+---
+"llamactl": minor
+---
+
+Restructure auth-related commands into top-level resource groups

--- a/packages/llamactl/src/llama_agents/cli/__init__.py
+++ b/packages/llamactl/src/llama_agents/cli/__init__.py
@@ -3,11 +3,14 @@ import warnings
 import llama_agents.cli.commands.agentcore  # noqa: F401
 import llama_agents.cli.commands.auth  # noqa: F401
 import llama_agents.cli.commands.completion  # noqa: F401
+import llama_agents.cli.commands.config  # noqa: F401
 import llama_agents.cli.commands.deployment  # noqa: F401
 import llama_agents.cli.commands.dev  # noqa: F401
-import llama_agents.cli.commands.env  # noqa: F401
+import llama_agents.cli.commands.environments  # noqa: F401
 import llama_agents.cli.commands.init  # noqa: F401
+import llama_agents.cli.commands.organizations  # noqa: F401
 import llama_agents.cli.commands.pkg  # noqa: F401
+import llama_agents.cli.commands.projects  # noqa: F401
 import llama_agents.cli.commands.serve  # noqa: F401
 
 from .app import app

--- a/packages/llamactl/src/llama_agents/cli/app.py
+++ b/packages/llamactl/src/llama_agents/cli/app.py
@@ -35,9 +35,7 @@ def print_version(ctx: click.Context, param: click.Parameter, value: Any) -> Non
 
 
 # Main CLI application
-@click.group(
-    help="Create, develop, and deploy LlamaIndex workflow based apps", cls=AliasedGroup
-)
+@click.group(help="Create, develop, and deploy LlamaDeploy apps.", cls=AliasedGroup)
 @click.option(
     "--version",
     is_flag=True,

--- a/packages/llamactl/src/llama_agents/cli/commands/agentcore.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/agentcore.py
@@ -12,12 +12,12 @@ from ..options import global_options
 
 
 @app.group(
-    help="LlamaAgents x Bedrock AgentCore deployment utilities",
+    help="LlamaAgents x Bedrock AgentCore deployment utilities.",
     no_args_is_help=True,
 )
 @global_options
 def agentcore() -> None:
-    """LlamaAgents x Bedrock AgentCore deployment utilities"""
+    """LlamaAgents x Bedrock AgentCore deployment utilities."""
     pass
 
 

--- a/packages/llamactl/src/llama_agents/cli/commands/auth.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/auth.py
@@ -12,12 +12,12 @@ from typing import TYPE_CHECKING
 import click
 from llama_agents.cli.interactive import is_interactive_session, select_or_exit
 from llama_agents.cli.output import status, warning
-from llama_agents.cli.param_types import OrgType, ProfileType, ProjectType
+from llama_agents.cli.param_types import ProfileType
 from llama_agents.cli.utils.capabilities import probe_organizations_support
 
 from ..app import app
-from ..display import AuthProfileDisplay, OrgDisplay
-from ..options import global_options, output_option, render_output
+from ..display import AuthProfileDisplay
+from ..options import global_options, render_output, simple_output_option
 
 if TYPE_CHECKING:
     from llama_agents.cli.config.auth_service import AuthService
@@ -29,6 +29,26 @@ if TYPE_CHECKING:
 
 class NoProjectsFoundError(Exception):
     """Raised when the authenticated user has no accessible projects on an org-less server."""
+
+
+class AuthGroup(click.Group):
+    _removed_command_hints = {
+        "list": "Use `llamactl auth get` instead.",
+        "switch": "Use `llamactl auth use` instead.",
+        "env": "Use `llamactl environments get` instead.",
+        "project": "Use `llamactl projects` instead.",
+        "organizations": "Use `llamactl organizations get` instead.",
+        "destroy": "Use `llamactl config destroy` instead.",
+        "show-db": "Use `llamactl config show-db` instead.",
+    }
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        command = super().get_command(ctx, cmd_name)
+        if command is not None:
+            return command
+        if hint := self._removed_command_hints.get(cmd_name):
+            raise click.ClickException(f"No such command '{cmd_name}'. {hint}")
+        return None
 
 
 _ClickPath = getattr(click, "Path")
@@ -47,12 +67,13 @@ def _get_service() -> EnvService:
 
 # Create sub-applications for organizing commands
 @app.group(
-    help="Login to llama cloud control plane to manage deployments",
+    help="Manage login profiles and credentials.",
+    cls=AuthGroup,
     no_args_is_help=True,
 )
 @global_options
 def auth() -> None:
-    """Login to llama cloud control plane"""
+    """Manage login profiles and credentials."""
     pass
 
 
@@ -120,7 +141,7 @@ def create_api_key_profile(
 @auth.command("login")
 @global_options
 def device_login() -> None:
-    """Login via web browser"""
+    """Log in with a web browser."""
     from llama_agents.cli.auth.client import OIDCNotEnabledError
 
     try:
@@ -144,15 +165,20 @@ def device_login() -> None:
         raise click.ClickException(str(e)) from e
 
 
-@auth.command("list")
+@auth.command("get")
+@click.argument("name", required=False, type=ProfileType())
 @global_options
-@output_option
-def list_profiles(output: str) -> None:
-    """List all logged in users/tokens"""
+@simple_output_option
+def get_profiles(name: str | None, output: str) -> None:
+    """List auth profiles or show one profile."""
     try:
         auth_svc = _get_service().current_auth_service()
         profiles = auth_svc.list_profiles()
         current = auth_svc.get_current_profile()
+        if name:
+            profiles = [profile for profile in profiles if profile.name == name]
+            if not profiles:
+                raise click.ClickException(f"Profile '{name}' not found")
 
         if not profiles and output == "text":
             status("no profiles found")
@@ -167,42 +193,22 @@ def list_profiles(output: str) -> None:
             AuthProfileDisplay.from_profile(p, current_name=current_name)
             for p in profiles
         ]
-        render_output(displays, output)
+        render_output(displays[0] if name and len(displays) == 1 else displays, output)
 
+    except click.ClickException:
+        raise
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
 
-@auth.command("destroy", hidden=True)
-@global_options
-def destroy_database() -> None:
-    """Destroy the database"""
-    from llama_agents.cli.config._config import ConfigManager
-
-    if is_interactive_session() and not click.confirm(
-        "Are you sure you want to destroy all of your local logins? This action cannot be undone."
-    ):
-        return
-    ConfigManager(init_database=False).destroy_database()
-    status("database destroyed")
-
-
-@auth.command("show-db", hidden=True)
-@global_options
-def config_database() -> None:
-    """Config the database"""
-    path = _get_service().config_manager().db_path
-    status(path)
-
-
-@auth.command("switch")
+@auth.command("use")
 @global_options
 @click.argument("name", required=False, type=ProfileType())
-def switch_profile(name: str | None) -> None:
-    """Switch to a different profile"""
+def use_profile(name: str | None) -> None:
+    """Switch to a different profile."""
     auth_svc = _get_service().current_auth_service()
     try:
-        selected_auth = _select_profile(auth_svc, name)
+        selected_auth = _select_profile(auth_svc, name, require_selection=True)
         if not selected_auth:
             status("no profile selected")
             return
@@ -218,7 +224,7 @@ def switch_profile(name: str | None) -> None:
 @global_options
 @click.argument("name", required=False, type=ProfileType())
 def delete_profile(name: str | None) -> None:
-    """Logout from a profile and wipe all associated data"""
+    """Log out from a profile and wipe its local credentials."""
     try:
         auth_svc = _get_service().current_auth_service()
         auth = _select_profile(auth_svc, name)
@@ -266,121 +272,6 @@ def me() -> None:
         raise click.ClickException(str(e)) from e
 
 
-# Organizations commands
-@auth.command("organizations")
-@global_options
-@output_option
-def list_organizations(output: str) -> None:
-    """List organizations available to the current profile"""
-    try:
-        auth_svc = _get_service().current_auth_service()
-        if not probe_organizations_support():
-            if output == "text":
-                warning("this server does not support organizations")
-                return
-            # Structured outputs: emit an empty list so scripts get a
-            # well-typed answer instead of an unparsable warning.
-            render_output([], output)
-            return
-
-        organizations = _list_organizations(auth_svc)
-        if not organizations and output == "text":
-            status("no organizations found")
-            return
-
-        default_org = next((o.org_id for o in organizations if o.is_default), None)
-        displays = [
-            OrgDisplay.from_org_summary(o, current_org_id=default_org)
-            for o in organizations
-        ]
-        render_output(displays, output)
-
-    except Exception as e:
-        raise click.ClickException(str(e)) from e
-
-
-# Projects commands
-@auth.command("project")
-@click.argument("project_id", required=False, type=ProjectType())
-@click.option(
-    "--org",
-    "org_id",
-    default=None,
-    type=OrgType(),
-    help="Organization ID to scope projects to",
-)
-@global_options
-def change_project(project_id: str | None, org_id: str | None) -> None:
-    """Change the active project for the current profile"""
-    auth_svc = _get_service().current_auth_service()
-    profile = validate_authenticated_profile()
-
-    # Discover org if not explicitly provided (profile exists, credentials available)
-    org = None
-    if org_id is None:
-        org = _discover_organization(auth_svc)
-        if org is not None:
-            org_id = org.org_id
-
-    if project_id and profile.project_id == project_id:
-        return
-    if project_id:
-        if auth_svc.env.requires_auth:
-            projects = _list_projects(auth_svc, org_id=org_id)
-            if not next(
-                (project for project in projects if project.project_id == project_id),
-                None,
-            ):
-                raise click.ClickException(f"Project {project_id} not found")
-        auth_svc.set_project(profile.name, project_id)
-        status(f"switched project {project_id}")
-        return
-    try:
-        projects = _list_projects(auth_svc)
-
-        if not projects:
-            status("no projects found")
-            return
-
-        current_project_id = profile.project_id
-        items = []
-        current_idx = 0
-        for i, project in enumerate(projects):
-            label = f"{project.project_id}  {project.project_name} ({project.deployment_count} deployments)"
-            if project.project_id == current_project_id:
-                label += " [current]"
-                current_idx = i
-            items.append((project.project_id, label))
-        if not auth_svc.env.requires_auth:
-            items.append(("__CREATE__", "Create new project"))
-
-        result = select_or_exit(
-            items,
-            "Select a project",
-            hint_flag="<project_id>",
-            hint_command="llamactl auth project <project_id>",
-            selected=current_idx,
-        )
-        if result == "__CREATE__":
-            project_id = click.prompt(
-                "Enter project ID", default="", show_default=False
-            ).strip()
-            result = project_id
-        if result:
-            selected_project = next(
-                (project for project in projects if project.project_id == result), None
-            )
-            name = selected_project.project_name if selected_project else result
-            auth_svc.set_project(profile.name, result)
-            status(f"switched project {name}")
-        else:
-            status("no project selected")
-    except click.ClickException:
-        raise
-    except Exception as e:
-        raise click.ClickException(str(e)) from e
-
-
 @auth.command("inject")
 @global_options
 @click.option(
@@ -393,7 +284,7 @@ def change_project(project_id: str | None, org_id: str | None) -> None:
 def inject_env_vars(
     env_file: Path,
 ) -> None:
-    """Inject auth environment variables into a .env file.
+    """Inject profile credentials into a .env file.
 
     Writes LLAMA_CLOUD_API_KEY, LLAMA_CLOUD_BASE_URL, and LLAMA_AGENTS_PROJECT_ID
     based on the current profile. Always overwrites and creates the file if missing.
@@ -681,7 +572,7 @@ def validate_authenticated_profile() -> Auth:
             [(profile, profile.name) for profile in env_profiles],
             "Select profile",
             hint_flag="<profile>",
-            hint_command="llamactl auth list",
+            hint_command="llamactl auth get",
         )
         auth_svc.set_current_profile(choice.name)
         return choice
@@ -816,7 +707,7 @@ def _select_or_enter_project(
         ],
         "Select a project",
         hint_flag="<project_id>",
-        hint_command="llamactl auth project <project_id>",
+        hint_command="llamactl projects use <project_id>",
     )
 
 
@@ -830,19 +721,22 @@ def _token_flow_for_env(auth_service: AuthService) -> Auth:
     return created
 
 
-def _select_profile(auth_svc: AuthService, profile_name: str | None) -> Auth | None:
+def _select_profile(
+    auth_svc: AuthService, profile_name: str | None, *, require_selection: bool = False
+) -> Auth | None:
     """
     Select a profile interactively if name not provided.
     Returns the selected profile name or None if cancelled.
 
-    In non-interactive sessions, returns None if profile_name is not provided.
+    In non-interactive sessions, returns None if profile_name is not provided
+    unless ``require_selection`` is true.
     """
     if profile_name:
         profile = auth_svc.get_profile(profile_name)
         if profile:
             return profile
 
-    if not is_interactive_session():
+    if not require_selection and not is_interactive_session():
         return None
 
     try:
@@ -866,7 +760,7 @@ def _select_profile(auth_svc: AuthService, profile_name: str | None) -> Auth | N
             choices,
             "Select profile:",
             hint_flag="<name>",
-            hint_command="llamactl auth list",
+            hint_command="llamactl auth get",
             selected=current_idx,
         )
 

--- a/packages/llamactl/src/llama_agents/cli/commands/config.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/config.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+from typing import Any
+
+import click
+from llama_agents.cli.config._config import ConfigManager
+from llama_agents.cli.interactive import is_interactive_session
+from llama_agents.cli.output import status
+from pydantic import BaseModel, ConfigDict
+
+from ..app import app
+from ..options import global_options, render_output, simple_output_option
+from .auth import _get_service, _list_projects
+
+
+class ConfigContext(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    environment: str | None
+    profile: str | None
+    project_id: str | None
+    project_name: str | None = None
+
+
+@app.group(
+    invoke_without_command=True,
+    help="Show local configuration.",
+)
+@click.pass_context
+@global_options
+@simple_output_option
+def config(ctx: click.Context, output: str) -> None:
+    if ctx.invoked_subcommand is not None:
+        return
+    context = _build_config_context()
+    render_output(context, output, text_renderer=lambda: _render_config_text(context))
+
+
+@config.command("destroy", hidden=True)
+@global_options
+def destroy_database() -> None:
+    """Destroy the database."""
+    if is_interactive_session() and not click.confirm(
+        "Are you sure you want to destroy all of your local logins? This action cannot be undone."
+    ):
+        return
+    ConfigManager(init_database=False).destroy_database()
+    status("database destroyed")
+
+
+@config.command("show-db", hidden=True)
+@global_options
+def show_database() -> None:
+    """Show the database path."""
+    path = _get_service().config_manager().db_path
+    status(path)
+
+
+def _build_config_context() -> ConfigContext:
+    service = _get_service()
+    current_env = service.get_current_environment()
+    auth_svc = service.current_auth_service()
+    profile = auth_svc.get_current_profile()
+    project_id = profile.project_id if profile else None
+    return ConfigContext(
+        environment=current_env.api_url if current_env else None,
+        profile=profile.name if profile else None,
+        project_id=project_id,
+        project_name=_resolve_project_name(auth_svc, project_id),
+    )
+
+
+def _resolve_project_name(auth_svc: Any, project_id: str | None) -> str | None:
+    if project_id is None:
+        return None
+    try:
+        projects = _list_projects(auth_svc)
+    except Exception:
+        return None
+    project = next(
+        (candidate for candidate in projects if candidate.project_id == project_id),
+        None,
+    )
+    return project.project_name if project else None
+
+
+def _render_config_text(context: ConfigContext) -> None:
+    project = context.project_id or "(none)"
+    if context.project_id and context.project_name:
+        project = f"{context.project_name} ({context.project_id})"
+    click.echo(f"environment:  {context.environment or '(none)'}")
+    click.echo(f"profile:      {context.profile or '(none)'}")
+    click.echo(f"project:      {project}")

--- a/packages/llamactl/src/llama_agents/cli/commands/dev.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/dev.py
@@ -26,7 +26,7 @@ _ClickPath = getattr(click, "Path")
 
 @app.group(
     name="dev",
-    help="Development utilities for llama-deploy projects",
+    help="Development utilities for llama-deploy projects.",
     cls=AliasedGroup,
     no_args_is_help=True,
 )

--- a/packages/llamactl/src/llama_agents/cli/commands/environments.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/environments.py
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
 from __future__ import annotations
 
 from importlib import metadata as importlib_metadata
@@ -10,9 +13,9 @@ from llama_agents.cli.output import status, warning
 from llama_agents.cli.param_types import EnvironmentType
 from packaging import version as packaging_version
 
+from ..app import app
 from ..display import EnvDisplay
-from ..options import global_options, output_option, render_output
-from .auth import auth
+from ..options import global_options, render_output, simple_output_option
 
 if TYPE_CHECKING:
     from llama_agents.cli.config.env_service import EnvService
@@ -29,24 +32,31 @@ def _env_service() -> EnvService:
     return service
 
 
-@auth.group(
-    name="env",
-    help="Manage environments (control plane API URLs)",
+@app.group(
+    name="environments",
+    help="Manage control plane API URLs.",
     no_args_is_help=True,
 )
 @global_options
-def env_group() -> None:
+def environments() -> None:
     pass
 
 
-@env_group.command("list")
+@environments.command("get")
+@click.argument("api_url", required=False, type=EnvironmentType())
 @global_options
-@output_option
-def list_environments_cmd(output: str) -> None:
+@simple_output_option
+def get_environments_cmd(api_url: str | None, output: str) -> None:
+    """List environments or show one environment."""
     try:
         service = _env_service()
         envs = service.list_environments()
         current_env = service.get_current_environment()
+        if api_url:
+            normalized = api_url.rstrip("/")
+            envs = [env for env in envs if env.api_url == normalized]
+            if not envs:
+                raise click.ClickException(f"Environment '{normalized}' not found")
 
         if not envs and output == "text":
             status("no environments found")
@@ -56,21 +66,26 @@ def list_environments_cmd(output: str) -> None:
         displays = [
             EnvDisplay.from_environment(env, current_url=current_url) for env in envs
         ]
-        render_output(displays, output)
+        render_output(
+            displays[0] if api_url and len(displays) == 1 else displays, output
+        )
+    except click.ClickException:
+        raise
     except Exception as e:
         raise click.ClickException(str(e)) from e
 
 
-@env_group.command("add")
+@environments.command("add")
 @click.argument("api_url", required=False)
 @global_options
 def add_environment_cmd(api_url: str | None) -> None:
+    """Probe and store an environment."""
     try:
         service = _env_service()
         if not api_url:
             if not is_interactive_session():
                 raise click.ClickException(
-                    "Pass <api_url> as an argument. To see existing environments, run: llamactl auth env list"
+                    "Pass <api_url> as an argument. To see existing environments, run: llamactl environments get"
                 )
             current_env = service.get_current_environment()
             entered = click.prompt(
@@ -99,10 +114,11 @@ def add_environment_cmd(api_url: str | None) -> None:
         raise click.ClickException(str(e)) from e
 
 
-@env_group.command("delete")
+@environments.command("delete")
 @click.argument("api_url", required=False, type=EnvironmentType())
 @global_options
 def delete_environment_cmd(api_url: str | None) -> None:
+    """Delete an environment and its profiles."""
     try:
         service = _env_service()
         if not api_url:
@@ -126,10 +142,11 @@ def delete_environment_cmd(api_url: str | None) -> None:
         raise click.ClickException(str(e)) from e
 
 
-@env_group.command("switch")
+@environments.command("use")
 @click.argument("api_url", required=False, type=EnvironmentType())
 @global_options
-def switch_environment_cmd(api_url: str | None) -> None:
+def use_environment_cmd(api_url: str | None) -> None:
+    """Set the active environment."""
     try:
         service = _env_service()
         selected_url = api_url
@@ -185,7 +202,7 @@ def _maybe_warn_min_version(min_required: str | None) -> None:
 
 def _select_environment(
     envs: list[Environment],
-    current_env: Environment,
+    current_env: Environment | None,
     message: str = "Select environment",
 ) -> Environment:
     if not envs:
@@ -196,7 +213,7 @@ def _select_environment(
     current_idx = 0
     for i, env in enumerate(envs):
         label = env.api_url
-        if env.api_url == current_env.api_url:
+        if current_env is not None and env.api_url == current_env.api_url:
             label += " [current]"
             current_idx = i
         items.append((env, label))
@@ -204,6 +221,6 @@ def _select_environment(
         items,
         message,
         hint_flag="<api_url>",
-        hint_command="llamactl auth env list",
+        hint_command="llamactl environments get",
         selected=current_idx,
     )

--- a/packages/llamactl/src/llama_agents/cli/commands/init.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/init.py
@@ -56,7 +56,7 @@ def init(
     dir: Path | None,
     force: bool,
 ) -> None:
-    """Create a new app repository from a template"""
+    """Create a new app repository from a template."""
     if update:
         _update()
     else:

--- a/packages/llamactl/src/llama_agents/cli/commands/organizations.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/organizations.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import click
+from llama_agents.cli.output import status, warning
+from llama_agents.cli.utils.capabilities import probe_organizations_support
+
+from ..app import app
+from ..display import OrgDisplay
+from ..options import global_options, render_output, simple_output_option
+from .auth import _get_service, _list_organizations
+
+
+@app.group(
+    help="Inspect organizations.",
+    no_args_is_help=True,
+)
+@global_options
+def organizations() -> None:
+    pass
+
+
+@organizations.command("get")
+@global_options
+@simple_output_option
+def get_organizations(output: str) -> None:
+    """List organizations available to the current profile."""
+    try:
+        auth_svc = _get_service().current_auth_service()
+        if not probe_organizations_support():
+            if output == "text":
+                warning("this server does not support organizations")
+                return
+            render_output([], output)
+            return
+
+        orgs = _list_organizations(auth_svc)
+        if not orgs and output == "text":
+            status("no organizations found")
+            return
+
+        default_org = next((o.org_id for o in orgs if o.is_default), None)
+        displays = [
+            OrgDisplay.from_org_summary(org, current_org_id=default_org) for org in orgs
+        ]
+        render_output(displays, output)
+
+    except Exception as e:
+        raise click.ClickException(str(e)) from e

--- a/packages/llamactl/src/llama_agents/cli/commands/pkg.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/pkg.py
@@ -18,7 +18,7 @@ SUPPORTED_FORMATS_STR = ", ".join(SUPPORTED_FORMATS)
 
 
 @app.group(
-    help=f"Package your application in different formats. Currently supported: {SUPPORTED_FORMATS_STR}",
+    help=f"Package your application in different formats. Currently supported: {SUPPORTED_FORMATS_STR}.",
     no_args_is_help=True,
     context_settings={"max_content_width": None},
 )

--- a/packages/llamactl/src/llama_agents/cli/commands/projects.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/projects.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import click
+from llama_agents.cli.interactive import is_interactive_session, select_or_exit
+from llama_agents.cli.output import status
+from llama_agents.cli.param_types import OrgType, ProjectType
+
+from ..app import app
+from ..display import ProjectDisplay
+from ..options import global_options, render_output, simple_output_option
+from .auth import (
+    _discover_organization,
+    _get_service,
+    _list_projects,
+    validate_authenticated_profile,
+)
+
+
+@app.group(
+    help="Inspect and select projects.",
+    no_args_is_help=True,
+)
+@global_options
+def projects() -> None:
+    pass
+
+
+@projects.command("get")
+@click.argument("project_id", required=False, type=ProjectType())
+@click.option(
+    "--org",
+    "org_id",
+    default=None,
+    type=OrgType(),
+    help="Organization ID to scope projects to",
+)
+@global_options
+@simple_output_option
+def get_projects(project_id: str | None, org_id: str | None, output: str) -> None:
+    """List projects available to the current profile."""
+    try:
+        auth_svc = _get_service().current_auth_service()
+        profile = validate_authenticated_profile()
+        if org_id is None:
+            org = _discover_organization(auth_svc)
+            if org is not None:
+                org_id = org.org_id
+
+        projects = _list_projects(auth_svc, org_id=org_id)
+        if project_id:
+            projects = [
+                project for project in projects if project.project_id == project_id
+            ]
+            if not projects:
+                raise click.ClickException(f"Project {project_id} not found")
+
+        if not projects and output == "text":
+            status("no projects found")
+            return
+
+        displays = [
+            ProjectDisplay.from_project_summary(
+                project, current_project_id=profile.project_id
+            )
+            for project in projects
+        ]
+        render_output(
+            displays[0] if project_id and len(displays) == 1 else displays, output
+        )
+
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
+
+
+@projects.command("use")
+@click.argument("project_id", required=False, type=ProjectType())
+@click.option(
+    "--org",
+    "org_id",
+    default=None,
+    type=OrgType(),
+    help="Organization ID to scope projects to",
+)
+@global_options
+def use_project(project_id: str | None, org_id: str | None) -> None:
+    """Set the active project for the current profile."""
+    auth_svc = _get_service().current_auth_service()
+    profile = validate_authenticated_profile()
+
+    try:
+        if org_id is None:
+            org = _discover_organization(auth_svc)
+            if org is not None:
+                org_id = org.org_id
+
+        if project_id and profile.project_id == project_id:
+            return
+
+        if project_id:
+            if auth_svc.env.requires_auth:
+                projects = _list_projects(auth_svc, org_id=org_id)
+                if not next(
+                    (
+                        project
+                        for project in projects
+                        if project.project_id == project_id
+                    ),
+                    None,
+                ):
+                    raise click.ClickException(f"Project {project_id} not found")
+            auth_svc.set_project(profile.name, project_id)
+            status(f"switched project {project_id}")
+            return
+
+        projects = _list_projects(auth_svc, org_id=org_id)
+
+        if not projects:
+            status("no projects found")
+            return
+
+        current_project_id = profile.project_id
+        items = []
+        current_idx = 0
+        for i, project in enumerate(projects):
+            label = f"{project.project_name}  {project.project_id} ({project.deployment_count} deployments)"
+            if project.project_id == current_project_id:
+                label += " [current]"
+                current_idx = i
+            items.append((project.project_id, label))
+        if not auth_svc.env.requires_auth:
+            items.append(("__CREATE__", "Create new project"))
+
+        result = select_or_exit(
+            items,
+            "Select a project",
+            hint_flag="<project_id>",
+            hint_command="llamactl projects get",
+            selected=current_idx,
+        )
+        if result == "__CREATE__":
+            if not is_interactive_session():
+                raise click.ClickException("Pass <project_id> to choose one")
+            result = click.prompt(
+                "Enter project ID", default="", show_default=False
+            ).strip()
+        if result:
+            selected_project = next(
+                (project for project in projects if project.project_id == result), None
+            )
+            name = selected_project.project_name if selected_project else result
+            auth_svc.set_project(profile.name, result)
+            status(f"switched project {name}")
+        else:
+            status("no project selected")
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(str(e)) from e

--- a/packages/llamactl/src/llama_agents/cli/commands/serve.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/serve.py
@@ -32,7 +32,7 @@ _ClickPath = getattr(click, "Path")
 
 @app.command(
     "serve",
-    help="Serve a LlamaDeploy app locally for development and testing",
+    help="Serve a LlamaDeploy app locally for development and testing.",
 )
 @click.argument(
     "deployment_file",
@@ -340,7 +340,7 @@ def _maybe_select_project_for_env_key() -> None:
             project_items,
             "Select a project",
             hint_flag="LLAMA_AGENTS_PROJECT_ID",
-            hint_command="llamactl auth project <project_id>",
+            hint_command="llamactl projects use <project_id>",
             selected=current_idx,
         )
         _set_project_id(choice)

--- a/packages/llamactl/src/llama_agents/cli/config/env_service.py
+++ b/packages/llamactl/src/llama_agents/cli/config/env_service.py
@@ -21,7 +21,7 @@ class EnvService:
         env = self.config_manager().get_environment(api_url)
         if not env:
             raise ValueError(
-                f"Environment '{api_url}' not found. Add it with 'llamactl auth env add <API_URL>'"
+                f"Environment '{api_url}' not found. Add it with 'llamactl environments add <API_URL>'"
             )
         self.config_manager().set_settings_current_environment(api_url)
         self.config_manager().set_settings_current_profile(None)

--- a/packages/llamactl/src/llama_agents/cli/display.py
+++ b/packages/llamactl/src/llama_agents/cli/display.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Callable, Literal, Union, get_args, get_origin
 
-from llama_agents.cli.render import format_iso_z, gh_short, short_sha, star_marker
+from llama_agents.cli.render import format_iso_z, gh_short, short_sha
 from llama_agents.core.schema.deployments import (
     DeploymentCreate,
     DeploymentResponse,
@@ -35,7 +35,7 @@ from llama_agents.core.schema.deployments import (
     LlamaDeploymentPhase,
     ReleaseHistoryItem,
 )
-from llama_agents.core.schema.projects import OrgSummary
+from llama_agents.core.schema.projects import OrgSummary, ProjectSummary
 from pydantic import BaseModel, ConfigDict
 from typing_extensions import Annotated
 
@@ -499,8 +499,12 @@ class ReleaseDisplay(BaseModel):
         )
 
 
+def _yes_no(value: bool) -> str:
+    return "yes" if value else "no"
+
+
 class AuthProfileDisplay(BaseModel):
-    """A locally-stored auth profile, projected for ``auth list``.
+    """A locally-stored auth profile, projected for ``auth get``.
 
     Secret material (``api_key``, OIDC tokens) is intentionally not surfaced.
     """
@@ -510,7 +514,7 @@ class AuthProfileDisplay(BaseModel):
     name: Annotated[str, Column("NAME")]
     api_url: Annotated[str, Column("API_URL")]
     project_id: Annotated[str | None, Column("PROJECT_ID", default="-")] = None
-    active: Annotated[bool, Column("ACTIVE", format=star_marker)] = False
+    active: Annotated[bool, Column("ACTIVE", format=_yes_no)] = False
     auth_type: Annotated[Literal["none", "token", "oidc"], Column("AUTH")] = "none"
 
     @classmethod
@@ -532,12 +536,8 @@ class AuthProfileDisplay(BaseModel):
         )
 
 
-def _bool_str_lower(value: bool) -> str:
-    return "true" if value else "false"
-
-
 class EnvDisplay(BaseModel):
-    """A configured environment, projected for ``auth env list``.
+    """A configured environment, projected for ``environments get``.
 
     ``min_llamactl_version`` is intentionally omitted — it isn't part of the
     public env-list contract.
@@ -546,8 +546,8 @@ class EnvDisplay(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     api_url: Annotated[str, Column("API_URL")]
-    requires_auth: Annotated[bool, Column("REQUIRES_AUTH", format=_bool_str_lower)]
-    active: Annotated[bool, Column("ACTIVE", format=star_marker)] = False
+    requires_auth: Annotated[bool, Column("REQUIRES_AUTH", format=_yes_no)]
+    active: Annotated[bool, Column("ACTIVE", format=_yes_no)] = False
 
     @classmethod
     def from_environment(cls, env: Any, *, current_url: str | None) -> EnvDisplay:
@@ -558,19 +558,15 @@ class EnvDisplay(BaseModel):
         )
 
 
-def _yes_if_true(value: bool) -> str:
-    return "yes" if value else ""
-
-
 class OrgDisplay(BaseModel):
-    """An organization summary, projected for ``auth organizations``."""
+    """An organization summary, projected for ``organizations get``."""
 
     model_config = ConfigDict(extra="forbid")
 
-    org_id: Annotated[str, Column("ORG_ID")]
     org_name: Annotated[str, Column("NAME")]
-    is_default: Annotated[bool, Column("DEFAULT", format=_yes_if_true)]
-    active: Annotated[bool, Column("ACTIVE", format=star_marker)] = False
+    org_id: Annotated[str, Column("ORG_ID")]
+    is_default: Annotated[bool, Column("DEFAULT", format=_yes_no)]
+    active: Annotated[bool, Column("ACTIVE", format=_yes_no)] = False
 
     @classmethod
     def from_org_summary(
@@ -582,3 +578,41 @@ class OrgDisplay(BaseModel):
             is_default=org.is_default,
             active=current_org_id is not None and org.org_id == current_org_id,
         )
+
+    def to_output_dict(self) -> dict[str, Any]:
+        return {
+            "org_id": self.org_id,
+            "org_name": self.org_name,
+            "is_default": self.is_default,
+            "active": self.active,
+        }
+
+
+class ProjectDisplay(BaseModel):
+    """A project summary, projected for ``projects get``."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    project_name: Annotated[str, Column("NAME")]
+    project_id: Annotated[str, Column("PROJECT_ID")]
+    deployment_count: Annotated[int, Column("DEPLOYMENTS")]
+    active: Annotated[bool, Column("ACTIVE", format=_yes_no)] = False
+
+    @classmethod
+    def from_project_summary(
+        cls, project: ProjectSummary, *, current_project_id: str | None = None
+    ) -> ProjectDisplay:
+        return cls(
+            project_id=project.project_id,
+            project_name=project.project_name,
+            deployment_count=project.deployment_count,
+            active=project.project_id == current_project_id,
+        )
+
+    def to_output_dict(self) -> dict[str, Any]:
+        return {
+            "project_id": self.project_id,
+            "project_name": self.project_name,
+            "deployment_count": self.deployment_count,
+            "active": self.active,
+        }

--- a/packages/llamactl/src/llama_agents/cli/options.py
+++ b/packages/llamactl/src/llama_agents/cli/options.py
@@ -25,6 +25,8 @@ _BASE_OUTPUT_HELP = (
     "Output format. 'json'/'yaml' for machine-readable output; "
     "'wide' for the text table with extra columns."
 )
+_SIMPLE_OUTPUT_CHOICES = ("text", "json", "yaml")
+_SIMPLE_OUTPUT_HELP = "Output format. 'json'/'yaml' for machine-readable output."
 
 
 def _output_option(
@@ -51,6 +53,20 @@ def output_option(f: Callable[P, R]) -> Callable[P, R]:
     """
 
     return _output_option()(f)
+
+
+def simple_output_option(f: Callable[P, R]) -> Callable[P, R]:
+    """Add ``-o/--output`` for commands without a wide text variant."""
+
+    return click.option(
+        "-o",
+        "--output",
+        "output",
+        type=click.Choice(_SIMPLE_OUTPUT_CHOICES, case_sensitive=False),
+        default="text",
+        show_default=True,
+        help=_SIMPLE_OUTPUT_HELP,
+    )(f)
 
 
 def output_option_with_template(f: Callable[P, R]) -> Callable[P, R]:

--- a/packages/llamactl/tests/test_auth_cli.py
+++ b/packages/llamactl/tests/test_auth_cli.py
@@ -80,19 +80,19 @@ def test_auth_create_api_key_profile_project_id_alias() -> None:
     mock_auth_svc.create_profile_from_token.assert_called_once_with("p", "key")
 
 
-def test_auth_list_profiles_no_profiles() -> None:
+def test_auth_get_profiles_no_profiles() -> None:
     runner = CliRunner()
     with patch("llama_agents.cli.config.env_service.service") as mock_service:
         mock_auth_svc = MagicMock()
         mock_auth_svc.list_profiles.return_value = []
         mock_auth_svc.get_current_profile.return_value = None
         mock_service.current_auth_service.return_value = mock_auth_svc
-        result = runner.invoke(app, ["auth", "list"])
+        result = runner.invoke(app, ["auth", "get"])
         assert result.exit_code == 0
         assert "no profiles found" in result.output
 
 
-def test_auth_switch_profile_success_and_missing() -> None:
+def test_auth_use_profile_success_and_missing() -> None:
     runner = CliRunner()
     with (
         patch("llama_agents.cli.commands.auth._select_profile") as mock_select,
@@ -101,7 +101,7 @@ def test_auth_switch_profile_success_and_missing() -> None:
         mock_auth_svc = MagicMock()
         mock_service.current_auth_service.return_value = mock_auth_svc
         mock_select.return_value = SimpleNamespace(name="p1")
-        result = runner.invoke(app, ["auth", "switch", "p1"])
+        result = runner.invoke(app, ["auth", "use", "p1"])
         assert result.exit_code == 0
         mock_auth_svc.set_current_profile.assert_called_once_with("p1")
 
@@ -110,9 +110,49 @@ def test_auth_switch_profile_success_and_missing() -> None:
         patch("llama_agents.cli.config.env_service.service") as mock_service2,
     ):
         mock_service2.current_auth_service.return_value = MagicMock()
-        result = runner.invoke(app, ["auth", "switch", "doesnt-exist"])
+        result = runner.invoke(app, ["auth", "use", "doesnt-exist"])
         assert result.exit_code == 0
         assert "no profile selected" in result.output
+
+
+def test_auth_use_non_interactive_lists_profiles_and_hints() -> None:
+    runner = CliRunner()
+    with patch("llama_agents.cli.config.env_service.service") as mock_service:
+        profile = SimpleNamespace(name="p1", api_url="https://api")
+        mock_auth_svc = MagicMock()
+        mock_auth_svc.get_profile.return_value = None
+        mock_auth_svc.list_profiles.return_value = [profile]
+        mock_auth_svc.get_current_profile.return_value = profile
+        mock_service.current_auth_service.return_value = mock_auth_svc
+
+        result = runner.invoke(app, ["auth", "use"])
+
+    assert result.exit_code != 0
+    assert "p1" in result.output
+    assert "Pass <name> to choose one" in result.output
+    assert "llamactl auth get" in result.output
+
+
+def test_removed_auth_commands_show_rename_hints() -> None:
+    runner = CliRunner()
+
+    result = runner.invoke(app, ["auth", "list"])
+    assert result.exit_code != 0
+    assert "Use `llamactl auth get` instead." in result.output
+
+    result = runner.invoke(app, ["auth", "env", "list"])
+    assert result.exit_code != 0
+    assert "Use `llamactl environments get` instead." in result.output
+
+    result = runner.invoke(app, ["auth", "project"])
+    assert result.exit_code != 0
+    assert "Use `llamactl projects` instead." in result.output
+
+
+def test_auth_get_does_not_offer_wide_output() -> None:
+    result = CliRunner().invoke(app, ["auth", "get", "-o", "wide"])
+    assert result.exit_code != 0
+    assert "'wide' is not one of 'text', 'json', 'yaml'" in result.output
 
 
 def test_auth_logout_existing() -> None:
@@ -141,19 +181,19 @@ def test_auth_logout_missing() -> None:
         assert "Profile 'missing' not found" in result.output
 
 
-def test_auth_project_non_interactive_lists_options_and_hints() -> None:
+def test_projects_use_non_interactive_lists_options_and_hints() -> None:
     runner = CliRunner()
     with (
         patch(
-            "llama_agents.cli.commands.auth.validate_authenticated_profile",
+            "llama_agents.cli.commands.projects.validate_authenticated_profile",
             return_value=MagicMock(name="p", project_id="x"),
         ),
         patch(
-            "llama_agents.cli.commands.auth._discover_organization",
+            "llama_agents.cli.commands.projects._discover_organization",
             return_value=None,
         ),
         patch(
-            "llama_agents.cli.commands.auth._list_projects",
+            "llama_agents.cli.commands.projects._list_projects",
             return_value=[
                 MagicMock(
                     project_id="abc-123", project_name="My Project", deployment_count=2
@@ -161,38 +201,41 @@ def test_auth_project_non_interactive_lists_options_and_hints() -> None:
             ],
         ),
         patch(
-            "llama_agents.cli.commands.auth.is_interactive_session", return_value=False
+            "llama_agents.cli.commands.projects.is_interactive_session",
+            return_value=False,
         ),
     ):
-        result = runner.invoke(app, ["auth", "project"])
+        result = runner.invoke(app, ["projects", "use"])
         assert result.exit_code != 0
         assert "abc-123" in result.output
         assert "Pass <project_id> to choose one" in result.output
+        assert "llamactl projects get" in result.output
 
 
-def test_auth_project_interactive_sets_selected() -> None:
+def test_projects_use_interactive_sets_selected() -> None:
     runner = CliRunner()
     with (
         patch(
-            "llama_agents.cli.commands.auth.validate_authenticated_profile",
+            "llama_agents.cli.commands.projects.validate_authenticated_profile",
             return_value=MagicMock(name="p"),
         ),
         patch(
-            "llama_agents.cli.commands.auth._list_projects",
+            "llama_agents.cli.commands.projects._list_projects",
             return_value=[
                 MagicMock(project_id="proj", project_name="Proj", deployment_count=1)
             ],
         ),
-        patch("llama_agents.cli.commands.auth.select_or_exit") as mock_select,
+        patch("llama_agents.cli.commands.projects.select_or_exit") as mock_select,
         patch("llama_agents.cli.config.env_service.service") as mock_service,
         patch(
-            "llama_agents.cli.commands.auth.is_interactive_session", return_value=True
+            "llama_agents.cli.commands.projects.is_interactive_session",
+            return_value=True,
         ),
     ):
         mock_auth_svc = MagicMock()
         mock_service.current_auth_service.return_value = mock_auth_svc
         mock_select.return_value = "proj"
-        result = runner.invoke(app, ["auth", "project"])
+        result = runner.invoke(app, ["projects", "use"])
         assert result.exit_code == 0
         mock_auth_svc.set_project.assert_called_once()
 

--- a/packages/llamactl/tests/test_config_cli.py
+++ b/packages/llamactl/tests/test_config_cli.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from llama_agents.cli.app import app
+
+
+def test_config_text_shows_current_context() -> None:
+    runner = CliRunner()
+    profile = SimpleNamespace(name="prof", project_id="project-1")
+    project = SimpleNamespace(project_id="project-1", project_name="Production")
+    with (
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+        patch(
+            "llama_agents.cli.commands.config._list_projects", return_value=[project]
+        ),
+    ):
+        mock_service.get_current_environment.return_value = SimpleNamespace(
+            api_url="https://api.example"
+        )
+        auth_svc = MagicMock()
+        auth_svc.get_current_profile.return_value = profile
+        mock_service.current_auth_service.return_value = auth_svc
+
+        result = runner.invoke(app, ["config"])
+
+    assert result.exit_code == 0, result.output
+    assert "environment:  https://api.example" in result.output
+    assert "profile:      prof" in result.output
+    assert "project:      Production (project-1)" in result.output
+
+
+def test_config_json_shows_none_values_without_error() -> None:
+    runner = CliRunner()
+    with patch("llama_agents.cli.config.env_service.service") as mock_service:
+        mock_service.get_current_environment.return_value = SimpleNamespace(
+            api_url="https://api.example"
+        )
+        auth_svc = MagicMock()
+        auth_svc.get_current_profile.return_value = None
+        mock_service.current_auth_service.return_value = auth_svc
+
+        result = runner.invoke(app, ["config", "-o", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data == {
+        "environment": "https://api.example",
+        "profile": None,
+        "project_id": None,
+        "project_name": None,
+    }
+
+
+def test_config_does_not_offer_wide_output() -> None:
+    result = CliRunner().invoke(app, ["config", "-o", "wide"])
+    assert result.exit_code != 0
+    assert "'wide' is not one of 'text', 'json', 'yaml'" in result.output
+
+
+def test_config_hidden_debug_commands() -> None:
+    runner = CliRunner()
+    with patch("llama_agents.cli.config.env_service.service") as mock_service:
+        mock_service.config_manager.return_value.db_path = "/tmp/llamactl.db"
+        result = runner.invoke(app, ["config", "show-db"])
+
+    assert result.exit_code == 0, result.output
+    assert "/tmp/llamactl.db" in result.output

--- a/packages/llamactl/tests/test_deployments_get_output.py
+++ b/packages/llamactl/tests/test_deployments_get_output.py
@@ -627,7 +627,7 @@ def test_deployments_get_template_no_name_errors(patched_auth: Any) -> None:
 def test_other_commands_reject_template_mode(patched_auth: Any) -> None:
     """``-o template`` is only meaningful for ``deployments get``."""
     runner = CliRunner()
-    result = runner.invoke(app, ["auth", "list", "-o", "template"])
+    result = runner.invoke(app, ["auth", "get", "-o", "template"])
     # The choice is accepted but render_output rejects it with a clear message.
     assert result.exit_code != 0
     assert "only supported for" in result.output or "template" in result.output

--- a/packages/llamactl/tests/test_deployments_template_cmd.py
+++ b/packages/llamactl/tests/test_deployments_template_cmd.py
@@ -251,8 +251,8 @@ def test_template_advertises_template_only_on_deployments_get() -> None:
     other read commands that share the same output decorator."""
     runner = CliRunner()
     for argv in (
-        ["auth", "organizations", "--help"],
-        ["auth", "env", "list", "--help"],
+        ["organizations", "get", "--help"],
+        ["environments", "get", "--help"],
         ["deployments", "history", "--help"],
     ):
         result = runner.invoke(app, argv)

--- a/packages/llamactl/tests/test_environments_cli.py
+++ b/packages/llamactl/tests/test_environments_cli.py
@@ -1,3 +1,8 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -5,43 +10,76 @@ from click.testing import CliRunner
 from llama_agents.cli.app import app
 from llama_agents.cli.config._config import Environment
 
-_INTERACTIVE_PATCH = "llama_agents.cli.commands.env.is_interactive_session"
+_INTERACTIVE_PATCH = "llama_agents.cli.commands.environments.is_interactive_session"
 
 
-def test_auth_env_list_prints_table() -> None:
+def test_environments_get_prints_table() -> None:
     runner = CliRunner()
     env1 = Environment(api_url="https://api1", requires_auth=False)
     env2 = Environment(api_url="https://api2", requires_auth=True)
     with patch("llama_agents.cli.config.env_service.service") as mock_service:
         mock_service.list_environments.return_value = [env1, env2]
         mock_service.get_current_environment.return_value = env2
-        result = runner.invoke(app, ["auth", "env", "list"])
+        result = runner.invoke(app, ["environments", "get"])
         assert result.exit_code == 0
+        assert "REQUIRES_AUTH  ACTIVE" in result.output
+        assert "https://api1  no" in result.output
+        assert "https://api2  yes" in result.output
         assert "https://api1" in result.output
         assert "https://api2" in result.output
 
 
-def test_auth_env_add_probes_and_upserts() -> None:
+def test_environments_get_single_environment_json() -> None:
+    runner = CliRunner()
+    env1 = Environment(api_url="https://api1", requires_auth=False)
+    env2 = Environment(api_url="https://api2", requires_auth=True)
+    with patch("llama_agents.cli.config.env_service.service") as mock_service:
+        mock_service.list_environments.return_value = [env1, env2]
+        mock_service.get_current_environment.return_value = None
+        result = runner.invoke(
+            app, ["environments", "get", "https://api2", "-o", "json"]
+        )
+        assert result.exit_code == 0, result.output
+        assert '"api_url": "https://api2"' in result.output
+        assert result.output.strip().startswith("{")
+
+
+def test_environments_help_describes_commands() -> None:
+    result = CliRunner().invoke(app, ["environments", "--help"])
+    assert result.exit_code == 0
+    assert "get     List environments or show one environment." in result.output
+    assert "add     Probe and store an environment." in result.output
+    assert "delete  Delete an environment and its profiles." in result.output
+    assert "use     Set the active environment." in result.output
+
+
+def test_environments_get_does_not_offer_wide_output() -> None:
+    result = CliRunner().invoke(app, ["environments", "get", "-o", "wide"])
+    assert result.exit_code != 0
+    assert "'wide' is not one of 'text', 'json', 'yaml'" in result.output
+
+
+def test_environments_add_probes_and_upserts() -> None:
     runner = CliRunner()
     env = Environment(
         api_url="https://api", requires_auth=True, min_llamactl_version=None
     )
     with patch("llama_agents.cli.config.env_service.service") as mock_service:
         mock_service.probe_environment.return_value = env
-        result = runner.invoke(app, ["auth", "env", "add", "https://api/"])
+        result = runner.invoke(app, ["environments", "add", "https://api/"])
         assert result.exit_code == 0
         mock_service.probe_environment.assert_called_once_with("https://api")
         mock_service.create_or_update_environment.assert_called_once_with(env)
 
 
-def test_auth_env_switch_argument_and_interactive() -> None:
+def test_environments_use_argument_and_interactive() -> None:
     runner = CliRunner()
     # Argument path
     env = Environment(api_url="https://api", requires_auth=False)
     with patch("llama_agents.cli.config.env_service.service") as mock_service:
         mock_service.switch_environment.return_value = env
         mock_service.auto_update_env.return_value = env
-        result = runner.invoke(app, ["auth", "env", "switch", "https://api"])
+        result = runner.invoke(app, ["environments", "use", "https://api"])
         assert result.exit_code == 0
         mock_service.switch_environment.assert_called_once_with("https://api")
 
@@ -52,7 +90,7 @@ def test_auth_env_switch_argument_and_interactive() -> None:
     ]
     with (
         patch("llama_agents.cli.config.env_service.service") as mock_service,
-        patch("llama_agents.cli.commands.env.select_or_exit") as mock_select,
+        patch("llama_agents.cli.commands.environments.select_or_exit") as mock_select,
         patch(_INTERACTIVE_PATCH, return_value=True),
     ):
         mock_service.list_environments.return_value = envs
@@ -60,26 +98,26 @@ def test_auth_env_switch_argument_and_interactive() -> None:
         mock_service.switch_environment.return_value = envs[1]
         mock_service.auto_update_env.return_value = envs[1]
         mock_select.return_value = SimpleNamespace(api_url="https://e2")
-        result = runner.invoke(app, ["auth", "env", "switch"])
+        result = runner.invoke(app, ["environments", "use"])
         assert result.exit_code == 0
         mock_service.switch_environment.assert_called_once_with("https://e2")
 
     # Missing environment should error
     with patch("llama_agents.cli.config.env_service.service") as mock_service:
         mock_service.switch_environment.side_effect = ValueError(
-            "Environment 'https://missing' not found. Add it with 'llamactl auth env add <API_URL>'"
+            "Environment 'https://missing' not found. Add it with 'llamactl environments add <API_URL>'"
         )
-        result = runner.invoke(app, ["auth", "env", "switch", "https://missing"])
+        result = runner.invoke(app, ["environments", "use", "https://missing"])
         assert result.exit_code != 0
         assert "not found" in result.output
 
 
-def test_auth_env_add_interactive_selection_for_url() -> None:
+def test_environments_add_interactive_selection_for_url() -> None:
     runner = CliRunner()
     env = Environment(api_url="https://x", requires_auth=False)
     with (
         patch("llama_agents.cli.config.env_service.service") as mock_service,
-        patch("llama_agents.cli.commands.env.click.prompt") as mock_prompt,
+        patch("llama_agents.cli.commands.environments.click.prompt") as mock_prompt,
         patch(_INTERACTIVE_PATCH, return_value=True),
     ):
         mock_service.get_current_environment.return_value = Environment(
@@ -87,23 +125,23 @@ def test_auth_env_add_interactive_selection_for_url() -> None:
         )
         mock_service.probe_environment.return_value = env
         mock_prompt.return_value = "https://x"
-        result = runner.invoke(app, ["auth", "env", "add"])
+        result = runner.invoke(app, ["environments", "add"])
         assert result.exit_code == 0
         mock_service.create_or_update_environment.assert_called_once_with(env)
 
     # Non-interactive missing URL should error with hint
     with patch(_INTERACTIVE_PATCH, return_value=False):
-        result = runner.invoke(app, ["auth", "env", "add"])
+        result = runner.invoke(app, ["environments", "add"])
     assert result.exit_code != 0
     assert "Pass <api_url>" in result.output
 
 
-def test_auth_env_delete_argument_and_prompt() -> None:
+def test_environments_delete_argument_and_prompt() -> None:
     runner = CliRunner()
     # Argument path
     with patch("llama_agents.cli.config.env_service.service") as mock_service:
         mock_service.delete_environment.return_value = True
-        result = runner.invoke(app, ["auth", "env", "delete", "https://api"])
+        result = runner.invoke(app, ["environments", "delete", "https://api"])
         assert result.exit_code == 0
         mock_service.delete_environment.assert_called_once_with("https://api")
 
@@ -114,14 +152,14 @@ def test_auth_env_delete_argument_and_prompt() -> None:
     ]
     with (
         patch("llama_agents.cli.config.env_service.service") as mock_service,
-        patch("llama_agents.cli.commands.env.select_or_exit") as mock_select,
+        patch("llama_agents.cli.commands.environments.select_or_exit") as mock_select,
         patch(_INTERACTIVE_PATCH, return_value=True),
     ):
         mock_service.list_environments.return_value = envs
         mock_service.get_current_environment.return_value = envs[0]
         mock_service.delete_environment.return_value = True
         mock_select.return_value = SimpleNamespace(api_url="https://e2")
-        result = runner.invoke(app, ["auth", "env", "delete"])
+        result = runner.invoke(app, ["environments", "delete"])
         assert result.exit_code == 0
         mock_service.delete_environment.assert_called_once_with("https://e2")
 
@@ -132,6 +170,6 @@ def test_auth_env_delete_argument_and_prompt() -> None:
     ):
         mock_service.list_environments.return_value = envs
         mock_service.get_current_environment.return_value = envs[0]
-        result = runner.invoke(app, ["auth", "env", "delete"])
+        result = runner.invoke(app, ["environments", "delete"])
     assert result.exit_code != 0
     assert "Pass <api_url>" in result.output

--- a/packages/llamactl/tests/test_organizations_cli.py
+++ b/packages/llamactl/tests/test_organizations_cli.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
-"""Tests for ``llamactl auth organizations`` output modes."""
+"""Tests for ``llamactl organizations get`` output modes."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from llama_agents.cli.app import app
 from llama_agents.core.schema.projects import OrgSummary
 
 
-def test_auth_organizations_text_lists_orgs() -> None:
+def test_organizations_get_text_lists_orgs() -> None:
     runner = CliRunner()
     orgs = [
         OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
@@ -21,26 +21,32 @@ def test_auth_organizations_text_lists_orgs() -> None:
     ]
     with (
         patch(
-            "llama_agents.cli.commands.auth.probe_organizations_support",
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
             return_value=True,
         ),
-        patch("llama_agents.cli.commands.auth._list_organizations", return_value=orgs),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
         mock_service.current_auth_service.return_value = MagicMock()
-        result = runner.invoke(app, ["auth", "organizations"])
+        result = runner.invoke(app, ["organizations", "get"])
     assert result.exit_code == 0, result.output
     assert "ORG_ID" in result.output
     assert "NAME" in result.output
     assert "DEFAULT" in result.output
     assert "ACTIVE" in result.output
+    assert result.output.splitlines()[0].startswith("NAME")
     assert "org-a" in result.output
     assert "Acme" in result.output
+    assert "yes" in result.output
+    assert "no" in result.output
     # ANSI / Rich markup should not leak.
     assert "\x1b[" not in result.output
 
 
-def test_auth_organizations_json() -> None:
+def test_organizations_get_json() -> None:
     runner = CliRunner()
     orgs = [
         OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
@@ -48,68 +54,81 @@ def test_auth_organizations_json() -> None:
     ]
     with (
         patch(
-            "llama_agents.cli.commands.auth.probe_organizations_support",
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
             return_value=True,
         ),
-        patch("llama_agents.cli.commands.auth._list_organizations", return_value=orgs),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
         mock_service.current_auth_service.return_value = MagicMock()
-        result = runner.invoke(app, ["auth", "organizations", "-o", "json"])
+        result = runner.invoke(app, ["organizations", "get", "-o", "json"])
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
     assert isinstance(data, list)
+    assert list(data[0]) == ["org_id", "org_name", "is_default", "active"]
     assert {d["org_id"] for d in data} == {"org-a", "org-b"}
     default = next(d for d in data if d["org_id"] == "org-a")
     assert default["is_default"] is True
     assert default["active"] is True
 
 
-def test_auth_organizations_yaml() -> None:
+def test_organizations_get_yaml() -> None:
     runner = CliRunner()
     orgs = [OrgSummary(org_id="org-a", org_name="Acme", is_default=True)]
     with (
         patch(
-            "llama_agents.cli.commands.auth.probe_organizations_support",
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
             return_value=True,
         ),
-        patch("llama_agents.cli.commands.auth._list_organizations", return_value=orgs),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
         mock_service.current_auth_service.return_value = MagicMock()
-        result = runner.invoke(app, ["auth", "organizations", "-o", "yaml"])
+        result = runner.invoke(app, ["organizations", "get", "-o", "yaml"])
     assert result.exit_code == 0, result.output
     data = yaml.safe_load(result.output)
     assert isinstance(data, list)
     assert data[0]["org_id"] == "org-a"
 
 
-def test_auth_organizations_unsupported_text_warns() -> None:
+def test_organizations_get_unsupported_text_warns() -> None:
     runner = CliRunner()
     with (
         patch(
-            "llama_agents.cli.commands.auth.probe_organizations_support",
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
             return_value=False,
         ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
         mock_service.current_auth_service.return_value = MagicMock()
-        result = runner.invoke(app, ["auth", "organizations"])
+        result = runner.invoke(app, ["organizations", "get"])
     assert result.exit_code == 0, result.output
     assert "does not support organizations" in result.output
 
 
-def test_auth_organizations_unsupported_json_emits_empty_list() -> None:
+def test_organizations_get_unsupported_json_emits_empty_list() -> None:
     """Structured outputs should be parseable even on unsupported servers."""
     runner = CliRunner()
     with (
         patch(
-            "llama_agents.cli.commands.auth.probe_organizations_support",
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
             return_value=False,
         ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
         mock_service.current_auth_service.return_value = MagicMock()
-        result = runner.invoke(app, ["auth", "organizations", "-o", "json"])
+        result = runner.invoke(app, ["organizations", "get", "-o", "json"])
     assert result.exit_code == 0, result.output
     assert json.loads(result.output) == []
+
+
+def test_organizations_get_does_not_offer_wide_output() -> None:
+    result = CliRunner().invoke(app, ["organizations", "get", "-o", "wide"])
+    assert result.exit_code != 0
+    assert "'wide' is not one of 'text', 'json', 'yaml'" in result.output

--- a/packages/llamactl/tests/test_projects_cli.py
+++ b/packages/llamactl/tests/test_projects_cli.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+from llama_agents.cli.app import app
+
+
+def test_projects_get_lists_projects_json() -> None:
+    runner = CliRunner()
+    projects = [
+        MagicMock(project_id="proj-a", project_name="Project A", deployment_count=2),
+        MagicMock(project_id="proj-b", project_name="Project B", deployment_count=0),
+    ]
+    with (
+        patch(
+            "llama_agents.cli.commands.projects.validate_authenticated_profile",
+            return_value=MagicMock(project_id="proj-a"),
+        ),
+        patch(
+            "llama_agents.cli.commands.projects._discover_organization",
+            return_value=None,
+        ),
+        patch(
+            "llama_agents.cli.commands.projects._list_projects", return_value=projects
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["projects", "get", "-o", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert [item["project_id"] for item in data] == ["proj-a", "proj-b"]
+    assert list(data[0]) == [
+        "project_id",
+        "project_name",
+        "deployment_count",
+        "active",
+    ]
+    assert data[0]["active"] is True
+
+
+def test_projects_get_text_puts_name_first_and_uses_yes_no() -> None:
+    runner = CliRunner()
+    projects = [
+        MagicMock(project_id="proj-a", project_name="Project A", deployment_count=2),
+        MagicMock(project_id="proj-b", project_name="Project B", deployment_count=0),
+    ]
+    with (
+        patch(
+            "llama_agents.cli.commands.projects.validate_authenticated_profile",
+            return_value=MagicMock(project_id="proj-a"),
+        ),
+        patch(
+            "llama_agents.cli.commands.projects._discover_organization",
+            return_value=None,
+        ),
+        patch(
+            "llama_agents.cli.commands.projects._list_projects", return_value=projects
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["projects", "get"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output.splitlines()[0].startswith("NAME")
+    assert "Project A" in result.output
+    assert "yes" in result.output
+    assert "no" in result.output
+
+
+def test_projects_get_single_project() -> None:
+    runner = CliRunner()
+    projects = [
+        MagicMock(project_id="proj-a", project_name="Project A", deployment_count=2),
+        MagicMock(project_id="proj-b", project_name="Project B", deployment_count=0),
+    ]
+    with (
+        patch(
+            "llama_agents.cli.commands.projects.validate_authenticated_profile",
+            return_value=MagicMock(project_id="proj-a"),
+        ),
+        patch(
+            "llama_agents.cli.commands.projects._discover_organization",
+            return_value=None,
+        ),
+        patch(
+            "llama_agents.cli.commands.projects._list_projects", return_value=projects
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["projects", "get", "proj-b", "-o", "json"])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.output)
+    assert data["project_id"] == "proj-b"
+    assert data["active"] is False
+
+
+def test_auth_project_no_longer_exists() -> None:
+    result = CliRunner().invoke(app, ["auth", "project"])
+    assert result.exit_code != 0
+    assert "Use `llamactl projects` instead." in result.output
+
+
+def test_projects_get_does_not_offer_wide_output() -> None:
+    result = CliRunner().invoke(app, ["projects", "get", "-o", "wide"])
+    assert result.exit_code != 0
+    assert "'wide' is not one of 'text', 'json', 'yaml'" in result.output


### PR DESCRIPTION
Splits the auth surface by resource so profiles, environments, projects, organizations, and local config each have their own command group instead of living under `auth`.

- `auth list` and `auth switch` become `auth get` and `auth use`; removed auth subcommands return rename hints instead of a generic missing-command error.
- Adds top-level `environments`, `projects`, `organizations`, and `config` groups with structured output where reads need it.
- Tightens CLI help, selector hints, text table ordering, and simple read output modes for the new command groups.