### PR TITLE
Update llamactl auth command docs

### DIFF
--- a/.agents/skills/llamactl-qa/SKILL.md
+++ b/.agents/skills/llamactl-qa/SKILL.md
@@ -38,7 +38,7 @@ Skip when the change is fully covered by pytest, or when the failure mode is in 
 ## Pick a backend
 
 1. **Test environment / test project.** Default for QA that creates or mutates deployments. Use a non-production environment or a dedicated test project so throwaway deployments don't pollute real workspaces. **Never run mutating QA commands against production.** When creating test deployments (to later edit/delete them as part of the QA), create them yourself rather than editing existing deployments that may be important. Pin every command with `--project <test-project-id>` so an active-profile slip can't write into the wrong project.
-2. **Local kind + tilt.** When the change is a new API contract (new endpoint, new field, new behavior on the control plane) and you need to exercise it against a control plane that actually has the change. `uv run operator/dev.py up`. See `AGENTS.md` and `operator/AGENTS.md` for setup. Local mode runs with no auth: the `http://localhost:8011` env is preconfigured; switch to it with `llamactl auth env switch http://localhost:8011` (arg is the API URL, not a name) and a `default` profile is created automatically. No tokens, no `auth login`. Before drafting the matrix, list existing deployments with `kubectl get llamadeployments -A` — there's often something already in the cluster from prior work that you can target with `--project <id>`, saving the cost of a fresh `deployments create`.
+2. **Local kind + tilt.** When the change is a new API contract (new endpoint, new field, new behavior on the control plane) and you need to exercise it against a control plane that actually has the change. `uv run operator/dev.py up`. See `AGENTS.md` and `operator/AGENTS.md` for setup. Local mode runs with no auth: the `http://localhost:8011` env is preconfigured; switch to it with `llamactl environments use http://localhost:8011` (arg is the API URL, not a name) and a `default` profile is created automatically. No tokens, no `auth login`. Before drafting the matrix, list existing deployments with `kubectl get llamadeployments -A` — there's often something already in the cluster from prior work that you can target with `--project <id>`, saving the cost of a fresh `deployments create`.
 3. **Offline only.** For changes that only affect local rendering (template output, help text, error formatting), no backend is needed at all. Run commands that don't hit the API (e.g., `deployments template`, `--help`, non-interactive error paths).
 
 Ask the user which backend before drafting the matrix. The answer changes which rows are realistic. Skip this in auto mode and choose from the rules above.
@@ -77,13 +77,13 @@ Don't try to make this temp project deployable to a real backend in the same run
 
 The bits that matter when designing a matrix.
 
-**Scoping hierarchy**: environments → profiles → organizations → projects → deployments. An environment is a control-plane URL (e.g., `http://localhost:8011` for local). Each environment can have one or more profiles (authenticated identities). Each profile has an active organization, and each organization contains projects. Deployments live inside projects. `llamactl auth env list` shows environments. `llamactl auth list` shows profiles in the active environment. `llamactl auth env switch <url>` changes environment. `llamactl auth project [id]` changes the active project within the current profile.
+**Scoping hierarchy**: environments → profiles → organizations → projects → deployments. An environment is a control-plane URL (e.g., `http://localhost:8011` for local). Each environment can have one or more profiles (authenticated identities). Each profile has an active organization, and each organization contains projects. Deployments live inside projects. `llamactl environments get` shows environments. `llamactl auth get` shows profiles in the active environment. `llamactl environments use <url>` changes environment. `llamactl projects use [id]` changes the active project within the current profile.
 
-A profile is `(env, oauth tokens, active org, active project)`. `--project <id>` overrides the profile's active project for one call. Before running any QA, check `llamactl auth env list` and `llamactl auth list` to confirm you're in the right environment and project — don't assume from a previous session. There are multiple environments with deployments available for testing; use a non-production one for mutating operations.
+A profile is `(env, oauth tokens, active org, active project)`. `--project <id>` overrides the profile's active project for one call. Before running any QA, check `llamactl environments get` and `llamactl auth get` to confirm you're in the right environment and project — don't assume from a previous session. There are multiple environments with deployments available for testing; use a non-production one for mutating operations.
 
 Read commands accept `-o text|json|yaml`. Text is human-facing; json/yaml are assertable. Prefer json for QA — exact-match assertions catch field-rename regressions text formatting hides.
 
-Read commands (`deployments get/list/history/logs`, `auth list`, `auth env list`) do not need `--no-interactive` when their argument is supplied. The flag is a no-op there post-Slice-A.5 and slated to be removed in the parent plan's Phase 3. Don't pad commands with it. Write/select commands (`deployments delete`, `deployments edit`, `deployments rollback` without `--git-sha`) still branch on the interactive flag — pass `--no-interactive` for those if you don't want a prompt, or supply every required arg.
+Read commands (`deployments get/list/history/logs`, `auth get`, `environments get`) do not need `--no-interactive` when their argument is supplied. The flag is a no-op there post-Slice-A.5 and slated to be removed in the parent plan's Phase 3. Don't pad commands with it. Write/select commands (`deployments delete`, `deployments edit`, `deployments rollback` without `--git-sha`) still branch on the interactive flag — pass `--no-interactive` for those if you don't want a prompt, or supply every required arg.
 
 The command surface is moving. Run `--help` on any command you're testing before assuming flag names; don't go from memory.
 
@@ -154,7 +154,7 @@ Branch: <branch>  Commit: <short sha>
 <3–6 bullets. These are the things you want the reader's eyes on. Not "all rows passed". Examples:
 - "Is `spec:` + `status:` the right split, or is the extra indent annoying?"
 - "REPO column gets pushed off-screen when the URL isn't a github short. Do we want a `--wide` mode or terminal-aware wrapping?"
-- "`auth list` text mode shows ACTIVE column but the indicator is `*` only — is that legible enough?"
+- "`auth get` text mode shows ACTIVE as yes/no — is that legible enough?"
 - "When secrets are unset, the JSON spec block is just `{display_name, repo_url, deployment_file_path, suspended: false}`. Is `suspended: false` worth showing on a fresh deploy or is it noise?"
 
 Lean open-ended. If a question has an obvious answer, it doesn't belong here.>
@@ -228,12 +228,12 @@ The inline chat reply is one or two sentences pointing at the file. Don't restat
 
 ## Common gotchas
 
-- Stale profile. `llamactl auth list` first, every session. A profile pointing at last week's env produces 401s that look like a code bug.
+- Stale profile. `llamactl auth get` first, every session. A profile pointing at last week's env produces 401s that look like a code bug.
 - Active project drift. A test that "works on my machine" can fail elsewhere because the active project differs. Pin every row with `--project`.
 - Non-test project mutation. If you mutate without `--project`, the active profile decides where it lands. Always pin write commands.
-- Wrong environment for mutations. `llamactl auth env list` shows which environment is active. Never run create/edit/delete against production — switch to a test environment first. The active environment persists across sessions, so always verify before running mutating commands.
+- Wrong environment for mutations. `llamactl environments get` shows which environment is active. Never run create/edit/delete against production — switch to a test environment first. The active environment persists across sessions, so always verify before running mutating commands.
 - Editing existing deployments. Don't edit deployments you didn't create — they may be someone's real work. Create throwaway deployments for QA and delete them when done.
-- TUI/prompt risk on write commands. `deployments delete/edit/rollback` and `create` will prompt when interactive. For QA, supply every required arg or pass `--no-interactive`. Read commands (`get`, `logs`, `history`, `auth list`, `auth env list`) don't need the flag.
+- TUI/prompt risk on write commands. `deployments delete/edit/rollback` and `create` will prompt when interactive. For QA, supply every required arg or pass `--no-interactive`. Read commands (`get`, `logs`, `history`, `auth get`, `environments get`) don't need the flag.
 - `tee` ate a row of a multi-line table once during a run. Use shell `>` redirect for QA captures, not `tee`, when you need every line preserved.
 - `serve` vs tilt. `llamactl serve` runs the appserver locally with no kubernetes. Tilt runs the full cloud stack in kind. Different scopes; pick one.
 - Don't leak IDs. Deployment and org IDs are fine in your terminal and in `thoughts/`, not fine in a public PR description. Strip or alias them in anything that might leave the repo.

--- a/architecture-docs/overall-architecture.md
+++ b/architecture-docs/overall-architecture.md
@@ -86,7 +86,7 @@ directory = "./ui"
 ### 5. CLI Tool (`llamactl`)
 **Purpose**: Command-line interface for users to interact with the control plane.
 ```bash
-llamactl auth env switch https://api.cloud.llamaindex.ai
+llamactl environments use https://api.cloud.llamaindex.ai
 llamactl auth login
 llamactl auth token --project <PROJECT_ID>
 llamactl auth logout

--- a/architecture-docs/quick-reference.md
+++ b/architecture-docs/quick-reference.md
@@ -73,9 +73,13 @@ directory = "./ui"
 
 ### CLI Commands Reference
 ```bash
-llamactl auth env list              # List environments
-llamactl auth env switch <URL>      # Switch current environment
+llamactl environments get           # List environments
+llamactl environments use <URL>     # Switch current environment
 llamactl auth token --project <PROJECT_ID>  # Create/select profile via API key
+llamactl auth get                   # List profiles
+llamactl auth use <NAME>            # Switch profile
+llamactl projects get               # List projects
+llamactl projects use <PROJECT_ID>  # Switch active project
 llamactl deployments template > deployment.yaml  # Generate apply YAML
 llamactl deployments apply -f deployment.yaml    # Create or update from YAML
 llamactl deployments create          # Create new deployment in $EDITOR

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-auth.md
@@ -13,19 +13,19 @@ llamactl auth [COMMAND] [options]
 
 Commands:
 
-- `token [--project PROJECT] [--api-key KEY]`: Create profile from API key; validates token and selects a project
-- `login`: Login via web browser (OIDC device flow) and create a profile
-- `list`: List login profiles in the current environment
-- `switch [NAME]`: Set currently logged in user/token
-- `logout [NAME]`: Delete a login and its local data
-- `organizations [-o text|json|yaml|wide]`: List organizations available to the current profile
-- `project [PROJECT_ID] [--org ORG_ID]`: Change the active project for the current profile
+- `token [--project PROJECT] [--api-key KEY]`: Create a profile from an API key; validates token and selects a project
+- `login`: Log in via web browser (OIDC device flow) and create a profile
+- `get [NAME] [-o text|json|yaml]`: List profiles or show one profile in the current environment
+- `use [NAME]`: Set the current profile
+- `logout [NAME]`: Delete a profile and its local credentials
 - `inject [--env-file PATH]`: Write profile credentials to a `.env` file
 
 Notes:
 
-- Profiles are filtered by the current environment (`llamactl auth env switch`).
+- Profiles are filtered by the current environment (`llamactl environments use`).
 - `auth token` creates a profile without prompts when both `--api-key` and `--project` are supplied.
+- Project selection moved to `llamactl projects use`.
+- Organization listing moved to `llamactl organizations get`.
 
 ## Commands
 
@@ -35,7 +35,7 @@ Notes:
 llamactl auth token [--project PROJECT] [--api-key KEY]
 ```
 
-Without flags, prompts for an API key, validates it by listing projects, then lets you choose a project. Creates an auto‑named profile and sets it current.
+Without flags, prompts for an API key, validates it by listing projects, then lets you choose a project. Creates an auto-named profile and sets it current.
 
 With both `--api-key` and `--project`, creates the profile without prompts.
 
@@ -51,20 +51,20 @@ llamactl auth token --api-key llx-... --project your-project-id
 llamactl auth login
 ```
 
-Login via your browser using the OIDC device flow, select a project, and create a login profile set as current.
+Log in via your browser using the OIDC device flow, select a project, and create a login profile set as current.
 
-### List
+### Get
 
 ```bash
-llamactl auth list
+llamactl auth get [NAME] [-o text|json|yaml]
 ```
 
-Shows a table of profiles for the current environment with name and active project. The current profile is marked with `*`.
+Shows profiles for the current environment. Pass `NAME` to show one profile.
 
-### Switch
+### Use
 
 ```bash
-llamactl auth switch [NAME]
+llamactl auth use [NAME]
 ```
 
 Set the current profile. If `NAME` is omitted in a TTY, choose from the available profiles. Scripts should pass `NAME`.
@@ -77,31 +77,6 @@ llamactl auth logout [NAME]
 
 Delete a profile. If the deleted profile is current, the current selection is cleared.
 
-### Organizations
-
-```bash
-llamactl auth organizations [-o text|json|yaml|wide]
-```
-
-List organizations available to the current profile. Text output marks the default organization.
-
-Examples:
-
-```bash
-llamactl auth organizations
-llamactl auth organizations -o json
-```
-
-### Project
-
-```bash
-llamactl auth project [PROJECT_ID] [--org ORG_ID]
-```
-
-Change the active project for the current profile. If `PROJECT_ID` is omitted in a TTY, choose from server projects. In environments that don't require auth, you can also enter a project ID.
-
-- `--org ORG_ID`: Scope project lookup to an organization.
-
 ### Inject
 
 ```bash
@@ -109,8 +84,6 @@ llamactl auth inject [--env-file PATH]
 ```
 
 Write `LLAMA_CLOUD_API_KEY`, `LLAMA_CLOUD_BASE_URL`, and `LLAMA_AGENTS_PROJECT_ID` from the current profile into a `.env` file. Creates the file if it doesn't exist; overwrites existing values.
-
-- `--env-file PATH`: Defaults to `.env` in the current directory.
 
 ## Environment Variables
 
@@ -139,6 +112,8 @@ Or generate a `.env` from your current profile with [`llamactl auth inject`](#in
 
 ## See also
 
-- Environments: [`llamactl auth env`](/python/llamaagents/llamactl-reference/commands-auth-env/)
+- Environments: [`llamactl environments`](/python/llamaagents/llamactl-reference/commands-environments/)
+- Projects: [`llamactl projects`](/python/llamaagents/llamactl-reference/commands-projects/)
+- Organizations: [`llamactl organizations`](/python/llamaagents/llamactl-reference/commands-organizations/)
 - Getting started: [Introduction](/python/llamaagents/llamactl/getting-started/)
 - Deployments: [`llamactl deployments`](/python/llamaagents/llamactl-reference/commands-deployments/)

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-config.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-config.md
@@ -1,0 +1,14 @@
+---
+title: config
+sidebar:
+  order: 108
+---
+Show local `llamactl` configuration.
+
+## Usage
+
+```bash
+llamactl config [-o text|json|yaml]
+```
+
+Shows the current environment, profile, and active project. Structured output is useful for scripts that need to inspect local context.

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-environments.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-environments.md
@@ -1,5 +1,5 @@
 ---
-title: auth env
+title: environments
 sidebar:
   order: 105
 ---
@@ -8,51 +8,51 @@ Manage environments (distinct control plane API URLs). Environments determine wh
 ## Usage
 
 ```bash
-llamactl auth env [COMMAND] [options]
+llamactl environments [COMMAND] [options]
 ```
 
 Commands:
 
-- `list`: List known environments and mark the current one
+- `get [API_URL] [-o text|json|yaml]`: List environments or show one environment
 - `add <API_URL>`: Probe the server and upsert the environment
-- `switch [API_URL]`: Select the current environment
+- `use [API_URL]`: Select the current environment; prompts if omitted in interactive mode
 - `delete [API_URL]`: Remove an environment and its associated profiles
 
 Notes:
 
 - Probing reads `requires_auth` and `min_llamactl_version` from the server version endpoint.
-- Switching environment filters profiles shown by `llamactl auth list` and used by other commands.
+- Switching environment filters profiles shown by `llamactl auth get` and used by other commands.
 
 ## Commands
 
-### List
+### Get
 
 ```bash
-llamactl auth env list
+llamactl environments get [API_URL]
 ```
 
-Shows a table of environments with API URL, whether auth is required, and the current marker.
+Shows a table of environments with API URL, whether auth is required, and the active environment. Pass `API_URL` to show one environment.
 
 ### Add
 
 ```bash
-llamactl auth env add <API_URL>
+llamactl environments add <API_URL>
 ```
 
-Probes the server at `<API_URL>` and stores discovered settings.
+Probes the server at `<API_URL>` and stores discovered settings. Interactive mode can prompt for the URL.
 
-### Switch
+### Use
 
 ```bash
-llamactl auth env switch [API_URL]
+llamactl environments use [API_URL]
 ```
 
-Sets the current environment. If `API_URL` is omitted in a TTY, choose from known environments. Scripts should pass `API_URL`.
+Sets the current environment. If omitted in interactive mode, you’ll be prompted to select one.
 
 ### Delete
 
 ```bash
-llamactl auth env delete [API_URL]
+llamactl environments delete [API_URL]
 ```
 
 Deletes an environment and all associated profiles. If the deleted environment was current, the current environment is reset to the default.
@@ -60,5 +60,6 @@ Deletes an environment and all associated profiles. If the deleted environment w
 ## See also
 
 - Profiles and tokens: [`llamactl auth`](/python/llamaagents/llamactl-reference/commands-auth/)
+- Projects: [`llamactl projects`](/python/llamaagents/llamactl-reference/commands-projects/)
 - Getting started: [Introduction](/python/llamaagents/llamactl/getting-started/)
 - Deployments: [`llamactl deployments`](/python/llamaagents/llamactl-reference/commands-deployments/)

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-organizations.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-organizations.md
@@ -1,0 +1,14 @@
+---
+title: organizations
+sidebar:
+  order: 107
+---
+List organizations available to the current profile.
+
+## Usage
+
+```bash
+llamactl organizations get [-o text|json|yaml]
+```
+
+The current/default organization is marked in text output. On servers without organization support, text output prints a warning and structured output returns an empty list.

--- a/docs/src/content/docs/llamaagents/llamactl-reference/commands-projects.md
+++ b/docs/src/content/docs/llamaagents/llamactl-reference/commands-projects.md
@@ -1,0 +1,19 @@
+---
+title: projects
+sidebar:
+  order: 106
+---
+List and select projects for the current profile.
+
+## Usage
+
+```bash
+llamactl projects [COMMAND] [options]
+```
+
+Commands:
+
+- `get [PROJECT_ID] [--org ORG_ID] [-o text|json|yaml]`: List projects or show one project
+- `use [PROJECT_ID] [--org ORG_ID]`: Set the active project for the current profile
+
+`--project` on deployment commands still overrides the active profile project for one call.

--- a/docs/src/content/docs/llamaagents/llamactl/getting-started.md
+++ b/docs/src/content/docs/llamaagents/llamactl/getting-started.md
@@ -57,7 +57,7 @@ export LLAMA_CLOUD_API_KEY="llx-..."
 export LLAMA_AGENTS_PROJECT_ID="project-id"
 ```
 
-See [`llamactl auth`](/python/llamaagents/llamactl-reference/commands-auth) and [`llamactl auth env`](/python/llamaagents/llamactl-reference/commands-auth-env) for profile and environment commands.
+See [`llamactl auth`](/python/llamaagents/llamactl-reference/commands-auth), [`llamactl environments`](/python/llamaagents/llamactl-reference/commands-environments), and [`llamactl projects`](/python/llamaagents/llamactl-reference/commands-projects) for profile, environment, and project commands.
 
 ## Initialize a Project
 

--- a/packages/llamactl/README.md
+++ b/packages/llamactl/README.md
@@ -63,8 +63,10 @@ llamactl deployments apply -f deployment.yaml
 
 ## Command Groups
 
-- `llamactl auth`: log in, create API-key profiles, switch profiles, select projects, and list organizations.
-- `llamactl auth env`: list, add, inspect, and switch LlamaCloud API environments.
+- `llamactl auth`: log in, create API-key profiles, and switch profiles.
+- `llamactl environments`: list, add, inspect, and switch LlamaCloud API environments.
+- `llamactl projects`: list and select projects.
+- `llamactl organizations`: list organizations.
 - `llamactl deployments`: create, apply, edit, update, inspect, delete, roll back, and stream deployment logs.
 - `llamactl init`: create a new LlamaAgents project from a starter template.
 - `llamactl serve`: run the local app server and optional frontend dev server.


### PR DESCRIPTION
Updates the llamactl reference docs for the new auth command shape. The old `auth env` page is replaced with top-level pages for `environments`, `projects`, `organizations`, and `config`, while the `auth` page now only covers credential and profile commands.

Architecture command examples now use `llamactl environments use` for environment switching.