### PR TITLE
Probe Coveralls coverage path mapping

### DIFF
--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -543,6 +543,7 @@ async def control_loop(
     """
     The main async control loop for a workflow run.
     """
+    logger.debug("starting workflow control loop for run %s", run_id)
     # Consume the RunContext immediately so the container's strong reference
     # to the workflow graph is dropped before any step gets a chance to schedule
     # an asyncio handle whose Context snapshot would otherwise pin it.


### PR DESCRIPTION
Disposable probe for Coveralls path mapping. This adds one covered line under the workflows package so the Coveralls comment can show whether changed Python lines resolve after the package base-path change.