### PR TITLE
workflows: harden dynamic imports in serializers

### DIFF
--- a/.changeset/harden-workflows-dynamic-imports.md
+++ b/.changeset/harden-workflows-dynamic-imports.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Harden workflow deserialization by validating dynamically imported event/exception types and adding `allow_unknown_types` to `JsonSerializer`.

--- a/packages/llama-index-workflows/src/workflows/context/serializers.py
+++ b/packages/llama-index-workflows/src/workflows/context/serializers.py
@@ -65,6 +65,7 @@ class JsonSerializer(BaseSerializer):
         self,
         *,
         allowed_types: Iterable[type[Any] | str] | None = None,
+        allow_unknown_types: bool | None = None,
     ) -> None:
         if allowed_types is None:
             self._allowed_type_names: frozenset[str] | None = None
@@ -74,13 +75,21 @@ class JsonSerializer(BaseSerializer):
                 for t in allowed_types
             )
 
+        # Backward compatibility:
+        # - When no allowlist is provided, allow unknown types by default.
+        # - When an allowlist is provided, fail closed by default.
+        if allow_unknown_types is None:
+            self._allow_unknown_types = allowed_types is None
+        else:
+            self._allow_unknown_types = allow_unknown_types
+
     def _validate_qualified_name(self, qualified_name: str) -> None:
-        if self._allowed_type_names is None:
+        if self._allow_unknown_types or self._allowed_type_names is None:
             return
         if qualified_name not in self._allowed_type_names:
             raise ValueError(
                 f"Refusing to import disallowed workflow state type: {qualified_name}. "
-                "Pass it via allowed_types to the JsonSerializer constructor."
+                "Pass it via allowed_types, or set allow_unknown_types=True only for trusted state."
             )
 
     def serialize_value(self, value: Any) -> Any:
@@ -149,10 +158,22 @@ class JsonSerializer(BaseSerializer):
             if data.get("__is_pydantic") and data.get("qualified_name"):
                 self._validate_qualified_name(data["qualified_name"])
                 module_class = import_module_from_qualified_name(data["qualified_name"])
+                if not isinstance(module_class, type) or not issubclass(
+                    module_class, BaseModel
+                ):
+                    raise ValueError(
+                        f"Refusing to deserialize non-Pydantic type: {data['qualified_name']}"
+                    )
                 return module_class.model_validate(data["value"])
             elif data.get("__is_component") and data.get("qualified_name"):
                 self._validate_qualified_name(data["qualified_name"])
                 module_class = import_module_from_qualified_name(data["qualified_name"])
+                if not isinstance(module_class, type) or not hasattr(
+                    module_class, "from_dict"
+                ):
+                    raise ValueError(
+                        f"Refusing to deserialize non-component type: {data['qualified_name']}"
+                    )
                 return module_class.from_dict(data["value"])
             return {k: self.deserialize_value(v) for k, v in data.items()}
         elif isinstance(data, list):

--- a/packages/llama-index-workflows/src/workflows/events.py
+++ b/packages/llama-index-workflows/src/workflows/events.py
@@ -206,8 +206,14 @@ def _deserialize_exception(data: Any) -> Exception:
     exc_message = data["exception_message"]
     try:
         exc_cls = import_module_from_qualified_name(data["exception_type"])
-        return exc_cls(exc_message)
-    except (ImportError, AttributeError, ValueError):
+        if not isinstance(exc_cls, type) or not issubclass(exc_cls, BaseException):
+            raise TypeError("Resolved exception type is not an exception class")
+        try:
+            return exc_cls(exc_message)
+        except TypeError:
+            # Some exceptions do not accept a message; fall back to a default ctor.
+            return exc_cls()
+    except (ImportError, AttributeError, ValueError, TypeError):
         return Exception(exc_message)
 
 
@@ -243,8 +249,17 @@ def _serialize_event_type(event_type: type[Event]) -> str:
 
 def _deserialize_event_type(data: Any) -> type[Event]:
     if isinstance(data, type):
-        return data
-    return import_module_from_qualified_name(data)
+        if issubclass(data, Event):
+            return data
+        raise ValueError(
+            "Resolved event type is not a subclass of workflows.events.Event"
+        )
+    resolved = import_module_from_qualified_name(data)
+    if not isinstance(resolved, type) or not issubclass(resolved, Event):
+        raise ValueError(
+            "Resolved event type is not a subclass of workflows.events.Event"
+        )
+    return resolved
 
 
 SerializableEventType = Annotated[

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -246,7 +246,12 @@ def _import_event_type(qualified_name: str) -> type[Event]:
     module_name, class_name = parts
 
     module = importlib.import_module(module_name)
-    return getattr(module, class_name)
+    resolved = getattr(module, class_name)
+    if not isinstance(resolved, type) or not issubclass(resolved, Event):
+        raise ValueError(
+            f"Resolved event type is not a subclass of workflows.events.Event: {qualified_name}"
+        )
+    return resolved
 
 
 @dataclass(frozen=True)

--- a/packages/llama-index-workflows/tests/context/test_serializers.py
+++ b/packages/llama-index-workflows/tests/context/test_serializers.py
@@ -3,8 +3,12 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
+from pydantic import BaseModel
 from workflows.context import Context
+from workflows.context.serializers import JsonSerializer
 from workflows.errors import ContextSerdeError
 from workflows.workflow import Workflow
 
@@ -27,3 +31,38 @@ def test_deserialization_invalid(ctx: Context, workflow: Workflow) -> None:
     }
     with pytest.raises(ContextSerdeError):
         Context.from_dict(workflow, old_payload)
+
+
+class _MyModel(BaseModel):
+    x: int
+
+
+def test_json_serializer_allow_unknown_types_default_roundtrip() -> None:
+    serializer = JsonSerializer()
+    payload = serializer.serialize(_MyModel(x=1))
+    restored = serializer.deserialize(payload)
+    assert isinstance(restored, _MyModel)
+    assert restored.x == 1
+
+
+def test_json_serializer_disallows_unknown_types_with_empty_allowlist() -> None:
+    serializer = JsonSerializer(allowed_types=())
+    payload = json.dumps(
+        {
+            "__is_pydantic": True,
+            "qualified_name": f"{_MyModel.__module__}.{_MyModel.__qualname__}",
+            "value": {"x": 1},
+        }
+    )
+    with pytest.raises(
+        ValueError, match="Refusing to import disallowed workflow state type"
+    ):
+        serializer.deserialize(payload)
+
+
+def test_json_serializer_allows_explicit_type_allowlist() -> None:
+    serializer = JsonSerializer(allowed_types=(_MyModel,))
+    payload = serializer.serialize(_MyModel(x=2))
+    restored = serializer.deserialize(payload)
+    assert isinstance(restored, _MyModel)
+    assert restored.x == 2

--- a/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
+++ b/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
@@ -41,6 +41,11 @@ class MyEvent(Event):
     value: str = "hello"
 
 
+class _NoMessageError(Exception):
+    def __init__(self) -> None:
+        super().__init__("no message")
+
+
 # -- Serialization helper roundtrip tests --
 
 
@@ -69,10 +74,32 @@ def test_exception_roundtrip_unimportable() -> None:
     assert str(result) == "oops"
 
 
+def test_exception_roundtrip_non_exception_type_falls_back() -> None:
+    data = {"exception_type": "builtins.int", "exception_message": "nope"}
+    result = _deserialize_exception(data)
+    assert type(result) is Exception
+    assert str(result) == "nope"
+
+
+def test_exception_roundtrip_bad_ctor_uses_default_ctor() -> None:
+    data = {
+        "exception_type": f"{_NoMessageError.__module__}.{_NoMessageError.__qualname__}",
+        "exception_message": "ignored",
+    }
+    result = _deserialize_exception(data)
+    assert isinstance(result, _NoMessageError)
+    assert str(result) == "no message"
+
+
 def test_event_type_roundtrip() -> None:
     serialized = _serialize_event_type(MyEvent)
     result = _deserialize_event_type(serialized)
     assert result is MyEvent
+
+
+def test_event_type_rejects_non_event_type() -> None:
+    with pytest.raises(ValueError, match="Resolved event type is not a subclass"):
+        _deserialize_event_type("builtins.int")
 
 
 # -- Tick roundtrip tests --


### PR DESCRIPTION
This hardens dynamic imports used during workflow state/event deserialization.

Changes:
- `JsonSerializer` now accepts `allow_unknown_types` (default preserves existing behavior). When an allowlist is provided, it continues to fail closed by default.
- Validate that imported `qualified_name` values resolve to an expected type:
  - Pydantic payloads must resolve to a `pydantic.BaseModel` subclass.
  - Component payloads must resolve to a type with `from_dict`.
  - Exception/event-type deserializers reject non-exception / non-Event types, and `SerializableException` no longer propagates `TypeError` for ctor mismatches.
- Add regression tests for strict allowlisting and for rejecting non-event / non-exception dynamic imports.

Verified locally:
- `PYTHONPATH=src uv run pytest -q` (packages/llama-index-workflows)
- `PYTHONPATH=src uv run ruff check src tests`