### PR TITLE
Fix Coveralls package coverage paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,7 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           file: ${{ matrix.package_dir }}/coverage.xml
+          base-path: ${{ matrix.package_dir }}/src
           flag-name: ${{ matrix.package }}
           parallel: true
         env:


### PR DESCRIPTION
Package coverage reports are generated from each package's `src` directory, so the XML contains paths like `workflows/runtime/control_loop.py` while the repo path is `packages/llama-index-workflows/src/workflows/runtime/control_loop.py`.

This passes the package `src` directory as the Coveralls base path for the per-package upload, so changed-line coverage resolves against the files GitHub is actually diffing.