### PR TITLE
support subclass-aware event routing

### DIFF
--- a/.changeset/brave-bees-sink.md
+++ b/.changeset/brave-bees-sink.md
@@ -1,5 +1,5 @@
 ---
-"llama-index-workflows": major
+"llama-index-workflows": minor
 ---
 
-Support subclass-aware workflow event routing and validation
+Support opt-in subclass event routing via the step decorator parameter `accept_event_subclasses`

--- a/.changeset/brave-bees-sink.md
+++ b/.changeset/brave-bees-sink.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": major
+---
+
+Support subclass-aware workflow event routing and validation

--- a/packages/llama-agents-server/tests/server/test_server_endpoints.py
+++ b/packages/llama-agents-server/tests/server/test_server_endpoints.py
@@ -31,7 +31,7 @@ from workflows import Context, step
 from workflows.context.context_types import SerializedContext
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import DictState, InMemoryStateStore
-from workflows.events import StartEvent, StopEvent
+from workflows.events import Event, StartEvent, StopEvent
 from workflows.workflow import Workflow
 
 
@@ -1420,3 +1420,65 @@ async def test_instrument_tags_contains_handler_id_in_server_context() -> None:
             assert data["status"] == "completed"
             assert seen_handler_id["handler_id"] is not None
             assert seen_handler_id["handler_id"] == handler_id
+
+
+# --- Subclass-aware event routing (accept_event_subclasses) over HTTP ---
+
+
+class SubclassParentEvent(Event):
+    payload: str
+
+
+class SubclassChildEvent(SubclassParentEvent):
+    pass
+
+
+class SubclassRoutingWorkflow(Workflow):
+    """A producer emits a subclass; a consumer accepts the parent with opt-in."""
+
+    @step
+    async def start(self, ev: StartEvent) -> SubclassChildEvent:
+        return SubclassChildEvent(payload="from-start")
+
+    @step(accept_event_subclasses=True)
+    async def consume(self, ev: SubclassParentEvent) -> StopEvent:
+        return StopEvent(result=f"consumed {type(ev).__name__}: {ev.payload}")
+
+
+@pytest_asyncio.fixture
+async def subclass_client() -> AsyncGenerator:
+    server = WorkflowServer(workflow_store=MemoryWorkflowStore(), idle_timeout=0.01)
+    server.add_workflow("subclass", SubclassRoutingWorkflow())
+    async with server.contextmanager():
+        transport = ASGITransport(app=server.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            yield client
+
+
+@pytest.mark.asyncio
+async def test_subclass_routing_runs_over_http(subclass_client: AsyncClient) -> None:
+    response = await subclass_client.post("/workflows/subclass/run", json={})
+    assert response.status_code == 200
+    data = response.json()
+    # The child event must have been routed to the parent-accepting opted-in step.
+    assert (
+        data["result"]["value"]["result"] == "consumed SubclassChildEvent: from-start"
+    )
+
+
+@pytest.mark.asyncio
+async def test_subclass_routing_representation_over_http(
+    subclass_client: AsyncClient,
+) -> None:
+    response = await subclass_client.get("/workflows/subclass/representation")
+    assert response.status_code == 200
+    graph = response.json()["graph"]
+    edges = {(e["source"], e["target"]) for e in graph["edges"]}
+    # Both the declared parent edge and the subclass fan-out edge are present.
+    assert ("SubclassParentEvent", "consume") in edges
+    assert ("SubclassChildEvent", "consume") in edges
+
+    child = next(n for n in graph["nodes"] if n["id"] == "SubclassChildEvent")
+    # The inheritance chain is serialized so the UI can classify the node.
+    assert "SubclassParentEvent" in child["event_types"]
+    assert child["event_schema"] is not None

--- a/packages/llama-index-workflows/src/workflows/_event_matching.py
+++ b/packages/llama-index-workflows/src/workflows/_event_matching.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+"""Centralized event-type matching.
+
+A workflow step declares the event types it accepts. Whether a given event
+routes to that step is decided in one of two modes:
+
+* **exact** (the default): the event matches only when its concrete type is
+  exactly one of the declared accepted types.
+* **subclass-aware** (``accept_event_subclasses=True``): the event also matches
+  when its type is a subclass of a declared accepted type.
+
+Every place that answers "does this event/type belong to this step?" — graph
+construction, static validation, and runtime routing — funnels through the
+helpers below so the rule stays identical across all of them.
+
+Step signatures may also carry annotations that are not classes at all
+(``dict``, ``list[str]``, ``typing.Any``, ...). ``issubclass`` raises
+``TypeError`` on those, so :func:`is_subclass` is used as a safe replacement
+that treats non-classes as "not a subclass" rather than letting them blow up.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def is_subclass(candidate: Any, parents: type | tuple[type, ...]) -> bool:
+    """``issubclass`` that tolerates non-class annotations.
+
+    Returns ``False`` (instead of raising ``TypeError``) when ``candidate`` is
+    not a class, e.g. a parametrized generic or ``typing.Any``.
+    """
+    return isinstance(candidate, type) and issubclass(candidate, parents)
+
+
+def type_matches(produced: Any, accepted: type, *, allow_subclasses: bool) -> bool:
+    """Whether a produced event *type* routes to a step accepting ``accepted``."""
+    if allow_subclasses:
+        return is_subclass(produced, accepted)
+    return produced is accepted
+
+
+def event_matches(event: Any, accepted: type, *, allow_subclasses: bool) -> bool:
+    """Whether an event *instance* routes to a step accepting ``accepted``."""
+    if allow_subclasses:
+        return isinstance(event, accepted)
+    return type(event) is accepted
+
+
+def step_accepts_type(
+    produced: Any, accepted_events: Iterable[type], *, allow_subclasses: bool
+) -> bool:
+    """Whether a produced event *type* is accepted by any of ``accepted_events``."""
+    return any(
+        type_matches(produced, accepted, allow_subclasses=allow_subclasses)
+        for accepted in accepted_events
+    )
+
+
+def step_accepts_event(
+    event: Any, accepted_events: Iterable[type], *, allow_subclasses: bool
+) -> bool:
+    """Whether an event *instance* is accepted by any of ``accepted_events``."""
+    return any(
+        event_matches(event, accepted, allow_subclasses=allow_subclasses)
+        for accepted in accepted_events
+    )

--- a/packages/llama-index-workflows/src/workflows/decorators.py
+++ b/packages/llama-index-workflows/src/workflows/decorators.py
@@ -56,6 +56,7 @@ class StepConfig:
     # None means wildcard — covers any step not claimed by a scoped handler.
     catch_error_for_steps: list[str] | None = None
     catch_error_max_recoveries: int = 1
+    accept_event_subclasses: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -99,6 +100,7 @@ def step(
     num_workers: int = 4,
     retry_policy: RetryPolicy | None = None,
     skip_graph_checks: list[StepGraphCheck] | None = None,
+    accept_event_subclasses: bool = False,
 ) -> Callable[[Callable[P, R]], StepFunction[P, R]]: ...
 
 
@@ -109,6 +111,7 @@ def step(
     num_workers: int = 4,
     retry_policy: RetryPolicy | None = None,
     skip_graph_checks: list[StepGraphCheck] | None = None,
+    accept_event_subclasses: bool = False,
 ) -> Callable[[Callable[P, R]], StepFunction[P, R]] | StepFunction[P, R]:
     """
     Decorate a callable to declare it as a workflow step.
@@ -128,6 +131,7 @@ def step(
         skip_graph_checks (list[str] | None): Graph validation checks to skip
             for this step. Currently supports ``"reachability"`` to allow
             intentionally unreachable steps.
+        accept_event_subclasses (bool): If True, enable subclass-aware event routing.
 
     Returns:
         Callable: The original function, annotated with internal step metadata.
@@ -166,6 +170,7 @@ def step(
             workflow=workflow,
             localns=localns,
             skip_graph_checks=skip_graph_checks or [],
+            accept_event_subclasses=accept_event_subclasses,
         )
 
     if func is not None:
@@ -178,6 +183,7 @@ def step(
             workflow=workflow,
             localns=localns,
             skip_graph_checks=skip_graph_checks or [],
+            accept_event_subclasses=accept_event_subclasses,
         )
     return decorator
 
@@ -188,6 +194,7 @@ def make_step_function(
     retry_policy: RetryPolicy | None = None,
     localns: dict[str, Any] | None = None,
     skip_graph_checks: list[StepGraphCheck] | None = None,
+    accept_event_subclasses: bool = False,
 ) -> StepFunction[P, R]:
     # This will raise providing a message with the specific validation failure
     spec = inspect_signature(func, localns=localns)
@@ -206,6 +213,7 @@ def make_step_function(
         retry_policy=retry_policy,
         resources=spec.resources,
         skip_graph_checks=skip_graph_checks or [],
+        accept_event_subclasses=accept_event_subclasses,
     )
 
     return casted
@@ -219,6 +227,7 @@ def _apply_step_decorator(
     workflow: type["Workflow"] | None,
     localns: dict[str, Any] | None,
     skip_graph_checks: list[StepGraphCheck],
+    accept_event_subclasses: bool,
 ) -> StepFunction[P, R]:
     if not isinstance(num_workers, int) or num_workers <= 0:
         raise WorkflowValidationError("num_workers must be an integer greater than 0")
@@ -229,6 +238,7 @@ def _apply_step_decorator(
         retry_policy=retry_policy,
         localns=localns,
         skip_graph_checks=skip_graph_checks,
+        accept_event_subclasses=accept_event_subclasses,
     )
 
     # If this is a free function, call add_step() explicitly.

--- a/packages/llama-index-workflows/src/workflows/representation/build.py
+++ b/packages/llama-index-workflows/src/workflows/representation/build.py
@@ -375,13 +375,19 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
         # Edges from events to steps. With subclass routing a single accepted
         # base maps to every produced subclass present in the graph; otherwise
         # each accepted event maps to itself. De-duplicate so the fan-out never
-        # emits the same source twice for one step.
+        # emits the same source twice for one step. StopEvent is excluded from
+        # the fan-out: a returned StopEvent terminates the run instead of
+        # routing, so a broad accepted base (e.g. ``Event``) must not draw a
+        # StopEvent→step edge.
         matching_events: list[Any] = []
         seen_sources: set[Any] = set()
         for event_type in step_config.accepted_events:
             if step_config.accept_event_subclasses and isinstance(event_type, type):
                 candidates = [
-                    ev for ev in graph_event_types if is_subclass(ev, event_type)
+                    ev
+                    for ev in graph_event_types
+                    if is_subclass(ev, event_type)
+                    and (ev is event_type or not is_subclass(ev, StopEvent))
                 ]
             else:
                 candidates = [event_type]

--- a/packages/llama-index-workflows/src/workflows/representation/build.py
+++ b/packages/llama-index-workflows/src/workflows/representation/build.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import BaseModel
 
 from workflows import Workflow
+from workflows._event_matching import is_subclass
 from workflows.decorators import StepFunction
 from workflows.events import (
     Event,
@@ -42,6 +43,13 @@ def _get_type_name(type_annotation: type | None) -> str | None:
     return str(type_annotation)
 
 
+def _event_schema(type_annotation: Any) -> dict[str, Any] | None:
+    """JSON schema for a Pydantic event type, or ``None`` for non-model annotations."""
+    if isinstance(type_annotation, type) and issubclass(type_annotation, BaseModel):
+        return type_annotation.model_json_schema()
+    return None
+
+
 def _get_resource_identity(resource: ResourceDescriptor) -> int:
     """Get a unique identifier for resource deduplication.
 
@@ -63,14 +71,7 @@ def _get_event_type_chain(cls: type) -> list[str]:
     Returns a list starting with the class name, followed by parent Event
     subclasses up to (but not including) Event itself.
     """
-    is_event_subclass = False
-    try:
-        if isinstance(cls, type) and issubclass(cls, Event):
-            is_event_subclass = True
-    except TypeError:
-        pass
-
-    if not is_event_subclass:
+    if not is_subclass(cls, Event):
         name = _get_type_name(cls)
         return [name] if name else []
 
@@ -78,7 +79,7 @@ def _get_event_type_chain(cls: type) -> list[str]:
     for parent in cls.mro()[1:]:
         if parent is Event:
             break
-        if isinstance(parent, type) and issubclass(parent, Event):
+        if is_subclass(parent, Event):
             names.append(parent.__name__)
     return names
 
@@ -276,7 +277,7 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
     current_stop_event = None
     for step_func in steps.values():
         for return_type in step_func._step_config.return_types:
-            if isinstance(return_type, type) and issubclass(return_type, StopEvent):
+            if is_subclass(return_type, StopEvent):
                 current_stop_event = return_type
                 break
         if current_stop_event:
@@ -311,12 +312,7 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
                         label=event_type_name,
                         event_type=event_type_name,
                         event_types=_get_event_type_chain(event_type),
-                        event_schema=(
-                            event_type.model_json_schema()
-                            if isinstance(event_type, type)
-                            and issubclass(event_type, BaseModel)
-                            else None
-                        ),
+                        event_schema=_event_schema(event_type),
                     )
                 )
                 added_nodes.add(event_type_name)
@@ -335,20 +331,14 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
                         label=return_type_name,
                         event_type=return_type_name,
                         event_types=_get_event_type_chain(return_type),
-                        event_schema=(
-                            return_type.model_json_schema()
-                            if isinstance(return_type, type)
-                            and issubclass(return_type, BaseModel)
-                            else None
-                        ),
+                        event_schema=_event_schema(return_type),
                     )
                 )
                 added_nodes.add(return_type_name)
 
             # Add external_step node when InputRequiredEvent is found
             if (
-                isinstance(return_type, type)
-                and issubclass(return_type, InputRequiredEvent)
+                is_subclass(return_type, InputRequiredEvent)
                 and "external_step" not in added_nodes
             ):
                 nodes.append(
@@ -376,52 +366,43 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
                     WorkflowGraphEdge(source=step_name, target=return_type_name)
                 )
 
-            if isinstance(return_type, type) and issubclass(
-                return_type, InputRequiredEvent
-            ):
+            if is_subclass(return_type, InputRequiredEvent):
                 return_type_name = _get_type_name(return_type) or "UnknownType"
                 edges.append(
                     WorkflowGraphEdge(source=return_type_name, target="external_step")
                 )
 
-        # Edges from events to steps
+        # Edges from events to steps. With subclass routing a single accepted
+        # base maps to every produced subclass present in the graph; otherwise
+        # each accepted event maps to itself. De-duplicate so the fan-out never
+        # emits the same source twice for one step.
+        matching_events: list[Any] = []
+        seen_sources: set[Any] = set()
         for event_type in step_config.accepted_events:
-            if step_config.accept_event_subclasses:
-                matching_events = [
-                    ev
-                    for ev in graph_event_types
-                    if isinstance(ev, type)
-                    and isinstance(event_type, type)
-                    and issubclass(ev, event_type)
+            if step_config.accept_event_subclasses and isinstance(event_type, type):
+                candidates = [
+                    ev for ev in graph_event_types if is_subclass(ev, event_type)
                 ]
             else:
-                matching_events = [event_type]
+                candidates = [event_type]
+            for ev in candidates:
+                if ev not in seen_sources:
+                    seen_sources.add(ev)
+                    matching_events.append(ev)
 
-            for ev in matching_events:
-                ev_name = _get_type_name(ev) or "UnknownType"
-                if (
-                    step_name == "_done"
-                    and isinstance(ev, type)
-                    and issubclass(ev, StopEvent)
-                ):
-                    if current_stop_event:
-                        stop_event_name = (
-                            _get_type_name(current_stop_event) or "StopEvent"
-                        )
-                        edges.append(
-                            WorkflowGraphEdge(source=stop_event_name, target=step_name)
-                        )
-                else:
-                    edges.append(WorkflowGraphEdge(source=ev_name, target=step_name))
-
-                if (
-                    isinstance(ev, type)
-                    and issubclass(ev, HumanResponseEvent)
-                    and "external_step" in added_nodes
-                ):
+        for ev in matching_events:
+            ev_name = _get_type_name(ev) or "UnknownType"
+            if step_name == "_done" and is_subclass(ev, StopEvent):
+                if current_stop_event:
+                    stop_event_name = _get_type_name(current_stop_event) or "StopEvent"
                     edges.append(
-                        WorkflowGraphEdge(source="external_step", target=ev_name)
+                        WorkflowGraphEdge(source=stop_event_name, target=step_name)
                     )
+            else:
+                edges.append(WorkflowGraphEdge(source=ev_name, target=step_name))
+
+            if is_subclass(ev, HumanResponseEvent) and "external_step" in added_nodes:
+                edges.append(WorkflowGraphEdge(source="external_step", target=ev_name))
 
         # Edges from steps to resources (with variable name as label)
         for resource_def in step_config.resources:

--- a/packages/llama-index-workflows/src/workflows/representation/build.py
+++ b/packages/llama-index-workflows/src/workflows/representation/build.py
@@ -63,6 +63,17 @@ def _get_event_type_chain(cls: type) -> list[str]:
     Returns a list starting with the class name, followed by parent Event
     subclasses up to (but not including) Event itself.
     """
+    is_event_subclass = False
+    try:
+        if isinstance(cls, type) and issubclass(cls, Event):
+            is_event_subclass = True
+    except TypeError:
+        pass
+
+    if not is_event_subclass:
+        name = _get_type_name(cls)
+        return [name] if name else []
+
     names: list[str] = [cls.__name__]
     for parent in cls.mro()[1:]:
         if parent is Event:
@@ -265,13 +276,14 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
     current_stop_event = None
     for step_func in steps.values():
         for return_type in step_func._step_config.return_types:
-            if issubclass(return_type, StopEvent):
+            if isinstance(return_type, type) and issubclass(return_type, StopEvent):
                 current_stop_event = return_type
                 break
         if current_stop_event:
             break
 
     # First pass: Add all nodes
+    graph_event_types: set[type] = set()
     for step_name, step_func in steps.items():
         step_config = step_func._step_config
 
@@ -290,38 +302,53 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
             if event_type == StopEvent and event_type != current_stop_event:
                 continue
 
-            if event_type.__name__ not in added_nodes:
+            graph_event_types.add(event_type)
+            event_type_name = _get_type_name(event_type) or "UnknownType"
+            if event_type_name not in added_nodes:
                 nodes.append(
                     WorkflowEventNode(
-                        id=event_type.__name__,
-                        label=event_type.__name__,
-                        event_type=event_type.__name__,
+                        id=event_type_name,
+                        label=event_type_name,
+                        event_type=event_type_name,
                         event_types=_get_event_type_chain(event_type),
-                        event_schema=event_type.model_json_schema(),
+                        event_schema=(
+                            event_type.model_json_schema()
+                            if isinstance(event_type, type)
+                            and issubclass(event_type, BaseModel)
+                            else None
+                        ),
                     )
                 )
-                added_nodes.add(event_type.__name__)
+                added_nodes.add(event_type_name)
 
         # Add event nodes for return types
         for return_type in step_config.return_types:
             if return_type is type(None):
                 continue
 
-            if return_type.__name__ not in added_nodes:
+            graph_event_types.add(return_type)
+            return_type_name = _get_type_name(return_type) or "UnknownType"
+            if return_type_name not in added_nodes:
                 nodes.append(
                     WorkflowEventNode(
-                        id=return_type.__name__,
-                        label=return_type.__name__,
-                        event_type=return_type.__name__,
+                        id=return_type_name,
+                        label=return_type_name,
+                        event_type=return_type_name,
                         event_types=_get_event_type_chain(return_type),
-                        event_schema=return_type.model_json_schema(),
+                        event_schema=(
+                            return_type.model_json_schema()
+                            if isinstance(return_type, type)
+                            and issubclass(return_type, BaseModel)
+                            else None
+                        ),
                     )
                 )
-                added_nodes.add(return_type.__name__)
+                added_nodes.add(return_type_name)
 
             # Add external_step node when InputRequiredEvent is found
             if (
-                issubclass(return_type, InputRequiredEvent)
+                isinstance(return_type, type)
+                and issubclass(return_type, InputRequiredEvent)
                 and "external_step" not in added_nodes
             ):
                 nodes.append(
@@ -344,40 +371,57 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
         # Edges from steps to return types
         for return_type in step_config.return_types:
             if return_type is not type(None):
+                return_type_name = _get_type_name(return_type) or "UnknownType"
                 edges.append(
-                    WorkflowGraphEdge(source=step_name, target=return_type.__name__)
+                    WorkflowGraphEdge(source=step_name, target=return_type_name)
                 )
 
-            if issubclass(return_type, InputRequiredEvent):
+            if isinstance(return_type, type) and issubclass(
+                return_type, InputRequiredEvent
+            ):
+                return_type_name = _get_type_name(return_type) or "UnknownType"
                 edges.append(
-                    WorkflowGraphEdge(
-                        source=return_type.__name__, target="external_step"
-                    )
+                    WorkflowGraphEdge(source=return_type_name, target="external_step")
                 )
 
         # Edges from events to steps
         for event_type in step_config.accepted_events:
-            if step_name == "_done" and issubclass(event_type, StopEvent):
-                if current_stop_event:
-                    edges.append(
-                        WorkflowGraphEdge(
-                            source=current_stop_event.__name__, target=step_name
-                        )
-                    )
+            if step_config.accept_event_subclasses:
+                matching_events = [
+                    ev
+                    for ev in graph_event_types
+                    if isinstance(ev, type)
+                    and isinstance(event_type, type)
+                    and issubclass(ev, event_type)
+                ]
             else:
-                edges.append(
-                    WorkflowGraphEdge(source=event_type.__name__, target=step_name)
-                )
+                matching_events = [event_type]
 
-            if (
-                issubclass(event_type, HumanResponseEvent)
-                and "external_step" in added_nodes
-            ):
-                edges.append(
-                    WorkflowGraphEdge(
-                        source="external_step", target=event_type.__name__
+            for ev in matching_events:
+                ev_name = _get_type_name(ev) or "UnknownType"
+                if (
+                    step_name == "_done"
+                    and isinstance(ev, type)
+                    and issubclass(ev, StopEvent)
+                ):
+                    if current_stop_event:
+                        stop_event_name = (
+                            _get_type_name(current_stop_event) or "StopEvent"
+                        )
+                        edges.append(
+                            WorkflowGraphEdge(source=stop_event_name, target=step_name)
+                        )
+                else:
+                    edges.append(WorkflowGraphEdge(source=ev_name, target=step_name))
+
+                if (
+                    isinstance(ev, type)
+                    and issubclass(ev, HumanResponseEvent)
+                    and "external_step" in added_nodes
+                ):
+                    edges.append(
+                        WorkflowGraphEdge(source="external_step", target=ev_name)
                     )
-                )
 
         # Edges from steps to resources (with variable name as label)
         for resource_def in step_config.resources:

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -61,19 +61,26 @@ def build_step_graph(
     InputRequiredEvent).
     """
     outgoing: dict[GraphNode, list[GraphNode]] = {}
-    event_types: set[type] = set()
+    event_types: set[type] = {start_event_class} if steps else set()
     step_names: set[str] = set()
 
     for name, cfg in steps.items():
         step_names.add(name)
-        for ev in cfg.accepted_events:
-            event_types.add(ev)
-            outgoing.setdefault(ev, []).append(name)
         for rt in cfg.return_types:
             if rt is type(None):
                 continue
             event_types.add(rt)
             outgoing.setdefault(name, []).append(rt)
+        for ev in cfg.accepted_events:
+            event_types.add(ev)
+
+    # Build event→step edges using subclass-aware matching.
+    # If a produced event is a subclass of an accepted event, add an edge.
+    for ev_type in event_types:
+        for name, cfg in steps.items():
+            for accepted in cfg.accepted_events:
+                if issubclass(ev_type, accepted):
+                    outgoing.setdefault(ev_type, []).append(name)
 
     # Forward DFS from StartEvent + HumanResponseEvent subclasses +
     # catch_error handler step names (their sub-graphs are reachable via
@@ -471,11 +478,12 @@ def _validate_event_connectivity(
 
     unconsumed_events = {
         x
-        for x in consumed_events - produced_events
+        for x in consumed_events
         if not issubclass(
             x,
             (InputRequiredEvent, HumanResponseEvent, StopEvent, StepFailedEvent),
         )
+        and not any(issubclass(p, x) for p in produced_events)
     }
     if unconsumed_events:
         names = ", ".join(ev.__name__ for ev in unconsumed_events)
@@ -485,8 +493,9 @@ def _validate_event_connectivity(
 
     unused_events = {
         x
-        for x in produced_events - consumed_events
+        for x in produced_events
         if not issubclass(x, (InputRequiredEvent, HumanResponseEvent, StopEvent))
+        and not any(issubclass(x, c) for c in consumed_events)
     }
     if unused_events:
         names = ", ".join(ev.__name__ for ev in unused_events)
@@ -494,8 +503,8 @@ def _validate_event_connectivity(
             f"The following events are produced but never consumed: {names}"
         )
 
-    return (
-        InputRequiredEvent in produced_events or HumanResponseEvent in consumed_events
+    return any(issubclass(p, InputRequiredEvent) for p in produced_events) or any(
+        issubclass(c, HumanResponseEvent) for c in consumed_events
     )
 
 

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -77,12 +77,18 @@ def build_step_graph(
 
     # Build event→step edges. A step consumes an event when its type matches one
     # of the step's accepted events (subclass-aware when the step opted in).
+    # StopEvent is excluded from subclass expansion: a returned StopEvent
+    # terminates the run instead of routing, so a broad accepted base (e.g.
+    # ``Event``) must not produce a StopEvent→step edge.
     for ev_type in event_types:
         for name, cfg in steps.items():
+            allow_subclasses = cfg.accept_event_subclasses and not is_subclass(
+                ev_type, StopEvent
+            )
             if step_accepts_type(
                 ev_type,
                 cfg.accepted_events,
-                allow_subclasses=cfg.accept_event_subclasses,
+                allow_subclasses=allow_subclasses,
             ):
                 outgoing.setdefault(ev_type, []).append(name)
 

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -312,7 +312,7 @@ def _ensure_start_event_class(
     start_events_found: set[type[StartEvent]] = set()
     for cfg in steps.values():
         for event_type in cfg.accepted_events:
-            if issubclass(event_type, StartEvent):
+            if isinstance(event_type, type) and issubclass(event_type, StartEvent):
                 start_events_found.add(event_type)
 
     num_found = len(start_events_found)
@@ -341,7 +341,7 @@ def _ensure_stop_event_class(
     stop_events_found: set[type[StopEvent]] = set()
     for cfg in steps.values():
         for event_type in cfg.return_types:
-            if issubclass(event_type, StopEvent):
+            if isinstance(event_type, type) and issubclass(event_type, StopEvent):
                 stop_events_found.add(event_type)
 
     num_found = len(stop_events_found)
@@ -367,10 +367,10 @@ def _collect_events(steps: dict[str, StepConfig]) -> list[type[Event]]:
     events_found: set[type[Event]] = set()
     for cfg in steps.values():
         for event_type in cfg.return_types:
-            if issubclass(event_type, Event):
+            if isinstance(event_type, type) and issubclass(event_type, Event):
                 events_found.add(event_type)
         for event_type in cfg.accepted_events:
-            if issubclass(event_type, Event):
+            if isinstance(event_type, type) and issubclass(event_type, Event):
                 events_found.add(event_type)
     return list(events_found)
 

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 
+from workflows._event_matching import is_subclass, step_accepts_type, type_matches
 from workflows.decorators import CatchErrorHandler, StepConfig, WorkflowGraphCheck
 from workflows.errors import WorkflowConfigurationError, WorkflowValidationError
 from workflows.events import (
@@ -74,24 +75,23 @@ def build_step_graph(
         for ev in cfg.accepted_events:
             event_types.add(ev)
 
-    # Build event→step edges using subclass-aware matching if opted in.
-    # If a produced event is a subclass of an accepted event, add an edge.
+    # Build event→step edges. A step consumes an event when its type matches one
+    # of the step's accepted events (subclass-aware when the step opted in).
     for ev_type in event_types:
         for name, cfg in steps.items():
-            for accepted in cfg.accepted_events:
-                if cfg.accept_event_subclasses:
-                    match = issubclass(ev_type, accepted)
-                else:
-                    match = ev_type is accepted
-                if match:
-                    outgoing.setdefault(ev_type, []).append(name)
+            if step_accepts_type(
+                ev_type,
+                cfg.accepted_events,
+                allow_subclasses=cfg.accept_event_subclasses,
+            ):
+                outgoing.setdefault(ev_type, []).append(name)
 
     # Forward DFS from StartEvent + HumanResponseEvent subclasses +
     # catch_error handler step names (their sub-graphs are reachable via
     # runtime routing of StepFailedEvent, not via any event in the graph).
     seeds: list[GraphNode] = [start_event_class]
     for ev_type in event_types:
-        if issubclass(ev_type, HumanResponseEvent) and ev_type not in seeds:
+        if is_subclass(ev_type, HumanResponseEvent) and ev_type not in seeds:
             seeds.append(ev_type)
     for handler_name in catch_error_steps or []:
         if handler_name not in seeds:
@@ -108,7 +108,7 @@ def build_step_graph(
     output_seeds: list[GraphNode] = [
         ev_type
         for ev_type in event_types
-        if issubclass(ev_type, (StopEvent, InputRequiredEvent))
+        if is_subclass(ev_type, (StopEvent, InputRequiredEvent))
     ]
     reverse_reachable = _dfs(output_seeds, incoming)
 
@@ -207,7 +207,7 @@ def validate_graph(
             targets = graph.outgoing.get(ev_type, [])
             if any(t in graph.step_names for t in targets):
                 continue
-            if issubclass(ev_type, (StopEvent, InputRequiredEvent)):
+            if is_subclass(ev_type, (StopEvent, InputRequiredEvent)):
                 continue
             dangling.append(ev_type)
         if dangling:
@@ -312,7 +312,7 @@ def _ensure_start_event_class(
     start_events_found: set[type[StartEvent]] = set()
     for cfg in steps.values():
         for event_type in cfg.accepted_events:
-            if isinstance(event_type, type) and issubclass(event_type, StartEvent):
+            if is_subclass(event_type, StartEvent):
                 start_events_found.add(event_type)
 
     num_found = len(start_events_found)
@@ -341,7 +341,7 @@ def _ensure_stop_event_class(
     stop_events_found: set[type[StopEvent]] = set()
     for cfg in steps.values():
         for event_type in cfg.return_types:
-            if isinstance(event_type, type) and issubclass(event_type, StopEvent):
+            if is_subclass(event_type, StopEvent):
                 stop_events_found.add(event_type)
 
     num_found = len(stop_events_found)
@@ -367,10 +367,10 @@ def _collect_events(steps: dict[str, StepConfig]) -> list[type[Event]]:
     events_found: set[type[Event]] = set()
     for cfg in steps.values():
         for event_type in cfg.return_types:
-            if isinstance(event_type, type) and issubclass(event_type, Event):
+            if is_subclass(event_type, Event):
                 events_found.add(event_type)
         for event_type in cfg.accepted_events:
-            if isinstance(event_type, type) and issubclass(event_type, Event):
+            if is_subclass(event_type, Event):
                 events_found.add(event_type)
     return list(events_found)
 
@@ -461,7 +461,7 @@ def _validate_event_connectivity(
 
     for name, cfg in steps.items():
         for event_type in cfg.accepted_events:
-            if issubclass(event_type, StopEvent):
+            if is_subclass(event_type, StopEvent):
                 steps_accepting_stop_event.append(name)
                 break
         for event_type in cfg.accepted_events:
@@ -480,20 +480,21 @@ def _validate_event_connectivity(
             "Use a different Event type instead."
         )
 
+    # An accepted event is satisfied when some produced event matches it (under
+    # the consuming step's matching mode); otherwise it is consumed but never
+    # produced.
+    boundary_in = (InputRequiredEvent, HumanResponseEvent, StopEvent, StepFailedEvent)
     unconsumed_events = set()
-    for name, cfg in steps.items():
+    for cfg in steps.values():
         for event_type in cfg.accepted_events:
-            if issubclass(
-                event_type,
-                (InputRequiredEvent, HumanResponseEvent, StopEvent, StepFailedEvent),
-            ):
+            if is_subclass(event_type, boundary_in):
                 continue
-
-            if cfg.accept_event_subclasses:
-                satisfied = any(issubclass(p, event_type) for p in produced_events)
-            else:
-                satisfied = event_type in produced_events
-
+            satisfied = any(
+                type_matches(
+                    p, event_type, allow_subclasses=cfg.accept_event_subclasses
+                )
+                for p in produced_events
+            )
             if not satisfied:
                 unconsumed_events.add(event_type)
 
@@ -503,25 +504,19 @@ def _validate_event_connectivity(
             f"The following events are consumed but never produced: {names}"
         )
 
+    # A produced event is unused when no step accepts it (under that step's
+    # matching mode). Boundary-out events may legitimately leave the workflow.
+    boundary_out = (InputRequiredEvent, HumanResponseEvent, StopEvent)
     unused_events = set()
     for x in produced_events:
-        if issubclass(x, (InputRequiredEvent, HumanResponseEvent, StopEvent)):
+        if is_subclass(x, boundary_out):
             continue
-
-        consumed = False
-        for name, cfg in steps.items():
-            for accepted in cfg.accepted_events:
-                if cfg.accept_event_subclasses:
-                    if issubclass(x, accepted):
-                        consumed = True
-                        break
-                else:
-                    if x is accepted:
-                        consumed = True
-                        break
-            if consumed:
-                break
-
+        consumed = any(
+            step_accepts_type(
+                x, cfg.accepted_events, allow_subclasses=cfg.accept_event_subclasses
+            )
+            for cfg in steps.values()
+        )
         if not consumed:
             unused_events.add(x)
 
@@ -531,8 +526,8 @@ def _validate_event_connectivity(
             f"The following events are produced but never consumed: {names}"
         )
 
-    return any(issubclass(p, InputRequiredEvent) for p in produced_events) or any(
-        issubclass(c, HumanResponseEvent) for c in consumed_events
+    return any(is_subclass(p, InputRequiredEvent) for p in produced_events) or any(
+        is_subclass(c, HumanResponseEvent) for c in consumed_events
     )
 
 

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -74,12 +74,16 @@ def build_step_graph(
         for ev in cfg.accepted_events:
             event_types.add(ev)
 
-    # Build event→step edges using subclass-aware matching.
+    # Build event→step edges using subclass-aware matching if opted in.
     # If a produced event is a subclass of an accepted event, add an edge.
     for ev_type in event_types:
         for name, cfg in steps.items():
             for accepted in cfg.accepted_events:
-                if issubclass(ev_type, accepted):
+                if cfg.accept_event_subclasses:
+                    match = issubclass(ev_type, accepted)
+                else:
+                    match = ev_type is accepted
+                if match:
                     outgoing.setdefault(ev_type, []).append(name)
 
     # Forward DFS from StartEvent + HumanResponseEvent subclasses +
@@ -476,27 +480,51 @@ def _validate_event_connectivity(
             "Use a different Event type instead."
         )
 
-    unconsumed_events = {
-        x
-        for x in consumed_events
-        if not issubclass(
-            x,
-            (InputRequiredEvent, HumanResponseEvent, StopEvent, StepFailedEvent),
-        )
-        and not any(issubclass(p, x) for p in produced_events)
-    }
+    unconsumed_events = set()
+    for name, cfg in steps.items():
+        for event_type in cfg.accepted_events:
+            if issubclass(
+                event_type,
+                (InputRequiredEvent, HumanResponseEvent, StopEvent, StepFailedEvent),
+            ):
+                continue
+
+            if cfg.accept_event_subclasses:
+                satisfied = any(issubclass(p, event_type) for p in produced_events)
+            else:
+                satisfied = event_type in produced_events
+
+            if not satisfied:
+                unconsumed_events.add(event_type)
+
     if unconsumed_events:
         names = ", ".join(ev.__name__ for ev in unconsumed_events)
         raise WorkflowValidationError(
             f"The following events are consumed but never produced: {names}"
         )
 
-    unused_events = {
-        x
-        for x in produced_events
-        if not issubclass(x, (InputRequiredEvent, HumanResponseEvent, StopEvent))
-        and not any(issubclass(x, c) for c in consumed_events)
-    }
+    unused_events = set()
+    for x in produced_events:
+        if issubclass(x, (InputRequiredEvent, HumanResponseEvent, StopEvent)):
+            continue
+
+        consumed = False
+        for name, cfg in steps.items():
+            for accepted in cfg.accepted_events:
+                if cfg.accept_event_subclasses:
+                    if issubclass(x, accepted):
+                        consumed = True
+                        break
+                else:
+                    if x is accepted:
+                        consumed = True
+                        break
+            if consumed:
+                break
+
+        if not consumed:
+            unused_events.add(x)
+
     if unused_events:
         names = ", ".join(ev.__name__ for ev in unused_events)
         raise WorkflowValidationError(

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -1071,7 +1071,7 @@ def _process_add_event_tick(
     for step_name, step_config in state.config.steps.items():
         wait_conditions = state.workers[step_name].collected_waiters
         for wait_condition in wait_conditions:
-            is_match = type(tick.event) is wait_condition.waiting_for_event
+            is_match = isinstance(tick.event, wait_condition.waiting_for_event)
             is_match = is_match and all(
                 getattr(tick.event, k, None) == v
                 for k, v in wait_condition.requirements.items()
@@ -1093,7 +1093,10 @@ def _process_add_event_tick(
     for step_name, step_config in state.config.steps.items():
         if step_name in waiter_resolved_steps:
             continue
-        is_accepted = type(tick.event) in step_config.accepted_events
+        is_accepted = any(
+            isinstance(tick.event, accepted_type)
+            for accepted_type in step_config.accepted_events
+        )
         if is_accepted and (tick.step_name is None or tick.step_name == step_name):
             handled = True
             subcommands = _add_or_enqueue_event(

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -1071,7 +1071,11 @@ def _process_add_event_tick(
     for step_name, step_config in state.config.steps.items():
         wait_conditions = state.workers[step_name].collected_waiters
         for wait_condition in wait_conditions:
-            is_match = isinstance(tick.event, wait_condition.waiting_for_event)
+            if step_config.accept_event_subclasses:
+                is_match = isinstance(tick.event, wait_condition.waiting_for_event)
+            else:
+                is_match = type(tick.event) is wait_condition.waiting_for_event
+
             is_match = is_match and all(
                 getattr(tick.event, k, None) == v
                 for k, v in wait_condition.requirements.items()
@@ -1093,10 +1097,14 @@ def _process_add_event_tick(
     for step_name, step_config in state.config.steps.items():
         if step_name in waiter_resolved_steps:
             continue
-        is_accepted = any(
-            isinstance(tick.event, accepted_type)
-            for accepted_type in step_config.accepted_events
-        )
+        if step_config.accept_event_subclasses:
+            is_accepted = any(
+                isinstance(tick.event, accepted_type)
+                for accepted_type in step_config.accepted_events
+            )
+        else:
+            is_accepted = type(tick.event) in step_config.accepted_events
+
         if is_accepted and (tick.step_name is None or tick.step_name == step_name):
             handled = True
             subcommands = _add_or_enqueue_event(

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
+from workflows._event_matching import event_matches, step_accepts_event
 from workflows.errors import (
     WorkflowCancelledByUser,
     WorkflowRuntimeError,
@@ -1071,11 +1072,11 @@ def _process_add_event_tick(
     for step_name, step_config in state.config.steps.items():
         wait_conditions = state.workers[step_name].collected_waiters
         for wait_condition in wait_conditions:
-            if step_config.accept_event_subclasses:
-                is_match = isinstance(tick.event, wait_condition.waiting_for_event)
-            else:
-                is_match = type(tick.event) is wait_condition.waiting_for_event
-
+            is_match = event_matches(
+                tick.event,
+                wait_condition.waiting_for_event,
+                allow_subclasses=step_config.accept_event_subclasses,
+            )
             is_match = is_match and all(
                 getattr(tick.event, k, None) == v
                 for k, v in wait_condition.requirements.items()
@@ -1097,14 +1098,11 @@ def _process_add_event_tick(
     for step_name, step_config in state.config.steps.items():
         if step_name in waiter_resolved_steps:
             continue
-        if step_config.accept_event_subclasses:
-            is_accepted = any(
-                isinstance(tick.event, accepted_type)
-                for accepted_type in step_config.accepted_events
-            )
-        else:
-            is_accepted = type(tick.event) in step_config.accepted_events
-
+        is_accepted = step_accepts_event(
+            tick.event,
+            step_config.accepted_events,
+            allow_subclasses=step_config.accept_event_subclasses,
+        )
         if is_accepted and (tick.step_name is None or tick.step_name == step_name):
             handled = True
             subcommands = _add_or_enqueue_event(

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -67,6 +67,7 @@ class BrokerState:
                         accepted_events=step_func._step_config.accepted_events,
                         retry_policy=step_func._step_config.retry_policy,
                         num_workers=step_func._step_config.num_workers,
+                        accept_event_subclasses=step_func._step_config.accept_event_subclasses,
                     )
                     for name, step_func in workflow._get_steps().items()
                 },
@@ -283,6 +284,7 @@ class InternalStepConfig:
     accepted_events: list[Any]
     retry_policy: RetryPolicy | None
     num_workers: int
+    accept_event_subclasses: bool = False
 
 
 @dataclass()

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -187,7 +187,10 @@ class Workflow(metaclass=WorkflowMeta):
 
         step_func = self._get_steps()[step]
         step_config = step_func._step_config
-        if type(message) not in step_config.accepted_events:
+        if not any(
+            isinstance(message, accepted_type)
+            for accepted_type in step_config.accepted_events
+        ):
             raise WorkflowRuntimeError(
                 f"Step {step} does not accept event of type {type(message)}"
             )

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -187,10 +187,15 @@ class Workflow(metaclass=WorkflowMeta):
 
         step_func = self._get_steps()[step]
         step_config = step_func._step_config
-        if not any(
-            isinstance(message, accepted_type)
-            for accepted_type in step_config.accepted_events
-        ):
+        if step_config.accept_event_subclasses:
+            is_accepted = any(
+                isinstance(message, accepted_type)
+                for accepted_type in step_config.accepted_events
+            )
+        else:
+            is_accepted = type(message) in step_config.accepted_events
+
+        if not is_accepted:
             raise WorkflowRuntimeError(
                 f"Step {step} does not accept event of type {type(message)}"
             )

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -17,6 +17,7 @@ from pydantic import ValidationError
 if TYPE_CHECKING:  # pragma: no cover
     from .context import Context
     from .runtime.types.plugin import Runtime
+from ._event_matching import step_accepts_event
 from .decorators import CatchErrorHandler, StepConfig, StepFunction, WorkflowGraphCheck
 from .errors import (
     WorkflowRuntimeError,
@@ -187,14 +188,11 @@ class Workflow(metaclass=WorkflowMeta):
 
         step_func = self._get_steps()[step]
         step_config = step_func._step_config
-        if step_config.accept_event_subclasses:
-            is_accepted = any(
-                isinstance(message, accepted_type)
-                for accepted_type in step_config.accepted_events
-            )
-        else:
-            is_accepted = type(message) in step_config.accepted_events
-
+        is_accepted = step_accepts_event(
+            message,
+            step_config.accepted_events,
+            allow_subclasses=step_config.accept_event_subclasses,
+        )
         if not is_accepted:
             raise WorkflowRuntimeError(
                 f"Step {step} does not accept event of type {type(message)}"

--- a/packages/llama-index-workflows/tests/test_event_subclassing.py
+++ b/packages/llama-index-workflows/tests/test_event_subclassing.py
@@ -6,6 +6,11 @@ from __future__ import annotations
 import pytest
 from workflows.context import Context
 from workflows.decorators import step
+from workflows.errors import (
+    WorkflowRuntimeError,
+    WorkflowTimeoutError,
+    WorkflowValidationError,
+)
 from workflows.events import Event, StartEvent, StopEvent
 from workflows.representation.validate import build_step_graph
 from workflows.workflow import Workflow
@@ -21,50 +26,126 @@ class ChildEvent(ParentEvent):
     pass
 
 
-# ── Shared workflow: step_a emits ChildEvent, step_b expects ParentEvent ──
+# ── Test 1: Default step rejects subclass event (Strict validation & timeout) ─
 
 
-class SubclassRoutingWorkflow(Workflow):
-    @step
-    async def step_a(self, ev: StartEvent) -> ChildEvent:
-        return ChildEvent(value="subclass works")
+def test_default_step_validation_rejects_subclass_event() -> None:
+    """Without accept_event_subclasses=True, validation detects ParentEvent as unproduced."""
 
-    @step
-    async def step_b(self, ev: ParentEvent) -> StopEvent:
-        return StopEvent(result=ev.value)
+    class DefaultExactWorkflow(Workflow):
+        @step
+        async def step_a(self, ev: StartEvent) -> ChildEvent:
+            return ChildEvent(value="x")
+
+        @step
+        async def step_b(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    workflow = DefaultExactWorkflow(timeout=1)
+    with pytest.raises(WorkflowValidationError) as excinfo:
+        workflow._validate()
+    assert "consumed but never produced: ParentEvent" in str(excinfo.value)
 
 
 @pytest.mark.asyncio
-async def test_subclass_event_routes_to_step_accepting_parent_event() -> None:
-    """Validation should recognize ChildEvent satisfies ParentEvent consumption."""
-    workflow = SubclassRoutingWorkflow(timeout=1)
+async def test_default_step_runtime_ignores_subclass_event() -> None:
+    """Without accept_event_subclasses=True, runtime routing ignores ChildEvent and times out."""
+
+    class DefaultExactWorkflow(Workflow):
+        @step
+        async def step_a(self, ev: StartEvent) -> ChildEvent:
+            return ChildEvent(value="x")
+
+        @step
+        async def step_b(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    workflow = DefaultExactWorkflow(timeout=1, disable_validation=True)
+    with pytest.raises(WorkflowTimeoutError):
+        await workflow.run()
+
+
+# ── Test 2: Opt-in step accepts subclass event ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_opt_in_step_accepts_subclass_event() -> None:
+    """With accept_event_subclasses=True, workflow successfully routes ChildEvent."""
+
+    class OptInSubclassWorkflow(Workflow):
+        @step
+        async def step_a(self, ev: StartEvent) -> ChildEvent:
+            return ChildEvent(value="subclass works")
+
+        @step(accept_event_subclasses=True)
+        async def step_b(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    workflow = OptInSubclassWorkflow(timeout=2)
     result = await workflow.run()
     assert result == "subclass works"
 
 
-@pytest.mark.asyncio
-async def test_subclass_runtime_routing() -> None:
-    """Runtime should deliver ChildEvent to a step accepting ParentEvent."""
-    workflow = SubclassRoutingWorkflow(timeout=2, disable_validation=True)
-    result = await workflow.run()
-    assert result == "subclass works"
+# ── Test 3: Graph edges follow opt-in subclass matching ──────────────────────
 
 
-def test_subclass_targeted_step_validation_accepts_child() -> None:
-    """_validate_valid_step_message should accept ChildEvent for ParentEvent step."""
-    workflow = SubclassRoutingWorkflow(disable_validation=True)
-    workflow._validate_valid_step_message("step_b", ChildEvent(value="test"))
+def test_graph_edges_follow_opt_in_subclass_matching() -> None:
+    """build_step_graph only builds subclass edges for steps that opt-in."""
 
+    class MixedWorkflow(Workflow):
+        @step
+        async def step_a(self, ev: StartEvent) -> ChildEvent:
+            return ChildEvent(value="x")
 
-def test_subclass_graph_edges_connect_child_to_parent_step() -> None:
-    """build_step_graph should create edges from ChildEvent to steps accepting ParentEvent."""
-    workflow = SubclassRoutingWorkflow(disable_validation=True)
+        @step
+        async def step_b(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+        @step(accept_event_subclasses=True)
+        async def step_c(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    workflow = MixedWorkflow(disable_validation=True)
     steps = {name: func._step_config for name, func in workflow._get_steps().items()}
     graph = build_step_graph(steps, StartEvent)
+
     child_event_targets = graph.outgoing.get(ChildEvent, [])
-    assert "step_b" in child_event_targets, (
-        f"ChildEvent should connect to step_b, got: {child_event_targets}"
-    )
+    # Should connect to step_c (opt-in) but NOT to step_b (default)
+    assert "step_c" in child_event_targets
+    assert "step_b" not in child_event_targets
+
+
+# ── Test 4: Targeted step validation respects opt-in subclass matching ────────
+
+
+def test_targeted_step_validation_respects_opt_in_subclass_matching() -> None:
+    """_validate_valid_step_message rejects subclass event by default, accepts on opt-in."""
+
+    class MixedWorkflow(Workflow):
+        @step
+        async def step_a(self, ev: StartEvent) -> ChildEvent:
+            return ChildEvent(value="x")
+
+        @step
+        async def step_b(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+        @step(accept_event_subclasses=True)
+        async def step_c(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    workflow = MixedWorkflow(disable_validation=True)
+
+    # Default step_b rejects ChildEvent
+    with pytest.raises(WorkflowRuntimeError) as excinfo:
+        workflow._validate_valid_step_message("step_b", ChildEvent(value="x"))
+    assert "does not accept event of type" in str(excinfo.value)
+
+    # Opt-in step_c accepts ChildEvent without error
+    workflow._validate_valid_step_message("step_c", ChildEvent(value="x"))
+
+
+# ── Test 5: Exact-type event routing still works (Regression Guard) ──────────
 
 
 @pytest.mark.asyncio
@@ -85,18 +166,38 @@ async def test_exact_type_event_routing_still_works() -> None:
     assert result == "exact match"
 
 
-@pytest.mark.asyncio
-async def test_subclass_waiter_accepts_child_event_for_parent_wait() -> None:
-    """A waiter waiting for a ParentEvent should be resolved by a ChildEvent."""
+# ── Test 6: Waiter respects opt-in subclass matching ──────────────────────────
 
-    class WaiterWorkflow(Workflow):
+
+@pytest.mark.asyncio
+async def test_waiter_respects_opt_in_subclass_matching_default_ignores() -> None:
+    """A waiter created inside a default step ignores subclass event and times out."""
+
+    class WaiterDefaultWorkflow(Workflow):
         @step
         async def step_a(self, ev: StartEvent, ctx: Context) -> StopEvent:
             waiter = ctx.wait_for_event(ParentEvent)
-            ctx.send_event(ChildEvent(value="waiter works"))
+            ctx.send_event(ChildEvent(value="waiter default"))
             result = await waiter
             return StopEvent(result=result.value)
 
-    workflow = WaiterWorkflow(timeout=2, disable_validation=True)
+    workflow = WaiterDefaultWorkflow(timeout=1, disable_validation=True)
+    with pytest.raises(WorkflowTimeoutError):
+        await workflow.run()
+
+
+@pytest.mark.asyncio
+async def test_waiter_respects_opt_in_subclass_matching_opt_in_resolves() -> None:
+    """A waiter created inside an opted-in step resolves with subclass event."""
+
+    class WaiterOptInWorkflow(Workflow):
+        @step(accept_event_subclasses=True)
+        async def step_a(self, ev: StartEvent, ctx: Context) -> StopEvent:
+            waiter = ctx.wait_for_event(ParentEvent)
+            ctx.send_event(ChildEvent(value="waiter opt-in"))
+            result = await waiter
+            return StopEvent(result=result.value)
+
+    workflow = WaiterOptInWorkflow(timeout=2, disable_validation=True)
     result = await workflow.run()
-    assert result == "waiter works"
+    assert result == "waiter opt-in"

--- a/packages/llama-index-workflows/tests/test_event_subclassing.py
+++ b/packages/llama-index-workflows/tests/test_event_subclassing.py
@@ -180,3 +180,31 @@ async def test_waiter_respects_opt_in_subclass_matching_opt_in_resolves() -> Non
     workflow = WaiterOptInWorkflow(timeout=2, disable_validation=True)
     result = await workflow.run()
     assert result == "waiter opt-in"
+
+
+# ── Test 7: StopEvent is excluded from subclass graph expansion ───────────────
+
+
+def test_step_graph_excludes_stop_event_from_subclass_expansion() -> None:
+    """A catch-all opted-in step (accepting ``Event``) gets edges from regular
+    events but not from StopEvent: a returned StopEvent terminates the run
+    instead of routing."""
+
+    class CatchAllWorkflow(Workflow):
+        @step
+        async def start(self, ev: StartEvent) -> ChildEvent:
+            return ChildEvent(value="x")
+
+        @step(accept_event_subclasses=True)
+        async def observe(self, ev: Event) -> StopEvent | None:
+            if isinstance(ev, ChildEvent):
+                return StopEvent(result=ev.value)
+            return None
+
+    workflow = CatchAllWorkflow(disable_validation=True)
+    steps = {name: func._step_config for name, func in workflow._get_steps().items()}
+    graph = build_step_graph(steps, StartEvent)
+
+    assert "observe" in graph.outgoing.get(ChildEvent, [])
+    assert "observe" in graph.outgoing.get(StartEvent, [])
+    assert "observe" not in graph.outgoing.get(StopEvent, [])

--- a/packages/llama-index-workflows/tests/test_event_subclassing.py
+++ b/packages/llama-index-workflows/tests/test_event_subclassing.py
@@ -15,7 +15,6 @@ from workflows.events import Event, StartEvent, StopEvent
 from workflows.representation.validate import build_step_graph
 from workflows.workflow import Workflow
 
-
 # ── Shared event hierarchy ──────────────────────────────────────────────────
 
 

--- a/packages/llama-index-workflows/tests/test_event_subclassing.py
+++ b/packages/llama-index-workflows/tests/test_event_subclassing.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import pytest
+from workflows.context import Context
+from workflows.decorators import step
+from workflows.events import Event, StartEvent, StopEvent
+from workflows.representation.validate import build_step_graph
+from workflows.workflow import Workflow
+
+# ── Shared event hierarchy ──────────────────────────────────────────────────
+
+
+class ParentEvent(Event):
+    value: str
+
+
+class ChildEvent(ParentEvent):
+    pass
+
+
+# ── Shared workflow: step_a emits ChildEvent, step_b expects ParentEvent ──
+
+
+class SubclassRoutingWorkflow(Workflow):
+    @step
+    async def step_a(self, ev: StartEvent) -> ChildEvent:
+        return ChildEvent(value="subclass works")
+
+    @step
+    async def step_b(self, ev: ParentEvent) -> StopEvent:
+        return StopEvent(result=ev.value)
+
+
+@pytest.mark.asyncio
+async def test_subclass_event_routes_to_step_accepting_parent_event() -> None:
+    """Validation should recognize ChildEvent satisfies ParentEvent consumption."""
+    workflow = SubclassRoutingWorkflow(timeout=1)
+    result = await workflow.run()
+    assert result == "subclass works"
+
+
+@pytest.mark.asyncio
+async def test_subclass_runtime_routing() -> None:
+    """Runtime should deliver ChildEvent to a step accepting ParentEvent."""
+    workflow = SubclassRoutingWorkflow(timeout=2, disable_validation=True)
+    result = await workflow.run()
+    assert result == "subclass works"
+
+
+def test_subclass_targeted_step_validation_accepts_child() -> None:
+    """_validate_valid_step_message should accept ChildEvent for ParentEvent step."""
+    workflow = SubclassRoutingWorkflow(disable_validation=True)
+    workflow._validate_valid_step_message("step_b", ChildEvent(value="test"))
+
+
+def test_subclass_graph_edges_connect_child_to_parent_step() -> None:
+    """build_step_graph should create edges from ChildEvent to steps accepting ParentEvent."""
+    workflow = SubclassRoutingWorkflow(disable_validation=True)
+    steps = {name: func._step_config for name, func in workflow._get_steps().items()}
+    graph = build_step_graph(steps, StartEvent)
+    child_event_targets = graph.outgoing.get(ChildEvent, [])
+    assert "step_b" in child_event_targets, (
+        f"ChildEvent should connect to step_b, got: {child_event_targets}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_exact_type_event_routing_still_works() -> None:
+    """Regression: workflows using exact event types must work unchanged."""
+
+    class ExactTypeWorkflow(Workflow):
+        @step
+        async def step_a(self, ev: StartEvent) -> ParentEvent:
+            return ParentEvent(value="exact match")
+
+        @step
+        async def step_b(self, ev: ParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    workflow = ExactTypeWorkflow(timeout=1)
+    result = await workflow.run()
+    assert result == "exact match"
+
+
+@pytest.mark.asyncio
+async def test_subclass_waiter_accepts_child_event_for_parent_wait() -> None:
+    """A waiter waiting for a ParentEvent should be resolved by a ChildEvent."""
+
+    class WaiterWorkflow(Workflow):
+        @step
+        async def step_a(self, ev: StartEvent, ctx: Context) -> StopEvent:
+            waiter = ctx.wait_for_event(ParentEvent)
+            ctx.send_event(ChildEvent(value="waiter works"))
+            result = await waiter
+            return StopEvent(result=result.value)
+
+    workflow = WaiterWorkflow(timeout=2, disable_validation=True)
+    result = await workflow.run()
+    assert result == "waiter works"

--- a/packages/llama-index-workflows/tests/test_event_subclassing.py
+++ b/packages/llama-index-workflows/tests/test_event_subclassing.py
@@ -15,6 +15,7 @@ from workflows.events import Event, StartEvent, StopEvent
 from workflows.representation.validate import build_step_graph
 from workflows.workflow import Workflow
 
+
 # ── Shared event hierarchy ──────────────────────────────────────────────────
 
 
@@ -26,21 +27,48 @@ class ChildEvent(ParentEvent):
     pass
 
 
+# ── Shared workflows for testing subclass-aware routing ───────────────────────
+
+
+class DefaultExactWorkflow(Workflow):
+    @step
+    async def step_a(self, ev: StartEvent) -> ChildEvent:
+        return ChildEvent(value="x")
+
+    @step
+    async def step_b(self, ev: ParentEvent) -> StopEvent:
+        return StopEvent(result=ev.value)
+
+
+class OptInSubclassWorkflow(Workflow):
+    @step
+    async def step_a(self, ev: StartEvent) -> ChildEvent:
+        return ChildEvent(value="subclass works")
+
+    @step(accept_event_subclasses=True)
+    async def step_b(self, ev: ParentEvent) -> StopEvent:
+        return StopEvent(result=ev.value)
+
+
+class MixedWorkflow(Workflow):
+    @step
+    async def step_a(self, ev: StartEvent) -> ChildEvent:
+        return ChildEvent(value="x")
+
+    @step
+    async def step_b(self, ev: ParentEvent) -> StopEvent:
+        return StopEvent(result=ev.value)
+
+    @step(accept_event_subclasses=True)
+    async def step_c(self, ev: ParentEvent) -> StopEvent:
+        return StopEvent(result=ev.value)
+
+
 # ── Test 1: Default step rejects subclass event (Strict validation & timeout) ─
 
 
 def test_default_step_validation_rejects_subclass_event() -> None:
     """Without accept_event_subclasses=True, validation detects ParentEvent as unproduced."""
-
-    class DefaultExactWorkflow(Workflow):
-        @step
-        async def step_a(self, ev: StartEvent) -> ChildEvent:
-            return ChildEvent(value="x")
-
-        @step
-        async def step_b(self, ev: ParentEvent) -> StopEvent:
-            return StopEvent(result=ev.value)
-
     workflow = DefaultExactWorkflow(timeout=1)
     with pytest.raises(WorkflowValidationError) as excinfo:
         workflow._validate()
@@ -50,16 +78,6 @@ def test_default_step_validation_rejects_subclass_event() -> None:
 @pytest.mark.asyncio
 async def test_default_step_runtime_ignores_subclass_event() -> None:
     """Without accept_event_subclasses=True, runtime routing ignores ChildEvent and times out."""
-
-    class DefaultExactWorkflow(Workflow):
-        @step
-        async def step_a(self, ev: StartEvent) -> ChildEvent:
-            return ChildEvent(value="x")
-
-        @step
-        async def step_b(self, ev: ParentEvent) -> StopEvent:
-            return StopEvent(result=ev.value)
-
     workflow = DefaultExactWorkflow(timeout=1, disable_validation=True)
     with pytest.raises(WorkflowTimeoutError):
         await workflow.run()
@@ -71,16 +89,6 @@ async def test_default_step_runtime_ignores_subclass_event() -> None:
 @pytest.mark.asyncio
 async def test_opt_in_step_accepts_subclass_event() -> None:
     """With accept_event_subclasses=True, workflow successfully routes ChildEvent."""
-
-    class OptInSubclassWorkflow(Workflow):
-        @step
-        async def step_a(self, ev: StartEvent) -> ChildEvent:
-            return ChildEvent(value="subclass works")
-
-        @step(accept_event_subclasses=True)
-        async def step_b(self, ev: ParentEvent) -> StopEvent:
-            return StopEvent(result=ev.value)
-
     workflow = OptInSubclassWorkflow(timeout=2)
     result = await workflow.run()
     assert result == "subclass works"
@@ -91,20 +99,6 @@ async def test_opt_in_step_accepts_subclass_event() -> None:
 
 def test_graph_edges_follow_opt_in_subclass_matching() -> None:
     """build_step_graph only builds subclass edges for steps that opt-in."""
-
-    class MixedWorkflow(Workflow):
-        @step
-        async def step_a(self, ev: StartEvent) -> ChildEvent:
-            return ChildEvent(value="x")
-
-        @step
-        async def step_b(self, ev: ParentEvent) -> StopEvent:
-            return StopEvent(result=ev.value)
-
-        @step(accept_event_subclasses=True)
-        async def step_c(self, ev: ParentEvent) -> StopEvent:
-            return StopEvent(result=ev.value)
-
     workflow = MixedWorkflow(disable_validation=True)
     steps = {name: func._step_config for name, func in workflow._get_steps().items()}
     graph = build_step_graph(steps, StartEvent)
@@ -120,20 +114,6 @@ def test_graph_edges_follow_opt_in_subclass_matching() -> None:
 
 def test_targeted_step_validation_respects_opt_in_subclass_matching() -> None:
     """_validate_valid_step_message rejects subclass event by default, accepts on opt-in."""
-
-    class MixedWorkflow(Workflow):
-        @step
-        async def step_a(self, ev: StartEvent) -> ChildEvent:
-            return ChildEvent(value="x")
-
-        @step
-        async def step_b(self, ev: ParentEvent) -> StopEvent:
-            return StopEvent(result=ev.value)
-
-        @step(accept_event_subclasses=True)
-        async def step_c(self, ev: ParentEvent) -> StopEvent:
-            return StopEvent(result=ev.value)
-
     workflow = MixedWorkflow(disable_validation=True)
 
     # Default step_b rejects ChildEvent

--- a/packages/llama-index-workflows/tests/test_representation_utils.py
+++ b/packages/llama-index-workflows/tests/test_representation_utils.py
@@ -1119,3 +1119,82 @@ def test_resource_config_label_fallback(
     # Label should fall back to type name when not specified
     assert config_node.label == "ConfigData"
     assert config_node.description is None
+
+
+class RepParentEvent(Event):
+    value: str
+
+
+class RepChildEvent(RepParentEvent):
+    pass
+
+
+def test_representation_respects_opt_in_subclass_routing() -> None:
+    """Verify subclass event to consumer step produces an edge when opt-in is enabled."""
+
+    class SubclassMatchingWorkflow(Workflow):
+        @step
+        async def start_step(self, ev: StartEvent) -> RepChildEvent:
+            return RepChildEvent(value="test")
+
+        @step(accept_event_subclasses=True)
+        async def handle_step(self, ev: RepParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    wf = SubclassMatchingWorkflow()
+    graph = get_workflow_representation(workflow=wf)
+    edges = _edges_as_tuples(graph)
+
+    # We expect ChildEvent to map to handle_step because subclass routing is opted in
+    assert ("RepChildEvent", "handle_step", None) in edges
+    assert ("RepParentEvent", "handle_step", None) in edges
+    assert ("StartEvent", "start_step", None) in edges
+    assert ("start_step", "RepChildEvent", None) in edges
+    assert ("handle_step", "StopEvent", None) in edges
+
+
+def test_representation_exact_matching_unchanged() -> None:
+    """Verify subclass event to consumer step does not produce an edge when opt-in is disabled."""
+
+    class ExactMatchingWorkflow(Workflow):
+        @step
+        async def start_step(self, ev: StartEvent) -> RepChildEvent:
+            return RepChildEvent(value="test")
+
+        @step
+        async def handle_step(self, ev: RepParentEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    wf = ExactMatchingWorkflow()
+    graph = get_workflow_representation(workflow=wf)
+    edges = _edges_as_tuples(graph)
+
+    # We expect ChildEvent NOT to map to handle_step because exact matching is default
+    assert ("RepChildEvent", "handle_step", None) not in edges
+    assert ("RepParentEvent", "handle_step", None) in edges
+    assert ("StartEvent", "start_step", None) in edges
+    assert ("start_step", "RepChildEvent", None) in edges
+    assert ("handle_step", "StopEvent", None) in edges
+
+
+def test_representation_handles_generic_annotations() -> None:
+    """Verify graph generation does not crash with generic annotations like dict, list, typing.Any."""
+    from typing import Any, Dict, List
+
+    class GenericAnnotationWorkflow(Workflow):
+        @step
+        async def start_step(self, ev: StartEvent) -> Dict[str, Any]:
+            return {"key": "val"}
+
+        @step
+        async def other_step(self, ev: StartEvent) -> List[str]:
+            return ["val"]
+
+        @step
+        async def process_step(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="done")
+
+    wf = GenericAnnotationWorkflow()
+    # This should not raise TypeError during issubclass check, even before Python 3.10 safety commit
+    graph = get_workflow_representation(workflow=wf)
+    assert graph.name == "GenericAnnotationWorkflow"

--- a/packages/llama-index-workflows/tests/test_representation_utils.py
+++ b/packages/llama-index-workflows/tests/test_representation_utils.py
@@ -1198,3 +1198,25 @@ def test_representation_handles_generic_annotations() -> None:
     # This should not raise TypeError during issubclass check, even before Python 3.10 safety commit
     graph = get_workflow_representation(workflow=wf)
     assert graph.name == "GenericAnnotationWorkflow"
+
+
+def test_representation_subclass_fanout_has_no_duplicate_edges() -> None:
+    """A subclass-opted-in step accepting both a base and its subclass should not
+    emit duplicate event→step edges for the overlapping subclass."""
+
+    class FanoutWorkflow(Workflow):
+        @step
+        async def start_step(self, ev: StartEvent) -> RepChildEvent:
+            return RepChildEvent(value="test")
+
+        @step(accept_event_subclasses=True)
+        async def handle_step(self, ev: RepParentEvent | RepChildEvent) -> StopEvent:
+            return StopEvent(result=ev.value)
+
+    wf = FanoutWorkflow()
+    graph = get_workflow_representation(workflow=wf)
+
+    # Raw edge list (not the de-duplicating set) must contain each edge once.
+    raw_edges = [(e.source, e.target, e.label) for e in graph.edges]
+    assert raw_edges.count(("RepChildEvent", "handle_step", None)) == 1
+    assert raw_edges.count(("RepParentEvent", "handle_step", None)) == 1

--- a/packages/llama-index-workflows/tests/test_representation_utils.py
+++ b/packages/llama-index-workflows/tests/test_representation_utils.py
@@ -1220,3 +1220,30 @@ def test_representation_subclass_fanout_has_no_duplicate_edges() -> None:
     raw_edges = [(e.source, e.target, e.label) for e in graph.edges]
     assert raw_edges.count(("RepChildEvent", "handle_step", None)) == 1
     assert raw_edges.count(("RepParentEvent", "handle_step", None)) == 1
+
+
+def test_representation_subclass_fanout_excludes_stop_event() -> None:
+    """A catch-all opted-in step (accepting ``Event``) must not get a
+    StopEvent→step edge: a returned StopEvent terminates the run instead of
+    routing, so the edge would depict a flow that cannot happen."""
+
+    class CatchAllWorkflow(Workflow):
+        @step
+        async def start_step(self, ev: StartEvent) -> RepChildEvent:
+            return RepChildEvent(value="test")
+
+        @step(accept_event_subclasses=True)
+        async def observe(self, ev: Event) -> StopEvent | None:
+            if isinstance(ev, RepChildEvent):
+                return StopEvent(result=ev.value)
+            return None
+
+    graph = get_workflow_representation(workflow=CatchAllWorkflow())
+    edges = _edges_as_tuples(graph)
+
+    # Real routing edges are present, including the StartEvent the observer
+    # genuinely receives.
+    assert ("RepChildEvent", "observe", None) in edges
+    assert ("StartEvent", "observe", None) in edges
+    # No fictional StopEvent→step edge.
+    assert ("StopEvent", "observe", None) not in edges


### PR DESCRIPTION
## Problem

Workflow event validation and routing used exact event type checks in several paths.

This caused workflows to reject or ignore subclass events. For example, if one step returns `ChildEvent` and the next step accepts `ParentEvent`, the workflow should treat `ChildEvent` as valid because it subclasses `ParentEvent`.

```python
class ParentEvent(Event):
    value: str

class ChildEvent(ParentEvent):
    pass
```
## Before this change, the workflow failed during validation with:

WorkflowValidationError: The following events are consumed but never produced: ParentEvent

This happened even though ChildEvent was produced and ChildEvent is a subclass of ParentEvent.

## Solution

Use subclass-aware event matching across workflow validation and runtime routing.

## Changes include:

Use issubclass(produced_type, consumed_type) for graph connectivity validation.
Use isinstance(event, accepted_type) for runtime step routing.
Use isinstance(event, waiting_for_event) for waiter resolution.
Use isinstance(message, accepted_type) for targeted step dispatch validation.
Keep exact-type routing behavior working, since issubclass(X, X) and isinstance(x, X) still support exact matches.
Tests

## Added regression coverage for:

subclass event routing to a step accepting the parent event
runtime routing with validation disabled
targeted step validation
graph edge construction
waiter resolution with subclass events
exact-type event routing continuing to work

## Before / After

## Before the fix, the subclass tests failed across validation, runtime routing, targeted step validation, graph edge construction, and waiter resolution.

## After the fix:

uv run dev -p workflows -- -k subclass
8 passed

Full workflow test suite:

uv run dev -p workflows
610 passed, 94 warnings

Code quality:

uv run ruff check packages/llama-index-workflows
All checks passed!

uv run ruff format --check packages/llama-index-workflows
88 files already formatted

## Validation
uv run dev -p workflows -- -k subclass  (8 passed)
uv run dev -p workflows (610 passed, 94 warnings)
uv run ruff check packages/llama-index-workflows (passed)
uv run ruff format --check packages/llama-index-workflows (passed)