### PR TITLE
Centralize workflow state decoding, seeding, and locking

### DIFF
--- a/.changeset/dbos-explicit-migrations.md
+++ b/.changeset/dbos-explicit-migrations.md
@@ -1,5 +1,5 @@
 ---
-"llama-agents-dbos": patch
+"llama-agents-dbos": minor
 ---
 
 DBOS postgres workflow store no longer auto-migrates on start; deployments with `run_migrations_on_launch=False` must run migrations explicitly.

--- a/.changeset/dbos-explicit-migrations.md
+++ b/.changeset/dbos-explicit-migrations.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-dbos": patch
+---
+
+DBOS postgres workflow store no longer auto-migrates on start; deployments with `run_migrations_on_launch=False` must run migrations explicitly.

--- a/.changeset/read-committed-state-reads.md
+++ b/.changeset/read-committed-state-reads.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": minor
+---
+
+State reads are lockless and read-committed on all backends; edit_state edits an isolated copy committed on block exit.

--- a/.changeset/state-codec-durable-resume.md
+++ b/.changeset/state-codec-durable-resume.md
@@ -5,4 +5,4 @@
 "llama-agents-appserver": patch
 ---
 
-Clarify state-store serialization and decode persisted state from stored metadata.
+Clarify state-store serialization, typed state metadata, and integration handoff APIs.

--- a/.changeset/state-codec-durable-resume.md
+++ b/.changeset/state-codec-durable-resume.md
@@ -1,0 +1,7 @@
+---
+"llama-index-workflows": patch
+"llama-agents-server": patch
+"llama-agents-dbos": patch
+---
+
+Decode persisted workflow state from stored metadata instead of constructor type.

--- a/.changeset/state-codec-durable-resume.md
+++ b/.changeset/state-codec-durable-resume.md
@@ -1,6 +1,6 @@
 ---
 "llama-index-workflows": minor
-"llama-agents-server": patch
+"llama-agents-server": minor
 "llama-agents-dbos": patch
 "llama-agents-appserver": patch
 ---

--- a/.changeset/state-codec-durable-resume.md
+++ b/.changeset/state-codec-durable-resume.md
@@ -1,7 +1,8 @@
 ---
-"llama-index-workflows": patch
+"llama-index-workflows": minor
 "llama-agents-server": patch
 "llama-agents-dbos": patch
+"llama-agents-appserver": patch
 ---
 
 Decode persisted workflow state from stored metadata instead of constructor type.

--- a/.changeset/state-codec-durable-resume.md
+++ b/.changeset/state-codec-durable-resume.md
@@ -5,4 +5,4 @@
 "llama-agents-appserver": patch
 ---
 
-Decode persisted workflow state from stored metadata instead of constructor type.
+Clarify state-store serialization and decode persisted state from stored metadata.

--- a/.changeset/state-codec-durable-resume.md
+++ b/.changeset/state-codec-durable-resume.md
@@ -5,4 +5,4 @@
 "llama-agents-appserver": patch
 ---
 
-Clarify state-store serialization, typed state metadata, and integration handoff APIs.
+Decode workflow state by payload shape instead of persisted type metadata, and make state-store runtime handoff explicit.

--- a/packages/llama-agents-appserver/pyproject.toml
+++ b/packages/llama-agents-appserver/pyproject.toml
@@ -26,8 +26,8 @@ authors = [
 ]
 requires-python = ">=3.10, <4"
 dependencies = [
-  "llama-index-workflows>=2.16.0,<3.0.0",
-  "llama-agents-server>=0.2.2",
+  "llama-index-workflows>=2.21.0,<3.0.0",
+  "llama-agents-server>=0.5.1",
   "pydantic-settings>=2.10.1",
   "fastapi>=0.100.0",
   "websockets>=12.0",

--- a/packages/llama-agents-appserver/tests/test_workflow_loader_install.py
+++ b/packages/llama-agents-appserver/tests/test_workflow_loader_install.py
@@ -557,7 +557,7 @@ def test_get_appserver_workflows_requirement() -> None:
     _get_appserver_workflows_requirement.cache_clear()
     req = _get_appserver_workflows_requirement()
     assert req is not None
-    assert Version("2.16.0") in req
+    assert Version("2.21.0") in req
     assert Version("2.14.0") not in req
     assert Version("3.0.0") not in req
 

--- a/packages/llama-agents-dbos/pyproject.toml
+++ b/packages/llama-agents-dbos/pyproject.toml
@@ -24,8 +24,8 @@ license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
   "dbos>=2.18.0",
-  "llama-agents-server[asyncpg]>=0.5.0",
-  "llama-index-workflows>=2.19.1,<3.0.0"
+  "llama-agents-server[asyncpg]>=0.5.1",
+  "llama-index-workflows>=2.21.0,<3.0.0"
 ]
 
 [tool.basedpyright]

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -25,6 +25,7 @@ from llama_agents.server._store.abstract_workflow_store import (
 from typing_extensions import override
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import infer_state_type
+from workflows.context.state_store_integration import StateStoreHandleProvider
 from workflows.events import Event, WorkflowIdleEvent
 from workflows.runtime.control_loop import (
     rebuild_state_from_ticks,
@@ -324,7 +325,8 @@ class DBOSIdleReleaseDecorator(BaseRuntimeDecorator):
                 old_state_store = self._store.create_state_store(
                     run_id, state_type=state_type
                 )
-                serialized_state = old_state_store.handle()
+                if isinstance(old_state_store, StateStoreHandleProvider):
+                    serialized_state = old_state_store.handle()
             except Exception:
                 logger.warning(
                     f"Failed to carry over state from run {run_id}", exc_info=True

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -25,7 +25,7 @@ from llama_agents.server._store.abstract_workflow_store import (
 from typing_extensions import override
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import infer_state_type
-from workflows.context.state_store_integration import StateStoreHandleProvider
+from workflows.context.state_store_integration import state_store_handoff
 from workflows.events import Event, WorkflowIdleEvent
 from workflows.runtime.control_loop import (
     rebuild_state_from_ticks,
@@ -325,8 +325,9 @@ class DBOSIdleReleaseDecorator(BaseRuntimeDecorator):
                 old_state_store = self._store.create_state_store(
                     run_id, state_type=state_type
                 )
-                if isinstance(old_state_store, StateStoreHandleProvider):
-                    serialized_state = old_state_store.handle()
+                serialized_state = await state_store_handoff(
+                    old_state_store, serializer
+                )
             except Exception:
                 logger.warning(
                     f"Failed to carry over state from run {run_id}", exc_info=True

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/idle_release.py
@@ -324,7 +324,7 @@ class DBOSIdleReleaseDecorator(BaseRuntimeDecorator):
                 old_state_store = self._store.create_state_store(
                     run_id, state_type=state_type
                 )
-                serialized_state = old_state_store.to_dict(serializer)
+                serialized_state = old_state_store.handle()
             except Exception:
                 logger.warning(
                     f"Failed to carry over state from run {run_id}", exc_info=True

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -58,6 +58,7 @@ from typing_extensions import Unpack
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     StateStore,
+    StateStoreFacade,
     infer_state_type,
 )
 from workflows.events import Event, StartEvent, StopEvent
@@ -121,6 +122,7 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
     """
 
     def __init__(self, factory: Callable[[], AbstractWorkflowStore]) -> None:
+        super().__init__()
         self._factory = factory
         self._inner: AbstractWorkflowStore | None = None
 
@@ -130,10 +132,7 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
         return self._inner
 
     async def start(self) -> None:
-        inner = self._resolve()
-        start = getattr(inner, "start", None)
-        if start is not None:
-            await start()
+        await self._resolve().start()
 
     @property
     def poll_interval(self) -> float:  # type: ignore[override]
@@ -146,9 +145,19 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
         serialized_state: dict[str, Any] | None = None,
         serializer: BaseSerializer | None = None,
     ) -> StateStore[Any]:
+        # Delegate the whole template method so memoization lives in the
+        # inner store's single cache (the proxy's own cache stays unused).
         return self._resolve().create_state_store(
             run_id, state_type, serialized_state, serializer
         )
+
+    def _build_state_store(
+        self,
+        run_id: str,
+        state_type: type[Any] | None,
+        serializer: BaseSerializer | None,
+    ) -> StateStoreFacade[Any]:
+        return self._resolve()._build_state_store(run_id, state_type, serializer)
 
     async def query(self, query: HandlerQuery) -> list[PersistentHandler]:
         return await self._resolve().query(query)
@@ -586,15 +595,17 @@ class DBOSRuntime(Runtime):
                 # Write initial state to DB before starting workflow (non-blocking to caller)
                 if serialized_state:
                     workflow_store = self.create_workflow_store()
-                    if isinstance(workflow_store, DBOSWorkflowStore):
-                        await workflow_store.start()
+                    await workflow_store.start()
                     store = workflow_store.create_state_store(
                         run_id,
                         infer_state_type(workflow),
                         serialized_state,
                         active_serializer,
                     )
-                    await store.get_state()
+                    # Materialize the seed before the workflow starts so the
+                    # first step observes the restored state.
+                    if isinstance(store, StateStoreFacade):
+                        await store.ensure_seeded()
 
                 try:
                     return await DBOS.start_workflow_async(

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -687,10 +687,13 @@ class DBOSRuntime(Runtime):
                 )
                 # Share the runtime's asyncpg pool — PostgresWorkflowStore
                 # borrows it via the factory and never owns its lifecycle.
+                # auto_migrate=False: DBOS run_migrations() already covers the
+                # server-store tables, and it honors run_migrations_on_launch.
                 return PostgresWorkflowStore(
                     dsn=dsn,
                     schema=schema,
                     pool=PoolProvider.borrowed(self._ensure_pool),
+                    auto_migrate=False,
                 )
 
             db_path = str(engine.url.database) if engine.url.database else ":memory:"

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -603,7 +603,6 @@ class DBOSRuntime(Runtime):
                     state = deserialize_state_from_dict(
                         serialized_state,
                         active_serializer,
-                        state_type=infer_state_type(workflow),
                     )
                     await store.set_state(state)
 

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -129,6 +129,12 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
             self._inner = self._factory()
         return self._inner
 
+    async def start(self) -> None:
+        inner = self._resolve()
+        start = getattr(inner, "start", None)
+        if start is not None:
+            await start()
+
     @property
     def poll_interval(self) -> float:  # type: ignore[override]
         return self._resolve().poll_interval
@@ -579,7 +585,10 @@ class DBOSRuntime(Runtime):
             with SetWorkflowID(run_id):
                 # Write initial state to DB before starting workflow (non-blocking to caller)
                 if serialized_state:
-                    store = self.create_workflow_store().create_state_store(
+                    workflow_store = self.create_workflow_store()
+                    if isinstance(workflow_store, DBOSWorkflowStore):
+                        await workflow_store.start()
+                    store = workflow_store.create_state_store(
                         run_id,
                         infer_state_type(workflow),
                         serialized_state,

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -58,7 +58,6 @@ from typing_extensions import Unpack
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     StateStore,
-    deserialize_state_from_dict,
     infer_state_type,
 )
 from workflows.events import Event, StartEvent, StopEvent
@@ -557,9 +556,8 @@ class DBOSRuntime(Runtime):
             workflow: The workflow to run.
             init_state: Initial broker state for the control loop.
             start_event: Optional start event to kick off the workflow.
-            serialized_state: Optional pre-populated state from InMemoryStateStore.to_dict().
-                If provided, this state is written to the database before the workflow
-                starts, allowing workflows to begin with pre-set initial values.
+            serialized_state: Optional state snapshot or durable state handle.
+                If provided, this state is seeded before the workflow starts.
             serializer: Serializer for state data. Defaults to JsonSerializer.
             adapter_state: Optional adapter state (unused for DBOS).
         """
@@ -581,30 +579,13 @@ class DBOSRuntime(Runtime):
             with SetWorkflowID(run_id):
                 # Write initial state to DB before starting workflow (non-blocking to caller)
                 if serialized_state:
-                    if self._dsn is not None:
-                        pool = await self._ensure_pool()
-                        store: StateStore[Any] = PostgresStateStore(
-                            pool=pool,
-                            run_id=run_id,
-                            state_type=infer_state_type(workflow),
-                            serializer=active_serializer,
-                            schema=self._schema,
-                        )
-                    elif self._db_path is not None:
-                        store = SqliteStateStore(
-                            db_path=self._db_path,
-                            run_id=run_id,
-                            state_type=infer_state_type(workflow),
-                            serializer=active_serializer,
-                        )
-                    else:
-                        raise RuntimeError("No pool or db_path configured.")
-                    # Deserialize and save the initial state
-                    state = deserialize_state_from_dict(
+                    store = self.create_workflow_store().create_state_store(
+                        run_id,
+                        infer_state_type(workflow),
                         serialized_state,
                         active_serializer,
                     )
-                    await store.set_state(state)
+                    await store.get_state()
 
                 try:
                     return await DBOS.start_workflow_async(

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -12,7 +12,7 @@ import asyncio
 from contextlib import suppress
 from types import SimpleNamespace
 from typing import Any, Generator, cast
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import asyncpg
 import pytest
@@ -26,9 +26,13 @@ from llama_agents.server._store.postgres_state_store import PostgresStateStore
 from pydantic import Field
 from sqlalchemy.engine import Engine
 from workflows.context import Context
+from workflows.context.serializers import JsonSerializer
+from workflows.context.state_store import DictState, StateStore
 from workflows.decorators import step
 from workflows.events import Event, StartEvent, StopEvent
+from workflows.runtime.types.internal_state import BrokerState
 from workflows.runtime.types.named_task import WorkerTask
+from workflows.runtime.types.plugin import RegisteredWorkflow
 from workflows.testing import WorkflowTestRunner
 from workflows.workflow import Workflow
 
@@ -286,6 +290,80 @@ async def test_run_workflow_does_not_create_store(dbos_runtime: DBOSRuntime) -> 
         await handler
 
     assert len(call_log) == 1, "run_workflow should be called exactly once"
+
+
+@pytest.mark.asyncio
+async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
+    class RecordingStateStore:
+        state_type = DictState
+
+        def __init__(self) -> None:
+            self.get_state_called = False
+
+        async def get_state(self) -> DictState:
+            self.get_state_called = True
+            return DictState()
+
+    class RecordingWorkflowStore:
+        def __init__(self) -> None:
+            self.state_store = RecordingStateStore()
+            self.create_state_store_calls: list[tuple[Any, ...]] = []
+
+        def create_state_store(
+            self,
+            run_id: str,
+            state_type: type[Any] | None = None,
+            serialized_state: dict[str, Any] | None = None,
+            serializer: Any = None,
+        ) -> StateStore[Any]:
+            self.create_state_store_calls.append(
+                (run_id, state_type, serialized_state, serializer)
+            )
+            return self.state_store  # type: ignore[return-value]
+
+    class SimpleWf(Workflow):
+        @step
+        async def do_it(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="done")
+
+    async def workflow_run_fn(*_: Any) -> None:
+        return None
+
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    runtime._dbos_launched = True
+    workflow = SimpleWf()
+    workflow_store = RecordingWorkflowStore()
+    serialized_state = {"store_type": "sqlite", "run_id": "old-run"}
+    serializer = JsonSerializer()
+    fake_handle = AsyncMock()
+
+    with (
+        patch.object(runtime, "create_workflow_store", return_value=workflow_store),
+        patch.object(
+            runtime,
+            "get_registered",
+            return_value=RegisteredWorkflow(
+                workflow=workflow, workflow_run_fn=workflow_run_fn, steps={}
+            ),
+        ),
+        patch(
+            "llama_agents.dbos.runtime.DBOS.start_workflow_async",
+            new=AsyncMock(return_value=fake_handle),
+        ),
+    ):
+        adapter = runtime.run_workflow(
+            "run-1",
+            workflow,
+            BrokerState.from_workflow(workflow),
+            serialized_state=serialized_state,
+            serializer=serializer,
+        )
+        await adapter._ensure_workflow_started()  # type: ignore[attr-defined]
+
+    assert workflow_store.state_store.get_state_called
+    assert workflow_store.create_state_store_calls == [
+        ("run-1", DictState, serialized_state, serializer)
+    ]
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -27,7 +27,7 @@ from pydantic import Field
 from sqlalchemy.engine import Engine
 from workflows.context import Context
 from workflows.context.serializers import JsonSerializer
-from workflows.context.state_store import DictState, StateStore
+from workflows.context.state_store import DictState, InMemoryStateStore, StateStore
 from workflows.decorators import step
 from workflows.events import Event, StartEvent, StopEvent
 from workflows.runtime.types.internal_state import BrokerState
@@ -294,15 +294,14 @@ async def test_run_workflow_does_not_create_store(dbos_runtime: DBOSRuntime) -> 
 
 @pytest.mark.asyncio
 async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
-    class RecordingStateStore:
-        state_type = DictState
-
+    class RecordingStateStore(InMemoryStateStore[DictState]):
         def __init__(self) -> None:
+            super().__init__(DictState())
             self.get_state_called = False
 
         async def get_state(self) -> DictState:
             self.get_state_called = True
-            return DictState()
+            return await super().get_state()
 
     class RecordingWorkflowStore:
         def __init__(self) -> None:
@@ -319,15 +318,19 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
             self.create_state_store_calls.append(
                 (run_id, state_type, serialized_state, serializer)
             )
-            return self.state_store  # type: ignore[return-value]
+            return self.state_store
 
     class SimpleWf(Workflow):
         @step
         async def do_it(self, ev: StartEvent) -> StopEvent:
             return StopEvent(result="done")
 
-    async def workflow_run_fn(*_: Any) -> None:
-        return None
+    async def workflow_run_fn(
+        init_state: BrokerState,
+        start_event: StartEvent | None = None,
+        tags: dict[str, Any] | None = None,
+    ) -> StopEvent:
+        return StopEvent(result="done")
 
     runtime = DBOSRuntime(polling_interval_sec=0.01)
     runtime._dbos_launched = True
@@ -358,7 +361,7 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
             serialized_state=serialized_state,
             serializer=serializer,
         )
-        await adapter._ensure_workflow_started()  # type: ignore[attr-defined]
+        await cast(Any, adapter)._ensure_workflow_started()
 
     assert workflow_store.state_store.get_state_called
     assert workflow_store.create_state_store_calls == [

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -68,7 +68,7 @@ def test_postgres_adapter_uses_resolved_pool_for_sync_state_store() -> None:
     assert state_store.run_id == "run-1"
     # The async factory raising above proves the resolved pool was used
     # synchronously; confirm it reached the storage layer.
-    assert state_store._postgres_storage._pool is pool
+    assert cast(Any, state_store)._storage._pool is pool
 
 
 @pytest.fixture(scope="module")

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -65,7 +65,10 @@ def test_postgres_adapter_uses_resolved_pool_for_sync_state_store() -> None:
     state_store = adapter.get_state_store()
 
     assert isinstance(state_store, PostgresStateStore)
-    assert state_store._pool is pool
+    assert state_store.run_id == "run-1"
+    # The async factory raising above proves the resolved pool was used
+    # synchronously; confirm it reached the storage layer.
+    assert state_store._postgres_storage._pool is pool
 
 
 @pytest.fixture(scope="module")
@@ -297,16 +300,20 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
     class RecordingStateStore(InMemoryStateStore[DictState]):
         def __init__(self) -> None:
             super().__init__(DictState())
-            self.get_state_called = False
+            self.ensure_seeded_called = False
 
-        async def get_state(self) -> DictState:
-            self.get_state_called = True
-            return await super().get_state()
+        async def ensure_seeded(self) -> None:
+            self.ensure_seeded_called = True
+            await super().ensure_seeded()
 
     class RecordingWorkflowStore:
         def __init__(self) -> None:
             self.state_store = RecordingStateStore()
+            self.start_called = False
             self.create_state_store_calls: list[tuple[Any, ...]] = []
+
+        async def start(self) -> None:
+            self.start_called = True
 
         def create_state_store(
             self,
@@ -363,7 +370,8 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
         )
         await cast(Any, adapter)._ensure_workflow_started()
 
-    assert workflow_store.state_store.get_state_called
+    assert workflow_store.start_called
+    assert workflow_store.state_store.ensure_seeded_called
     assert workflow_store.create_state_store_calls == [
         ("run-1", DictState, serialized_state, serializer)
     ]

--- a/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
+++ b/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
@@ -191,6 +191,7 @@ def _patch_client(
 def create_agent_data_store(
     backend: FakeAgentDataBackend,
     monkeypatch: pytest.MonkeyPatch,
+    collection: str = "handlers",
 ) -> AgentDataStore:
     """Create an AgentDataStore with httpx patched to use the fake backend."""
     store = AgentDataStore(
@@ -198,7 +199,7 @@ def create_agent_data_store(
         api_key="test-key",
         project_id="test-project",
         deployment_name="test-deploy",
-        collection="handlers",
+        collection=collection,
     )
     _patch_client(store._client, backend, monkeypatch)
     return store

--- a/packages/llama-agents-server/pyproject.toml
+++ b/packages/llama-agents-server/pyproject.toml
@@ -24,7 +24,7 @@ description = "HTTP server for deploying and serving LlamaIndex workflows as web
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "llama-index-workflows>=2.20.0,<3.0.0",
+  "llama-index-workflows>=2.21.0,<3.0.0",
   "llama-agents-client>=0.2.0",
   "starlette>=0.39.0",
   "uvicorn>=0.32.0",

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -21,6 +21,7 @@ from typing_extensions import override
 from workflows import Context
 from workflows.context.context_types import SerializedContext
 from workflows.context.serializers import BaseSerializer, JsonSerializer
+from workflows.context.state_store_integration import decode_seed_state
 from workflows.errors import WorkflowCancelledByUser
 from workflows.events import IdleReleasedEvent, StartEvent, StopEvent
 from workflows.runtime.control_loop import replay_ticks_stream
@@ -209,7 +210,7 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
             return None
 
         if legacy_ctx:
-            self._seed_legacy_state(run_id, legacy_ctx)
+            await self._seed_legacy_state(run_id, legacy_ctx)
             parsed = SerializedContext.from_dict_auto(legacy_ctx)
             init_state = BrokerState.from_serialized(parsed, workflow, serializer)
         else:
@@ -247,7 +248,12 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
             )
             return None
 
-    def _seed_legacy_state(self, run_id: str, legacy_ctx: dict[str, Any]) -> None:
+    async def _seed_legacy_state(self, run_id: str, legacy_ctx: dict[str, Any]) -> None:
+        """Eagerly migrate a legacy ctx state snapshot into the state table.
+
+        No-op when the state table already has a row for the run (a previous
+        partial run's state must win over the legacy snapshot).
+        """
         try:
             parsed = SerializedContext.from_dict_auto(legacy_ctx)
         except Exception:
@@ -274,7 +280,8 @@ class TickPersistenceDecorator(BaseRuntimeDecorator):
         finally:
             conn.close()
 
-        state_store._write_in_memory_state(state_data)
+        state = decode_seed_state(state_data, JsonSerializer())
+        await state_store.set_state(state)
 
 
 class PersistenceDecorator(TickPersistenceDecorator):

--- a/packages/llama-agents-server/src/llama_agents/server/_service.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_service.py
@@ -23,7 +23,7 @@ from llama_agents.server._runtime.server_runtime import ServerRuntimeDecorator
 from llama_index_instrumentation.dispatcher import instrument_tags
 from workflows import Context
 from workflows.context.serializers import JsonSerializer
-from workflows.context.state_store_integration import StateStoreHandleProvider
+from workflows.context.state_store_integration import state_store_handoff
 from workflows.events import Event, StartEvent
 from workflows.handler import WorkflowHandler
 from workflows.utils import _nanoid as nanoid
@@ -277,9 +277,7 @@ class _WorkflowService:
 
         try:
             old_state_store = self._store.create_state_store(handler.run_id)
-            if not isinstance(old_state_store, StateStoreHandleProvider):
-                return None
-            state_dict = old_state_store.handle()
+            state_dict = await state_store_handoff(old_state_store, JsonSerializer())
             if not state_dict:
                 return None
             return Context.from_dict(

--- a/packages/llama-agents-server/src/llama_agents/server/_service.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_service.py
@@ -275,15 +275,14 @@ class _WorkflowService:
             return None
 
         try:
-            serializer = JsonSerializer()
             old_state_store = self._store.create_state_store(handler.run_id)
-            state_dict = old_state_store.to_dict(serializer)
+            state_dict = old_state_store.handle()
             if not state_dict:
                 return None
             return Context.from_dict(
                 workflow=workflow,
                 data={"version": 1, "state": state_dict},
-                serializer=serializer,
+                serializer=JsonSerializer(),
             )
         except Exception:
             logger.warning(

--- a/packages/llama-agents-server/src/llama_agents/server/_service.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_service.py
@@ -23,6 +23,7 @@ from llama_agents.server._runtime.server_runtime import ServerRuntimeDecorator
 from llama_index_instrumentation.dispatcher import instrument_tags
 from workflows import Context
 from workflows.context.serializers import JsonSerializer
+from workflows.context.state_store_integration import StateStoreHandleProvider
 from workflows.events import Event, StartEvent
 from workflows.handler import WorkflowHandler
 from workflows.utils import _nanoid as nanoid
@@ -276,6 +277,8 @@ class _WorkflowService:
 
         try:
             old_state_store = self._store.create_state_store(handler.run_id)
+            if not isinstance(old_state_store, StateStoreHandleProvider):
+                return None
             state_dict = old_state_store.handle()
             if not state_dict:
                 return None

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -120,8 +120,9 @@ class AbstractWorkflowStore(ABC):
     ) -> StateStore[Any]:
         """Create a persistent state store for the given run.
 
-        If *serialized_state* and *serializer* are provided, the store is
-        seeded from the serialized data during construction.
+        If *serialized_state* and *serializer* are provided, the returned store
+        restores from the serialized data. Implementations may materialize that
+        seed lazily on first async state access or handoff.
         """
 
     @abstractmethod

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import weakref
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, MutableMapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
@@ -21,7 +22,7 @@ from pydantic import (
 )
 from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
-from workflows.context.state_store import StateStore
+from workflows.context.state_store import DictState, StateStore, StateStoreFacade
 from workflows.events import StopEvent
 from workflows.runtime.types.ticks import WorkflowTick, WorkflowTickAdapter
 
@@ -110,7 +111,18 @@ class StoredEvent(BaseModel):
 class AbstractWorkflowStore(ABC):
     poll_interval: float = 0.1
 
-    @abstractmethod
+    def __init__(self) -> None:
+        # Per-run facade cache: the single memoization site for state stores.
+        # Weak-valued by default so facades die with their last consumer.
+        # Backends needing a different lifecycle (strong refs + explicit
+        # eviction) assign a plain dict in their __init__.
+        self._state_store_cache: MutableMapping[str, StateStoreFacade[Any]] = (
+            weakref.WeakValueDictionary()
+        )
+
+    async def start(self) -> None:
+        """Initialize backend resources. Default is a no-op."""
+
     def create_state_store(
         self,
         run_id: str,
@@ -118,12 +130,33 @@ class AbstractWorkflowStore(ABC):
         serialized_state: dict[str, Any] | None = None,
         serializer: BaseSerializer | None = None,
     ) -> StateStore[Any]:
-        """Create a persistent state store for the given run.
+        """Return the per-run state store, creating and caching it on first use.
 
-        If *serialized_state* and *serializer* are provided, the returned store
-        restores from the serialized data. Implementations may materialize that
-        seed lazily on first async state access or handoff.
+        One facade per run per process, so its write lock is a real guarantee.
+        If *serialized_state* is provided, it is staged as a seed on the
+        (possibly already handed-out) facade: validation is eager, the I/O to
+        materialize it stays lazy (first async state access or handoff).
         """
+        store = self._state_store_cache.get(run_id)
+        if store is None:
+            store = self._build_state_store(run_id, state_type, serializer)
+            self._state_store_cache[run_id] = store
+        elif state_type is not None and store.state_type is DictState:
+            # An earlier type-less caller (e.g. handler continuation) must
+            # not shadow the workflow's concrete state type.
+            store.state_type = state_type
+        if serialized_state is not None:
+            store.add_seed(serialized_state, serializer or JsonSerializer())
+        return store
+
+    @abstractmethod
+    def _build_state_store(
+        self,
+        run_id: str,
+        state_type: type[Any] | None,
+        serializer: BaseSerializer | None,
+    ) -> StateStoreFacade[Any]:
+        """Construct the backend facade for a run. No caching, no seeding."""
 
     @abstractmethod
     async def query(self, query: HandlerQuery) -> list[PersistentHandler]: ...

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -4,16 +4,16 @@
 
 from __future__ import annotations
 
-import uuid
 from typing import Any, Generic, Literal
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
-from workflows.context.serializers import BaseSerializer, JsonSerializer
+from workflows.context.serializers import BaseSerializer
 from workflows.context.state_store import DictState
 from workflows.context.state_store_integration import (
     StateRecord,
     StateStoreFacade,
+    restored_run_id,
 )
 
 from .agent_data_client import AgentDataClient
@@ -152,20 +152,11 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         collection: str = "workflow_state",
         serializer: BaseSerializer | None = None,
     ) -> None:
-        self._agent_data_storage = _AgentDataStateStorage(
-            client=client,
-            run_id=run_id,
-            collection=collection,
-        )
         super().__init__(
-            self._agent_data_storage,
-            state_type or DictState,  # type: ignore[arg-type]
-            serializer or JsonSerializer(),
+            _AgentDataStateStorage(client=client, run_id=run_id, collection=collection),
+            state_type,
+            serializer,
         )
-
-    @property
-    def run_id(self) -> str:
-        return self._agent_data_storage.run_id
 
     @classmethod
     def from_dict(
@@ -186,13 +177,12 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         if not serialized_state:
             raise ValueError("Cannot restore AgentDataStateStore from empty dict")
 
-        effective_run_id = run_id or serialized_state.get("run_id") or str(uuid.uuid4())
         effective_collection = (
             collection or serialized_state.get("collection") or "workflow_state"
         )
         store: AgentDataStateStore[Any] = cls(
             client=client,
-            run_id=effective_run_id,
+            run_id=restored_run_id(run_id, serialized_state),
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             collection=effective_collection,
             serializer=serializer,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -4,12 +4,14 @@
 
 from __future__ import annotations
 
-from typing import Any, Generic, Literal
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, Generic, Literal, cast
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 from workflows.context.serializers import BaseSerializer
-from workflows.context.state_store import DictState
+from workflows.context.state_store import DictState, _StateStorage
 from workflows.context.state_store_integration import (
     StateRecord,
     StateStoreFacade,
@@ -44,8 +46,8 @@ class _AgentDataStateStorage:
     """Raw state storage backed by the LlamaCloud Agent Data API.
 
     Uses a single item in a ``workflow_state`` collection, keyed by ``run_id``.
-    Caches the item id and last-seen record to avoid a search round-trip per
-    operation.
+    Caches the item id (the run→item-id mapping is immutable) to avoid a
+    search round-trip per operation.
     """
 
     def __init__(
@@ -59,11 +61,15 @@ class _AgentDataStateStorage:
         self._run_id = run_id
         self._collection = collection
         self._item_id: str | None = None
-        self._cached_record: StateRecord | None = None
 
     @property
     def run_id(self) -> str:
         return self._run_id
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[_AgentDataStateStorage]:
+        # HTTP-backed: no per-call connections, the storage scopes itself.
+        yield self
 
     async def _load_record(self) -> _AgentDataStateRecord | None:
         items = await self._client.search(
@@ -77,13 +83,10 @@ class _AgentDataStateStorage:
         return _AgentDataStateRecord.model_validate(items[0]["data"])
 
     async def load(self) -> StateRecord | None:
-        if self._cached_record is not None:
-            return self._cached_record.model_copy(deep=True)
         record = await self._load_record()
         if record is None:
             return None
-        self._cached_record = StateRecord(data=record.data)
-        return self._cached_record.model_copy(deep=True)
+        return StateRecord(data=record.data)
 
     async def save(self, record: StateRecord) -> None:
         stored = _AgentDataStateRecord(
@@ -108,7 +111,6 @@ class _AgentDataStateStorage:
             else:
                 result = await self._client.create(self._collection, payload)
                 self._item_id = result["id"]
-        self._cached_record = StateRecord(data=stored.data)
 
     def to_handle(self) -> dict[str, Any]:
         payload = AgentDataSerializedState(
@@ -126,8 +128,8 @@ class _AgentDataStateStorage:
     async def copy_from_handle(self, handle: AgentDataSerializedState) -> None:
         """Copy the source target's record into this one (no-op if absent).
 
-        Goes through ``save`` so ``_cached_record``/``_item_id`` stay
-        consistent with the copied row.
+        Goes through ``save`` so ``_item_id`` stays consistent with the
+        copied row.
         """
         source = _AgentDataStateStorage(
             client=self._client,
@@ -141,7 +143,13 @@ class _AgentDataStateStorage:
 
 
 class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
-    """StateStore facade backed by Agent Data storage."""
+    """StateStore facade backed by Agent Data storage.
+
+    Caches the decoded state model: the backend is a database over HTTP and
+    reads are single-process, so reads after the first skip the round-trip
+    and the re-decode. The cached instance is private — loads and saves
+    exchange deep copies, never the cached object itself.
+    """
 
     def __init__(
         self,
@@ -157,6 +165,35 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
             state_type,
             serializer,
         )
+        self._cached_state: MODEL_T | None = None
+
+    async def ensure_seeded(self) -> None:
+        if self._pending_seed is None:
+            return
+        await super().ensure_seeded()
+        # Seed materialization can bypass _write_state (copy_from_handle),
+        # so any materialized seed drops the cache.
+        self._cached_state = None
+
+    async def _load_state_or_none(
+        self, storage: _StateStorage | None = None
+    ) -> MODEL_T | None:
+        # The cache check must come after seeding: a late re-staged seed
+        # invalidates the cache in ensure_seeded.
+        await self.ensure_seeded()
+        if self._cached_state is not None:
+            return self._cached_state.model_copy(deep=True)
+        state = await super()._load_state_or_none(storage)
+        if state is not None:
+            self._cached_state = state.model_copy(deep=True)
+        return state
+
+    async def _write_state(
+        self, state: BaseModel, storage: _StateStorage | None = None
+    ) -> None:
+        await super()._write_state(state, storage)
+        # The caller still holds a reference to `state`; cache a private copy.
+        self._cached_state = cast(MODEL_T, state.model_copy(deep=True))
 
     @classmethod
     def from_dict(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
 from typing import Any, Generic, Literal
@@ -140,7 +141,9 @@ class _AgentDataStateStorage:
         await self._save_without_seed(record)
 
     async def _save_without_seed(self, record: StateRecord) -> None:
-        data = record.data if isinstance(record.data, str) else str(record.data)
+        # json.dumps raises TypeError for non-JSON data rather than
+        # silently writing a Python repr into the stored record.
+        data = record.data if isinstance(record.data, str) else json.dumps(record.data)
         stored = _AgentDataStateRecord(
             run_id=self._run_id,
             data=data,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import json
 import logging
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator, Generic, Literal
@@ -17,12 +16,11 @@ from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
     create_cleared_state,
+    decode_seed_state,
     decode_state,
-    deserialize_state_from_dict,
-    encode_state,
+    encode_state_to_str,
     get_by_path,
     merge_state,
-    parse_in_memory_state,
     set_by_path,
 )
 
@@ -41,8 +39,8 @@ class _StoredStateRecord(BaseModel):
 
     run_id: str
     data: str
-    state_type: str | None = "DictState"
-    state_module: str | None = "workflows.context.state_store"
+    state_type: str | None = None
+    state_module: str | None = None
 
 
 class AgentDataSerializedState(BaseModel):
@@ -94,14 +92,6 @@ class AgentDataStateStore(Generic[MODEL_T]):
     # State serialization
     # ------------------------------------------------------------------
 
-    def _deserialize_state(
-        self,
-        state_json: str,
-        state_type_name: str | None,
-        state_module: str | None,
-    ) -> MODEL_T:
-        return decode_state(state_json, state_type_name, state_module, self._serializer)  # type: ignore[return-value]
-
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()
 
@@ -144,45 +134,41 @@ class AgentDataStateStore(Generic[MODEL_T]):
             await self._save_state(state)
             return
 
-        parse_in_memory_state(serialized_state)
-        state = deserialize_state_from_dict(serialized_state, serializer)
+        state = decode_seed_state(serialized_state, serializer)
         await self._save_state(state)
+
+    async def _load_existing_state(self) -> MODEL_T | None:
+        if self._cached_state is not None:
+            return self._cached_state.model_copy()
+        record = await self._load_record()
+        if record is None:
+            return None
+        state = decode_state(
+            record.data, record.state_type, record.state_module, self._serializer
+        )  # type: ignore[return-value]
+        self._cached_state = state
+        return state.model_copy()
 
     async def _load_state(self) -> MODEL_T:
         await self._flush_pending_seed()
-        if self._cached_state is not None:
-            return self._cached_state.model_copy()
-        record = await self._load_record()
-        if record is not None:
-            state = self._deserialize_state(
-                record.data, record.state_type, record.state_module
-            )
-            self._cached_state = state
-            return state.model_copy()
-        state = self._create_default_state()
-        await self._save_state(state)
-        return state.model_copy()
+        state = await self._load_existing_state()
+        if state is not None:
+            return state
+        default_state = self._create_default_state()
+        await self._save_state(default_state)
+        return default_state.model_copy()
 
     async def _load_state_or_none(self) -> MODEL_T | None:
         await self._flush_pending_seed()
-        if self._cached_state is not None:
-            return self._cached_state.model_copy()
-        record = await self._load_record()
-        if record is not None:
-            state = self._deserialize_state(
-                record.data, record.state_type, record.state_module
-            )
-            self._cached_state = state
-            return state.model_copy()
-        return None
+        return await self._load_existing_state()
 
     async def _save_state(self, state: BaseModel) -> None:
-        state_data, state_type_name, state_module = encode_state(
+        state_json, state_type_name, state_module = encode_state_to_str(
             state, self._serializer
         )
         record = _StoredStateRecord(
             run_id=self._run_id,
-            data=state_data if isinstance(state_data, str) else json.dumps(state_data),
+            data=state_json,
             state_type=state_type_name,
             state_module=state_module,
         )

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -4,24 +4,18 @@
 
 from __future__ import annotations
 
-import asyncio
-import functools
 import logging
-from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Generic, Literal, cast
+from typing import Any, Generic, Literal
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
-    create_cleared_state,
+    StoredStateRecord,
+    TypedStateStore,
     decode_seed_state,
-    decode_state,
-    encode_state_to_str,
-    get_by_path,
-    merge_state,
-    set_by_path,
+    string_record_from_state,
 )
 
 from .agent_data_client import AgentDataClient
@@ -51,49 +45,28 @@ class AgentDataSerializedState(BaseModel):
     collection: str = "workflow_state"
 
 
-class AgentDataStateStore(Generic[MODEL_T]):
-    """StateStore backed by the LlamaCloud Agent Data API.
+class AgentDataStateStorage:
+    """Raw state storage backed by the LlamaCloud Agent Data API.
 
     Uses a single item in a ``workflow_state`` collection, keyed by ``run_id``.
     """
-
-    state_type: type[MODEL_T]
 
     def __init__(
         self,
         *,
         client: AgentDataClient,
         run_id: str,
-        state_type: type[MODEL_T] | None = None,
         collection: str = "workflow_state",
-        serializer: BaseSerializer | None = None,
     ) -> None:
         self._client = client
         self._run_id = run_id
-        self.state_type = state_type or DictState  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         self._collection = collection
-        self._serializer = serializer or JsonSerializer()
-        # Cache the agent data item ID once found
         self._item_id: str | None = None
-        # Write-through state cache — avoids HTTP searches when state is
-        # already known from a previous load or save.
-        self._cached_state: MODEL_T | None = None
-        self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
+        self._cached_record: StoredStateRecord | None = None
 
     @property
     def run_id(self) -> str:
         return self._run_id
-
-    @functools.cached_property
-    def _lock(self) -> asyncio.Lock:
-        return asyncio.Lock()
-
-    # ------------------------------------------------------------------
-    # State serialization
-    # ------------------------------------------------------------------
-
-    def _create_default_state(self) -> MODEL_T:
-        return self.state_type()
 
     # ------------------------------------------------------------------
     # Load / save through API
@@ -110,72 +83,28 @@ class AgentDataStateStore(Generic[MODEL_T]):
         self._item_id = items[0]["id"]
         return _StoredStateRecord.model_validate(items[0]["data"])
 
-    async def _flush_pending_seed(self) -> None:
-        if self._pending_seed is None:
-            return
-
-        serialized_state, serializer = self._pending_seed
-        self._pending_seed = None
-        self._serializer = serializer
-        store_type = serialized_state.get("store_type")
-
-        if store_type == "agent_data":
-            parsed = AgentDataSerializedState.model_validate(serialized_state)
-            if parsed.collection == self._collection and parsed.run_id == self._run_id:
-                return
-            source = AgentDataStateStore(
-                client=self._client,
-                run_id=parsed.run_id,
-                state_type=self.state_type,
-                collection=parsed.collection,
-                serializer=serializer,
-            )
-            state = await source._load_state()
-            await self._save_state(state)
-            return
-
-        state = decode_seed_state(serialized_state, serializer)
-        await self._save_state(state)
-
-    async def _load_existing_state(self) -> MODEL_T | None:
-        if self._cached_state is not None:
-            return self._cached_state.model_copy()
+    async def load(self) -> StoredStateRecord | None:
+        if self._cached_record is not None:
+            return self._cached_record.model_copy(deep=True)
         record = await self._load_record()
         if record is None:
             return None
-        state = cast(
-            MODEL_T,
-            decode_state(
-                record.data, record.state_type, record.state_module, self._serializer
-            ),
+        self._cached_record = StoredStateRecord(
+            data=record.data,
+            state_type=record.state_type,
+            state_module=record.state_module,
         )
-        self._cached_state = state
-        return state.model_copy()
+        return self._cached_record.model_copy(deep=True)
 
-    async def _load_state(self) -> MODEL_T:
-        await self._flush_pending_seed()
-        state = await self._load_existing_state()
-        if state is not None:
-            return state
-        default_state = self._create_default_state()
-        await self._save_state(default_state)
-        return default_state.model_copy()
-
-    async def _load_state_or_none(self) -> MODEL_T | None:
-        await self._flush_pending_seed()
-        return await self._load_existing_state()
-
-    async def _save_state(self, state: BaseModel) -> None:
-        state_json, state_type_name, state_module = encode_state_to_str(
-            state, self._serializer
-        )
-        record = _StoredStateRecord(
+    async def save(self, record: StoredStateRecord) -> None:
+        data = record.data if isinstance(record.data, str) else str(record.data)
+        stored = _StoredStateRecord(
             run_id=self._run_id,
-            data=state_json,
-            state_type=state_type_name,
-            state_module=state_module,
+            data=data,
+            state_type=record.state_type,
+            state_module=record.state_module,
         )
-        payload = record.model_dump()
+        payload = stored.model_dump()
         if self._item_id is not None:
             await self._client.update_item(self._item_id, payload)
         else:
@@ -191,47 +120,85 @@ class AgentDataStateStore(Generic[MODEL_T]):
             else:
                 result = await self._client.create(self._collection, payload)
                 self._item_id = result["id"]
-        self._cached_state = state.model_copy()  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        self._cached_record = StoredStateRecord(
+            data=stored.data,
+            state_type=stored.state_type,
+            state_module=stored.state_module,
+        )
 
-    # ------------------------------------------------------------------
-    # StateStore protocol
-    # ------------------------------------------------------------------
-
-    async def get_state(self) -> MODEL_T:
-        return await self._load_state()
-
-    async def set_state(self, state: MODEL_T) -> None:
-        current = await self._load_state_or_none()
-        if current is None:
-            await self._save_state(state)
-            return
-        merged = merge_state(current, state)
-        await self._save_state(merged)
-
-    async def get(self, path: str, default: Any = ...) -> Any:
-        state = await self._load_state()
-        return get_by_path(state, path, default)
-
-    async def set(self, path: str, value: Any) -> None:
-        async with self.edit_state() as state:
-            set_by_path(state, path, value)
-
-    async def clear(self) -> None:
-        cleared = create_cleared_state(self.state_type)
-        await self._save_state(cleared)
-
-    @asynccontextmanager
-    async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
-        async with self._lock:
-            state = await self._load_state()
-            yield state
-            await self._save_state(state)
-
-    def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
+    def to_handle(self) -> dict[str, Any]:
         payload = AgentDataSerializedState(
             run_id=self._run_id, collection=self._collection
         )
         return payload.model_dump()
+
+
+class AgentDataStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
+    """Compatibility StateStore facade backed by Agent Data storage."""
+
+    def __init__(
+        self,
+        *,
+        client: AgentDataClient,
+        run_id: str,
+        state_type: type[MODEL_T] | None = None,
+        collection: str = "workflow_state",
+        serializer: BaseSerializer | None = None,
+    ) -> None:
+        self._agent_data_storage = AgentDataStateStorage(
+            client=client,
+            run_id=run_id,
+            collection=collection,
+        )
+        self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
+        super().__init__(
+            self._agent_data_storage,
+            state_type or DictState,  # type: ignore[arg-type]
+            serializer or JsonSerializer(),
+            to_dict_mode="handle",
+        )
+
+    @property
+    def run_id(self) -> str:
+        return self._agent_data_storage.run_id
+
+    async def _flush_pending_seed(self) -> None:
+        if self._pending_seed is None:
+            return
+
+        serialized_state, serializer = self._pending_seed
+        self._pending_seed = None
+        self._serializer = serializer
+        store_type = serialized_state.get("store_type")
+
+        if store_type == "agent_data":
+            parsed = AgentDataSerializedState.model_validate(serialized_state)
+            if (
+                parsed.collection == self._agent_data_storage._collection
+                and parsed.run_id == self.run_id
+            ):
+                return
+            source = AgentDataStateStorage(
+                client=self._agent_data_storage._client,
+                run_id=parsed.run_id,
+                collection=parsed.collection,
+            )
+            record = await source.load()
+            if record is not None:
+                await self._agent_data_storage.save(record)
+            return
+
+        state = decode_seed_state(serialized_state, serializer)
+        await self._save_state(state)
+
+    async def _load_state_or_none(self) -> MODEL_T | None:
+        await self._flush_pending_seed()
+        return await super()._load_state_or_none()
+
+    async def _save_state(self, state: BaseModel) -> None:
+        await self._agent_data_storage.save(
+            string_record_from_state(state, self._serializer)
+        )
 
     @classmethod
     def from_dict(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -44,8 +44,8 @@ class _AgentDataStateStorage:
     """Raw state storage backed by the LlamaCloud Agent Data API.
 
     Uses a single item in a ``workflow_state`` collection, keyed by ``run_id``.
-    Caches the item id and last-seen record — genuine backend I/O policy to
-    avoid a search round-trip per operation.
+    Caches the item id and last-seen record to avoid a search round-trip per
+    operation.
     """
 
     def __init__(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -17,10 +17,12 @@ from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
     create_cleared_state,
-    deserialize_dict_state_data,
+    decode_state,
+    deserialize_state_from_dict,
+    encode_state,
     get_by_path,
     merge_state,
-    serialize_dict_state_data,
+    parse_in_memory_state,
     set_by_path,
 )
 
@@ -39,6 +41,8 @@ class _StoredStateRecord(BaseModel):
 
     run_id: str
     data: str
+    state_type: str | None = "DictState"
+    state_module: str | None = "workflows.context.state_store"
 
 
 class AgentDataSerializedState(BaseModel):
@@ -76,6 +80,7 @@ class AgentDataStateStore(Generic[MODEL_T]):
         # Write-through state cache — avoids HTTP searches when state is
         # already known from a previous load or save.
         self._cached_state: MODEL_T | None = None
+        self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
 
     @property
     def run_id(self) -> str:
@@ -89,16 +94,13 @@ class AgentDataStateStore(Generic[MODEL_T]):
     # State serialization
     # ------------------------------------------------------------------
 
-    def _serialize_state(self, state: MODEL_T) -> str:
-        if isinstance(state, DictState):
-            return json.dumps(serialize_dict_state_data(state, self._serializer))
-        return self._serializer.serialize(state)
-
-    def _deserialize_state(self, state_json: str) -> MODEL_T:
-        if issubclass(self.state_type, DictState):
-            data = json.loads(state_json)
-            return deserialize_dict_state_data(data, self._serializer)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-        return self._serializer.deserialize(state_json)
+    def _deserialize_state(
+        self,
+        state_json: str,
+        state_type_name: str | None,
+        state_module: str | None,
+    ) -> MODEL_T:
+        return decode_state(state_json, state_type_name, state_module, self._serializer)  # type: ignore[return-value]
 
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()
@@ -118,12 +120,43 @@ class AgentDataStateStore(Generic[MODEL_T]):
         self._item_id = items[0]["id"]
         return _StoredStateRecord.model_validate(items[0]["data"])
 
+    async def _flush_pending_seed(self) -> None:
+        if self._pending_seed is None:
+            return
+
+        serialized_state, serializer = self._pending_seed
+        self._pending_seed = None
+        self._serializer = serializer
+        store_type = serialized_state.get("store_type")
+
+        if store_type == "agent_data":
+            parsed = AgentDataSerializedState.model_validate(serialized_state)
+            if parsed.collection == self._collection and parsed.run_id == self._run_id:
+                return
+            source = AgentDataStateStore(
+                client=self._client,
+                run_id=parsed.run_id,
+                state_type=self.state_type,
+                collection=parsed.collection,
+                serializer=serializer,
+            )
+            state = await source._load_state()
+            await self._save_state(state)
+            return
+
+        parse_in_memory_state(serialized_state)
+        state = deserialize_state_from_dict(serialized_state, serializer)
+        await self._save_state(state)
+
     async def _load_state(self) -> MODEL_T:
+        await self._flush_pending_seed()
         if self._cached_state is not None:
             return self._cached_state.model_copy()
         record = await self._load_record()
         if record is not None:
-            state = self._deserialize_state(record.data)
+            state = self._deserialize_state(
+                record.data, record.state_type, record.state_module
+            )
             self._cached_state = state
             return state.model_copy()
         state = self._create_default_state()
@@ -131,19 +164,27 @@ class AgentDataStateStore(Generic[MODEL_T]):
         return state.model_copy()
 
     async def _load_state_or_none(self) -> MODEL_T | None:
+        await self._flush_pending_seed()
         if self._cached_state is not None:
             return self._cached_state.model_copy()
         record = await self._load_record()
         if record is not None:
-            state = self._deserialize_state(record.data)
+            state = self._deserialize_state(
+                record.data, record.state_type, record.state_module
+            )
             self._cached_state = state
             return state.model_copy()
         return None
 
     async def _save_state(self, state: BaseModel) -> None:
+        state_data, state_type_name, state_module = encode_state(
+            state, self._serializer
+        )
         record = _StoredStateRecord(
             run_id=self._run_id,
-            data=self._serialize_state(state),  # type: ignore[arg-type]
+            data=state_data if isinstance(state_data, str) else json.dumps(state_data),
+            state_type=state_type_name,
+            state_module=state_module,
         )
         payload = record.model_dump()
         if self._item_id is not None:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -10,10 +10,10 @@ from typing import Any, Generic, Literal
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 from workflows.context.serializers import BaseSerializer, JsonSerializer
-from workflows.context.state_store import (
-    DictState,
-    StoredStateRecord,
-    TypedStateStore,
+from workflows.context.state_store import DictState
+from workflows.context.state_store_integration import (
+    StateRecord,
+    StateStoreFacade,
     decode_seed_state,
     string_record_from_state,
 )
@@ -28,7 +28,7 @@ _FIELD_RUN_ID = "run_id"
 _FIELD_DATA = "data"
 
 
-class _StoredStateRecord(BaseModel):
+class _AgentDataStateRecord(BaseModel):
     """Validates the shape persisted in the Agent Data API."""
 
     run_id: str
@@ -45,7 +45,7 @@ class AgentDataSerializedState(BaseModel):
     collection: str = "workflow_state"
 
 
-class AgentDataStateStorage:
+class _AgentDataStateStorage:
     """Raw state storage backed by the LlamaCloud Agent Data API.
 
     Uses a single item in a ``workflow_state`` collection, keyed by ``run_id``.
@@ -62,7 +62,7 @@ class AgentDataStateStorage:
         self._run_id = run_id
         self._collection = collection
         self._item_id: str | None = None
-        self._cached_record: StoredStateRecord | None = None
+        self._cached_record: StateRecord | None = None
 
     @property
     def run_id(self) -> str:
@@ -72,7 +72,7 @@ class AgentDataStateStorage:
     # Load / save through API
     # ------------------------------------------------------------------
 
-    async def _load_record(self) -> _StoredStateRecord | None:
+    async def _load_record(self) -> _AgentDataStateRecord | None:
         items = await self._client.search(
             self._collection,
             {_FIELD_RUN_ID: {"eq": self._run_id}},
@@ -81,24 +81,24 @@ class AgentDataStateStorage:
         if not items:
             return None
         self._item_id = items[0]["id"]
-        return _StoredStateRecord.model_validate(items[0]["data"])
+        return _AgentDataStateRecord.model_validate(items[0]["data"])
 
-    async def load(self) -> StoredStateRecord | None:
+    async def load(self) -> StateRecord | None:
         if self._cached_record is not None:
             return self._cached_record.model_copy(deep=True)
         record = await self._load_record()
         if record is None:
             return None
-        self._cached_record = StoredStateRecord(
+        self._cached_record = StateRecord(
             data=record.data,
             state_type=record.state_type,
             state_module=record.state_module,
         )
         return self._cached_record.model_copy(deep=True)
 
-    async def save(self, record: StoredStateRecord) -> None:
+    async def save(self, record: StateRecord) -> None:
         data = record.data if isinstance(record.data, str) else str(record.data)
-        stored = _StoredStateRecord(
+        stored = _AgentDataStateRecord(
             run_id=self._run_id,
             data=data,
             state_type=record.state_type,
@@ -120,7 +120,7 @@ class AgentDataStateStorage:
             else:
                 result = await self._client.create(self._collection, payload)
                 self._item_id = result["id"]
-        self._cached_record = StoredStateRecord(
+        self._cached_record = StateRecord(
             data=stored.data,
             state_type=stored.state_type,
             state_module=stored.state_module,
@@ -133,7 +133,7 @@ class AgentDataStateStorage:
         return payload.model_dump()
 
 
-class AgentDataStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
+class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
     """Compatibility StateStore facade backed by Agent Data storage."""
 
     def __init__(
@@ -145,7 +145,7 @@ class AgentDataStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
         collection: str = "workflow_state",
         serializer: BaseSerializer | None = None,
     ) -> None:
-        self._agent_data_storage = AgentDataStateStorage(
+        self._agent_data_storage = _AgentDataStateStorage(
             client=client,
             run_id=run_id,
             collection=collection,
@@ -178,7 +178,7 @@ class AgentDataStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
                 and parsed.run_id == self.run_id
             ):
                 return
-            source = AgentDataStateStorage(
+            source = _AgentDataStateStorage(
                 client=self._agent_data_storage._client,
                 run_id=parsed.run_id,
                 collection=parsed.collection,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -4,9 +4,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import json
-import logging
 import uuid
 from typing import Any, Generic, Literal
 
@@ -17,18 +14,13 @@ from workflows.context.state_store import DictState
 from workflows.context.state_store_integration import (
     StateRecord,
     StateStoreFacade,
-    decode_seed_state,
-    string_record_from_state,
 )
 
 from .agent_data_client import AgentDataClient
 
-logger = logging.getLogger(__name__)
-
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
 _FIELD_RUN_ID = "run_id"
-_FIELD_DATA = "data"
 
 
 class _AgentDataStateRecord(BaseModel):
@@ -52,6 +44,8 @@ class _AgentDataStateStorage:
     """Raw state storage backed by the LlamaCloud Agent Data API.
 
     Uses a single item in a ``workflow_state`` collection, keyed by ``run_id``.
+    Caches the item id and last-seen record — genuine backend I/O policy to
+    avoid a search round-trip per operation.
     """
 
     def __init__(
@@ -60,53 +54,16 @@ class _AgentDataStateStorage:
         client: AgentDataClient,
         run_id: str,
         collection: str = "workflow_state",
-        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._client = client
         self._run_id = run_id
         self._collection = collection
-        self._pending_seed = pending_seed
-        self._seed_lock = asyncio.Lock()
         self._item_id: str | None = None
         self._cached_record: StateRecord | None = None
 
     @property
     def run_id(self) -> str:
         return self._run_id
-
-    # ------------------------------------------------------------------
-    # Load / save through API
-    # ------------------------------------------------------------------
-
-    async def ensure_seeded(self) -> None:
-        if self._pending_seed is None:
-            return
-        async with self._seed_lock:
-            if self._pending_seed is None:
-                return
-            serialized_state, serializer = self._pending_seed
-            self._pending_seed = None
-            store_type = serialized_state.get("store_type")
-
-            if store_type == "agent_data":
-                parsed = AgentDataSerializedState.model_validate(serialized_state)
-                if (
-                    parsed.collection == self._collection
-                    and parsed.run_id == self._run_id
-                ):
-                    return
-                source = _AgentDataStateStorage(
-                    client=self._client,
-                    run_id=parsed.run_id,
-                    collection=parsed.collection,
-                )
-                record = await source._load_without_seed()
-                if record is not None:
-                    await self._save_without_seed(record)
-                return
-
-            state = decode_seed_state(serialized_state, serializer)
-            await self._save_without_seed(string_record_from_state(state, serializer))
 
     async def _load_record(self) -> _AgentDataStateRecord | None:
         items = await self._client.search(
@@ -120,33 +77,18 @@ class _AgentDataStateStorage:
         return _AgentDataStateRecord.model_validate(items[0]["data"])
 
     async def load(self) -> StateRecord | None:
-        await self.ensure_seeded()
-        return await self._load_without_seed()
-
-    async def _load_without_seed(self) -> StateRecord | None:
         if self._cached_record is not None:
             return self._cached_record.model_copy(deep=True)
         record = await self._load_record()
         if record is None:
             return None
-        self._cached_record = StateRecord(
-            data=record.data,
-            state_type=record.state_type,
-            state_module=record.state_module,
-        )
+        self._cached_record = StateRecord(data=record.data)
         return self._cached_record.model_copy(deep=True)
 
     async def save(self, record: StateRecord) -> None:
-        await self.ensure_seeded()
-        await self._save_without_seed(record)
-
-    async def _save_without_seed(self, record: StateRecord) -> None:
-        # json.dumps raises TypeError for non-JSON data rather than
-        # silently writing a Python repr into the stored record.
-        data = record.data if isinstance(record.data, str) else json.dumps(record.data)
         stored = _AgentDataStateRecord(
             run_id=self._run_id,
-            data=data,
+            data=record.data,
             state_type=record.state_type,
             state_module=record.state_module,
         )
@@ -166,11 +108,7 @@ class _AgentDataStateStorage:
             else:
                 result = await self._client.create(self._collection, payload)
                 self._item_id = result["id"]
-        self._cached_record = StateRecord(
-            data=stored.data,
-            state_type=stored.state_type,
-            state_module=stored.state_module,
-        )
+        self._cached_record = StateRecord(data=stored.data)
 
     def to_handle(self) -> dict[str, Any]:
         payload = AgentDataSerializedState(
@@ -178,9 +116,32 @@ class _AgentDataStateStorage:
         )
         return payload.model_dump()
 
+    def parse_own_handle(
+        self, payload: dict[str, Any]
+    ) -> AgentDataSerializedState | None:
+        if payload.get("store_type") != "agent_data":
+            return None
+        return AgentDataSerializedState.model_validate(payload)
+
+    async def copy_from_handle(self, handle: AgentDataSerializedState) -> None:
+        """Copy the source target's record into this one (no-op if absent).
+
+        Goes through ``save`` so ``_cached_record``/``_item_id`` stay
+        consistent with the copied row.
+        """
+        source = _AgentDataStateStorage(
+            client=self._client,
+            run_id=handle.run_id,
+            collection=handle.collection,
+        )
+        record = await source.load()
+        if record is None:
+            return
+        await self.save(record)
+
 
 class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
-    """Compatibility StateStore facade backed by Agent Data storage."""
+    """StateStore facade backed by Agent Data storage."""
 
     def __init__(
         self,
@@ -190,30 +151,21 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         state_type: type[MODEL_T] | None = None,
         collection: str = "workflow_state",
         serializer: BaseSerializer | None = None,
-        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._agent_data_storage = _AgentDataStateStorage(
             client=client,
             run_id=run_id,
             collection=collection,
-            pending_seed=pending_seed,
         )
         super().__init__(
             self._agent_data_storage,
             state_type or DictState,  # type: ignore[arg-type]
             serializer or JsonSerializer(),
-            to_dict_mode="handle",
         )
 
     @property
     def run_id(self) -> str:
         return self._agent_data_storage.run_id
-
-    async def _save_state(self, state: BaseModel) -> None:
-        await self.ensure_seeded()
-        await self._agent_data_storage.save(
-            string_record_from_state(state, self._serializer)
-        )
 
     @classmethod
     def from_dict(
@@ -226,41 +178,24 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         run_id: str | None = None,
         collection: str | None = None,
     ) -> AgentDataStateStore[Any]:
+        """Restore a state store from a serialized payload.
+
+        Construct + seed: ``add_seed`` validates the payload eagerly
+        (foreign durable handles raise) and materializes it lazily.
+        """
         if not serialized_state:
             raise ValueError("Cannot restore AgentDataStateStore from empty dict")
-        store_type = serialized_state.get("store_type")
 
-        if store_type == "agent_data":
-            parsed = AgentDataSerializedState.model_validate(serialized_state)
-            effective_run_id = run_id or parsed.run_id
-            effective_collection = collection or parsed.collection
-            return cls(
-                client=client,
-                run_id=effective_run_id,
-                state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-                collection=effective_collection,
-                serializer=serializer,
-                pending_seed=(
-                    (serialized_state, serializer)
-                    if (
-                        parsed.run_id != effective_run_id
-                        or parsed.collection != effective_collection
-                    )
-                    else None
-                ),
-            )
-
-        if store_type not in (None, "in_memory"):
-            raise ValueError(
-                f"Cannot restore store_type '{store_type}' with AgentDataStateStore.from_dict()"
-            )
-
-        effective_run_id = run_id or str(uuid.uuid4())
-        return cls(
+        effective_run_id = run_id or serialized_state.get("run_id") or str(uuid.uuid4())
+        effective_collection = (
+            collection or serialized_state.get("collection") or "workflow_state"
+        )
+        store: AgentDataStateStore[Any] = cls(
             client=client,
             run_id=effective_run_id,
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-            collection=collection or "workflow_state",
+            collection=effective_collection,
             serializer=serializer,
-            pending_seed=(serialized_state, serializer),
         )
+        store.add_seed(serialized_state, serializer)
+        return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -8,7 +8,7 @@ import asyncio
 import functools
 import logging
 from contextlib import asynccontextmanager
-from typing import Any, AsyncGenerator, Generic, Literal
+from typing import Any, AsyncGenerator, Generic, Literal, cast
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
@@ -143,9 +143,12 @@ class AgentDataStateStore(Generic[MODEL_T]):
         record = await self._load_record()
         if record is None:
             return None
-        state = decode_state(
-            record.data, record.state_type, record.state_module, self._serializer
-        )  # type: ignore[return-value]
+        state = cast(
+            MODEL_T,
+            decode_state(
+                record.data, record.state_type, record.state_module, self._serializer
+            ),
+        )
         self._cached_state = state
         return state.model_copy()
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -4,7 +4,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
+import uuid
 from typing import Any, Generic, Literal
 
 from pydantic import BaseModel
@@ -57,10 +59,13 @@ class _AgentDataStateStorage:
         client: AgentDataClient,
         run_id: str,
         collection: str = "workflow_state",
+        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._client = client
         self._run_id = run_id
         self._collection = collection
+        self._pending_seed = pending_seed
+        self._seed_lock = asyncio.Lock()
         self._item_id: str | None = None
         self._cached_record: StateRecord | None = None
 
@@ -71,6 +76,36 @@ class _AgentDataStateStorage:
     # ------------------------------------------------------------------
     # Load / save through API
     # ------------------------------------------------------------------
+
+    async def ensure_seeded(self) -> None:
+        if self._pending_seed is None:
+            return
+        async with self._seed_lock:
+            if self._pending_seed is None:
+                return
+            serialized_state, serializer = self._pending_seed
+            self._pending_seed = None
+            store_type = serialized_state.get("store_type")
+
+            if store_type == "agent_data":
+                parsed = AgentDataSerializedState.model_validate(serialized_state)
+                if (
+                    parsed.collection == self._collection
+                    and parsed.run_id == self._run_id
+                ):
+                    return
+                source = _AgentDataStateStorage(
+                    client=self._client,
+                    run_id=parsed.run_id,
+                    collection=parsed.collection,
+                )
+                record = await source._load_without_seed()
+                if record is not None:
+                    await self._save_without_seed(record)
+                return
+
+            state = decode_seed_state(serialized_state, serializer)
+            await self._save_without_seed(string_record_from_state(state, serializer))
 
     async def _load_record(self) -> _AgentDataStateRecord | None:
         items = await self._client.search(
@@ -84,6 +119,10 @@ class _AgentDataStateStorage:
         return _AgentDataStateRecord.model_validate(items[0]["data"])
 
     async def load(self) -> StateRecord | None:
+        await self.ensure_seeded()
+        return await self._load_without_seed()
+
+    async def _load_without_seed(self) -> StateRecord | None:
         if self._cached_record is not None:
             return self._cached_record.model_copy(deep=True)
         record = await self._load_record()
@@ -97,6 +136,10 @@ class _AgentDataStateStorage:
         return self._cached_record.model_copy(deep=True)
 
     async def save(self, record: StateRecord) -> None:
+        await self.ensure_seeded()
+        await self._save_without_seed(record)
+
+    async def _save_without_seed(self, record: StateRecord) -> None:
         data = record.data if isinstance(record.data, str) else str(record.data)
         stored = _AgentDataStateRecord(
             run_id=self._run_id,
@@ -144,13 +187,14 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         state_type: type[MODEL_T] | None = None,
         collection: str = "workflow_state",
         serializer: BaseSerializer | None = None,
+        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._agent_data_storage = _AgentDataStateStorage(
             client=client,
             run_id=run_id,
             collection=collection,
+            pending_seed=pending_seed,
         )
-        self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
         super().__init__(
             self._agent_data_storage,
             state_type or DictState,  # type: ignore[arg-type]
@@ -162,40 +206,8 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
     def run_id(self) -> str:
         return self._agent_data_storage.run_id
 
-    async def _flush_pending_seed(self) -> None:
-        if self._pending_seed is None:
-            return
-
-        serialized_state, serializer = self._pending_seed
-        self._pending_seed = None
-        self._serializer = serializer
-        store_type = serialized_state.get("store_type")
-
-        if store_type == "agent_data":
-            parsed = AgentDataSerializedState.model_validate(serialized_state)
-            if (
-                parsed.collection == self._agent_data_storage._collection
-                and parsed.run_id == self.run_id
-            ):
-                return
-            source = _AgentDataStateStorage(
-                client=self._agent_data_storage._client,
-                run_id=parsed.run_id,
-                collection=parsed.collection,
-            )
-            record = await source.load()
-            if record is not None:
-                await self._agent_data_storage.save(record)
-            return
-
-        state = decode_seed_state(serialized_state, serializer)
-        await self._save_state(state)
-
-    async def _load_state_or_none(self) -> MODEL_T | None:
-        await self._flush_pending_seed()
-        return await super()._load_state_or_none()
-
     async def _save_state(self, state: BaseModel) -> None:
+        await self.ensure_seeded()
         await self._agent_data_storage.save(
             string_record_from_state(state, self._serializer)
         )
@@ -209,15 +221,43 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         client: AgentDataClient,
         state_type: type[BaseModel] | None = None,
         run_id: str | None = None,
+        collection: str | None = None,
     ) -> AgentDataStateStore[Any]:
         if not serialized_state:
             raise ValueError("Cannot restore AgentDataStateStore from empty dict")
-        parsed = AgentDataSerializedState.model_validate(serialized_state)
-        effective_run_id = run_id or parsed.run_id
+        store_type = serialized_state.get("store_type")
+
+        if store_type == "agent_data":
+            parsed = AgentDataSerializedState.model_validate(serialized_state)
+            effective_run_id = run_id or parsed.run_id
+            effective_collection = collection or parsed.collection
+            return cls(
+                client=client,
+                run_id=effective_run_id,
+                state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
+                collection=effective_collection,
+                serializer=serializer,
+                pending_seed=(
+                    (serialized_state, serializer)
+                    if (
+                        parsed.run_id != effective_run_id
+                        or parsed.collection != effective_collection
+                    )
+                    else None
+                ),
+            )
+
+        if store_type not in (None, "in_memory"):
+            raise ValueError(
+                f"Cannot restore store_type '{store_type}' with AgentDataStateStore.from_dict()"
+            )
+
+        effective_run_id = run_id or str(uuid.uuid4())
         return cls(
             client=client,
             run_id=effective_run_id,
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-            collection=parsed.collection,
+            collection=collection or "workflow_state",
             serializer=serializer,
+            pending_seed=(serialized_state, serializer),
         )

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -510,13 +510,12 @@ class AgentDataStore(AbstractWorkflowStore):
         cached = self._state_stores.get(run_id)
         if cached is not None:
             return cached
-        reconnecting = (
+        if (
             serialized_state is not None
             and serializer is not None
             and serialized_state.get("store_type") == "agent_data"
             and serialized_state.get("run_id") == run_id
-        )
-        if reconnecting:
+        ):
             store = AgentDataStateStore.from_dict(
                 serialized_state,
                 serializer,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -12,7 +12,6 @@ from typing import Any
 
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from workflows.context.serializers import BaseSerializer
-from workflows.context.state_store import StateStore
 
 from .._keyed_lock import KeyedLock
 from .._lru_cache import LRUCache
@@ -55,6 +54,7 @@ class AgentDataStore(AbstractWorkflowStore):
         collection: str = "workflow_contexts",
         poll_interval: float = 30.0,
     ) -> None:
+        super().__init__()
         self._client = AgentDataClient(
             base_url=base_url,
             api_key=api_key,
@@ -76,7 +76,9 @@ class AgentDataStore(AbstractWorkflowStore):
         self._tick_seq_lock: asyncio.Lock | None = None
 
         self._subscriber_queues: dict[str, list[asyncio.Queue[StoredEvent | None]]] = {}
-        self._state_stores: dict[str, AgentDataStateStore[Any]] = {}
+        # Strong refs: facades stay alive for the run; _cleanup_run evicts
+        # them on terminal events.
+        self._state_store_cache = {}
         self._pending_ticks: dict[str, list[asyncio.Task[Any]]] = {}
         self._pending_events: dict[str, list[asyncio.Task[Any]]] = {}
 
@@ -167,7 +169,7 @@ class AgentDataStore(AbstractWorkflowStore):
         # Clean up sequence counters and cached state store
         self._event_sequences.pop(run_id, None)
         self._tick_sequences.pop(run_id, None)
-        self._state_stores.pop(run_id, None)
+        self._state_store_cache.pop(run_id, None)
 
     # ------------------------------------------------------------------
     # Sequence helpers
@@ -486,7 +488,7 @@ class AgentDataStore(AbstractWorkflowStore):
     # State store
     # ------------------------------------------------------------------
 
-    def _create_agent_data_state_store(
+    def _build_state_store(
         self,
         run_id: str,
         state_type: type[Any] | None,
@@ -499,32 +501,3 @@ class AgentDataStore(AbstractWorkflowStore):
             collection=f"{self._collection}_state",
             serializer=serializer,
         )
-
-    def create_state_store(
-        self,
-        run_id: str,
-        state_type: type[Any] | None = None,
-        serialized_state: dict[str, Any] | None = None,
-        serializer: BaseSerializer | None = None,
-    ) -> StateStore[Any]:
-        cached = self._state_stores.get(run_id)
-        if cached is not None and serialized_state is None:
-            return cached
-        if serialized_state is not None and serializer is not None:
-            collection = (
-                None
-                if serialized_state.get("store_type") == "agent_data"
-                else f"{self._collection}_state"
-            )
-            store = AgentDataStateStore.from_dict(
-                serialized_state,
-                serializer,
-                client=self._client,
-                state_type=state_type,
-                run_id=run_id,
-                collection=collection,
-            )
-        else:
-            store = self._create_agent_data_state_store(run_id, state_type, serializer)
-        self._state_stores[run_id] = store
-        return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -496,11 +496,34 @@ class AgentDataStore(AbstractWorkflowStore):
         cached = self._state_stores.get(run_id)
         if cached is not None:
             return cached
-        store = AgentDataStateStore(
-            client=self._client,
-            run_id=run_id,
-            state_type=state_type,
-            collection=f"{self._collection}_state",
-        )
+        if serialized_state is not None and serializer is not None:
+            if (
+                serialized_state.get("store_type") == "agent_data"
+                and serialized_state.get("run_id") == run_id
+            ):
+                store = AgentDataStateStore.from_dict(
+                    serialized_state,
+                    serializer,
+                    client=self._client,
+                    state_type=state_type,
+                    run_id=run_id,
+                )
+            else:
+                store = AgentDataStateStore(
+                    client=self._client,
+                    run_id=run_id,
+                    state_type=state_type,
+                    collection=f"{self._collection}_state",
+                    serializer=serializer,
+                )
+                store._pending_seed = (serialized_state, serializer)
+        else:
+            store = AgentDataStateStore(
+                client=self._client,
+                run_id=run_id,
+                state_type=state_type,
+                collection=f"{self._collection}_state",
+                serializer=serializer,
+            )
         self._state_stores[run_id] = store
         return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -508,24 +508,23 @@ class AgentDataStore(AbstractWorkflowStore):
         serializer: BaseSerializer | None = None,
     ) -> StateStore[Any]:
         cached = self._state_stores.get(run_id)
-        if cached is not None:
+        if cached is not None and serialized_state is None:
             return cached
-        if (
-            serialized_state is not None
-            and serializer is not None
-            and serialized_state.get("store_type") == "agent_data"
-            and serialized_state.get("run_id") == run_id
-        ):
+        if serialized_state is not None and serializer is not None:
+            collection = (
+                None
+                if serialized_state.get("store_type") == "agent_data"
+                else f"{self._collection}_state"
+            )
             store = AgentDataStateStore.from_dict(
                 serialized_state,
                 serializer,
                 client=self._client,
                 state_type=state_type,
                 run_id=run_id,
+                collection=collection,
             )
         else:
             store = self._create_agent_data_state_store(run_id, state_type, serializer)
-            if serialized_state is not None and serializer is not None:
-                store._pending_seed = (serialized_state, serializer)
         self._state_stores[run_id] = store
         return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -486,6 +486,20 @@ class AgentDataStore(AbstractWorkflowStore):
     # State store
     # ------------------------------------------------------------------
 
+    def _create_agent_data_state_store(
+        self,
+        run_id: str,
+        state_type: type[Any] | None,
+        serializer: BaseSerializer | None,
+    ) -> AgentDataStateStore[Any]:
+        return AgentDataStateStore(
+            client=self._client,
+            run_id=run_id,
+            state_type=state_type,
+            collection=f"{self._collection}_state",
+            serializer=serializer,
+        )
+
     def create_state_store(
         self,
         run_id: str,
@@ -496,34 +510,23 @@ class AgentDataStore(AbstractWorkflowStore):
         cached = self._state_stores.get(run_id)
         if cached is not None:
             return cached
-        if serialized_state is not None and serializer is not None:
-            if (
-                serialized_state.get("store_type") == "agent_data"
-                and serialized_state.get("run_id") == run_id
-            ):
-                store = AgentDataStateStore.from_dict(
-                    serialized_state,
-                    serializer,
-                    client=self._client,
-                    state_type=state_type,
-                    run_id=run_id,
-                )
-            else:
-                store = AgentDataStateStore(
-                    client=self._client,
-                    run_id=run_id,
-                    state_type=state_type,
-                    collection=f"{self._collection}_state",
-                    serializer=serializer,
-                )
-                store._pending_seed = (serialized_state, serializer)
-        else:
-            store = AgentDataStateStore(
+        reconnecting = (
+            serialized_state is not None
+            and serializer is not None
+            and serialized_state.get("store_type") == "agent_data"
+            and serialized_state.get("run_id") == run_id
+        )
+        if reconnecting:
+            store = AgentDataStateStore.from_dict(
+                serialized_state,
+                serializer,
                 client=self._client,
-                run_id=run_id,
                 state_type=state_type,
-                collection=f"{self._collection}_state",
-                serializer=serializer,
+                run_id=run_id,
             )
+        else:
+            store = self._create_agent_data_state_store(run_id, state_type, serializer)
+            if serialized_state is not None and serializer is not None:
+                store._pending_seed = (serialized_state, serializer)
         self._state_stores[run_id] = store
         return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 import weakref
 from collections import deque
 from collections.abc import AsyncIterator
@@ -10,7 +9,11 @@ from typing import Any
 
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from workflows.context.serializers import BaseSerializer
-from workflows.context.state_store import DictState, InMemoryStateStore
+from workflows.context.state_store import (
+    DictState,
+    InMemoryStateStore,
+    StateStoreFacade,
+)
 
 from .abstract_workflow_store import (
     AbstractWorkflowStore,
@@ -20,8 +23,6 @@ from .abstract_workflow_store import (
     StoredTick,
     is_terminal_status,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _matches_query(handler: PersistentHandler, query: HandlerQuery) -> bool:
@@ -60,42 +61,30 @@ def _matches_query(handler: PersistentHandler, query: HandlerQuery) -> bool:
 
 class MemoryWorkflowStore(AbstractWorkflowStore):
     def __init__(self, max_completed: int | None = 1000) -> None:
+        super().__init__()
         if max_completed is not None and max_completed < 0:
             raise ValueError("max_completed must be >= 0 or None")
 
         self.handlers: dict[str, PersistentHandler] = {}
         self.events: dict[str, list[StoredEvent]] = {}
         self.ticks: dict[str, list[StoredTick]] = {}
-        self.state_stores: dict[str, InMemoryStateStore[Any]] = {}
+        # Strong refs: facades live until eviction. Public alias kept for
+        # tests/plugins that inject stores; the ABC template reads the cache.
+        self.state_stores: dict[str, StateStoreFacade[Any]] = {}
+        self._state_store_cache = self.state_stores
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
             weakref.WeakValueDictionary()
         )
         self.max_completed = max_completed
         self._terminal_queue: deque[str] = deque()
 
-    def create_state_store(
+    def _build_state_store(
         self,
         run_id: str,
-        state_type: type[Any] | None = None,
-        serialized_state: dict[str, Any] | None = None,
-        serializer: BaseSerializer | None = None,
+        state_type: type[Any] | None,
+        serializer: BaseSerializer | None,
     ) -> InMemoryStateStore[Any]:
-        if run_id not in self.state_stores:
-            if serialized_state is not None and serializer is not None:
-                try:
-                    self.state_stores[run_id] = InMemoryStateStore.from_dict(
-                        serialized_state, serializer
-                    )
-                except Exception:
-                    logger.warning("Failed to seed InMemoryStateStore", exc_info=True)
-                    self.state_stores[run_id] = InMemoryStateStore(
-                        state_type() if state_type else DictState()
-                    )
-            else:
-                self.state_stores[run_id] = InMemoryStateStore(
-                    state_type() if state_type else DictState()
-                )
-        return self.state_stores[run_id]
+        return InMemoryStateStore(state_type() if state_type else DictState())
 
     async def query(self, query: HandlerQuery) -> list[PersistentHandler]:
         return [

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -9,7 +9,7 @@ import logging
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Generic, Literal
+from typing import Any, AsyncGenerator, Generic, Literal, cast
 
 import asyncpg
 from pydantic import BaseModel
@@ -143,12 +143,15 @@ class PostgresStateStore(Generic[MODEL_T]):
                 state = self._create_default_state()
                 await self._save_state(state, conn)
                 return state
-            return decode_state(
-                row["state_json"],
-                row["state_type"],
-                row["state_module"],
-                self._serializer,
-            )  # type: ignore[return-value]
+            return cast(
+                MODEL_T,
+                decode_state(
+                    row["state_json"],
+                    row["state_type"],
+                    row["state_module"],
+                    self._serializer,
+                ),
+            )
         finally:
             if should_release:
                 await self._pool.release(conn)  # type: ignore[arg-type]

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -3,18 +3,18 @@
 
 from __future__ import annotations
 
-import uuid
 from datetime import datetime, timezone
 from typing import Any, Generic, Literal
 
 import asyncpg
 from pydantic import BaseModel
 from typing_extensions import TypeVar
-from workflows.context.serializers import BaseSerializer, JsonSerializer
+from workflows.context.serializers import BaseSerializer
 from workflows.context.state_store import DictState
 from workflows.context.state_store_integration import (
     StateRecord,
     StateStoreFacade,
+    restored_run_id,
 )
 
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
@@ -131,16 +131,9 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         serializer: BaseSerializer | None = None,
         schema: str | None = None,
     ) -> None:
-        self._postgres_storage = _PostgresStateStorage(pool, run_id, schema)
         super().__init__(
-            self._postgres_storage,
-            state_type or DictState,  # type: ignore[arg-type]
-            serializer or JsonSerializer(),
+            _PostgresStateStorage(pool, run_id, schema), state_type, serializer
         )
-
-    @property
-    def run_id(self) -> str:
-        return self._postgres_storage.run_id
 
     @classmethod
     def from_dict(
@@ -162,10 +155,9 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         if pool is None:
             raise ValueError("pool is required for PostgresStateStore.from_dict()")
 
-        effective_run_id = run_id or serialized_state.get("run_id") or str(uuid.uuid4())
         store: PostgresStateStore[Any] = cls(
             pool=pool,
-            run_id=effective_run_id,
+            run_id=restored_run_id(run_id, serialized_state),
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             serializer=serializer,
             schema=schema,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -3,9 +3,6 @@
 
 from __future__ import annotations
 
-import asyncio
-import json
-import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Generic, Literal
@@ -18,11 +15,7 @@ from workflows.context.state_store import DictState
 from workflows.context.state_store_integration import (
     StateRecord,
     StateStoreFacade,
-    decode_seed_state,
-    string_record_from_state,
 )
-
-logger = logging.getLogger(__name__)
 
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
@@ -39,20 +32,17 @@ def _utc_now() -> datetime:
 
 
 class _PostgresStateStorage:
-    """Asyncpg-backed raw state storage."""
+    """Asyncpg-backed raw state storage (genuine I/O only)."""
 
     def __init__(
         self,
         pool: asyncpg.Pool,
         run_id: str,
         schema: str | None = None,
-        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._pool = pool
         self._run_id = run_id
         self._schema = schema
-        self._pending_seed = pending_seed
-        self._seed_lock = asyncio.Lock()
 
     @property
     def run_id(self) -> str:
@@ -64,27 +54,54 @@ class _PostgresStateStorage:
             return f"{self._schema}.workflow_state"
         return "workflow_state"
 
-    async def ensure_seeded(self) -> None:
-        if self._pending_seed is None:
-            return
-        async with self._seed_lock:
-            if self._pending_seed is None:
-                return
-            serialized_state, serializer = self._pending_seed
-            self._pending_seed = None
-            store_type = serialized_state.get("store_type")
-            if store_type == "postgres":
-                source_run_id = serialized_state.get("run_id")
-                if source_run_id and source_run_id != self._run_id:
-                    await self._copy_state_from_run(source_run_id)
-                return
-            state = decode_seed_state(serialized_state, serializer)
-            await self._save_record(string_record_from_state(state, serializer))
-
-    async def _copy_state_from_run(self, source_run_id: str) -> None:
-        """Copy state from another run_id using SQL INSERT...SELECT."""
+    async def load(self) -> StateRecord | None:
+        """Load raw state from the database."""
         async with self._pool.acquire() as conn:
-            now = _utc_now()
+            row = await conn.fetchrow(
+                f"SELECT state_json FROM {self._table_ref} WHERE run_id = $1",
+                self._run_id,
+            )
+        if row is None:
+            return None
+        return StateRecord(data=row["state_json"])
+
+    async def save(self, record: StateRecord) -> None:
+        """Save raw state to the database via upsert."""
+        now = _utc_now()
+        async with self._pool.acquire() as conn:
+            await conn.execute(
+                f"""
+                INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6)
+                ON CONFLICT(run_id) DO UPDATE SET
+                    state_json = EXCLUDED.state_json,
+                    state_type = EXCLUDED.state_type,
+                    state_module = EXCLUDED.state_module,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                self._run_id,
+                record.data,
+                record.state_type,
+                record.state_module,
+                now,
+                now,
+            )
+
+    def to_handle(self) -> dict[str, Any]:
+        payload = PostgresSerializedState(run_id=self._run_id)
+        return payload.model_dump()
+
+    def parse_own_handle(
+        self, payload: dict[str, Any]
+    ) -> PostgresSerializedState | None:
+        if payload.get("store_type") != "postgres":
+            return None
+        return PostgresSerializedState.model_validate(payload)
+
+    async def copy_from_handle(self, handle: PostgresSerializedState) -> None:
+        """Copy state from another run's row using SQL INSERT...SELECT."""
+        now = _utc_now()
+        async with self._pool.acquire() as conn:
             await conn.execute(
                 f"""
                 INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
@@ -99,88 +116,12 @@ class _PostgresStateStorage:
                 self._run_id,
                 now,
                 now,
-                source_run_id,
+                handle.run_id,
             )
-
-    async def load(
-        self,
-        conn: asyncpg.Connection | None = None,
-    ) -> StateRecord | None:
-        """Load raw state from database."""
-        await self.ensure_seeded()
-        return await self._load_without_seed(conn)
-
-    async def _load_without_seed(
-        self,
-        conn: asyncpg.Connection | None = None,
-    ) -> StateRecord | None:
-        should_release = conn is None
-        if conn is None:
-            conn = await self._pool.acquire()  # type: ignore[assignment]
-        try:
-            row = await conn.fetchrow(  # type: ignore[union-attr]
-                f"SELECT state_json, state_type, state_module FROM {self._table_ref} WHERE run_id = $1",
-                self._run_id,
-            )
-            if row is None:
-                return None
-            return StateRecord(
-                data=row["state_json"],
-                state_type=row["state_type"],
-                state_module=row["state_module"],
-            )
-        finally:
-            if should_release:
-                await self._pool.release(conn)  # type: ignore[arg-type]
-
-    async def save(self, record: StateRecord) -> None:
-        await self.ensure_seeded()
-        await self._save_record(record)
-
-    async def _save_record(
-        self,
-        record: StateRecord,
-        conn: asyncpg.Connection | asyncpg.pool.PoolConnectionProxy | None = None,
-    ) -> None:
-        """Save raw state to database via upsert."""
-        should_release = conn is None
-        if conn is None:
-            conn = await self._pool.acquire()  # type: ignore[assignment]
-        try:
-            now = _utc_now()
-            # json.dumps raises TypeError for non-JSON data rather than
-            # silently writing a Python repr into the JSON column.
-            data = (
-                record.data if isinstance(record.data, str) else json.dumps(record.data)
-            )
-            await conn.execute(  # type: ignore[union-attr]
-                f"""
-                INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
-                VALUES ($1, $2, $3, $4, $5, $6)
-                ON CONFLICT(run_id) DO UPDATE SET
-                    state_json = EXCLUDED.state_json,
-                    state_type = EXCLUDED.state_type,
-                    state_module = EXCLUDED.state_module,
-                    updated_at = EXCLUDED.updated_at
-                """,
-                self._run_id,
-                data,
-                record.state_type,
-                record.state_module,
-                now,
-                now,
-            )
-        finally:
-            if should_release:
-                await self._pool.release(conn)  # type: ignore[arg-type]
-
-    def to_handle(self) -> dict[str, Any]:
-        payload = PostgresSerializedState(run_id=self._run_id)
-        return payload.model_dump()
 
 
 class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
-    """Compatibility StateStore facade backed by postgres storage."""
+    """StateStore facade backed by postgres storage."""
 
     def __init__(
         self,
@@ -189,28 +130,18 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         state_type: type[MODEL_T] | None = None,
         serializer: BaseSerializer | None = None,
         schema: str | None = None,
-        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._pool = pool
-        self._postgres_storage = _PostgresStateStorage(
-            pool, run_id, schema, pending_seed
-        )
+        self._postgres_storage = _PostgresStateStorage(pool, run_id, schema)
         super().__init__(
             self._postgres_storage,
             state_type or DictState,  # type: ignore[arg-type]
             serializer or JsonSerializer(),
-            to_dict_mode="handle",
         )
 
     @property
     def run_id(self) -> str:
         return self._postgres_storage.run_id
-
-    async def _save_state(self, state: BaseModel) -> None:
-        await self.ensure_seeded()
-        await self._postgres_storage.save(
-            string_record_from_state(state, self._serializer)
-        )
 
     @classmethod
     def from_dict(
@@ -222,46 +153,23 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         run_id: str | None = None,
         schema: str | None = None,
     ) -> PostgresStateStore[Any]:
-        """Restore a state store from serialized payload.
+        """Restore a state store from a serialized payload.
 
-        Handles both InMemorySerializedState (migrates data to DB on first use)
-        and PostgresSerializedState (reconnects to existing row).
+        Construct + seed: ``add_seed`` validates the payload eagerly
+        (foreign durable handles raise) and materializes it lazily.
         """
         if not serialized_state:
             raise ValueError("Cannot restore PostgresStateStore from empty dict")
         if pool is None:
             raise ValueError("pool is required for PostgresStateStore.from_dict()")
 
-        store_type = serialized_state.get("store_type")
-
-        if store_type == "postgres":
-            parsed = PostgresSerializedState.model_validate(serialized_state)
-            effective_run_id = run_id or parsed.run_id
-            return cls(
-                pool=pool,
-                run_id=effective_run_id,
-                state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-                serializer=serializer,
-                schema=schema,
-                pending_seed=(
-                    (serialized_state, serializer)
-                    if parsed.run_id != effective_run_id
-                    else None
-                ),
-            )
-
-        if store_type not in (None, "in_memory"):
-            raise ValueError(
-                f"Cannot restore store_type '{store_type}' with PostgresStateStore.from_dict()"
-            )
-
-        # InMemory format — migrate on first DB access
-        effective_run_id = run_id or str(uuid.uuid4())
-        return cls(
+        effective_run_id = run_id or serialized_state.get("run_id") or str(uuid.uuid4())
+        store: PostgresStateStore[Any] = cls(
             pool=pool,
             run_id=effective_run_id,
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             serializer=serializer,
             schema=schema,
-            pending_seed=(serialized_state, serializer),
         )
+        store.add_seed(serialized_state, serializer)
+        return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -32,7 +32,7 @@ def _utc_now() -> datetime:
 
 
 class _PostgresStateStorage:
-    """Asyncpg-backed raw state storage (genuine I/O only)."""
+    """Asyncpg-backed raw state storage."""
 
     def __init__(
         self,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -147,7 +148,9 @@ class _PostgresStateStorage:
             conn = await self._pool.acquire()  # type: ignore[assignment]
         try:
             now = _utc_now()
-            data = record.data if isinstance(record.data, str) else str(record.data)
+            # json.dumps raises TypeError for non-JSON data rather than
+            # silently writing a Python repr into the JSON column.
+            data = record.data if isinstance(record.data, str) else json.dumps(record.data)
             await conn.execute(  # type: ignore[union-attr]
                 f"""
                 INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import datetime, timezone
@@ -44,10 +45,13 @@ class _PostgresStateStorage:
         pool: asyncpg.Pool,
         run_id: str,
         schema: str | None = None,
+        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._pool = pool
         self._run_id = run_id
         self._schema = schema
+        self._pending_seed = pending_seed
+        self._seed_lock = asyncio.Lock()
 
     @property
     def run_id(self) -> str:
@@ -58,6 +62,23 @@ class _PostgresStateStorage:
         if self._schema:
             return f"{self._schema}.workflow_state"
         return "workflow_state"
+
+    async def ensure_seeded(self) -> None:
+        if self._pending_seed is None:
+            return
+        async with self._seed_lock:
+            if self._pending_seed is None:
+                return
+            serialized_state, serializer = self._pending_seed
+            self._pending_seed = None
+            store_type = serialized_state.get("store_type")
+            if store_type == "postgres":
+                source_run_id = serialized_state.get("run_id")
+                if source_run_id and source_run_id != self._run_id:
+                    await self._copy_state_from_run(source_run_id)
+                return
+            state = decode_seed_state(serialized_state, serializer)
+            await self._save_record(string_record_from_state(state, serializer))
 
     async def _copy_state_from_run(self, source_run_id: str) -> None:
         """Copy state from another run_id using SQL INSERT...SELECT."""
@@ -85,6 +106,13 @@ class _PostgresStateStorage:
         conn: asyncpg.Connection | None = None,
     ) -> StateRecord | None:
         """Load raw state from database."""
+        await self.ensure_seeded()
+        return await self._load_without_seed(conn)
+
+    async def _load_without_seed(
+        self,
+        conn: asyncpg.Connection | None = None,
+    ) -> StateRecord | None:
         should_release = conn is None
         if conn is None:
             conn = await self._pool.acquire()  # type: ignore[assignment]
@@ -105,6 +133,7 @@ class _PostgresStateStorage:
                 await self._pool.release(conn)  # type: ignore[arg-type]
 
     async def save(self, record: StateRecord) -> None:
+        await self.ensure_seeded()
         await self._save_record(record)
 
     async def _save_record(
@@ -155,10 +184,12 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         state_type: type[MODEL_T] | None = None,
         serializer: BaseSerializer | None = None,
         schema: str | None = None,
+        pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None,
     ) -> None:
         self._pool = pool
-        self._postgres_storage = _PostgresStateStorage(pool, run_id, schema)
-        self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
+        self._postgres_storage = _PostgresStateStorage(
+            pool, run_id, schema, pending_seed
+        )
         super().__init__(
             self._postgres_storage,
             state_type or DictState,  # type: ignore[arg-type]
@@ -170,32 +201,8 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
     def run_id(self) -> str:
         return self._postgres_storage.run_id
 
-    async def _flush_pending_seed(self) -> None:
-        """Flush pending seed data to the database if present."""
-        if self._pending_seed is None:
-            return
-        serialized_state, serializer = self._pending_seed
-        self._pending_seed = None
-        self._serializer = serializer
-        store_type = serialized_state.get("store_type")
-        if store_type == "postgres":
-            source_run_id = serialized_state.get("run_id")
-            if source_run_id and source_run_id != self.run_id:
-                await self._postgres_storage._copy_state_from_run(source_run_id)
-            return
-        await self._write_in_memory_state(serialized_state)
-
-    async def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
-        state = decode_seed_state(serialized_state, self._serializer)
-        await self._postgres_storage.save(
-            string_record_from_state(state, self._serializer)
-        )
-
-    async def _load_state_or_none(self) -> MODEL_T | None:
-        await self._flush_pending_seed()
-        return await super()._load_state_or_none()
-
     async def _save_state(self, state: BaseModel) -> None:
+        await self.ensure_seeded()
         await self._postgres_storage.save(
             string_record_from_state(state, self._serializer)
         )
@@ -231,16 +238,25 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
                 state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
                 serializer=serializer,
                 schema=schema,
+                pending_seed=(
+                    (serialized_state, serializer)
+                    if parsed.run_id != effective_run_id
+                    else None
+                ),
+            )
+
+        if store_type not in (None, "in_memory"):
+            raise ValueError(
+                f"Cannot restore store_type '{store_type}' with PostgresStateStore.from_dict()"
             )
 
         # InMemory format — migrate on first DB access
         effective_run_id = run_id or str(uuid.uuid4())
-        store = cls(
+        return cls(
             pool=pool,
             run_id=effective_run_id,
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             serializer=serializer,
             schema=schema,
+            pending_seed=(serialized_state, serializer),
         )
-        store._pending_seed = (serialized_state, serializer)
-        return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -19,12 +19,12 @@ from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
     create_cleared_state,
-    deserialize_dict_state_data,
+    decode_state,
     deserialize_state_from_dict,
+    encode_state,
     get_by_path,
     merge_state,
     parse_in_memory_state,
-    serialize_dict_state_data,
     set_by_path,
 )
 
@@ -83,18 +83,14 @@ class PostgresStateStore(Generic[MODEL_T]):
         """Lazy lock initialization for Python 3.14+ compatibility."""
         return asyncio.Lock()
 
-    def _serialize_state(self, state: MODEL_T) -> str:
-        """Serialize state model to JSON string."""
-        if isinstance(state, DictState):
-            return json.dumps(serialize_dict_state_data(state, self._serializer))
-        return self._serializer.serialize(state)
-
-    def _deserialize_state(self, state_json: str) -> MODEL_T:
+    def _deserialize_state(
+        self,
+        state_json: str,
+        state_type_name: str | None,
+        state_module: str | None,
+    ) -> MODEL_T:
         """Deserialize state from JSON string."""
-        if issubclass(self.state_type, DictState):
-            data = json.loads(state_json)
-            return deserialize_dict_state_data(data, self._serializer)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-        return self._serializer.deserialize(state_json)
+        return decode_state(state_json, state_type_name, state_module, self._serializer)  # type: ignore[return-value]
 
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()
@@ -110,6 +106,7 @@ class PostgresStateStore(Generic[MODEL_T]):
             return
         serialized_state, serializer = self._pending_seed
         self._pending_seed = None
+        self._serializer = serializer
         store_type = serialized_state.get("store_type")
         if store_type == "postgres":
             source_run_id = serialized_state.get("run_id")
@@ -150,14 +147,16 @@ class PostgresStateStore(Generic[MODEL_T]):
             conn = await self._pool.acquire()  # type: ignore[assignment]
         try:
             row = await conn.fetchrow(  # type: ignore[union-attr]
-                f"SELECT state_json FROM {self._table_ref} WHERE run_id = $1",
+                f"SELECT state_json, state_type, state_module FROM {self._table_ref} WHERE run_id = $1",
                 self._run_id,
             )
             if row is None:
                 state = self._create_default_state()
                 await self._save_state(state, conn)
                 return state
-            return self._deserialize_state(row["state_json"])
+            return self._deserialize_state(
+                row["state_json"], row["state_type"], row["state_module"]
+            )
         finally:
             if should_release:
                 await self._pool.release(conn)  # type: ignore[arg-type]
@@ -173,7 +172,12 @@ class PostgresStateStore(Generic[MODEL_T]):
             conn = await self._pool.acquire()  # type: ignore[assignment]
         try:
             now = _utc_now()
-            state_json = self._serialize_state(state)
+            state_data, state_type_name, state_module = encode_state(
+                state, self._serializer
+            )
+            state_json = (
+                state_data if isinstance(state_data, str) else json.dumps(state_data)
+            )
             await conn.execute(  # type: ignore[union-attr]
                 f"""
                 INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
@@ -186,8 +190,8 @@ class PostgresStateStore(Generic[MODEL_T]):
                 """,
                 self._run_id,
                 state_json,
-                type(state).__name__,
-                type(state).__module__,
+                state_type_name,
+                state_module,
                 now,
                 now,
             )
@@ -204,14 +208,16 @@ class PostgresStateStore(Generic[MODEL_T]):
         """Replace or merge into the current state model."""
         async with self._pool.acquire() as conn:
             row = await conn.fetchrow(
-                f"SELECT state_json FROM {self._table_ref} WHERE run_id = $1",
+                f"SELECT state_json, state_type, state_module FROM {self._table_ref} WHERE run_id = $1",
                 self._run_id,
             )
             if row is None:
                 await self._save_state(state, conn)
                 return
 
-            current_state = self._deserialize_state(row["state_json"])
+            current_state = self._deserialize_state(
+                row["state_json"], row["state_type"], row["state_module"]
+            )
             merged = merge_state(current_state, state)
             await self._save_state(merged, conn)  # type: ignore[arg-type]
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any, Generic, Literal
 
@@ -39,10 +41,12 @@ class _PostgresStateStorage:
         pool: asyncpg.Pool,
         run_id: str,
         schema: str | None = None,
+        connection: asyncpg.Connection | asyncpg.pool.PoolConnectionProxy | None = None,
     ) -> None:
         self._pool = pool
         self._run_id = run_id
         self._schema = schema
+        self._shared_conn = connection
 
     @property
     def run_id(self) -> str:
@@ -54,9 +58,35 @@ class _PostgresStateStorage:
             return f"{self._schema}.workflow_state"
         return "workflow_state"
 
+    @asynccontextmanager
+    async def _acquire(
+        self,
+    ) -> AsyncIterator[asyncpg.Connection | asyncpg.pool.PoolConnectionProxy]:
+        """One query-API surface: the bound connection or a pool checkout."""
+        if self._shared_conn is not None:
+            yield self._shared_conn
+            return
+        async with self._pool.acquire() as conn:
+            yield conn
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[_PostgresStateStorage]:
+        """Scope a load+save pair to one pool connection.
+
+        Yields a separate conn-bound storage so concurrent readers on this
+        storage keep acquiring their own connections.
+        """
+        if self._shared_conn is not None:
+            yield self
+            return
+        async with self._pool.acquire() as conn:
+            yield _PostgresStateStorage(
+                self._pool, self._run_id, self._schema, connection=conn
+            )
+
     async def load(self) -> StateRecord | None:
         """Load raw state from the database."""
-        async with self._pool.acquire() as conn:
+        async with self._acquire() as conn:
             row = await conn.fetchrow(
                 f"SELECT state_json FROM {self._table_ref} WHERE run_id = $1",
                 self._run_id,
@@ -68,7 +98,7 @@ class _PostgresStateStorage:
     async def save(self, record: StateRecord) -> None:
         """Save raw state to the database via upsert."""
         now = _utc_now()
-        async with self._pool.acquire() as conn:
+        async with self._acquire() as conn:
             await conn.execute(
                 f"""
                 INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
@@ -101,7 +131,7 @@ class _PostgresStateStorage:
     async def copy_from_handle(self, handle: PostgresSerializedState) -> None:
         """Copy state from another run's row using SQL INSERT...SELECT."""
         now = _utc_now()
-        async with self._pool.acquire() as conn:
+        async with self._acquire() as conn:
             await conn.execute(
                 f"""
                 INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -3,13 +3,10 @@
 
 from __future__ import annotations
 
-import asyncio
-import functools
 import logging
 import uuid
-from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Generic, Literal, cast
+from typing import Any, Generic, Literal
 
 import asyncpg
 from pydantic import BaseModel
@@ -17,13 +14,10 @@ from typing_extensions import TypeVar
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
-    create_cleared_state,
+    StoredStateRecord,
+    TypedStateStore,
     decode_seed_state,
-    decode_state,
-    encode_state_to_str,
-    get_by_path,
-    merge_state,
-    set_by_path,
+    string_record_from_state,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,29 +36,18 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-class PostgresStateStore(Generic[MODEL_T]):
-    """Asyncpg-backed StateStore implementation.
-
-    Every get() reads from the database, every set() writes through.
-    No in-memory cache — the database is the source of truth.
-    """
-
-    state_type: type[MODEL_T]
+class PostgresStateStorage:
+    """Asyncpg-backed raw state storage."""
 
     def __init__(
         self,
         pool: asyncpg.Pool,
         run_id: str,
-        state_type: type[MODEL_T] | None = None,
-        serializer: BaseSerializer | None = None,
         schema: str | None = None,
     ) -> None:
         self._pool = pool
         self._run_id = run_id
-        self.state_type = state_type or DictState  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
-        self._serializer = serializer or JsonSerializer()
         self._schema = schema
-        self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
 
     @property
     def run_id(self) -> str:
@@ -75,34 +58,6 @@ class PostgresStateStore(Generic[MODEL_T]):
         if self._schema:
             return f"{self._schema}.workflow_state"
         return "workflow_state"
-
-    @functools.cached_property
-    def _lock(self) -> asyncio.Lock:
-        """Lazy lock initialization for Python 3.14+ compatibility."""
-        return asyncio.Lock()
-
-    def _create_default_state(self) -> MODEL_T:
-        return self.state_type()
-
-    async def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
-        """Migrate InMemory-format state into the database."""
-        state = decode_seed_state(serialized_state, self._serializer)
-        await self._save_state(state)  # type: ignore[arg-type]
-
-    async def _flush_pending_seed(self) -> None:
-        """Flush pending seed data to the database if present."""
-        if self._pending_seed is None:
-            return
-        serialized_state, serializer = self._pending_seed
-        self._pending_seed = None
-        self._serializer = serializer
-        store_type = serialized_state.get("store_type")
-        if store_type == "postgres":
-            source_run_id = serialized_state.get("run_id")
-            if source_run_id and source_run_id != self._run_id:
-                await self._copy_state_from_run(source_run_id)
-        else:
-            await self._write_in_memory_state(serialized_state)
 
     async def _copy_state_from_run(self, source_run_id: str) -> None:
         """Copy state from another run_id using SQL INSERT...SELECT."""
@@ -125,12 +80,11 @@ class PostgresStateStore(Generic[MODEL_T]):
                 source_run_id,
             )
 
-    async def _load_state(
+    async def load(
         self,
         conn: asyncpg.Connection | None = None,
-    ) -> MODEL_T:
-        """Load state from database. Creates default if row doesn't exist."""
-        await self._flush_pending_seed()
+    ) -> StoredStateRecord | None:
+        """Load raw state from database."""
         should_release = conn is None
         if conn is None:
             conn = await self._pool.acquire()  # type: ignore[assignment]
@@ -140,36 +94,31 @@ class PostgresStateStore(Generic[MODEL_T]):
                 self._run_id,
             )
             if row is None:
-                state = self._create_default_state()
-                await self._save_state(state, conn)
-                return state
-            return cast(
-                MODEL_T,
-                decode_state(
-                    row["state_json"],
-                    row["state_type"],
-                    row["state_module"],
-                    self._serializer,
-                ),
+                return None
+            return StoredStateRecord(
+                data=row["state_json"],
+                state_type=row["state_type"],
+                state_module=row["state_module"],
             )
         finally:
             if should_release:
                 await self._pool.release(conn)  # type: ignore[arg-type]
 
-    async def _save_state(
+    async def save(self, record: StoredStateRecord) -> None:
+        await self._save_record(record)
+
+    async def _save_record(
         self,
-        state: MODEL_T,
+        record: StoredStateRecord,
         conn: asyncpg.Connection | asyncpg.pool.PoolConnectionProxy | None = None,
     ) -> None:
-        """Save state to database via upsert."""
+        """Save raw state to database via upsert."""
         should_release = conn is None
         if conn is None:
             conn = await self._pool.acquire()  # type: ignore[assignment]
         try:
             now = _utc_now()
-            state_json, state_type_name, state_module = encode_state_to_str(
-                state, self._serializer
-            )
+            data = record.data if isinstance(record.data, str) else str(record.data)
             await conn.execute(  # type: ignore[union-attr]
                 f"""
                 INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
@@ -181,9 +130,9 @@ class PostgresStateStore(Generic[MODEL_T]):
                     updated_at = EXCLUDED.updated_at
                 """,
                 self._run_id,
-                state_json,
-                state_type_name,
-                state_module,
+                data,
+                record.state_type,
+                record.state_module,
                 now,
                 now,
             )
@@ -191,60 +140,65 @@ class PostgresStateStore(Generic[MODEL_T]):
             if should_release:
                 await self._pool.release(conn)  # type: ignore[arg-type]
 
-    async def get_state(self) -> MODEL_T:
-        """Return a copy of the current state model."""
-        state = await self._load_state()
-        return state.model_copy()
-
-    async def set_state(self, state: MODEL_T) -> None:
-        """Replace or merge into the current state model."""
-        async with self._pool.acquire() as conn:
-            row = await conn.fetchrow(
-                f"SELECT state_json, state_type, state_module FROM {self._table_ref} WHERE run_id = $1",
-                self._run_id,
-            )
-            if row is None:
-                await self._save_state(state, conn)
-                return
-
-            current_state = decode_state(
-                row["state_json"],
-                row["state_type"],
-                row["state_module"],
-                self._serializer,
-            )
-            merged = merge_state(current_state, state)
-            await self._save_state(merged, conn)  # type: ignore[arg-type]
-
-    async def get(self, path: str, default: Any = ...) -> Any:
-        """Get a nested value using dot-separated paths."""
-        state = await self._load_state()
-        return get_by_path(state, path, default)
-
-    async def set(self, path: str, value: Any) -> None:
-        """Set a nested value using dot-separated paths."""
-        async with self.edit_state() as state:
-            set_by_path(state, path, value)
-
-    async def clear(self) -> None:
-        """Reset the state to its type defaults."""
-        await self.set_state(create_cleared_state(self.state_type))
-
-    @asynccontextmanager
-    async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
-        """Edit state transactionally under a lock."""
-        async with self._lock:
-            state = await self._load_state()
-            yield state
-            await self._save_state(state)
-
-    def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
-        """Serialize state store metadata for persistence.
-
-        Returns metadata only — actual state lives in the database.
-        """
+    def to_handle(self) -> dict[str, Any]:
         payload = PostgresSerializedState(run_id=self._run_id)
         return payload.model_dump()
+
+
+class PostgresStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
+    """Compatibility StateStore facade backed by postgres storage."""
+
+    def __init__(
+        self,
+        pool: asyncpg.Pool,
+        run_id: str,
+        state_type: type[MODEL_T] | None = None,
+        serializer: BaseSerializer | None = None,
+        schema: str | None = None,
+    ) -> None:
+        self._pool = pool
+        self._postgres_storage = PostgresStateStorage(pool, run_id, schema)
+        self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
+        super().__init__(
+            self._postgres_storage,
+            state_type or DictState,  # type: ignore[arg-type]
+            serializer or JsonSerializer(),
+            to_dict_mode="handle",
+        )
+
+    @property
+    def run_id(self) -> str:
+        return self._postgres_storage.run_id
+
+    async def _flush_pending_seed(self) -> None:
+        """Flush pending seed data to the database if present."""
+        if self._pending_seed is None:
+            return
+        serialized_state, serializer = self._pending_seed
+        self._pending_seed = None
+        self._serializer = serializer
+        store_type = serialized_state.get("store_type")
+        if store_type == "postgres":
+            source_run_id = serialized_state.get("run_id")
+            if source_run_id and source_run_id != self.run_id:
+                await self._postgres_storage._copy_state_from_run(source_run_id)
+            return
+        await self._write_in_memory_state(serialized_state)
+
+    async def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
+        state = decode_seed_state(serialized_state, self._serializer)
+        await self._postgres_storage.save(
+            string_record_from_state(state, self._serializer)
+        )
+
+    async def _load_state_or_none(self) -> MODEL_T | None:
+        await self._flush_pending_seed()
+        return await super()._load_state_or_none()
+
+    async def _save_state(self, state: BaseModel) -> None:
+        await self._postgres_storage.save(
+            string_record_from_state(state, self._serializer)
+        )
 
     @classmethod
     def from_dict(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -12,10 +12,10 @@ import asyncpg
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 from workflows.context.serializers import BaseSerializer, JsonSerializer
-from workflows.context.state_store import (
-    DictState,
-    StoredStateRecord,
-    TypedStateStore,
+from workflows.context.state_store import DictState
+from workflows.context.state_store_integration import (
+    StateRecord,
+    StateStoreFacade,
     decode_seed_state,
     string_record_from_state,
 )
@@ -36,7 +36,7 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-class PostgresStateStorage:
+class _PostgresStateStorage:
     """Asyncpg-backed raw state storage."""
 
     def __init__(
@@ -83,7 +83,7 @@ class PostgresStateStorage:
     async def load(
         self,
         conn: asyncpg.Connection | None = None,
-    ) -> StoredStateRecord | None:
+    ) -> StateRecord | None:
         """Load raw state from database."""
         should_release = conn is None
         if conn is None:
@@ -95,7 +95,7 @@ class PostgresStateStorage:
             )
             if row is None:
                 return None
-            return StoredStateRecord(
+            return StateRecord(
                 data=row["state_json"],
                 state_type=row["state_type"],
                 state_module=row["state_module"],
@@ -104,12 +104,12 @@ class PostgresStateStorage:
             if should_release:
                 await self._pool.release(conn)  # type: ignore[arg-type]
 
-    async def save(self, record: StoredStateRecord) -> None:
+    async def save(self, record: StateRecord) -> None:
         await self._save_record(record)
 
     async def _save_record(
         self,
-        record: StoredStateRecord,
+        record: StateRecord,
         conn: asyncpg.Connection | asyncpg.pool.PoolConnectionProxy | None = None,
     ) -> None:
         """Save raw state to database via upsert."""
@@ -145,7 +145,7 @@ class PostgresStateStorage:
         return payload.model_dump()
 
 
-class PostgresStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
+class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
     """Compatibility StateStore facade backed by postgres storage."""
 
     def __init__(
@@ -157,7 +157,7 @@ class PostgresStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
         schema: str | None = None,
     ) -> None:
         self._pool = pool
-        self._postgres_storage = PostgresStateStorage(pool, run_id, schema)
+        self._postgres_storage = _PostgresStateStorage(pool, run_id, schema)
         self._pending_seed: tuple[dict[str, Any], BaseSerializer] | None = None
         super().__init__(
             self._postgres_storage,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -131,7 +131,6 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         serializer: BaseSerializer | None = None,
         schema: str | None = None,
     ) -> None:
-        self._pool = pool
         self._postgres_storage = _PostgresStateStorage(pool, run_id, schema)
         super().__init__(
             self._postgres_storage,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -150,7 +150,9 @@ class _PostgresStateStorage:
             now = _utc_now()
             # json.dumps raises TypeError for non-JSON data rather than
             # silently writing a Python repr into the JSON column.
-            data = record.data if isinstance(record.data, str) else json.dumps(record.data)
+            data = (
+                record.data if isinstance(record.data, str) else json.dumps(record.data)
+            )
             await conn.execute(  # type: ignore[union-attr]
                 f"""
                 INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import json
 import logging
 import uuid
 from contextlib import asynccontextmanager
@@ -19,12 +18,11 @@ from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
     create_cleared_state,
+    decode_seed_state,
     decode_state,
-    deserialize_state_from_dict,
-    encode_state,
+    encode_state_to_str,
     get_by_path,
     merge_state,
-    parse_in_memory_state,
     set_by_path,
 )
 
@@ -83,21 +81,12 @@ class PostgresStateStore(Generic[MODEL_T]):
         """Lazy lock initialization for Python 3.14+ compatibility."""
         return asyncio.Lock()
 
-    def _deserialize_state(
-        self,
-        state_json: str,
-        state_type_name: str | None,
-        state_module: str | None,
-    ) -> MODEL_T:
-        """Deserialize state from JSON string."""
-        return decode_state(state_json, state_type_name, state_module, self._serializer)  # type: ignore[return-value]
-
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()
 
     async def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
         """Migrate InMemory-format state into the database."""
-        state = deserialize_state_from_dict(serialized_state, self._serializer)
+        state = decode_seed_state(serialized_state, self._serializer)
         await self._save_state(state)  # type: ignore[arg-type]
 
     async def _flush_pending_seed(self) -> None:
@@ -154,9 +143,12 @@ class PostgresStateStore(Generic[MODEL_T]):
                 state = self._create_default_state()
                 await self._save_state(state, conn)
                 return state
-            return self._deserialize_state(
-                row["state_json"], row["state_type"], row["state_module"]
-            )
+            return decode_state(
+                row["state_json"],
+                row["state_type"],
+                row["state_module"],
+                self._serializer,
+            )  # type: ignore[return-value]
         finally:
             if should_release:
                 await self._pool.release(conn)  # type: ignore[arg-type]
@@ -172,11 +164,8 @@ class PostgresStateStore(Generic[MODEL_T]):
             conn = await self._pool.acquire()  # type: ignore[assignment]
         try:
             now = _utc_now()
-            state_data, state_type_name, state_module = encode_state(
+            state_json, state_type_name, state_module = encode_state_to_str(
                 state, self._serializer
-            )
-            state_json = (
-                state_data if isinstance(state_data, str) else json.dumps(state_data)
             )
             await conn.execute(  # type: ignore[union-attr]
                 f"""
@@ -215,8 +204,11 @@ class PostgresStateStore(Generic[MODEL_T]):
                 await self._save_state(state, conn)
                 return
 
-            current_state = self._deserialize_state(
-                row["state_json"], row["state_type"], row["state_module"]
+            current_state = decode_state(
+                row["state_json"],
+                row["state_type"],
+                row["state_module"],
+                self._serializer,
             )
             merged = merge_state(current_state, state)
             await self._save_state(merged, conn)  # type: ignore[arg-type]
@@ -284,9 +276,7 @@ class PostgresStateStore(Generic[MODEL_T]):
                 schema=schema,
             )
 
-        # InMemory format — will need async migration
-        parse_in_memory_state(serialized_state)
-
+        # InMemory format — migrate on first DB access
         effective_run_id = run_id or str(uuid.uuid4())
         store = cls(
             pool=pool,
@@ -295,6 +285,5 @@ class PostgresStateStore(Generic[MODEL_T]):
             serializer=serializer,
             schema=schema,
         )
-        # Note: caller must await store._write_in_memory_state(serialized_state)
-        # since from_dict is synchronous but migration requires async DB access
+        store._pending_seed = (serialized_state, serializer)
         return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -272,9 +272,12 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
                     "Failed to release listen connection during close", exc_info=True
                 )
             self._listen_conn = None
-        if self._pool is not None:
-            await self._pool_provider.close()
-            self._pool = None
+        # Close the provider unconditionally: if start() failed after the
+        # provider resolved a pool but before self._pool was published (e.g.
+        # migrations or LISTEN setup raised), the pool would otherwise leak.
+        # Idempotent, and a no-op for borrowed pools.
+        await self._pool_provider.close()
+        self._pool = None
         # Cached facades hold the closed pool; drop them so a re-start()
         # builds fresh stores against the new pool.
         self._state_store_cache.clear()

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -17,7 +17,6 @@ import asyncpg
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
-from workflows.context.state_store import DictState
 
 from .._pool import PoolProvider
 from .abstract_workflow_store import (
@@ -64,6 +63,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         When it is omitted, the store owns a lazily-created asyncpg pool using
         the provided DSN and pool size settings.
         """
+        super().__init__()
         self._dsn = dsn
         self._schema = schema
         self.poll_interval = poll_interval
@@ -82,9 +82,6 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
             weakref.WeakValueDictionary()
         )
-        self._state_stores: weakref.WeakValueDictionary[
-            str, PostgresStateStore[Any]
-        ] = weakref.WeakValueDictionary()
         # LISTEN reconnect bookkeeping.
         self._closing = False
         self._reconnect_lock = asyncio.Lock()
@@ -122,8 +119,10 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
 
         Safe to call concurrently: the lock plus re-check ensures exactly one
         caller resolves the pool, runs migrations, and acquires the LISTEN
-        connection. Re-checking inside the lock (instead of latching a
-        "started" flag) keeps re-start after ``close()`` working.
+        connection. ``self._pool`` is published only after everything
+        succeeded, so a late joiner's fast path never observes a half-started
+        store. Re-checking inside the lock (instead of latching a "started"
+        flag) keeps re-start after ``close()`` working.
         """
         if self._pool is not None:
             return
@@ -132,15 +131,15 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
                 return
             # Reset for re-start after a close().
             self._closing = False
-            self._pool = await self._pool_provider.get()
+            pool = await self._pool_provider.get()
             if self._auto_migrate:
-                await self.run_migrations()
-            await self._setup_listener()
+                await self._run_migrations_on(pool)
+            await self._setup_listener(pool)
+            self._pool = pool
 
-    async def _setup_listener(self) -> None:
+    async def _setup_listener(self, pool: asyncpg.Pool) -> None:
         """Set up a dedicated connection for LISTEN/NOTIFY."""
-        assert self._pool is not None
-        conn = cast(asyncpg.Connection, await self._pool.acquire())
+        conn = cast(asyncpg.Connection, await pool.acquire())
         try:
             await conn.add_listener(self._notify_channel, self._on_notify)
             # Recover from network blips / Postgres restarts.
@@ -152,7 +151,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
                     "Connection.add_termination_listener unavailable; LISTEN reconnect disabled"
                 )
         except Exception:
-            await self._pool.release(conn)
+            await pool.release(conn)
             raise
         self._listen_conn = conn
 
@@ -212,6 +211,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         async with self._reconnect_lock:
             if self._closing or self._pool is None:
                 return
+            pool = self._pool
 
             logger.warning("LISTEN connection dropped; reconnecting")
 
@@ -219,7 +219,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             # closed connections gracefully on release.
             if self._listen_conn is not None:
                 try:
-                    await self._pool.release(self._listen_conn)
+                    await pool.release(self._listen_conn)
                 except Exception:
                     logger.debug(
                         "Failed to release dead listen connection", exc_info=True
@@ -229,7 +229,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             delay = _LISTEN_RECONNECT_INITIAL_DELAY
             while not self._closing:
                 try:
-                    await self._setup_listener()
+                    await self._setup_listener(pool)
                 except Exception:
                     logger.warning(
                         "LISTEN reconnect attempt failed; retrying in %.1fs",
@@ -277,7 +277,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             self._pool = None
         # Cached facades hold the closed pool; drop them so a re-start()
         # builds fresh stores against the new pool.
-        self._state_stores.clear()
+        self._state_store_cache.clear()
 
     async def _ensure_pool(self) -> asyncpg.Pool:
         if self._pool is None:
@@ -292,51 +292,33 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             self._conditions[run_id] = cond
         return cond
 
-    def create_state_store(
+    def _build_state_store(
         self,
         run_id: str,
-        state_type: type[Any] | None = None,
-        serialized_state: dict[str, Any] | None = None,
-        serializer: BaseSerializer | None = None,
+        state_type: type[Any] | None,
+        serializer: BaseSerializer | None,
     ) -> PostgresStateStore[Any]:
         if self._pool is None:
             raise RuntimeError(
                 "PostgresWorkflowStore pool not initialized. Call start() first."
             )
-        # One facade per run per process so its write lock is a real
-        # guarantee. Serialized restore requests always rebuild the store.
-        cached = self._state_stores.get(run_id)
-        if cached is not None and serialized_state is None:
-            if state_type is not None and cached.state_type is DictState:
-                # An earlier type-less caller (e.g. handler continuation)
-                # must not shadow the workflow's concrete state type.
-                cached.state_type = state_type
-            return cached
-        if serialized_state is not None and serializer is not None:
-            store = PostgresStateStore.from_dict(
-                serialized_state,
-                serializer,
-                pool=self._pool,
-                state_type=state_type,
-                run_id=run_id,
-                schema=self._schema,
-            )
-        else:
-            store = PostgresStateStore(
-                pool=self._pool,
-                run_id=run_id,
-                state_type=state_type,
-                serializer=serializer,
-                schema=self._schema,
-            )
-        self._state_stores[run_id] = store
-        return store
+        return PostgresStateStore(
+            pool=self._pool,
+            run_id=run_id,
+            state_type=state_type,
+            serializer=serializer,
+            schema=self._schema,
+        )
 
     # ── Migrations ──────────────────────────────────────────────────────
 
     async def run_migrations(self) -> None:
         """Apply file-based migrations to create/update schema."""
         pool = await self._ensure_pool()
+        await self._run_migrations_on(pool)
+
+    async def _run_migrations_on(self, pool: asyncpg.Pool) -> None:
+        """Run migrations against an explicit pool (usable mid-start)."""
         async with pool.acquire() as conn:
             await _run_migrations(cast(asyncpg.Connection, conn), schema=self._schema)
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import concurrent.futures
 import contextlib
+import functools
 import json
 import logging
 import weakref
@@ -111,16 +112,30 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
     def _notify_channel(self) -> str:
         return self._events_table_name
 
+    @functools.cached_property
+    def _start_lock(self) -> asyncio.Lock:
+        """Lazy lock initialization for Python 3.14+ compatibility."""
+        return asyncio.Lock()
+
     async def start(self) -> None:
-        """Resolve the connection pool, run migrations if enabled, and set up LISTEN."""
+        """Resolve the connection pool, run migrations if enabled, and set up LISTEN.
+
+        Safe to call concurrently: the lock plus re-check ensures exactly one
+        caller resolves the pool, runs migrations, and acquires the LISTEN
+        connection. Re-checking inside the lock (instead of latching a
+        "started" flag) keeps re-start after ``close()`` working.
+        """
         if self._pool is not None:
             return
-        # Reset for re-start after a close().
-        self._closing = False
-        self._pool = await self._pool_provider.get()
-        if self._auto_migrate:
-            await self.run_migrations()
-        await self._setup_listener()
+        async with self._start_lock:
+            if self._pool is not None:
+                return
+            # Reset for re-start after a close().
+            self._closing = False
+            self._pool = await self._pool_provider.get()
+            if self._auto_migrate:
+                await self.run_migrations()
+            await self._setup_listener()
 
     async def _setup_listener(self) -> None:
         """Set up a dedicated connection for LISTEN/NOTIFY."""

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -281,16 +281,22 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             raise RuntimeError(
                 "PostgresWorkflowStore pool not initialized. Call start() first."
             )
-        store = PostgresStateStore(
+        if serialized_state is not None and serializer is not None:
+            return PostgresStateStore.from_dict(
+                serialized_state,
+                serializer,
+                pool=self._pool,
+                state_type=state_type,
+                run_id=run_id,
+                schema=self._schema,
+            )
+        return PostgresStateStore(
             pool=self._pool,
             run_id=run_id,
             state_type=state_type,
             serializer=serializer,
             schema=self._schema,
         )
-        if serialized_state is not None and serializer is not None:
-            store._pending_seed = (serialized_state, serializer)
-        return store
 
     # ── Migrations ──────────────────────────────────────────────────────
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -285,6 +285,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             pool=self._pool,
             run_id=run_id,
             state_type=state_type,
+            serializer=serializer,
             schema=self._schema,
         )
         if serialized_state is not None and serializer is not None:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -16,6 +16,7 @@ import asyncpg
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
+from workflows.context.state_store import DictState
 
 from .._pool import PoolProvider
 from .abstract_workflow_store import (
@@ -80,6 +81,9 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
             weakref.WeakValueDictionary()
         )
+        self._state_stores: weakref.WeakValueDictionary[
+            str, PostgresStateStore[Any]
+        ] = weakref.WeakValueDictionary()
         # LISTEN reconnect bookkeeping.
         self._closing = False
         self._reconnect_lock = asyncio.Lock()
@@ -256,6 +260,9 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         if self._pool is not None:
             await self._pool_provider.close()
             self._pool = None
+        # Cached facades hold the closed pool; drop them so a re-start()
+        # builds fresh stores against the new pool.
+        self._state_stores.clear()
 
     async def _ensure_pool(self) -> asyncpg.Pool:
         if self._pool is None:
@@ -281,8 +288,17 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
             raise RuntimeError(
                 "PostgresWorkflowStore pool not initialized. Call start() first."
             )
+        # One facade per run per process so its write lock is a real
+        # guarantee. Serialized restore requests always rebuild the store.
+        cached = self._state_stores.get(run_id)
+        if cached is not None and serialized_state is None:
+            if state_type is not None and cached.state_type is DictState:
+                # An earlier type-less caller (e.g. handler continuation)
+                # must not shadow the workflow's concrete state type.
+                cached.state_type = state_type
+            return cached
         if serialized_state is not None and serializer is not None:
-            return PostgresStateStore.from_dict(
+            store = PostgresStateStore.from_dict(
                 serialized_state,
                 serializer,
                 pool=self._pool,
@@ -290,13 +306,16 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
                 run_id=run_id,
                 schema=self._schema,
             )
-        return PostgresStateStore(
-            pool=self._pool,
-            run_id=run_id,
-            state_type=state_type,
-            serializer=serializer,
-            schema=self._schema,
-        )
+        else:
+            store = PostgresStateStore(
+                pool=self._pool,
+                run_id=run_id,
+                state_type=state_type,
+                serializer=serializer,
+                schema=self._schema,
+            )
+        self._state_stores[run_id] = store
+        return store
 
     # ── Migrations ──────────────────────────────────────────────────────
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -111,7 +111,9 @@ class _SqliteStateStorage:
             now = _utc_now().isoformat()
             # json.dumps raises TypeError for non-JSON data rather than
             # silently writing a Python repr into the JSON column.
-            data = record.data if isinstance(record.data, str) else json.dumps(record.data)
+            data = (
+                record.data if isinstance(record.data, str) else json.dumps(record.data)
+            )
             conn.execute(
                 """
                 INSERT INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import sqlite3
 import uuid
@@ -108,7 +109,9 @@ class _SqliteStateStorage:
             context = None
         try:
             now = _utc_now().isoformat()
-            data = record.data if isinstance(record.data, str) else str(record.data)
+            # json.dumps raises TypeError for non-JSON data rather than
+            # silently writing a Python repr into the JSON column.
+            data = record.data if isinstance(record.data, str) else json.dumps(record.data)
             conn.execute(
                 """
                 INSERT INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-import json
-import logging
 import sqlite3
 import uuid
 from collections.abc import Iterator
@@ -19,11 +17,7 @@ from workflows.context.state_store import DictState
 from workflows.context.state_store_integration import (
     StateRecord,
     StateStoreFacade,
-    decode_seed_state,
-    string_record_from_state,
 )
-
-logger = logging.getLogger(__name__)
 
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
@@ -40,7 +34,7 @@ def _utc_now() -> datetime:
 
 
 class _SqliteStateStorage:
-    """Sqlite-backed raw state storage."""
+    """Sqlite-backed raw state storage (genuine I/O only)."""
 
     def __init__(
         self,
@@ -67,53 +61,23 @@ class _SqliteStateStorage:
         finally:
             conn.close()
 
-    def _copy_state_from_run(self, source_run_id: str) -> None:
-        """Copy state from another run_id using SQL INSERT...SELECT."""
-        with self._connect() as conn:
-            now = _utc_now().isoformat()
-            conn.execute(
-                """
-                INSERT OR REPLACE INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
-                SELECT ?, state_json, state_type, state_module, ?, ?
-                FROM workflow_state WHERE run_id = ?
-                """,
-                (self._run_id, now, now, source_run_id),
-            )
-            conn.commit()
-
     async def load(self) -> StateRecord | None:
-        """Load raw state from database."""
+        """Load raw state from the database."""
         with self._connect() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT state_json, state_type, state_module FROM workflow_state WHERE run_id = ?",
+                "SELECT state_json FROM workflow_state WHERE run_id = ?",
                 (self._run_id,),
             )
             row = cursor.fetchone()
-            if row is None:
-                return None
-            return StateRecord(data=row[0], state_type=row[1], state_module=row[2])
+        if row is None:
+            return None
+        return StateRecord(data=row[0])
 
     async def save(self, record: StateRecord) -> None:
-        """Save raw state to database."""
-        self._save_record(record)
-
-    def _save_record(
-        self, record: StateRecord, conn: sqlite3.Connection | None = None
-    ) -> None:
-        should_commit = conn is None
-        if conn is None:
-            context = self._connect()
-            conn = context.__enter__()
-        else:
-            context = None
-        try:
+        """Save raw state to the database via upsert."""
+        with self._connect() as conn:
             now = _utc_now().isoformat()
-            # json.dumps raises TypeError for non-JSON data rather than
-            # silently writing a Python repr into the JSON column.
-            data = (
-                record.data if isinstance(record.data, str) else json.dumps(record.data)
-            )
             conn.execute(
                 """
                 INSERT INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
@@ -126,26 +90,41 @@ class _SqliteStateStorage:
                 """,
                 (
                     self._run_id,
-                    data,
+                    record.data,
                     record.state_type,
                     record.state_module,
                     now,
                     now,
                 ),
             )
-            if should_commit:
-                conn.commit()
-        finally:
-            if context is not None:
-                context.__exit__(None, None, None)
+            conn.commit()
 
     def to_handle(self) -> dict[str, Any]:
         payload = SqliteSerializedState(run_id=self._run_id)
         return payload.model_dump()
 
+    def parse_own_handle(self, payload: dict[str, Any]) -> SqliteSerializedState | None:
+        if payload.get("store_type") != "sqlite":
+            return None
+        return SqliteSerializedState.model_validate(payload)
+
+    async def copy_from_handle(self, handle: SqliteSerializedState) -> None:
+        """Copy state from another run's row using SQL INSERT...SELECT."""
+        with self._connect() as conn:
+            now = _utc_now().isoformat()
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
+                SELECT ?, state_json, state_type, state_module, ?, ?
+                FROM workflow_state WHERE run_id = ?
+                """,
+                (self._run_id, now, now, handle.run_id),
+            )
+            conn.commit()
+
 
 class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
-    """Compatibility StateStore facade backed by sqlite storage."""
+    """StateStore facade backed by sqlite storage."""
 
     def __init__(
         self,
@@ -161,37 +140,11 @@ class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
             self._sqlite_storage,
             state_type or DictState,  # type: ignore[arg-type]
             serializer or JsonSerializer(),
-            to_dict_mode="handle",
         )
 
     @property
     def run_id(self) -> str:
         return self._sqlite_storage.run_id
-
-    def _seed_from_serialized(
-        self, serialized_state: dict[str, Any], serializer: BaseSerializer
-    ) -> None:
-        """Seed this store from serialized state data."""
-        self._serializer = serializer
-        store_type = serialized_state.get("store_type")
-        if store_type == "sqlite":
-            source_run_id = serialized_state.get("run_id")
-            if source_run_id and source_run_id != self.run_id:
-                self._sqlite_storage._copy_state_from_run(source_run_id)
-            return
-        self._write_in_memory_state(serialized_state)
-
-    def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
-        """Migrate InMemory-format state into the database."""
-        state = decode_seed_state(serialized_state, self._serializer)
-        self._sqlite_storage._save_record(
-            string_record_from_state(state, self._serializer)
-        )
-
-    async def _save_state(self, state: BaseModel) -> None:
-        await self._sqlite_storage.save(
-            string_record_from_state(state, self._serializer)
-        )
 
     @classmethod
     def from_dict(
@@ -202,40 +155,22 @@ class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         state_type: type[BaseModel] | None = None,
         run_id: str | None = None,
     ) -> SqliteStateStore[Any]:
-        """Restore a state store from serialized payload.
+        """Restore a state store from a serialized payload.
 
-        Handles both InMemorySerializedState (migrates data to DB on first use)
-        and SqliteSerializedState (reconnects to existing row).
+        Construct + seed: ``add_seed`` validates the payload eagerly
+        (foreign durable handles raise) and materializes it lazily.
         """
         if not serialized_state:
             raise ValueError("Cannot restore SqliteStateStore from empty dict")
-
-        store_type = serialized_state.get("store_type")
-
-        if store_type == "sqlite":
-            parsed = SqliteSerializedState.model_validate(serialized_state)
-            effective_run_id = run_id or parsed.run_id
-            if db_path is None:
-                raise ValueError("db_path is required for SqliteStateStore.from_dict()")
-            store = cls(
-                db_path=db_path,
-                run_id=effective_run_id,
-                state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
-                serializer=serializer,
-            )
-            if parsed.run_id != effective_run_id:
-                store._seed_from_serialized(serialized_state, serializer)
-            return store
-
-        # InMemory format — migrate data to DB immediately
-        effective_run_id = run_id or str(uuid.uuid4())
         if db_path is None:
             raise ValueError("db_path is required for SqliteStateStore.from_dict()")
-        store = cls(
+
+        effective_run_id = run_id or serialized_state.get("run_id") or str(uuid.uuid4())
+        store: SqliteStateStore[Any] = cls(
             db_path=db_path,
             run_id=effective_run_id,
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             serializer=serializer,
         )
-        store._write_in_memory_state(serialized_state)
+        store.add_seed(serialized_state, serializer)
         return store

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -12,10 +12,10 @@ from typing import Any, Generic, Literal
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 from workflows.context.serializers import BaseSerializer, JsonSerializer
-from workflows.context.state_store import (
-    DictState,
-    StoredStateRecord,
-    TypedStateStore,
+from workflows.context.state_store import DictState
+from workflows.context.state_store_integration import (
+    StateRecord,
+    StateStoreFacade,
     decode_seed_state,
     string_record_from_state,
 )
@@ -36,7 +36,7 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-class SqliteStateStorage:
+class _SqliteStateStorage:
     """Sqlite-backed raw state storage."""
 
     def __init__(
@@ -75,7 +75,7 @@ class SqliteStateStorage:
         finally:
             conn.close()
 
-    async def load(self) -> StoredStateRecord | None:
+    async def load(self) -> StateRecord | None:
         """Load raw state from database."""
         conn = self._connect()
         try:
@@ -87,18 +87,16 @@ class SqliteStateStorage:
             row = cursor.fetchone()
             if row is None:
                 return None
-            return StoredStateRecord(
-                data=row[0], state_type=row[1], state_module=row[2]
-            )
+            return StateRecord(data=row[0], state_type=row[1], state_module=row[2])
         finally:
             conn.close()
 
-    async def save(self, record: StoredStateRecord) -> None:
+    async def save(self, record: StateRecord) -> None:
         """Save raw state to database."""
         self._save_record(record)
 
     def _save_record(
-        self, record: StoredStateRecord, conn: sqlite3.Connection | None = None
+        self, record: StateRecord, conn: sqlite3.Connection | None = None
     ) -> None:
         should_close = conn is None
         if conn is None:
@@ -136,7 +134,7 @@ class SqliteStateStorage:
         return payload.model_dump()
 
 
-class SqliteStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
+class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
     """Compatibility StateStore facade backed by sqlite storage."""
 
     def __init__(
@@ -148,7 +146,7 @@ class SqliteStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
         connection: sqlite3.Connection | None = None,
     ) -> None:
         self._db_path = db_path
-        self._sqlite_storage = SqliteStateStorage(db_path, run_id, connection)
+        self._sqlite_storage = _SqliteStateStorage(db_path, run_id, connection)
         super().__init__(
             self._sqlite_storage,
             state_type or DictState,  # type: ignore[arg-type]

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -10,7 +10,7 @@ import sqlite3
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Generic, Literal
+from typing import Any, AsyncGenerator, Generic, Literal, cast
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
@@ -135,7 +135,7 @@ class SqliteStateStore(Generic[MODEL_T]):
                 self._save_state(state, conn)
                 conn.commit()
                 return state
-            return decode_state(row[0], row[1], row[2], self._serializer)  # type: ignore[return-value]
+            return cast(MODEL_T, decode_state(row[0], row[1], row[2], self._serializer))
         finally:
             conn.close()
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -19,12 +19,12 @@ from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
     create_cleared_state,
-    deserialize_dict_state_data,
+    decode_state,
     deserialize_state_from_dict,
+    encode_state,
     get_by_path,
     merge_state,
     parse_in_memory_state,
-    serialize_dict_state_data,
     set_by_path,
 )
 
@@ -93,6 +93,7 @@ class SqliteStateStore(Generic[MODEL_T]):
 
         Handles both sqlite references (SQL-level copy) and InMemory format.
         """
+        self._serializer = serializer
         store_type = serialized_state.get("store_type")
         if store_type == "sqlite":
             source_run_id = serialized_state.get("run_id")
@@ -118,18 +119,14 @@ class SqliteStateStore(Generic[MODEL_T]):
         finally:
             conn.close()
 
-    def _serialize_state(self, state: MODEL_T) -> str:
-        """Serialize state model to JSON string."""
-        if isinstance(state, DictState):
-            return json.dumps(serialize_dict_state_data(state, self._serializer))
-        return self._serializer.serialize(state)
-
-    def _deserialize_state(self, state_json: str) -> MODEL_T:
+    def _deserialize_state(
+        self,
+        state_json: str,
+        state_type_name: str | None,
+        state_module: str | None,
+    ) -> MODEL_T:
         """Deserialize state from JSON string."""
-        if issubclass(self.state_type, DictState):
-            data = json.loads(state_json)
-            return deserialize_dict_state_data(data, self._serializer)  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
-        return self._serializer.deserialize(state_json)
+        return decode_state(state_json, state_type_name, state_module, self._serializer)  # type: ignore[return-value]
 
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()
@@ -140,7 +137,7 @@ class SqliteStateStore(Generic[MODEL_T]):
         try:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT state_json FROM workflow_state WHERE run_id = ?",
+                "SELECT state_json, state_type, state_module FROM workflow_state WHERE run_id = ?",
                 (self._run_id,),
             )
             row = cursor.fetchone()
@@ -149,7 +146,7 @@ class SqliteStateStore(Generic[MODEL_T]):
                 self._save_state(state, conn)
                 conn.commit()
                 return state
-            return self._deserialize_state(row[0])
+            return self._deserialize_state(row[0], row[1], row[2])
         finally:
             conn.close()
 
@@ -162,7 +159,12 @@ class SqliteStateStore(Generic[MODEL_T]):
             conn = self._connect()
         try:
             now = _utc_now().isoformat()
-            state_json = self._serialize_state(state)
+            state_data, state_type_name, state_module = encode_state(
+                state, self._serializer
+            )
+            state_json = (
+                state_data if isinstance(state_data, str) else json.dumps(state_data)
+            )
             conn.execute(
                 """
                 INSERT INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
@@ -176,8 +178,8 @@ class SqliteStateStore(Generic[MODEL_T]):
                 (
                     self._run_id,
                     state_json,
-                    type(state).__name__,
-                    type(state).__module__,
+                    state_type_name,
+                    state_module,
                     now,
                     now,
                 ),
@@ -199,7 +201,7 @@ class SqliteStateStore(Generic[MODEL_T]):
         try:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT state_json FROM workflow_state WHERE run_id = ?",
+                "SELECT state_json, state_type, state_module FROM workflow_state WHERE run_id = ?",
                 (self._run_id,),
             )
             row = cursor.fetchone()
@@ -209,7 +211,7 @@ class SqliteStateStore(Generic[MODEL_T]):
                 conn.commit()
                 return
 
-            current_state = self._deserialize_state(row[0])
+            current_state = self._deserialize_state(row[0], row[1], row[2])
             merged = merge_state(current_state, state)
             self._save_state(merged, conn)  # type: ignore[arg-type]
             conn.commit()

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import logging
 import sqlite3
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Any, Generic, Literal
 
@@ -53,15 +55,20 @@ class _SqliteStateStorage:
     def run_id(self) -> str:
         return self._run_id
 
-    def _connect(self) -> sqlite3.Connection:
+    @contextmanager
+    def _connect(self) -> Iterator[sqlite3.Connection]:
         if self._shared_conn is not None:
-            return self._shared_conn
-        return sqlite3.connect(self._db_path, timeout=30.0)
+            yield self._shared_conn
+            return
+        conn = sqlite3.connect(self._db_path, timeout=30.0)
+        try:
+            yield conn
+        finally:
+            conn.close()
 
     def _copy_state_from_run(self, source_run_id: str) -> None:
         """Copy state from another run_id using SQL INSERT...SELECT."""
-        conn = self._connect()
-        try:
+        with self._connect() as conn:
             now = _utc_now().isoformat()
             conn.execute(
                 """
@@ -72,13 +79,10 @@ class _SqliteStateStorage:
                 (self._run_id, now, now, source_run_id),
             )
             conn.commit()
-        finally:
-            conn.close()
 
     async def load(self) -> StateRecord | None:
         """Load raw state from database."""
-        conn = self._connect()
-        try:
+        with self._connect() as conn:
             cursor = conn.cursor()
             cursor.execute(
                 "SELECT state_json, state_type, state_module FROM workflow_state WHERE run_id = ?",
@@ -88,8 +92,6 @@ class _SqliteStateStorage:
             if row is None:
                 return None
             return StateRecord(data=row[0], state_type=row[1], state_module=row[2])
-        finally:
-            conn.close()
 
     async def save(self, record: StateRecord) -> None:
         """Save raw state to database."""
@@ -98,9 +100,12 @@ class _SqliteStateStorage:
     def _save_record(
         self, record: StateRecord, conn: sqlite3.Connection | None = None
     ) -> None:
-        should_close = conn is None
+        should_commit = conn is None
         if conn is None:
-            conn = self._connect()
+            context = self._connect()
+            conn = context.__enter__()
+        else:
+            context = None
         try:
             now = _utc_now().isoformat()
             data = record.data if isinstance(record.data, str) else str(record.data)
@@ -123,11 +128,11 @@ class _SqliteStateStorage:
                     now,
                 ),
             )
-            if should_close:
+            if should_commit:
                 conn.commit()
         finally:
-            if should_close:
-                conn.close()
+            if context is not None:
+                context.__exit__(None, None, None)
 
     def to_handle(self) -> dict[str, Any]:
         payload = SqliteSerializedState(run_id=self._run_id)
@@ -207,12 +212,15 @@ class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
             effective_run_id = run_id or parsed.run_id
             if db_path is None:
                 raise ValueError("db_path is required for SqliteStateStore.from_dict()")
-            return cls(
+            store = cls(
                 db_path=db_path,
                 run_id=effective_run_id,
                 state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
                 serializer=serializer,
             )
+            if parsed.run_id != effective_run_id:
+                store._seed_from_serialized(serialized_state, serializer)
+            return store
 
         # InMemory format — migrate data to DB immediately
         effective_run_id = run_id or str(uuid.uuid4())

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import asyncio
 import functools
-import json
 import logging
 import sqlite3
 import uuid
@@ -19,12 +18,11 @@ from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
     create_cleared_state,
+    decode_seed_state,
     decode_state,
-    deserialize_state_from_dict,
-    encode_state,
+    encode_state_to_str,
     get_by_path,
     merge_state,
-    parse_in_memory_state,
     set_by_path,
 )
 
@@ -83,7 +81,7 @@ class SqliteStateStore(Generic[MODEL_T]):
 
     def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
         """Migrate InMemory-format state into the database."""
-        state = deserialize_state_from_dict(serialized_state, self._serializer)
+        state = decode_seed_state(serialized_state, self._serializer)
         self._save_state(state)  # type: ignore[arg-type]
 
     def _seed_from_serialized(
@@ -119,15 +117,6 @@ class SqliteStateStore(Generic[MODEL_T]):
         finally:
             conn.close()
 
-    def _deserialize_state(
-        self,
-        state_json: str,
-        state_type_name: str | None,
-        state_module: str | None,
-    ) -> MODEL_T:
-        """Deserialize state from JSON string."""
-        return decode_state(state_json, state_type_name, state_module, self._serializer)  # type: ignore[return-value]
-
     def _create_default_state(self) -> MODEL_T:
         return self.state_type()
 
@@ -146,7 +135,7 @@ class SqliteStateStore(Generic[MODEL_T]):
                 self._save_state(state, conn)
                 conn.commit()
                 return state
-            return self._deserialize_state(row[0], row[1], row[2])
+            return decode_state(row[0], row[1], row[2], self._serializer)  # type: ignore[return-value]
         finally:
             conn.close()
 
@@ -159,11 +148,8 @@ class SqliteStateStore(Generic[MODEL_T]):
             conn = self._connect()
         try:
             now = _utc_now().isoformat()
-            state_data, state_type_name, state_module = encode_state(
+            state_json, state_type_name, state_module = encode_state_to_str(
                 state, self._serializer
-            )
-            state_json = (
-                state_data if isinstance(state_data, str) else json.dumps(state_data)
             )
             conn.execute(
                 """
@@ -211,7 +197,7 @@ class SqliteStateStore(Generic[MODEL_T]):
                 conn.commit()
                 return
 
-            current_state = self._deserialize_state(row[0], row[1], row[2])
+            current_state = decode_state(row[0], row[1], row[2], self._serializer)
             merged = merge_state(current_state, state)
             self._save_state(merged, conn)  # type: ignore[arg-type]
             conn.commit()
@@ -280,8 +266,6 @@ class SqliteStateStore(Generic[MODEL_T]):
             )
 
         # InMemory format — migrate data to DB immediately
-        parse_in_memory_state(serialized_state)
-
         effective_run_id = run_id or str(uuid.uuid4())
         if db_path is None:
             raise ValueError("db_path is required for SqliteStateStore.from_dict()")

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -3,27 +3,21 @@
 
 from __future__ import annotations
 
-import asyncio
-import functools
 import logging
 import sqlite3
 import uuid
-from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, AsyncGenerator, Generic, Literal, cast
+from typing import Any, Generic, Literal
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
     DictState,
-    create_cleared_state,
+    StoredStateRecord,
+    TypedStateStore,
     decode_seed_state,
-    decode_state,
-    encode_state_to_str,
-    get_by_path,
-    merge_state,
-    set_by_path,
+    string_record_from_state,
 )
 
 logger = logging.getLogger(__name__)
@@ -42,63 +36,27 @@ def _utc_now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-class SqliteStateStore(Generic[MODEL_T]):
-    """Sqlite-backed StateStore implementation.
-
-    Every get() reads from the database, every set() writes through.
-    No in-memory cache — the database is the source of truth.
-    """
-
-    state_type: type[MODEL_T]
+class SqliteStateStorage:
+    """Sqlite-backed raw state storage."""
 
     def __init__(
         self,
         db_path: str,
         run_id: str,
-        state_type: type[MODEL_T] | None = None,
-        serializer: BaseSerializer | None = None,
         connection: sqlite3.Connection | None = None,
     ) -> None:
         self._db_path = db_path
         self._run_id = run_id
-        self.state_type = state_type or DictState  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
-        self._serializer = serializer or JsonSerializer()
         self._shared_conn = connection
 
     @property
     def run_id(self) -> str:
         return self._run_id
 
-    @functools.cached_property
-    def _lock(self) -> asyncio.Lock:
-        """Lazy lock initialization for Python 3.14+ compatibility."""
-        return asyncio.Lock()
-
     def _connect(self) -> sqlite3.Connection:
         if self._shared_conn is not None:
             return self._shared_conn
         return sqlite3.connect(self._db_path, timeout=30.0)
-
-    def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
-        """Migrate InMemory-format state into the database."""
-        state = decode_seed_state(serialized_state, self._serializer)
-        self._save_state(state)  # type: ignore[arg-type]
-
-    def _seed_from_serialized(
-        self, serialized_state: dict[str, Any], serializer: BaseSerializer
-    ) -> None:
-        """Seed this store from serialized state data.
-
-        Handles both sqlite references (SQL-level copy) and InMemory format.
-        """
-        self._serializer = serializer
-        store_type = serialized_state.get("store_type")
-        if store_type == "sqlite":
-            source_run_id = serialized_state.get("run_id")
-            if source_run_id and source_run_id != self._run_id:
-                self._copy_state_from_run(source_run_id)
-        else:
-            self._write_in_memory_state(serialized_state)
 
     def _copy_state_from_run(self, source_run_id: str) -> None:
         """Copy state from another run_id using SQL INSERT...SELECT."""
@@ -117,11 +75,8 @@ class SqliteStateStore(Generic[MODEL_T]):
         finally:
             conn.close()
 
-    def _create_default_state(self) -> MODEL_T:
-        return self.state_type()
-
-    def _load_state(self) -> MODEL_T:
-        """Load state from database. Creates default if row doesn't exist."""
+    async def load(self) -> StoredStateRecord | None:
+        """Load raw state from database."""
         conn = self._connect()
         try:
             cursor = conn.cursor()
@@ -131,26 +86,26 @@ class SqliteStateStore(Generic[MODEL_T]):
             )
             row = cursor.fetchone()
             if row is None:
-                state = self._create_default_state()
-                self._save_state(state, conn)
-                conn.commit()
-                return state
-            return cast(MODEL_T, decode_state(row[0], row[1], row[2], self._serializer))
+                return None
+            return StoredStateRecord(
+                data=row[0], state_type=row[1], state_module=row[2]
+            )
         finally:
             conn.close()
 
-    def _save_state(
-        self, state: MODEL_T, conn: sqlite3.Connection | None = None
+    async def save(self, record: StoredStateRecord) -> None:
+        """Save raw state to database."""
+        self._save_record(record)
+
+    def _save_record(
+        self, record: StoredStateRecord, conn: sqlite3.Connection | None = None
     ) -> None:
-        """Save state to database."""
         should_close = conn is None
         if conn is None:
             conn = self._connect()
         try:
             now = _utc_now().isoformat()
-            state_json, state_type_name, state_module = encode_state_to_str(
-                state, self._serializer
-            )
+            data = record.data if isinstance(record.data, str) else str(record.data)
             conn.execute(
                 """
                 INSERT INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
@@ -163,9 +118,9 @@ class SqliteStateStore(Generic[MODEL_T]):
                 """,
                 (
                     self._run_id,
-                    state_json,
-                    state_type_name,
-                    state_module,
+                    data,
+                    record.state_type,
+                    record.state_module,
                     now,
                     now,
                 ),
@@ -176,63 +131,59 @@ class SqliteStateStore(Generic[MODEL_T]):
             if should_close:
                 conn.close()
 
-    async def get_state(self) -> MODEL_T:
-        """Return a copy of the current state model."""
-        state = self._load_state()
-        return state.model_copy()
-
-    async def set_state(self, state: MODEL_T) -> None:
-        """Replace or merge into the current state model."""
-        conn = self._connect()
-        try:
-            cursor = conn.cursor()
-            cursor.execute(
-                "SELECT state_json, state_type, state_module FROM workflow_state WHERE run_id = ?",
-                (self._run_id,),
-            )
-            row = cursor.fetchone()
-
-            if row is None:
-                self._save_state(state, conn)
-                conn.commit()
-                return
-
-            current_state = decode_state(row[0], row[1], row[2], self._serializer)
-            merged = merge_state(current_state, state)
-            self._save_state(merged, conn)  # type: ignore[arg-type]
-            conn.commit()
-        finally:
-            conn.close()
-
-    async def get(self, path: str, default: Any = ...) -> Any:
-        """Get a nested value using dot-separated paths."""
-        state = self._load_state()
-        return get_by_path(state, path, default)
-
-    async def set(self, path: str, value: Any) -> None:
-        """Set a nested value using dot-separated paths."""
-        async with self.edit_state() as state:
-            set_by_path(state, path, value)
-
-    async def clear(self) -> None:
-        """Reset the state to its type defaults."""
-        await self.set_state(create_cleared_state(self.state_type))
-
-    @asynccontextmanager
-    async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
-        """Edit state transactionally under a lock."""
-        async with self._lock:
-            state = self._load_state()
-            yield state
-            self._save_state(state)
-
-    def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
-        """Serialize state store metadata for persistence.
-
-        Returns metadata only — actual state lives in the database.
-        """
+    def to_handle(self) -> dict[str, Any]:
         payload = SqliteSerializedState(run_id=self._run_id)
         return payload.model_dump()
+
+
+class SqliteStateStore(TypedStateStore[MODEL_T], Generic[MODEL_T]):
+    """Compatibility StateStore facade backed by sqlite storage."""
+
+    def __init__(
+        self,
+        db_path: str,
+        run_id: str,
+        state_type: type[MODEL_T] | None = None,
+        serializer: BaseSerializer | None = None,
+        connection: sqlite3.Connection | None = None,
+    ) -> None:
+        self._db_path = db_path
+        self._sqlite_storage = SqliteStateStorage(db_path, run_id, connection)
+        super().__init__(
+            self._sqlite_storage,
+            state_type or DictState,  # type: ignore[arg-type]
+            serializer or JsonSerializer(),
+            to_dict_mode="handle",
+        )
+
+    @property
+    def run_id(self) -> str:
+        return self._sqlite_storage.run_id
+
+    def _seed_from_serialized(
+        self, serialized_state: dict[str, Any], serializer: BaseSerializer
+    ) -> None:
+        """Seed this store from serialized state data."""
+        self._serializer = serializer
+        store_type = serialized_state.get("store_type")
+        if store_type == "sqlite":
+            source_run_id = serialized_state.get("run_id")
+            if source_run_id and source_run_id != self.run_id:
+                self._sqlite_storage._copy_state_from_run(source_run_id)
+            return
+        self._write_in_memory_state(serialized_state)
+
+    def _write_in_memory_state(self, serialized_state: dict[str, Any]) -> None:
+        """Migrate InMemory-format state into the database."""
+        state = decode_seed_state(serialized_state, self._serializer)
+        self._sqlite_storage._save_record(
+            string_record_from_state(state, self._serializer)
+        )
+
+    async def _save_state(self, state: BaseModel) -> None:
+        await self._sqlite_storage.save(
+            string_record_from_state(state, self._serializer)
+        )
 
     @classmethod
     def from_dict(

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import sqlite3
-from collections.abc import Iterator
-from contextlib import contextmanager
+from collections.abc import AsyncIterator, Iterator
+from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime, timezone
 from typing import Any, Generic, Literal
 
@@ -58,6 +58,22 @@ class _SqliteStateStorage:
         conn = sqlite3.connect(self._db_path, timeout=30.0)
         try:
             yield conn
+        finally:
+            conn.close()
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[_SqliteStateStorage]:
+        """Scope a load+save pair to one connection.
+
+        Yields a separate conn-bound storage so concurrent readers on this
+        storage keep opening their own connections.
+        """
+        if self._shared_conn is not None:
+            yield self
+            return
+        conn = sqlite3.connect(self._db_path, timeout=30.0)
+        try:
+            yield _SqliteStateStorage(self._db_path, self._run_id, connection=conn)
         finally:
             conn.close()
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -34,7 +34,7 @@ def _utc_now() -> datetime:
 
 
 class _SqliteStateStorage:
-    """Sqlite-backed raw state storage (genuine I/O only)."""
+    """Sqlite-backed raw state storage."""
 
     def __init__(
         self,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import sqlite3
-import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -12,11 +11,12 @@ from typing import Any, Generic, Literal
 
 from pydantic import BaseModel
 from typing_extensions import TypeVar
-from workflows.context.serializers import BaseSerializer, JsonSerializer
+from workflows.context.serializers import BaseSerializer
 from workflows.context.state_store import DictState
 from workflows.context.state_store_integration import (
     StateRecord,
     StateStoreFacade,
+    restored_run_id,
 )
 
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
@@ -135,16 +135,9 @@ class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         connection: sqlite3.Connection | None = None,
     ) -> None:
         self._db_path = db_path
-        self._sqlite_storage = _SqliteStateStorage(db_path, run_id, connection)
         super().__init__(
-            self._sqlite_storage,
-            state_type or DictState,  # type: ignore[arg-type]
-            serializer or JsonSerializer(),
+            _SqliteStateStorage(db_path, run_id, connection), state_type, serializer
         )
-
-    @property
-    def run_id(self) -> str:
-        return self._sqlite_storage.run_id
 
     @classmethod
     def from_dict(
@@ -165,10 +158,9 @@ class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         if db_path is None:
             raise ValueError("db_path is required for SqliteStateStore.from_dict()")
 
-        effective_run_id = run_id or serialized_state.get("run_id") or str(uuid.uuid4())
         store: SqliteStateStore[Any] = cls(
             db_path=db_path,
-            run_id=effective_run_id,
+            run_id=restored_run_id(run_id, serialized_state),
             state_type=state_type,  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
             serializer=serializer,
         )

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -82,6 +82,7 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
             db_path=self.db_path,
             run_id=run_id,
             state_type=state_type,
+            serializer=serializer,
             connection=self._persistent_conn,
         )
         if serialized_state is not None and serializer is not None:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import logging
 import sqlite3
 import weakref
 from collections.abc import AsyncIterator
@@ -15,7 +16,6 @@ from typing import Any, Iterator, Sequence
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
-from workflows.context.state_store import DictState
 
 from ..abstract_workflow_store import (
     AbstractWorkflowStore,
@@ -26,6 +26,8 @@ from ..abstract_workflow_store import (
 )
 from .migrate import run_migrations as _run_migrations
 from .sqlite_state_store import SqliteStateStore
+
+logger = logging.getLogger(__name__)
 
 _TICK_PAGE_SIZE = 100
 
@@ -38,14 +40,12 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
         auto_migrate: bool = True,
         single_connection: bool = False,
     ) -> None:
+        super().__init__()
         self.db_path = db_path
         self.poll_interval = poll_interval
         self._single_connection = single_connection
         self._persistent_conn: sqlite3.Connection | None = None
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
-            weakref.WeakValueDictionary()
-        )
-        self._state_stores: weakref.WeakValueDictionary[str, SqliteStateStore[Any]] = (
             weakref.WeakValueDictionary()
         )
         if single_connection:
@@ -66,7 +66,13 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
             conn = sqlite3.connect(f"file:{db_path}?vfs=unix-none", uri=True)
             conn.execute("SELECT 1 FROM sqlite_master LIMIT 1").fetchone()
             return conn
-        except sqlite3.OperationalError:
+        except sqlite3.OperationalError as exc:
+            logger.warning(
+                "unix-none VFS probe failed for %s (%s); falling back to a "
+                "regular fcntl-locking sqlite connection",
+                db_path,
+                exc,
+            )
             if conn is not None:
                 with contextlib.suppress(Exception):
                     conn.close()
@@ -84,33 +90,19 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
             finally:
                 conn.close()
 
-    def create_state_store(
+    def _build_state_store(
         self,
         run_id: str,
-        state_type: type[Any] | None = None,
-        serialized_state: dict[str, Any] | None = None,
-        serializer: BaseSerializer | None = None,
+        state_type: type[Any] | None,
+        serializer: BaseSerializer | None,
     ) -> SqliteStateStore[Any]:
-        # One facade per run per process so its write lock is a real
-        # guarantee. Serialized restore requests always rebuild the store.
-        cached = self._state_stores.get(run_id)
-        if cached is not None and serialized_state is None:
-            if state_type is not None and cached.state_type is DictState:
-                # An earlier type-less caller (e.g. handler continuation)
-                # must not shadow the workflow's concrete state type.
-                cached.state_type = state_type
-            return cached
-        store = SqliteStateStore(
+        return SqliteStateStore(
             db_path=self.db_path,
             run_id=run_id,
             state_type=state_type,
             serializer=serializer,
             connection=self._persistent_conn,
         )
-        if serialized_state is not None and serializer is not None:
-            store._seed_from_serialized(serialized_state, serializer)
-        self._state_stores[run_id] = store
-        return store
 
     def _get_or_create_condition(self, run_id: str) -> asyncio.Condition:
         cond = self._conditions.get(run_id)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -15,6 +15,7 @@ from typing import Any, Iterator, Sequence
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from workflows.context import JsonSerializer
 from workflows.context.serializers import BaseSerializer
+from workflows.context.state_store import DictState
 
 from ..abstract_workflow_store import (
     AbstractWorkflowStore,
@@ -42,6 +43,9 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
         self._single_connection = single_connection
         self._persistent_conn: sqlite3.Connection | None = None
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
+            weakref.WeakValueDictionary()
+        )
+        self._state_stores: weakref.WeakValueDictionary[str, SqliteStateStore[Any]] = (
             weakref.WeakValueDictionary()
         )
         if single_connection:
@@ -87,6 +91,15 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
         serialized_state: dict[str, Any] | None = None,
         serializer: BaseSerializer | None = None,
     ) -> SqliteStateStore[Any]:
+        # One facade per run per process so its write lock is a real
+        # guarantee. Serialized restore requests always rebuild the store.
+        cached = self._state_stores.get(run_id)
+        if cached is not None and serialized_state is None:
+            if state_type is not None and cached.state_type is DictState:
+                # An earlier type-less caller (e.g. handler continuation)
+                # must not shadow the workflow's concrete state type.
+                cached.state_type = state_type
+            return cached
         store = SqliteStateStore(
             db_path=self.db_path,
             run_id=run_id,
@@ -96,6 +109,7 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
         )
         if serialized_state is not None and serializer is not None:
             store._seed_from_serialized(serialized_state, serializer)
+        self._state_stores[run_id] = store
         return store
 
     def _get_or_create_condition(self, run_id: str) -> asyncio.Condition:

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -57,7 +57,16 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
         lock calls.  Safe when the database is only accessed by a single
         process (e.g. AgentCore session storage).
         """
-        return sqlite3.connect(f"file:{db_path}?vfs=unix-none", uri=True)
+        conn: sqlite3.Connection | None = None
+        try:
+            conn = sqlite3.connect(f"file:{db_path}?vfs=unix-none", uri=True)
+            conn.execute("SELECT 1 FROM sqlite_master LIMIT 1").fetchone()
+            return conn
+        except sqlite3.OperationalError:
+            if conn is not None:
+                with contextlib.suppress(Exception):
+                    conn.close()
+            return sqlite3.connect(db_path, timeout=30.0)
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -7,6 +7,7 @@ import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
+import httpx
 import pytest
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from llama_agents.server import (
@@ -22,7 +23,7 @@ from llama_agents_integration_tests.fake_agent_data import (
 )
 from server_test_fixtures import wait_for_passing  # type: ignore[import]
 from workflows.context.serializers import JsonSerializer
-from workflows.context.state_store import DictState
+from workflows.context.state_store import DictState, InMemoryStateStore
 from workflows.events import Event, StopEvent
 
 # ---------------------------------------------------------------------------
@@ -65,6 +66,28 @@ def make_envelope(
     if event is None:
         event = Event(data=f"seq-{seq_label}")
     return EventEnvelopeWithMetadata.from_event(event, include_qualified_name=False)
+
+
+def create_agent_data_store_with_collection(
+    backend: FakeAgentDataBackend,
+    monkeypatch: pytest.MonkeyPatch,
+    collection: str,
+) -> AgentDataStore:
+    store = AgentDataStore(
+        base_url="https://fake-api.example.com",
+        api_key="test-key",
+        project_id="test-project",
+        deployment_name="test-deploy",
+        collection=collection,
+    )
+    mock_http = httpx.AsyncClient(
+        base_url=store._client._base_url,
+        headers=store._client._headers(),
+        params={"project_id": store._client._project_id},
+        transport=httpx.MockTransport(backend.handle_request),
+    )
+    monkeypatch.setattr(store._client, "_shared_client", mock_http)
+    return store
 
 
 async def _subscribe_and_collect(
@@ -464,6 +487,63 @@ async def test_create_state_store_with_type(store: AgentDataStore) -> None:
     state_store = store.create_state_store("run-1", state_type=DictState)
     assert isinstance(state_store, AgentDataStateStore)
     assert state_store.state_type is DictState
+
+
+@pytest.mark.asyncio
+async def test_create_state_store_seeds_from_in_memory_serialized_state(
+    backend: FakeAgentDataBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serializer = JsonSerializer()
+    seed = InMemoryStateStore(DictState())
+    await seed.set("token", "persisted")
+    serialized_state = seed.to_dict(serializer)
+    store = create_agent_data_store_with_collection(
+        backend, monkeypatch, collection="handlers"
+    )
+
+    state_store = store.create_state_store(
+        "run-seeded",
+        serialized_state=serialized_state,
+        serializer=serializer,
+    )
+
+    assert await state_store.get("token") == "persisted"
+
+    restored = create_agent_data_store_with_collection(
+        backend, monkeypatch, collection="handlers"
+    )
+    reconnected = restored.create_state_store(
+        "run-seeded",
+        serialized_state=state_store.to_dict(serializer),
+        serializer=serializer,
+    )
+    assert await reconnected.get("token") == "persisted"
+
+
+@pytest.mark.asyncio
+async def test_create_state_store_reconnects_agent_data_handle_collection(
+    backend: FakeAgentDataBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serializer = JsonSerializer()
+    original = create_agent_data_store_with_collection(
+        backend, monkeypatch, collection="handlers"
+    )
+    original_state = original.create_state_store("run-agent-data-handle")
+    await original_state.set("token", "persisted")
+    serialized_state = original_state.to_dict(serializer)
+
+    restored = create_agent_data_store_with_collection(
+        backend, monkeypatch, collection="other_handlers"
+    )
+    restored_state = restored.create_state_store(
+        "run-agent-data-handle",
+        serialized_state=serialized_state,
+        serializer=serializer,
+    )
+
+    assert await restored_state.get("token") == "persisted"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -7,7 +7,6 @@ import asyncio
 from datetime import datetime, timezone
 from typing import Any
 
-import httpx
 import pytest
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from llama_agents.server import (
@@ -73,28 +72,6 @@ def make_envelope(
     if event is None:
         event = Event(data=f"seq-{seq_label}")
     return EventEnvelopeWithMetadata.from_event(event, include_qualified_name=False)
-
-
-def create_agent_data_store_with_collection(
-    backend: FakeAgentDataBackend,
-    monkeypatch: pytest.MonkeyPatch,
-    collection: str,
-) -> AgentDataStore:
-    store = AgentDataStore(
-        base_url="https://fake-api.example.com",
-        api_key="test-key",
-        project_id="test-project",
-        deployment_name="test-deploy",
-        collection=collection,
-    )
-    mock_http = httpx.AsyncClient(
-        base_url=store._client._base_url,
-        headers=store._client._headers(),
-        params={"project_id": store._client._project_id},
-        transport=httpx.MockTransport(backend.handle_request),
-    )
-    monkeypatch.setattr(store._client, "_shared_client", mock_http)
-    return store
 
 
 async def _subscribe_and_collect(
@@ -519,9 +496,7 @@ async def test_create_state_store_seeds_from_in_memory_serialized_state(
     seed = InMemoryStateStore(DictState())
     await seed.set("token", "persisted")
     serialized_state = seed.to_dict(serializer)
-    store = create_agent_data_store_with_collection(
-        backend, monkeypatch, collection="handlers"
-    )
+    store = create_agent_data_store(backend, monkeypatch, collection="handlers")
 
     state_store = store.create_state_store(
         "run-seeded",
@@ -531,9 +506,7 @@ async def test_create_state_store_seeds_from_in_memory_serialized_state(
 
     assert await state_store.get("token") == "persisted"
 
-    restored = create_agent_data_store_with_collection(
-        backend, monkeypatch, collection="handlers"
-    )
+    restored = create_agent_data_store(backend, monkeypatch, collection="handlers")
     reconnected = restored.create_state_store(
         "run-seeded",
         serialized_state=state_store.to_dict(serializer),
@@ -566,14 +539,12 @@ async def test_create_state_store_reconnects_agent_data_handle_collection(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     serializer = JsonSerializer()
-    original = create_agent_data_store_with_collection(
-        backend, monkeypatch, collection="handlers"
-    )
+    original = create_agent_data_store(backend, monkeypatch, collection="handlers")
     original_state = original.create_state_store("run-agent-data-handle")
     await original_state.set("token", "persisted")
     serialized_state = original_state.to_dict(serializer)
 
-    restored = create_agent_data_store_with_collection(
+    restored = create_agent_data_store(
         backend, monkeypatch, collection="other_handlers"
     )
     restored_state = restored.create_state_store(
@@ -645,9 +616,7 @@ async def test_legacy_agent_data_typed_state_decodes_without_metadata(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     serializer = JsonSerializer()
-    store = create_agent_data_store_with_collection(
-        backend, monkeypatch, collection="handlers"
-    )
+    store = create_agent_data_store(backend, monkeypatch, collection="handlers")
     backend.create(
         "test-deploy",
         "handlers_state",

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel
 from server_test_fixtures import wait_for_passing  # type: ignore[import]
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import DictState, InMemoryStateStore
+from workflows.context.state_store_integration import state_store_handoff
 from workflows.events import Event, StopEvent
 
 # ---------------------------------------------------------------------------
@@ -528,6 +529,24 @@ async def test_create_state_store_seeds_from_in_memory_serialized_state(
 
 
 @pytest.mark.asyncio
+async def test_create_state_store_cached_run_applies_serialized_restore(
+    store: AgentDataStore,
+) -> None:
+    serializer = JsonSerializer()
+    seed = InMemoryStateStore(DictState(token="restored"))
+    cached = store.create_state_store("run-cached-restore")
+    await cached.set("token", "cached")
+
+    restored = store.create_state_store(
+        "run-cached-restore",
+        serialized_state=seed.to_dict(serializer),
+        serializer=serializer,
+    )
+
+    assert await restored.get("token") == "restored"
+
+
+@pytest.mark.asyncio
 async def test_create_state_store_reconnects_agent_data_handle_collection(
     backend: FakeAgentDataBackend,
     monkeypatch: pytest.MonkeyPatch,
@@ -550,6 +569,60 @@ async def test_create_state_store_reconnects_agent_data_handle_collection(
     )
 
     assert await restored_state.get("token") == "persisted"
+
+
+@pytest.mark.asyncio
+async def test_agent_data_handoff_materializes_new_run_copy(
+    store: AgentDataStore,
+) -> None:
+    serializer = JsonSerializer()
+    source = store.create_state_store("run-handoff-source")
+    await source.set("token", "persisted")
+    target = AgentDataStateStore.from_dict(
+        source.to_dict(serializer),
+        serializer,
+        client=store._client,
+        run_id="run-handoff-target",
+    )
+
+    target_handle = await state_store_handoff(target, serializer)
+    reconnected = AgentDataStateStore.from_dict(
+        target_handle,
+        serializer,
+        client=store._client,
+        run_id="run-handoff-target",
+    )
+
+    assert await reconnected.get("token") == "persisted"
+
+
+@pytest.mark.asyncio
+async def test_agent_data_from_dict_accepts_in_memory_snapshot(
+    store: AgentDataStore,
+) -> None:
+    serializer = JsonSerializer()
+    seed = InMemoryStateStore(DictState(token="portable"))
+
+    restored = AgentDataStateStore.from_dict(
+        seed.to_dict(serializer),
+        serializer,
+        client=store._client,
+        run_id="run-in-memory-snapshot",
+        collection="handlers_state",
+    )
+
+    assert await restored.get("token") == "portable"
+
+
+def test_agent_data_from_dict_rejects_wrong_provider_handle(
+    store: AgentDataStore,
+) -> None:
+    with pytest.raises(ValueError, match="Cannot restore store_type 'postgres'"):
+        AgentDataStateStore.from_dict(
+            {"store_type": "postgres", "run_id": "run-1"},
+            JsonSerializer(),
+            client=store._client,
+        )
 
 
 @pytest.mark.asyncio
@@ -674,6 +747,25 @@ async def test_state_store_from_dict_preserves_collection(
     )
 
     # Should be able to read data written by the original store
+    val = await restored.get("key")
+    assert val == "hello"
+
+
+@pytest.mark.asyncio
+async def test_state_store_from_dict_with_new_run_copies_state(
+    store: AgentDataStore,
+) -> None:
+    state_store = store.create_state_store("run-source")
+    await state_store.set(path="key", value="hello")
+
+    serialized = state_store.to_dict(JsonSerializer())
+    restored = AgentDataStateStore.from_dict(
+        serialized,
+        JsonSerializer(),
+        client=store._client,
+        run_id="run-target",
+    )
+
     val = await restored.get("key")
     assert val == "hello"
 

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -21,6 +21,7 @@ from llama_agents_integration_tests.fake_agent_data import (
     FakeAgentDataBackend,
     create_agent_data_store,
 )
+from pydantic import BaseModel
 from server_test_fixtures import wait_for_passing  # type: ignore[import]
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import DictState, InMemoryStateStore
@@ -29,6 +30,11 @@ from workflows.events import Event, StopEvent
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+class AgentDataCounterState(BaseModel):
+    count: int = 0
+    label: str = "default"
 
 
 @pytest.fixture()
@@ -544,6 +550,38 @@ async def test_create_state_store_reconnects_agent_data_handle_collection(
     )
 
     assert await restored_state.get("token") == "persisted"
+
+
+@pytest.mark.asyncio
+async def test_legacy_agent_data_typed_state_decodes_without_metadata(
+    backend: FakeAgentDataBackend,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    serializer = JsonSerializer()
+    store = create_agent_data_store_with_collection(
+        backend, monkeypatch, collection="handlers"
+    )
+    backend.create(
+        "test-deploy",
+        "handlers_state",
+        {
+            "run_id": "run-legacy-typed",
+            "data": serializer.serialize(
+                AgentDataCounterState(count=7, label="legacy")
+            ),
+        },
+    )
+
+    state_store = store.create_state_store(
+        "run-legacy-typed",
+        state_type=AgentDataCounterState,
+        serializer=serializer,
+    )
+
+    state = await state_store.get_state()
+    assert isinstance(state, AgentDataCounterState)
+    assert state.count == 7
+    assert state.label == "legacy"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -497,6 +497,20 @@ async def test_create_state_store_with_type(store: AgentDataStore) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_state_store_upgrades_default_state_type(
+    store: AgentDataStore,
+) -> None:
+    """A later typed caller upgrades the cached type-less facade (no shadowing)."""
+    first = store.create_state_store("run-upgrade")
+    assert first.state_type is DictState
+
+    second = store.create_state_store("run-upgrade", state_type=AgentDataCounterState)
+
+    assert second is first
+    assert first.state_type is AgentDataCounterState
+
+
+@pytest.mark.asyncio
 async def test_create_state_store_seeds_from_in_memory_serialized_state(
     backend: FakeAgentDataBackend,
     monkeypatch: pytest.MonkeyPatch,
@@ -617,7 +631,7 @@ async def test_agent_data_from_dict_accepts_in_memory_snapshot(
 def test_agent_data_from_dict_rejects_wrong_provider_handle(
     store: AgentDataStore,
 ) -> None:
-    with pytest.raises(ValueError, match="Cannot restore store_type 'postgres'"):
+    with pytest.raises(ValueError, match="store_type 'postgres'"):
         AgentDataStateStore.from_dict(
             {"store_type": "postgres", "run_id": "run-1"},
             JsonSerializer(),

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -18,6 +18,7 @@ from llama_agents.server._store.agent_data_state_store import AgentDataStateStor
 from llama_agents.server._store.agent_data_store import AgentDataStore
 from llama_agents_integration_tests.fake_agent_data import (
     FakeAgentDataBackend,
+    create_agent_data_state_store,
     create_agent_data_store,
 )
 from pydantic import BaseModel
@@ -638,6 +639,82 @@ async def test_legacy_agent_data_typed_state_decodes_without_metadata(
     assert isinstance(state, AgentDataCounterState)
     assert state.count == 7
     assert state.label == "legacy"
+
+
+# ---------------------------------------------------------------------------
+# Decoded-state cache (AgentDataStateStore)
+# ---------------------------------------------------------------------------
+
+
+def _count_backend_searches(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> list[int]:
+    """Count search round-trips reaching the fake backend."""
+    counter = [0]
+    original = backend.search
+
+    def counting_search(*args: Any, **kwargs: Any) -> list[dict[str, Any]]:
+        counter[0] += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(backend, "search", counting_search)
+    return counter
+
+
+@pytest.mark.asyncio
+async def test_consecutive_reads_hit_backend_once(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    writer = create_agent_data_state_store(backend, monkeypatch, "run-read-cache")
+    await writer.set("k", "v")
+
+    reader = create_agent_data_state_store(backend, monkeypatch, "run-read-cache")
+    searches = _count_backend_searches(backend, monkeypatch)
+
+    assert (await reader.get_state())["k"] == "v"
+    assert (await reader.get_state())["k"] == "v"
+
+    assert searches[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_read_after_write_skips_backend(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_store = create_agent_data_state_store(backend, monkeypatch, "run-write-cache")
+    await state_store.set("k", "v")
+
+    searches = _count_backend_searches(backend, monkeypatch)
+    assert await state_store.get("k") == "v"
+    assert searches[0] == 0
+
+
+@pytest.mark.asyncio
+async def test_mutating_returned_state_does_not_poison_cache(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_store = create_agent_data_state_store(backend, monkeypatch, "run-mutate")
+    await state_store.set("nums", [1])
+
+    state = await state_store.get_state()
+    state["nums"].append(2)
+
+    assert await state_store.get("nums") == [1]
+
+
+@pytest.mark.asyncio
+async def test_restaged_seed_invalidates_cached_state(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    serializer = JsonSerializer()
+    state_store = create_agent_data_state_store(backend, monkeypatch, "run-reseed")
+    await state_store.set("token", "old")
+    assert await state_store.get("token") == "old"  # cache is warm
+
+    seed = InMemoryStateStore(DictState(token="new")).to_dict(serializer)
+    state_store.add_seed(seed, serializer)
+
+    assert await state_store.get("token") == "new"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/llama-agents-server/tests/server/test_durable_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_durable_runtime.py
@@ -767,15 +767,7 @@ async def test_legacy_ctx_state_not_overwritten_on_second_resume(
 
     # Pre-seed the state table with new_value (simulating a previous partial run)
     state_store = sqlite_store.create_state_store("run-nooverwrite-1")
-    new_state = DictState()
-    new_state["my_key"] = "new_value"
-    new_state_data = {
-        "store_type": "in_memory",
-        "state_type": "DictState",
-        "state_module": "workflows.context.state_store",
-        "state_data": serialize_dict_state_data(new_state, serializer, ()),
-    }
-    state_store._write_in_memory_state(new_state_data)
+    await state_store.set("my_key", "new_value")
 
     server = WorkflowServer(workflow_store=sqlite_store, idle_timeout=0.01)
     server.add_workflow("test", wf)

--- a/packages/llama-agents-server/tests/server/test_postgres_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_state_store.py
@@ -14,6 +14,7 @@ from llama_agents.server._store.postgres_state_store import (
 from pydantic import BaseModel
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import DictState, InMemoryStateStore
+from workflows.context.state_store_integration import state_store_handoff
 
 SCHEMA = "test_pg_state"
 
@@ -235,6 +236,60 @@ async def test_from_dict_postgres_format(pool: asyncpg.Pool) -> None:
 
 
 @pytest.mark.docker
+async def test_from_dict_postgres_format_with_new_run_copies_state(
+    pool: asyncpg.Pool,
+) -> None:
+    store1: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-fromdict-source", schema=SCHEMA
+    )
+    await store1.set("saved", True)
+
+    serializer = JsonSerializer()
+    payload = store1.to_dict(serializer)
+
+    store2 = PostgresStateStore.from_dict(
+        payload,
+        serializer,
+        pool=pool,
+        state_type=DictState,
+        run_id="run-fromdict-target",
+        schema=SCHEMA,
+    )
+    value = await store2.get("saved")
+    assert value is True
+
+
+@pytest.mark.docker
+async def test_handoff_materializes_new_run_copy(pool: asyncpg.Pool) -> None:
+    store1: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-handoff-source", schema=SCHEMA
+    )
+    await store1.set("saved", True)
+
+    serializer = JsonSerializer()
+    store2 = PostgresStateStore.from_dict(
+        store1.to_dict(serializer),
+        serializer,
+        pool=pool,
+        state_type=DictState,
+        run_id="run-handoff-target",
+        schema=SCHEMA,
+    )
+
+    payload = await state_store_handoff(store2, serializer)
+
+    assert payload["store_type"] == "postgres"
+    assert payload["run_id"] == "run-handoff-target"
+    async with pool.acquire() as conn:
+        row = await conn.fetchrow(
+            f"SELECT state_json FROM {SCHEMA}.workflow_state WHERE run_id = $1",
+            "run-handoff-target",
+        )
+    assert row is not None
+    assert '"saved": "true"' in row["state_json"]
+
+
+@pytest.mark.docker
 async def test_from_dict_in_memory_format_migrates(pool: asyncpg.Pool) -> None:
     serializer = JsonSerializer()
     in_memory_store = InMemoryStateStore(DictState(migrated_key="migrated_value"))
@@ -250,6 +305,17 @@ async def test_from_dict_in_memory_format_migrates(pool: asyncpg.Pool) -> None:
     )
     value = await store.get("migrated_key")
     assert value == "migrated_value"
+
+
+@pytest.mark.docker
+async def test_from_dict_rejects_wrong_provider_handle(pool: asyncpg.Pool) -> None:
+    with pytest.raises(ValueError, match="Cannot restore store_type 'agent_data'"):
+        PostgresStateStore.from_dict(
+            {"store_type": "agent_data", "run_id": "run-1"},
+            JsonSerializer(),
+            pool=pool,
+            schema=SCHEMA,
+        )
 
 
 async def test_from_dict_empty_raises() -> None:

--- a/packages/llama-agents-server/tests/server/test_postgres_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_state_store.py
@@ -318,6 +318,67 @@ async def test_from_dict_rejects_wrong_provider_handle(pool: asyncpg.Pool) -> No
         )
 
 
+class FakeConnection:
+    """Connection-level fake speaking the storage's fetchrow/execute dialect."""
+
+    def __init__(self, rows: dict[str, str]) -> None:
+        self._rows = rows
+
+    async def fetchrow(self, query: str, run_id: str) -> dict[str, str] | None:
+        state_json = self._rows.get(run_id)
+        if state_json is None:
+            return None
+        return {"state_json": state_json}
+
+    async def execute(self, query: str, *args: object) -> None:
+        # Save upsert: (run_id, state_json, state_type, state_module, now, now)
+        run_id, state_json = str(args[0]), str(args[1])
+        self._rows[run_id] = state_json
+
+
+class FakePoolAcquire:
+    def __init__(self, pool: FakePool) -> None:
+        self._pool = pool
+
+    async def __aenter__(self) -> FakeConnection:
+        self._pool.acquire_count += 1
+        return self._pool.connection
+
+    async def __aexit__(self, *exc: object) -> None:
+        self._pool.release_count += 1
+
+
+class FakePool:
+    """Counting asyncpg.Pool stand-in."""
+
+    def __init__(self) -> None:
+        self.rows: dict[str, str] = {}
+        self.connection = FakeConnection(self.rows)
+        self.acquire_count = 0
+        self.release_count = 0
+
+    def acquire(self) -> FakePoolAcquire:
+        return FakePoolAcquire(self)
+
+
+async def test_set_state_acquires_exactly_one_pool_connection() -> None:
+    """A write's load+save run through a single pool checkout."""
+    pool = FakePool()
+    store: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool,  # type: ignore[arg-type]
+        run_id="run-conn-count",
+    )
+    await store.set("x", 1)  # materialize the row before counting
+    pool.acquire_count = 0
+    pool.release_count = 0
+
+    await store.set_state(DictState(y=2))
+
+    assert pool.acquire_count == 1
+    assert pool.release_count == 1
+    assert "run-conn-count" in pool.rows
+
+
 async def test_from_dict_empty_raises() -> None:
     with pytest.raises(ValueError, match="Cannot restore"):
         PostgresStateStore.from_dict({}, JsonSerializer())

--- a/packages/llama-agents-server/tests/server/test_postgres_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_state_store.py
@@ -309,7 +309,7 @@ async def test_from_dict_in_memory_format_migrates(pool: asyncpg.Pool) -> None:
 
 @pytest.mark.docker
 async def test_from_dict_rejects_wrong_provider_handle(pool: asyncpg.Pool) -> None:
-    with pytest.raises(ValueError, match="Cannot restore store_type 'agent_data'"):
+    with pytest.raises(ValueError, match="store_type 'agent_data'"):
         PostgresStateStore.from_dict(
             {"store_type": "agent_data", "run_id": "run-1"},
             JsonSerializer(),

--- a/packages/llama-agents-server/tests/server/test_postgres_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_state_store.py
@@ -248,7 +248,6 @@ async def test_from_dict_in_memory_format_migrates(pool: asyncpg.Pool) -> None:
         run_id="run-migrate",
         schema=SCHEMA,
     )
-    await store._write_in_memory_state(payload)
     value = await store.get("migrated_key")
     assert value == "migrated_value"
 

--- a/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock
 import pytest
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
 from llama_agents.server._pool import PoolProvider
+from llama_agents.server._store import postgres_workflow_store
 from llama_agents.server._store.abstract_workflow_store import (
     HandlerQuery,
     PersistentHandler,
@@ -140,7 +141,7 @@ async def test_borrowed_pool_not_closed_on_close(
         return fake_pool
 
     # _setup_listener acquires from the pool — short-circuit it for this unit test.
-    async def noop_setup_listener(self: PostgresWorkflowStore) -> None:
+    async def noop_setup_listener(self: PostgresWorkflowStore, pool: Any) -> None:
         return None
 
     monkeypatch.setattr(PostgresWorkflowStore, "_setup_listener", noop_setup_listener)
@@ -173,13 +174,15 @@ async def test_concurrent_start_initializes_once(
 
     calls = {"migrate": 0, "listen": 0}
 
-    async def fake_run_migrations(self: PostgresWorkflowStore) -> None:
+    async def fake_run_migrations(self: PostgresWorkflowStore, pool: Any) -> None:
         calls["migrate"] += 1
 
-    async def fake_setup_listener(self: PostgresWorkflowStore) -> None:
+    async def fake_setup_listener(self: PostgresWorkflowStore, pool: Any) -> None:
         calls["listen"] += 1
 
-    monkeypatch.setattr(PostgresWorkflowStore, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(
+        PostgresWorkflowStore, "_run_migrations_on", fake_run_migrations
+    )
     monkeypatch.setattr(PostgresWorkflowStore, "_setup_listener", fake_setup_listener)
 
     store = PostgresWorkflowStore(
@@ -194,6 +197,62 @@ async def test_concurrent_start_initializes_once(
     await store.close()
     await asyncio.gather(store.start(), store.start())
     assert calls == {"migrate": 2, "listen": 2}
+
+
+class _FakePoolAcquire:
+    async def __aenter__(self) -> Any:
+        return MagicMock()
+
+    async def __aexit__(self, *exc: Any) -> bool:
+        return False
+
+
+class _FakePool:
+    """Minimal asyncpg.Pool stand-in: acquire() as an async context manager."""
+
+    def acquire(self) -> _FakePoolAcquire:
+        return _FakePoolAcquire()
+
+
+async def test_start_late_joiner_waits_for_migrations_and_listener(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A second concurrent start() caller must not return before migrations
+    and LISTEN setup have completed."""
+    migrations_started = asyncio.Event()
+    release_migrations = asyncio.Event()
+    listener_ready = False
+
+    async def fake_migrations(conn: Any, schema: str | None = None) -> None:
+        migrations_started.set()
+        await release_migrations.wait()
+
+    async def fake_setup_listener(self: PostgresWorkflowStore, *args: Any) -> None:
+        nonlocal listener_ready
+        listener_ready = True
+
+    monkeypatch.setattr(postgres_workflow_store, "_run_migrations", fake_migrations)
+    monkeypatch.setattr(PostgresWorkflowStore, "_setup_listener", fake_setup_listener)
+
+    async def factory() -> Any:
+        return cast(Any, _FakePool())
+
+    store = PostgresWorkflowStore(
+        dsn="postgresql://localhost/test",
+        pool=PoolProvider.borrowed(factory),
+    )
+
+    first = asyncio.create_task(store.start())
+    await asyncio.wait_for(migrations_started.wait(), timeout=2.0)
+
+    second = asyncio.create_task(store.start())
+    await asyncio.sleep(0.01)
+    assert not second.done(), "late joiner returned before start() finished"
+    assert listener_ready is False
+
+    release_migrations.set()
+    await asyncio.wait_for(asyncio.gather(first, second), timeout=2.0)
+    assert listener_ready is True
 
 
 async def test_listen_termination_callback_schedules_reconnect(
@@ -237,7 +296,7 @@ async def test_reconnect_listener_wakes_subscribers(
 ) -> None:
     """After a successful reconnect, all active subscribe_events conditions are notified."""
 
-    async def fake_setup_listener(self: PostgresWorkflowStore) -> None:
+    async def fake_setup_listener(self: PostgresWorkflowStore, pool: Any) -> None:
         return None
 
     monkeypatch.setattr(PostgresWorkflowStore, "_setup_listener", fake_setup_listener)

--- a/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
@@ -351,3 +351,30 @@ async def test_integration_tick_append_and_get(postgres_dsn: str) -> None:
         assert await store.get_ticks("other-run") == []
     finally:
         await store.close()
+
+
+@pytest.mark.docker
+async def test_integration_create_state_store_memoizes_per_run(
+    postgres_dsn: str,
+) -> None:
+    store = PostgresWorkflowStore(dsn=postgres_dsn, schema="test_pg_store")
+    try:
+        await store.start()
+        await store.run_migrations()
+
+        first = store.create_state_store("pg-memo-run")
+        second = store.create_state_store("pg-memo-run")
+        assert first is second
+        assert store.create_state_store("pg-memo-other") is not first
+
+        await first.set("count", 0)
+
+        async def increment(state_store: Any) -> None:
+            for _ in range(5):
+                async with state_store.edit_state() as state:
+                    state["count"] = state["count"] + 1
+
+        await asyncio.gather(increment(first), increment(second))
+        assert await first.get("count") == 10
+    finally:
+        await store.close()

--- a/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timezone
 from typing import Any, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from llama_agents.client.protocol.serializable_events import EventEnvelopeWithMetadata
@@ -159,6 +159,35 @@ async def test_borrowed_pool_not_closed_on_close(
     await store.close()
     fake_pool.close.assert_not_called()
     assert store._pool is None
+
+
+async def test_failed_start_still_closes_owned_pool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pool resolved during a failed start() must not leak past close()."""
+    fake_pool = MagicMock()
+    fake_pool.close = AsyncMock()
+
+    async def factory() -> Any:
+        return fake_pool
+
+    async def failing_migrations(self: PostgresWorkflowStore, pool: Any) -> None:
+        raise RuntimeError("migration boom")
+
+    monkeypatch.setattr(PostgresWorkflowStore, "_run_migrations_on", failing_migrations)
+
+    store = PostgresWorkflowStore(
+        dsn="postgresql://localhost/test",
+        pool=PoolProvider(factory, owns_pool=True),
+    )
+
+    with pytest.raises(RuntimeError, match="migration boom"):
+        await store.start()
+    # start() never published the pool, but the provider holds one.
+    assert store._pool is None
+
+    await store.close()
+    fake_pool.close.assert_awaited_once()
 
 
 async def test_concurrent_start_initializes_once(

--- a/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_workflow_store.py
@@ -160,6 +160,42 @@ async def test_borrowed_pool_not_closed_on_close(
     assert store._pool is None
 
 
+async def test_concurrent_start_initializes_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent first-callers get one migration run and one LISTEN setup."""
+    fake_pool = MagicMock()
+
+    async def factory() -> Any:
+        # Yield so a second start() caller can interleave with the first.
+        await asyncio.sleep(0)
+        return fake_pool
+
+    calls = {"migrate": 0, "listen": 0}
+
+    async def fake_run_migrations(self: PostgresWorkflowStore) -> None:
+        calls["migrate"] += 1
+
+    async def fake_setup_listener(self: PostgresWorkflowStore) -> None:
+        calls["listen"] += 1
+
+    monkeypatch.setattr(PostgresWorkflowStore, "run_migrations", fake_run_migrations)
+    monkeypatch.setattr(PostgresWorkflowStore, "_setup_listener", fake_setup_listener)
+
+    store = PostgresWorkflowStore(
+        dsn="postgresql://localhost/test",
+        pool=PoolProvider.borrowed(factory),
+    )
+
+    await asyncio.gather(store.start(), store.start())
+    assert calls == {"migrate": 1, "listen": 1}
+
+    # The guard must not latch: a re-start after close() initializes again.
+    await store.close()
+    await asyncio.gather(store.start(), store.start())
+    assert calls == {"migrate": 2, "listen": 2}
+
+
 async def test_listen_termination_callback_schedules_reconnect(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -8,7 +8,7 @@ import sqlite3
 from pathlib import Path
 
 import pytest
-from llama_agents.server import SqliteWorkflowStore
+from llama_agents.server import HandlerQuery, SqliteWorkflowStore
 from llama_agents.server._store.sqlite.migrate import run_migrations
 from llama_agents.server._store.sqlite.sqlite_state_store import (
     SqliteStateStore,
@@ -311,6 +311,29 @@ async def test_from_dict_sqlite_format(db_path: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_from_dict_sqlite_format_with_new_run_copies_state(
+    db_path: str,
+) -> None:
+    store1: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-fromdict-source"
+    )
+    await store1.set("saved", True)
+
+    serializer = JsonSerializer()
+    payload = store1.to_dict(serializer)
+
+    store2 = SqliteStateStore.from_dict(
+        payload,
+        serializer,
+        db_path=db_path,
+        state_type=DictState,
+        run_id="run-fromdict-target",
+    )
+    value = await store2.get("saved")
+    assert value is True
+
+
+@pytest.mark.asyncio
 async def test_from_dict_in_memory_format_migrates(db_path: str) -> None:
     """from_dict with InMemorySerializedState format stores data on first DB access."""
     serializer = JsonSerializer()
@@ -351,3 +374,36 @@ async def test_migration_applies_on_existing_db(tmp_path: Path) -> None:
     await store.set("coexist", True)
     value = await store.get("coexist")
     assert value is True
+
+
+@pytest.mark.asyncio
+async def test_sqlite_workflow_store_single_connection_keeps_state_connection_open(
+    tmp_path: Path,
+) -> None:
+    db_path = str(tmp_path / "single-connection.db")
+    workflow_store = SqliteWorkflowStore(db_path, single_connection=True)
+    state_store = workflow_store.create_state_store("run-single")
+
+    await state_store.set("x", 1)
+    assert await state_store.get("x") == 1
+
+    await workflow_store.query(HandlerQuery())
+
+
+@pytest.mark.asyncio
+async def test_sqlite_workflow_store_single_connection_opens_existing_regular_db(
+    tmp_path: Path,
+) -> None:
+    db_path = str(tmp_path / "existing-regular.db")
+    conn = sqlite3.connect(db_path)
+    try:
+        run_migrations(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    workflow_store = SqliteWorkflowStore(db_path, single_connection=True)
+    state_store = workflow_store.create_state_store("run-existing-single")
+
+    await state_store.set("x", 1)
+    assert await state_store.get("x") == 1

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -239,6 +239,30 @@ async def test_typed_state_persists_across_instances(db_path: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_typed_state_decodes_from_row_metadata_when_store_type_changes(
+    db_path: str,
+) -> None:
+    store1: SqliteStateStore[CounterState] = SqliteStateStore(
+        db_path=db_path,
+        run_id="run-typed-metadata",
+        state_type=CounterState,
+    )
+    await store1.set_state(CounterState(count=7, label="typed-row"))
+
+    store2: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path,
+        run_id="run-typed-metadata",
+        state_type=DictState,
+    )
+
+    state = await store2.get_state()
+
+    assert isinstance(state, CounterState)
+    assert state.count == 7
+    assert state.label == "typed-row"
+
+
+@pytest.mark.asyncio
 async def test_different_run_ids_are_isolated(db_path: str) -> None:
     store_a: SqliteStateStore[DictState] = SqliteStateStore(
         db_path=db_path, run_id="run-a"

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -239,9 +239,10 @@ async def test_typed_state_persists_across_instances(db_path: str) -> None:
 
 
 @pytest.mark.asyncio
-async def test_typed_state_decodes_from_row_metadata_when_store_type_changes(
+async def test_typed_state_decodes_when_store_type_changes(
     db_path: str,
 ) -> None:
+    """The self-describing payload drives decode even if the reader's declared type differs."""
     store1: SqliteStateStore[CounterState] = SqliteStateStore(
         db_path=db_path,
         run_id="run-typed-metadata",

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -244,7 +244,7 @@ async def test_typeless_clear_over_typed_row(db_path: str) -> None:
 async def test_get_inside_edit_state_does_not_deadlock(
     store: SqliteStateStore[DictState],
 ) -> None:
-    """Reads are lockless: `get` must work inside an `edit_state` block."""
+    """`get` must work inside an `edit_state` block on a durable backend."""
     await store.set("counter", 1)
 
     async def nested_read() -> int:

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 from pathlib import Path
+from typing import Any
 
 import pytest
 from llama_agents.server import HandlerQuery, SqliteWorkflowStore
@@ -253,6 +254,34 @@ async def test_get_inside_edit_state_does_not_deadlock(
             return int(await store.get("counter"))
 
     assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
+
+
+# -- Writer-scoped connection sessions --
+
+
+@pytest.mark.asyncio
+async def test_set_state_opens_exactly_one_connection(
+    store: SqliteStateStore[DictState], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """In default multi-connection mode, a write's load+save share one connection."""
+    await store.set("x", 1)  # materialize the row before counting
+
+    connect_count = 0
+    real_connect = sqlite3.connect
+
+    def counting_connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        nonlocal connect_count
+        connect_count += 1
+        return real_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", counting_connect)
+
+    await store.set_state(DictState(y=2))
+    assert connect_count == 1
+
+    connect_count = 0
+    await store.clear()
+    assert connect_count == 1
 
 
 # -- Persistence across instances --

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from pathlib import Path
 
@@ -199,6 +200,59 @@ async def test_clear_resets_typed_state(
     state = await typed_store.get_state()
     assert state.count == 0
     assert state.label == "default"
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_subclass_fields(db_path: str) -> None:
+    """Clear resets to the stored state's type; child-only fields don't survive."""
+    store: SqliteStateStore[CounterState] = SqliteStateStore(
+        db_path=db_path,
+        run_id="run-clear-subclass",
+        state_type=CounterState,
+    )
+    await store.set_state(ExtendedCounterState(count=1, extra="dirty"))
+
+    await store.clear()
+
+    state = await store.get_state()
+    assert isinstance(state, ExtendedCounterState)
+    assert state.count == 0
+    assert state.extra == "extra_default"
+
+
+@pytest.mark.asyncio
+async def test_typeless_clear_over_typed_row(db_path: str) -> None:
+    """A DictState-typed facade over a row holding a typed model can still clear."""
+    typed: SqliteStateStore[CounterState] = SqliteStateStore(
+        db_path=db_path,
+        run_id="run-typeless-clear",
+        state_type=CounterState,
+    )
+    await typed.set_state(CounterState(count=9, label="dirty"))
+
+    typeless: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path,
+        run_id="run-typeless-clear",
+    )
+    await typeless.clear()
+
+    state = await typed.get_state()
+    assert state == CounterState()
+
+
+@pytest.mark.asyncio
+async def test_get_inside_edit_state_does_not_deadlock(
+    store: SqliteStateStore[DictState],
+) -> None:
+    """Reads are lockless: `get` must work inside an `edit_state` block."""
+    await store.set("counter", 1)
+
+    async def nested_read() -> int:
+        async with store.edit_state() as state:
+            state["other"] = 2
+            return int(await store.get("counter"))
+
+    assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
 
 
 # -- Persistence across instances --

--- a/packages/llama-agents-server/tests/server/test_sqlite_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_workflow_store.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
+from typing import Any
 
 import pytest
 from llama_agents.server import (
@@ -8,6 +10,9 @@ from llama_agents.server import (
     PersistentHandler,
     SqliteWorkflowStore,
 )
+from llama_agents.server._store.sqlite.sqlite_state_store import SqliteStateStore
+from pydantic import BaseModel
+from workflows.context.state_store import DictState
 from workflows.events import StopEvent
 
 
@@ -196,3 +201,57 @@ async def test_update_pydantic_result_serialization(
 
     # The row's result should deserialize to a StopEvent
     assert found.result == event
+
+
+class _MemoCounterState(BaseModel):
+    count: int = 0
+
+
+@pytest.mark.asyncio
+async def test_create_state_store_memoizes_per_run(tmp_path: Path) -> None:
+    db_path: str = str(tmp_path / "handlers.db")
+    store = SqliteWorkflowStore(db_path)
+
+    first = store.create_state_store("run-1")
+    second = store.create_state_store("run-1")
+    other = store.create_state_store("run-2")
+
+    assert first is second
+    assert other is not first
+
+
+@pytest.mark.asyncio
+async def test_create_state_store_upgrades_default_state_type(tmp_path: Path) -> None:
+    db_path: str = str(tmp_path / "handlers.db")
+    store = SqliteWorkflowStore(db_path)
+
+    # A type-less caller (e.g. handler continuation) comes first...
+    first = store.create_state_store("run-1")
+    assert first.state_type is DictState
+
+    # ...and must not shadow the workflow's concrete state type.
+    second = store.create_state_store("run-1", state_type=_MemoCounterState)
+
+    assert second is first
+    assert first.state_type is _MemoCounterState
+
+
+@pytest.mark.asyncio
+async def test_create_state_store_concurrent_writers_share_lock(
+    tmp_path: Path,
+) -> None:
+    db_path: str = str(tmp_path / "handlers.db")
+    store = SqliteWorkflowStore(db_path)
+
+    first = store.create_state_store("run-1")
+    second = store.create_state_store("run-1")
+    await first.set("count", 0)
+
+    async def increment(state_store: SqliteStateStore[Any]) -> None:
+        for _ in range(10):
+            async with state_store.edit_state() as state:
+                state["count"] = state["count"] + 1
+
+    await asyncio.gather(increment(first), increment(second))
+
+    assert await first.get("count") == 20

--- a/packages/llama-agents-server/tests/server/test_sqlite_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_workflow_store.py
@@ -10,9 +10,13 @@ from llama_agents.server import (
     PersistentHandler,
     SqliteWorkflowStore,
 )
-from llama_agents.server._store.sqlite.sqlite_state_store import SqliteStateStore
 from pydantic import BaseModel
-from workflows.context.state_store import DictState
+from workflows.context.serializers import JsonSerializer
+from workflows.context.state_store import (
+    DictState,
+    InMemoryStateStore,
+    StateStore,
+)
 from workflows.events import StopEvent
 
 
@@ -237,6 +241,26 @@ async def test_create_state_store_upgrades_default_state_type(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_create_state_store_restore_reuses_cached_facade(tmp_path: Path) -> None:
+    """A restore call must seed the already-handed-out facade, not rebuild it."""
+    db_path: str = str(tmp_path / "handlers.db")
+    store = SqliteWorkflowStore(db_path)
+    serializer = JsonSerializer()
+
+    first = store.create_state_store("run-1")
+    seed = InMemoryStateStore(DictState(token="restored"))
+
+    second = store.create_state_store(
+        "run-1",
+        serialized_state=seed.to_dict(serializer),
+        serializer=serializer,
+    )
+
+    assert second is first
+    assert await asyncio.wait_for(first.get("token"), timeout=2.0) == "restored"
+
+
+@pytest.mark.asyncio
 async def test_create_state_store_concurrent_writers_share_lock(
     tmp_path: Path,
 ) -> None:
@@ -247,7 +271,7 @@ async def test_create_state_store_concurrent_writers_share_lock(
     second = store.create_state_store("run-1")
     await first.set("count", 0)
 
-    async def increment(state_store: SqliteStateStore[Any]) -> None:
+    async def increment(state_store: StateStore[Any]) -> None:
         for _ in range(10):
             async with state_store.edit_state() as state:
                 state["count"] = state["count"] + 1

--- a/packages/llama-agents-server/tests/server/test_workflow_service.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_service.py
@@ -21,9 +21,12 @@ from server_test_fixtures import (  # type: ignore[import]
     wait_for_passing,
     wait_for_requested_external_event,
 )
-from workflows import Workflow
+from pydantic import BaseModel
+from workflows import Context, Workflow
 from workflows.context.serializers import BaseSerializer
 from workflows.context.state_store import DictState, InMemoryStateStore
+from workflows.decorators import step
+from workflows.events import StartEvent, StopEvent
 
 
 class ToDictOnlyStateStore:
@@ -336,3 +339,93 @@ async def test_context_from_handler_id_falls_back_to_legacy_state_snapshot(
 
     assert ctx is not None
     assert await ctx.store.get("count") == 7
+
+
+class _InnerValue(BaseModel):
+    x: int = 1
+
+
+class _TypedHandoffState(BaseModel):
+    counter: int = 0
+
+
+class _TypedHandoffWorkflow(Workflow):
+    @step
+    async def go(
+        self, ev: StartEvent, ctx: Context[_TypedHandoffState]
+    ) -> StopEvent:
+        async with ctx.store.edit_state() as st:
+            st.counter += 1
+            return StopEvent(result=st.counter)
+
+
+class _DictHandoffWorkflow(Workflow):
+    @step
+    async def go(self, ev: StartEvent, ctx: Context) -> StopEvent:
+        obj = await ctx.store.get("obj", default=None)
+        return StopEvent(result=type(obj).__name__)
+
+
+@pytest.mark.asyncio
+async def test_typed_state_continuation_via_memory_store(
+    memory_store: MemoryWorkflowStore,
+) -> None:
+    """Handler continuation must round-trip typed state through the handoff payload."""
+    server = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    wf = _TypedHandoffWorkflow()
+    server.add_workflow("typed", wf)
+    await memory_store.update(
+        PersistentHandler(
+            handler_id="h-typed-continuation",
+            workflow_name="typed",
+            status="completed",
+            run_id="run-typed-continuation",
+            started_at=datetime.now(timezone.utc),
+        )
+    )
+    # Previous run left typed state in the memory store.
+    prev = memory_store.create_state_store(
+        "run-typed-continuation", state_type=_TypedHandoffState
+    )
+    await prev.set("counter", 41)
+
+    async with server.contextmanager():
+        ctx = await server._service._context_from_handler_id(
+            wf, "h-typed-continuation"
+        )
+        assert ctx is not None
+        handler = wf.run(ctx=ctx)
+        # The continued run must see the previous run's typed state (41) and
+        # be able to use it as the typed model (crash/degradation regression).
+        result = await handler
+        assert result == 42
+
+
+@pytest.mark.asyncio
+async def test_dict_state_pydantic_value_continuation_via_memory_store(
+    memory_store: MemoryWorkflowStore,
+) -> None:
+    """Pydantic values in DictState must survive handler continuation undegraded."""
+    server = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    wf = _DictHandoffWorkflow()
+    server.add_workflow("dictwf", wf)
+    await memory_store.update(
+        PersistentHandler(
+            handler_id="h-dict-continuation",
+            workflow_name="dictwf",
+            status="completed",
+            run_id="run-dict-continuation",
+            started_at=datetime.now(timezone.utc),
+        )
+    )
+    prev = memory_store.create_state_store("run-dict-continuation")
+    await prev.set("obj", _InnerValue(x=42))
+
+    async with server.contextmanager():
+        ctx = await server._service._context_from_handler_id(
+            wf, "h-dict-continuation"
+        )
+        assert ctx is not None
+        handler = wf.run(ctx=ctx)
+        result = await handler
+        assert result == "_InnerValue", f"pydantic value degraded to {result}"

--- a/packages/llama-agents-server/tests/server/test_workflow_service.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_service.py
@@ -15,13 +15,13 @@ from llama_agents.server import (
     WorkflowServer,
 )
 from llama_agents.server._service import EventSendError, HandlerCompletedError
+from pydantic import BaseModel
 from server_test_fixtures import (  # type: ignore[import]
     ErrorWorkflow,
     ExternalEvent,
     wait_for_passing,
     wait_for_requested_external_event,
 )
-from pydantic import BaseModel
 from workflows import Context, Workflow
 from workflows.context.serializers import BaseSerializer
 from workflows.context.state_store import DictState, InMemoryStateStore
@@ -351,9 +351,7 @@ class _TypedHandoffState(BaseModel):
 
 class _TypedHandoffWorkflow(Workflow):
     @step
-    async def go(
-        self, ev: StartEvent, ctx: Context[_TypedHandoffState]
-    ) -> StopEvent:
+    async def go(self, ev: StartEvent, ctx: Context[_TypedHandoffState]) -> StopEvent:
         async with ctx.store.edit_state() as st:
             st.counter += 1
             return StopEvent(result=st.counter)
@@ -390,9 +388,7 @@ async def test_typed_state_continuation_via_memory_store(
     await prev.set("counter", 41)
 
     async with server.contextmanager():
-        ctx = await server._service._context_from_handler_id(
-            wf, "h-typed-continuation"
-        )
+        ctx = await server._service._context_from_handler_id(wf, "h-typed-continuation")
         assert ctx is not None
         handler = wf.run(ctx=ctx)
         # The continued run must see the previous run's typed state (41) and
@@ -422,9 +418,7 @@ async def test_dict_state_pydantic_value_continuation_via_memory_store(
     await prev.set("obj", _InnerValue(x=42))
 
     async with server.contextmanager():
-        ctx = await server._service._context_from_handler_id(
-            wf, "h-dict-continuation"
-        )
+        ctx = await server._service._context_from_handler_id(wf, "h-dict-continuation")
         assert ctx is not None
         handler = wf.run(ctx=ctx)
         result = await handler

--- a/packages/llama-agents-server/tests/server/test_workflow_service.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_service.py
@@ -3,7 +3,9 @@
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
+from typing import Any, AsyncGenerator, cast
 
 import pytest
 from llama_agents.server import (
@@ -20,6 +22,38 @@ from server_test_fixtures import (  # type: ignore[import]
     wait_for_requested_external_event,
 )
 from workflows import Workflow
+from workflows.context.serializers import BaseSerializer
+from workflows.context.state_store import DictState, InMemoryStateStore
+
+
+class ToDictOnlyStateStore:
+    state_type = DictState
+
+    def __init__(self) -> None:
+        self._inner = InMemoryStateStore(DictState(count=7))
+
+    async def get_state(self) -> DictState:
+        return await self._inner.get_state()
+
+    async def set_state(self, state: DictState) -> None:
+        await self._inner.set_state(state)
+
+    async def get(self, path: str, default: Any = ...) -> Any:
+        return await self._inner.get(path, default)
+
+    async def set(self, path: str, value: Any) -> None:
+        await self._inner.set(path, value)
+
+    async def clear(self) -> None:
+        await self._inner.clear()
+
+    @asynccontextmanager
+    async def edit_state(self) -> AsyncGenerator[DictState, None]:
+        async with self._inner.edit_state() as state:
+            yield state
+
+    def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
+        return self._inner.to_dict(serializer)
 
 
 @pytest.mark.asyncio
@@ -275,3 +309,30 @@ async def test_cancel_terminal_handler_without_purge(
         )
         assert len(persisted) == 1
         assert persisted[0].status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_context_from_handler_id_falls_back_to_legacy_state_snapshot(
+    memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
+) -> None:
+    server = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    server.add_workflow("simple", simple_test_workflow)
+    await memory_store.update(
+        PersistentHandler(
+            handler_id="completed-with-plugin-state",
+            workflow_name="simple",
+            status="completed",
+            run_id="plugin-run",
+            started_at=datetime.now(timezone.utc),
+        )
+    )
+    state_stores = cast(dict[str, Any], memory_store.state_stores)
+    state_stores["plugin-run"] = ToDictOnlyStateStore()
+
+    async with server.contextmanager():
+        ctx = await server._service._context_from_handler_id(
+            simple_test_workflow, "completed-with-plugin-state"
+        )
+
+    assert ctx is not None
+    assert await ctx.store.get("count") == 7

--- a/packages/llama-index-workflows/src/workflows/context/pre_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/pre_context.py
@@ -12,6 +12,7 @@ from workflows.context.state_store import (
     InMemoryStateStore,
     StateStore,
     infer_state_type,
+    is_durable_serialized_state,
 )
 from workflows.errors import ContextSerdeError
 from workflows.runtime.types.internal_state import BrokerState
@@ -75,8 +76,8 @@ class PreContext(Generic[MODEL_T]):
         if self._store is None:
             serialized_state = self._init_snapshot.state
             if serialized_state:
-                store_type = serialized_state.get("store_type", "in_memory")
-                if store_type != "in_memory":
+                if is_durable_serialized_state(serialized_state):
+                    store_type = serialized_state.get("store_type")
                     raise ContextSerdeError(
                         "Context.store cannot be accessed before workflow start "
                         f"for durable state store '{store_type}'. Pass the context "

--- a/packages/llama-index-workflows/src/workflows/context/pre_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/pre_context.py
@@ -75,6 +75,13 @@ class PreContext(Generic[MODEL_T]):
         if self._store is None:
             serialized_state = self._init_snapshot.state
             if serialized_state:
+                store_type = serialized_state.get("store_type", "in_memory")
+                if store_type != "in_memory":
+                    raise ContextSerdeError(
+                        "Context.store cannot be accessed before workflow start "
+                        f"for durable state store '{store_type}'. Pass the context "
+                        "to workflow.run() so the runtime can restore it."
+                    )
                 self._store = cast(
                     InMemoryStateStore[MODEL_T],
                     InMemoryStateStore.from_dict(serialized_state, self._serializer),

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -120,9 +120,9 @@ def _resolve_state_type(
     state_type_name: str | None,
     state_module: str | None,
     serializer: BaseSerializer,
-) -> type[BaseModel]:
+) -> type[BaseModel] | None:
     if not state_type_name or not state_module:
-        return DictState
+        return None
 
     qualified_name = f"{state_module}.{state_type_name}"
     validate_qualified_name = getattr(serializer, "_validate_qualified_name", None)
@@ -132,11 +132,11 @@ def _resolve_state_type(
     try:
         resolved = import_module_from_qualified_name(qualified_name)
     except Exception:
-        return DictState
+        return None
 
     if isinstance(resolved, type) and issubclass(resolved, BaseModel):
         return resolved
-    return DictState
+    return None
 
 
 def encode_state(
@@ -155,6 +155,20 @@ def encode_state(
     return state_data, type(state).__name__, type(state).__module__
 
 
+def encode_state_to_str(
+    state: BaseModel,
+    serializer: BaseSerializer,
+    known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
+) -> tuple[str, str, str]:
+    """Encode state for durable stores that persist a single string column."""
+    state_data, state_type_name, state_module = encode_state(
+        state, serializer, known_unserializable_keys
+    )
+    if not isinstance(state_data, str):
+        state_data = json.dumps(state_data)
+    return state_data, state_type_name, state_module
+
+
 def decode_state(
     state_data: Any,
     state_type_name: str | None,
@@ -164,14 +178,25 @@ def decode_state(
     """Decode a state model using the persisted type metadata."""
     state_type = _resolve_state_type(state_type_name, state_module, serializer)
 
-    if issubclass(state_type, DictState):
+    if state_type is not None and issubclass(state_type, DictState):
         if isinstance(state_data, str):
             state_data = json.loads(state_data)
         if not isinstance(state_data, dict):
             state_data = {}
         return deserialize_dict_state_data(state_data, serializer)
 
-    return serializer.deserialize(state_data)
+    if state_type is not None:
+        return serializer.deserialize(state_data)
+
+    if isinstance(state_data, str):
+        deserialized = serializer.deserialize(state_data)
+        if isinstance(deserialized, BaseModel):
+            return deserialized
+        state_data = deserialized
+
+    if not isinstance(state_data, dict):
+        state_data = {}
+    return deserialize_dict_state_data(state_data, serializer)
 
 
 def create_in_memory_payload(
@@ -579,10 +604,7 @@ class InMemoryStateStore(Generic[MODEL_T]):
         if not serialized_state:
             return cls(DictState())  # type: ignore[arg-type]
 
-        # Validate it's in_memory format (raises ValueError if not)
-        parse_in_memory_state(serialized_state)
-
-        state_instance = deserialize_state_from_dict(serialized_state, serializer)
+        state_instance = decode_seed_state(serialized_state, serializer)
         return cls(state_instance)  # type: ignore[arg-type]
 
     @asynccontextmanager
@@ -695,6 +717,15 @@ def deserialize_state_from_dict(
         serialized_state.get("state_module"),
         serializer,
     )
+
+
+def decode_seed_state(
+    serialized_state: dict[str, Any],
+    serializer: "BaseSerializer",
+) -> BaseModel:
+    """Validate and decode an in-memory serialized state seed."""
+    parse_in_memory_state(serialized_state)
+    return deserialize_state_from_dict(serialized_state, serializer)
 
 
 def infer_state_type(workflow: "Workflow") -> type[BaseModel]:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -82,6 +82,22 @@ class _StateStorage(Protocol):
         ...
 
 
+@runtime_checkable
+class _SeededStateStorage(Protocol):
+    """Internal storage lifecycle hook for lazy seed materialization."""
+
+    async def ensure_seeded(self) -> None:
+        """Materialize any deferred seed before observable storage operations."""
+        ...
+
+
+def is_durable_serialized_state(data: dict[str, Any] | None) -> bool:
+    """Return whether a serialized state payload is a durable provider handle."""
+    if not data:
+        return False
+    return data.get("store_type", "in_memory") != "in_memory"
+
+
 def _record_from_state(
     state: BaseModel,
     serializer: BaseSerializer,
@@ -532,7 +548,11 @@ class StateStore(Protocol[MODEL_T]):
         ...
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
-        """Serialize state for legacy persistence."""
+        """Serialize state for legacy persistence.
+
+        Runtime integrations should prefer
+        `workflows.context.state_store_integration.state_store_handoff`.
+        """
         ...
 
 
@@ -562,7 +582,13 @@ class _TypedStateStore(Generic[MODEL_T]):
     def _create_default_state(self) -> MODEL_T:
         return create_cleared_state(self.state_type)
 
+    async def ensure_seeded(self) -> None:
+        """Materialize any deferred storage seed."""
+        if isinstance(self._storage, _SeededStateStorage):
+            await self._storage.ensure_seeded()
+
     async def _load_state_or_none(self) -> MODEL_T | None:
+        await self.ensure_seeded()
         record = await self._storage.load()
         if record is None:
             return None
@@ -585,6 +611,7 @@ class _TypedStateStore(Generic[MODEL_T]):
         return state
 
     async def _save_state(self, state: BaseModel) -> None:
+        await self.ensure_seeded()
         await self._storage.save(_record_from_state(state, self._serializer))
 
     async def get_state(self) -> MODEL_T:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -552,10 +552,13 @@ class StateStore(Protocol[MODEL_T]):
 class _TypedStateStore(Generic[MODEL_T]):
     """Typed StateStore facade over raw storage.
 
-    Concurrency contract: the internal lock serializes read-modify-write
-    operations within one process *through the same facade instance*.
-    Workflow stores memoize one facade per run so in-process writers share
-    that lock. Writers in other processes or replicas are not serialized;
+    Concurrency contract: reads (`get_state`, `get`, `snapshot`) take no
+    lock; writers (`set_state`, `set`, `clear`, `edit_state`) take the
+    internal lock, which serializes read-modify-write cycles within one
+    process *through the same facade instance*. Calling a writer inside
+    an `edit_state` block deadlocks and is unsupported. Workflow stores
+    memoize one facade per run so in-process writers share that lock.
+    Writers in other processes or replicas are not serialized;
     cross-replica consistency requires backend-level atomicity.
     """
 
@@ -621,9 +624,12 @@ class _TypedStateStore(Generic[MODEL_T]):
             await self._save_state(merged)
 
     async def get(self, path: str, default: Any = Ellipsis) -> Any:
-        """Get a nested value using dot-separated paths."""
-        async with self._lock:
-            return get_by_path(await self._load_state(), path, default)
+        """Get a nested value using dot-separated paths.
+
+        Lockless read, like `get_state`, so it stays safe inside
+        `edit_state`.
+        """
+        return get_by_path(await self._load_state(), path, default)
 
     async def set(self, path: str, value: Any) -> None:
         """Set a nested value using dot-separated paths."""
@@ -631,12 +637,26 @@ class _TypedStateStore(Generic[MODEL_T]):
             set_by_path(state, path, value)
 
     async def clear(self) -> None:
-        """Reset the state to its type defaults."""
-        await self.set_state(create_cleared_state(self.state_type))
+        """Reset the state to its type defaults.
+
+        Clear is a reset, not a merge: the stored state is replaced with a
+        default instance of its *current* type, so subclass fields are reset
+        too. Falls back to the construction-time `state_type` when storage
+        is empty.
+        """
+        async with self._lock:
+            current = await self._load_state_or_none()
+            target = type(current) if current is not None else self.state_type
+            await self._save_state(create_cleared_state(target))
 
     @asynccontextmanager
     async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
-        """Edit state transactionally under a lock."""
+        """Edit state transactionally under a lock.
+
+        Reads (`get_state`, `get`, `snapshot`) are safe inside the block;
+        calling a writer (`set_state`, `set`, `clear`, or a nested
+        `edit_state`) deadlocks and is unsupported.
+        """
         async with self._lock:
             state = await self._load_state()
             yield state
@@ -851,6 +871,7 @@ def deserialize_dict_state_data(
 def deserialize_state_from_dict(
     serialized_state: dict[str, Any],
     serializer: "BaseSerializer",
+    state_type: type[BaseModel] | None = None,
 ) -> BaseModel:
     """Deserialize state from a serialized payload.
 
@@ -861,6 +882,9 @@ def deserialize_state_from_dict(
         serialized_state: The payload from to_dict(), containing state_data,
             state_type, and state_module.
         serializer: Strategy to decode stored values.
+        state_type: Deprecated and ignored. Decoding dispatches on the
+            payload shape; the kwarg is kept so released callers
+            (llama-agents-dbos <= 0.3.x) don't break.
 
     Returns:
         The deserialized state model instance.

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -722,8 +722,11 @@ class StateStoreFacade(Generic[MODEL_T]):
                 await self._write_state(state)
             # Popped only after success so a failed materialization stays
             # pending; concurrent readers block on the seed lock above
-            # until the seed is committed.
-            self._pending_seed = None
+            # until the seed is committed. Identity-checked: sync add_seed
+            # may have staged a fresh seed during the awaits above, which
+            # must survive for the next ensure_seeded call.
+            if self._pending_seed is seed:
+                self._pending_seed = None
 
     async def _load_state_or_none(self) -> MODEL_T | None:
         await self.ensure_seeded()

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -27,7 +27,6 @@ from workflows.decorators import StepConfig
 from workflows.events import DictLikeModel
 
 from .serializers import BaseSerializer, JsonSerializer
-from .utils import import_module_from_qualified_name
 
 if TYPE_CHECKING:
     from workflows.workflow import Workflow
@@ -190,29 +189,6 @@ def serialize_dict_state_data(
     return {"_data": serialized_data}
 
 
-def _resolve_state_type(
-    state_type_name: str | None,
-    state_module: str | None,
-    serializer: BaseSerializer,
-) -> type[BaseModel] | None:
-    if not state_type_name or not state_module:
-        return None
-
-    qualified_name = f"{state_module}.{state_type_name}"
-    validate_qualified_name = getattr(serializer, "_validate_qualified_name", None)
-    if callable(validate_qualified_name):
-        validate_qualified_name(qualified_name)
-
-    try:
-        resolved = import_module_from_qualified_name(qualified_name)
-    except Exception:
-        return None
-
-    if isinstance(resolved, type) and issubclass(resolved, BaseModel):
-        return resolved
-    return None
-
-
 def encode_state(
     state: BaseModel,
     serializer: BaseSerializer,
@@ -245,31 +221,43 @@ def encode_state_to_str(
 
 def decode_state(
     state_data: Any,
-    state_type_name: str | None,
-    state_module: str | None,
     serializer: BaseSerializer,
 ) -> BaseModel:
-    """Decode a state model using the persisted type metadata."""
+    """Decode a persisted state payload by dispatching on its shape.
+
+    Persisted type metadata is intentionally not consulted, so rows cannot
+    drive module imports. Typed payloads self-describe through the serializer
+    (which validates the embedded qualified name before importing anything);
+    DictState payloads are recognized by their ``{"_data": ...}`` wrapper.
+    """
     if isinstance(state_data, BaseModel):
+        # Live model from an in-process handoff.
         return state_data
 
-    state_type = _resolve_state_type(state_type_name, state_module, serializer)
-
-    if state_type is not None and issubclass(state_type, DictState):
-        if isinstance(state_data, str):
-            state_data = json.loads(state_data)
-        if not isinstance(state_data, dict):
-            state_data = {}
-        return deserialize_dict_state_data(state_data, serializer)
-
-    if state_type is not None:
-        return serializer.deserialize(state_data)
-
     if isinstance(state_data, str):
-        deserialized = serializer.deserialize(state_data)
-        if isinstance(deserialized, BaseModel):
-            return deserialized
-        state_data = deserialized
+        try:
+            parsed: Any = json.loads(state_data)
+        except ValueError:
+            parsed = None
+        if isinstance(parsed, dict) and "_data" in parsed:
+            state_data = parsed
+        else:
+            # Non-JSON strings (e.g. pickled payloads) and JSON-encoded typed
+            # payloads both reconstruct through the serializer, which fails
+            # closed on disallowed embedded types.
+            deserialized = serializer.deserialize(state_data)
+            if isinstance(deserialized, BaseModel):
+                return deserialized
+            state_data = deserialized
+
+    if isinstance(state_data, dict) and "_data" not in state_data:
+        # Already-parsed typed payload. JsonSerializer-style serializers can
+        # reconstruct it from the embedded self-description.
+        deserialize_value = getattr(serializer, "deserialize_value", None)
+        if callable(deserialize_value):
+            value = deserialize_value(state_data)
+            if isinstance(value, BaseModel):
+                return value
 
     if not isinstance(state_data, dict):
         state_data = {}
@@ -592,15 +580,7 @@ class _TypedStateStore(Generic[MODEL_T]):
         record = await self._storage.load()
         if record is None:
             return None
-        return cast(
-            MODEL_T,
-            decode_state(
-                record.data,
-                record.state_type,
-                record.state_module,
-                self._serializer,
-            ),
-        )
+        return cast(MODEL_T, decode_state(record.data, self._serializer))
 
     async def _load_state(self) -> MODEL_T:
         state = await self._load_state_or_none()
@@ -775,12 +755,7 @@ class InMemoryStateStore(_TypedStateStore[MODEL_T]):
             [from_dict][workflows.context.state_store.InMemoryStateStore.from_dict].
         """
         record = self._sync_snapshot_record()
-        state = decode_state(
-            record.data,
-            record.state_type,
-            record.state_module,
-            JsonSerializer(),
-        )
+        state = decode_state(record.data, JsonSerializer())
         payload = create_in_memory_payload(state, serializer)
         return payload.model_dump()
 
@@ -849,16 +824,7 @@ def deserialize_dict_state_data(
     deserialized_data = {}
     for key, value in _data_serialized.items():
         try:
-            if isinstance(value, str):
-                try:
-                    deserialized_data[key] = serializer.deserialize(value)
-                except (TypeError, ValueError):
-                    deserialized_data[key] = value
-            else:
-                deserialize_value = getattr(serializer, "deserialize_value", None)
-                deserialized_data[key] = (
-                    deserialize_value(value) if callable(deserialize_value) else value
-                )
+            deserialized_data[key] = serializer.deserialize(value)
         except Exception as e:
             raise ValueError(f"Failed to deserialize state value for key {key}: {e}")
     return DictState(_data=deserialized_data)
@@ -884,12 +850,7 @@ def deserialize_state_from_dict(
     Raises:
         ValueError: If deserialization fails for any key.
     """
-    return decode_state(
-        serialized_state.get("state_data", {}),
-        serialized_state.get("state_type"),
-        serialized_state.get("state_module"),
-        serializer,
-    )
+    return decode_state(serialized_state.get("state_data", {}), serializer)
 
 
 def _decode_seed_state(

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -578,12 +578,12 @@ class StateStore(Protocol[MODEL_T]):
         ...
 
 
-class _OwnerAwareLock:
+class _WriterLock:
     """asyncio.Lock that records its holder task.
 
     Writers acquire exclusively and fail loudly when the current task
-    already holds the lock; reads pass through in that case so reads
-    inside an `edit_state` block work.
+    already holds the lock (a nested writer inside `edit_state`). Reads
+    never take this lock: they return committed state.
     """
 
     def __init__(self) -> None:
@@ -606,14 +606,6 @@ class _OwnerAwareLock:
             finally:
                 self._holder = None
 
-    @asynccontextmanager
-    async def acquire_read(self) -> AsyncGenerator[None, None]:
-        if self._held_by_current_task():
-            yield
-            return
-        async with self._lock:
-            yield
-
 
 class _CopySeed:
     """Pending seed: copy state from another target of the same backend."""
@@ -634,9 +626,11 @@ class StateStoreFacade(Generic[MODEL_T]):
     """Typed StateStore facade over raw storage.
 
     Concurrency contract: Writers serialize on the per-run lock; reads
-    return committed state — durable reads via the backend's committed row
-    (lockless), in-memory reads via the owner-aware lock; a task holding
-    the lock reads through without blocking, and nested writers raise.
+    are lockless and read-committed on every backend — durable reads see
+    the backend's committed row, in-memory reads see the committed record.
+    An in-flight `edit_state` block works on an isolated copy, so reads
+    (including reads inside the block) return the pre-edit state until the
+    block commits on exit. Nested writers raise.
 
     Workflow stores memoize one facade per run so in-process writers share
     that lock. Writers in other processes or replicas are not serialized;
@@ -672,9 +666,9 @@ class StateStoreFacade(Generic[MODEL_T]):
         raise AttributeError("run_id is only available on durable state stores")
 
     @functools.cached_property
-    def _lock(self) -> _OwnerAwareLock:
+    def _lock(self) -> _WriterLock:
         """Lazy lock initialization for Python 3.14+ compatibility."""
-        return _OwnerAwareLock()
+        return _WriterLock()
 
     @functools.cached_property
     def _seed_lock(self) -> asyncio.Lock:
@@ -756,10 +750,22 @@ class StateStoreFacade(Generic[MODEL_T]):
         else:
             await self._storage.save(_record_from_state(state, self._serializer))
 
+    async def _load_state_for_edit(self) -> MODEL_T:
+        """State instance handed to `edit_state`.
+
+        Must be isolated from concurrent readers: mutations inside the
+        block may not become observable until the block commits. Durable
+        backends get this for free (each load decodes a fresh instance
+        from the committed row); in-memory storage overrides this to edit
+        a copy of its live record.
+        """
+        return await self._load_state()
+
     async def get_state(self) -> MODEL_T:
         """Return a copy of the current state model.
 
-        Durable reads are lockless (read-committed via the backend row).
+        Reads are lockless and read-committed: an in-flight `edit_state`
+        block is not observable until it commits.
         """
         state = await self._load_state()
         return state.model_copy()
@@ -776,7 +782,7 @@ class StateStoreFacade(Generic[MODEL_T]):
     async def get(self, path: str, default: Any = Ellipsis) -> Any:
         """Get a nested value using dot-separated paths.
 
-        Durable reads are lockless (read-committed via the backend row).
+        Reads are lockless and read-committed (see `get_state`).
         """
         return get_by_path(await self._load_state(), path, default)
 
@@ -800,14 +806,16 @@ class StateStoreFacade(Generic[MODEL_T]):
 
     @asynccontextmanager
     async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
-        """Edit state transactionally under the writer lock.
+        """Edit an isolated copy of the state, committed on block exit.
 
-        Reads (`get_state`, `get`, `snapshot`) are safe inside the block;
-        calling a writer (`set_state`, `set`, `clear`, or a nested
-        `edit_state`) raises RuntimeError.
+        Reads (`get_state`, `get`, `snapshot`) never block on the writer
+        lock; inside or concurrent with the block they return the
+        committed pre-edit state. Calling a writer (`set_state`, `set`,
+        `clear`, or a nested `edit_state`) inside the block raises
+        RuntimeError.
         """
         async with self._lock.acquire_write():
-            state = await self._load_state()
+            state = await self._load_state_for_edit()
             yield state
             await self._save_state(state)
 
@@ -875,9 +883,11 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
     [DictState][workflows.context.state_store.DictState] for flexible,
     dictionary-like usage.
 
-    Thread-safety is ensured with an internal `asyncio.Lock`. Consumers can
-    either perform atomic reads/writes via `get_state` and `set_state`, or make
-    in-place, transactional edits via the `edit_state` context manager.
+    Writers serialize on an internal `asyncio.Lock`; reads are lockless and
+    read-committed. Consumers can either perform atomic reads/writes via
+    `get_state` and `set_state`, or make transactional edits via the
+    `edit_state` context manager — the block edits an isolated copy that is
+    committed when the block exits.
 
     Examples:
         Typed state model:
@@ -918,24 +928,13 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
             JsonSerializer(),
         )
 
-    async def get_state(self) -> MODEL_T:
-        """Return a shallow copy of the state, captured under the read lock.
-
-        The owner-aware lock keeps the copy from observing a half-applied
-        `edit_state` block; a task already holding the lock reads through.
-        """
-        async with self._lock.acquire_read():
-            return await super().get_state()
-
-    async def get(self, path: str, default: Any = Ellipsis) -> Any:
-        """Get a nested value, captured under the read lock."""
-        async with self._lock.acquire_read():
-            return await super().get(path, default)
-
-    async def snapshot(self, serializer: BaseSerializer) -> dict[str, Any]:
-        """Serialize portable state data, captured under the read lock."""
-        async with self._lock.acquire_read():
-            return await super().snapshot(serializer)
+    async def _load_state_for_edit(self) -> MODEL_T:
+        # The live record IS the committed state. Hand `edit_state` a deep
+        # copy so lockless readers keep seeing the committed state until
+        # the block commits (matching durable backends, where each load
+        # decodes a fresh instance from the committed row).
+        state = await self._load_state()
+        return state.model_copy(deep=True)
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
         """Serialize the state and model metadata for persistence.

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -76,6 +76,11 @@ class _StateStorage(Protocol):
         """Persist a raw state record."""
         ...
 
+
+@runtime_checkable
+class _DurableStateStorage(_StateStorage, Protocol):
+    """Storage whose state outlives the process and can emit a reconnect handle."""
+
     def to_handle(self) -> dict[str, Any]:
         """Return backend-specific reconnect metadata."""
         ...
@@ -635,14 +640,30 @@ class _TypedStateStore(Generic[MODEL_T]):
         state = await self._load_state()
         return create_in_memory_payload(state, serializer).model_dump()
 
-    def handle(self) -> dict[str, Any]:
-        """Serialize reconnect metadata for durable storage."""
-        return self._storage.to_handle()
+    async def serialize_for_handoff(self, serializer: BaseSerializer) -> dict[str, Any]:
+        """Serialize this store for runtime handoff.
+
+        Durable stores return a reconnect handle (the state stays in the
+        backend); in-memory stores return a portable, serializer-encoded
+        snapshot that round-trips through ``from_dict``.
+        """
+        await self.ensure_seeded()
+        if self._to_dict_mode == "handle":
+            return self._durable_storage().to_handle()
+        return await self.snapshot(serializer)
+
+    def _durable_storage(self) -> _DurableStateStorage:
+        """Constructor invariant: handle mode implies durable storage."""
+        if not isinstance(self._storage, _DurableStateStorage):
+            raise TypeError(
+                "to_dict_mode='handle' requires storage implementing to_handle()"
+            )
+        return self._storage
 
     def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
         """Serialize state for legacy callers."""
         if self._to_dict_mode == "handle":
-            return self.handle()
+            return self._durable_storage().to_handle()
         record = self._sync_snapshot_record()
         return InMemorySerializedState(
             state_type=record.state_type or "DictState",
@@ -668,16 +689,6 @@ class _InMemoryStateStorage:
 
     def load_sync(self) -> _StateRecord | None:
         return self._record.model_copy() if self._record is not None else None
-
-    def to_handle(self) -> dict[str, Any]:
-        record = self.load_sync()
-        if record is None:
-            return InMemorySerializedState().model_dump()
-        return InMemorySerializedState(
-            state_type=record.state_type or "DictState",
-            state_module=record.state_module or "workflows.context.state_store",
-            state_data=record.data,
-        ).model_dump()
 
 
 class InMemoryStateStore(_TypedStateStore[MODEL_T]):

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -81,6 +81,15 @@ class _StateStorage(Protocol):
         """Persist a raw state record."""
         ...
 
+    def session(self) -> AsyncContextManager[_StateStorage]:
+        """Scope a load+save pair to one backend connection.
+
+        Yields a *separate* storage value bound to that connection; the
+        receiver storage (and concurrent readers going through it) stays
+        untouched. Backends without per-call connections yield themselves.
+        """
+        ...
+
 
 @runtime_checkable
 class StateStorage(_StateStorage, Protocol):
@@ -653,6 +662,11 @@ class StateStoreFacade(Generic[MODEL_T]):
         serializer: BaseSerializer | None = None,
     ) -> None:
         self._storage = storage
+        # The durability decision is made exactly once, here; everything
+        # downstream branches on this typed field.
+        self._durable: StateStorage | None = (
+            storage if isinstance(storage, StateStorage) else None
+        )
         self.state_type = state_type or DictState  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
         self._serializer = serializer or JsonSerializer()
         self._pending_seed: _CopySeed | _PayloadSeed | None = None
@@ -660,9 +674,8 @@ class StateStoreFacade(Generic[MODEL_T]):
     @property
     def run_id(self) -> str:
         """Run id of the durable storage target."""
-        storage = self._storage
-        if isinstance(storage, StateStorage):
-            return storage.run_id
+        if self._durable is not None:
+            return self._durable.run_id
         raise AttributeError("run_id is only available on durable state stores")
 
     @functools.cached_property
@@ -688,10 +701,10 @@ class StateStoreFacade(Generic[MODEL_T]):
         """
         if not payload:
             raise ValueError("Cannot seed state store from an empty payload")
-        if isinstance(self._storage, StateStorage):
-            handle = self._storage.parse_own_handle(payload)
+        if self._durable is not None:
+            handle = self._durable.parse_own_handle(payload)
             if handle is not None:
-                own = self._storage.parse_own_handle(self._storage.to_handle())
+                own = self._durable.parse_own_handle(self._durable.to_handle())
                 # Same target: state already lives in the backend, nothing
                 # to copy (and any previously staged seed is superseded).
                 self._pending_seed = None if handle == own else _CopySeed(handle)
@@ -713,8 +726,9 @@ class StateStoreFacade(Generic[MODEL_T]):
             if seed is None:
                 return
             if isinstance(seed, _CopySeed):
-                durable = cast(StateStorage, self._storage)
-                await durable.copy_from_handle(seed.handle)
+                # add_seed only stages _CopySeed on durable storage.
+                assert self._durable is not None
+                await self._durable.copy_from_handle(seed.handle)
             else:
                 state = decode_seed_state(seed.payload, seed.serializer)
                 # Bypass _save_state: its ensure_seeded re-entry would
@@ -728,32 +742,43 @@ class StateStoreFacade(Generic[MODEL_T]):
             if self._pending_seed is seed:
                 self._pending_seed = None
 
-    async def _load_state_or_none(self) -> MODEL_T | None:
+    async def _load_state_or_none(
+        self, storage: _StateStorage | None = None
+    ) -> MODEL_T | None:
         await self.ensure_seeded()
-        record = await self._storage.load()
+        record = await (storage or self._storage).load()
         if record is None:
             return None
         return cast(MODEL_T, decode_state(record.data, self._serializer))
 
-    async def _load_state(self) -> MODEL_T:
-        state = await self._load_state_or_none()
+    async def _load_state(self, storage: _StateStorage | None = None) -> MODEL_T:
+        state = await self._load_state_or_none(storage)
         if state is not None:
             return state
         # Reads are pure: return a default without persisting it.
         return self._create_default_state()
 
-    async def _save_state(self, state: BaseModel) -> None:
+    async def _save_state(
+        self, state: BaseModel, storage: _StateStorage | None = None
+    ) -> None:
         await self.ensure_seeded()
-        await self._write_state(state)
+        await self._write_state(state, storage)
 
-    async def _write_state(self, state: BaseModel) -> None:
-        """Single save chokepoint: durable rows persist string data."""
-        if isinstance(self._storage, StateStorage):
-            await self._storage.save(string_record_from_state(state, self._serializer))
-        else:
-            await self._storage.save(_record_from_state(state, self._serializer))
+    async def _write_state(
+        self, state: BaseModel, storage: _StateStorage | None = None
+    ) -> None:
+        """Single save chokepoint: persists string records.
 
-    async def _load_state_for_edit(self) -> MODEL_T:
+        Non-durable facades override this (`InMemoryStateStore` saves
+        live-model records instead).
+        """
+        await (storage or self._storage).save(
+            string_record_from_state(state, self._serializer)
+        )
+
+    async def _load_state_for_edit(
+        self, storage: _StateStorage | None = None
+    ) -> MODEL_T:
         """State instance handed to `edit_state`.
 
         Must be isolated from concurrent readers: mutations inside the
@@ -762,7 +787,7 @@ class StateStoreFacade(Generic[MODEL_T]):
         from the committed row); in-memory storage overrides this to edit
         a copy of its live record.
         """
-        return await self._load_state()
+        return await self._load_state(storage)
 
     async def get_state(self) -> MODEL_T:
         """Return a copy of the current state model.
@@ -776,11 +801,12 @@ class StateStoreFacade(Generic[MODEL_T]):
     async def set_state(self, state: MODEL_T) -> None:
         """Replace or merge into the current state model."""
         async with self._lock.acquire_write():
-            current = await self._load_state_or_none()
-            merged: BaseModel = (
-                state if current is None else merge_state(current, state)
-            )
-            await self._save_state(merged)
+            async with self._storage.session() as storage:
+                current = await self._load_state_or_none(storage)
+                merged: BaseModel = (
+                    state if current is None else merge_state(current, state)
+                )
+                await self._save_state(merged, storage)
 
     async def get(self, path: str, default: Any = Ellipsis) -> Any:
         """Get a nested value using dot-separated paths.
@@ -803,9 +829,10 @@ class StateStoreFacade(Generic[MODEL_T]):
         is empty.
         """
         async with self._lock.acquire_write():
-            current = await self._load_state_or_none()
-            target = type(current) if current is not None else self.state_type
-            await self._save_state(create_cleared_state(target))
+            async with self._storage.session() as storage:
+                current = await self._load_state_or_none(storage)
+                target = type(current) if current is not None else self.state_type
+                await self._save_state(create_cleared_state(target), storage)
 
     @asynccontextmanager
     async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
@@ -818,9 +845,10 @@ class StateStoreFacade(Generic[MODEL_T]):
         RuntimeError.
         """
         async with self._lock.acquire_write():
-            state = await self._load_state_for_edit()
-            yield state
-            await self._save_state(state)
+            async with self._storage.session() as storage:
+                state = await self._load_state_for_edit(storage)
+                yield state
+                await self._save_state(state, storage)
 
     async def snapshot(self, serializer: BaseSerializer) -> dict[str, Any]:
         """Serialize portable state data."""
@@ -837,8 +865,8 @@ class StateStoreFacade(Generic[MODEL_T]):
         seeds.
         """
         await self.ensure_seeded()
-        if isinstance(self._storage, StateStorage):
-            return self._storage.to_handle()
+        if self._durable is not None:
+            return self._durable.to_handle()
         return await self.snapshot(serializer)
 
     def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
@@ -847,8 +875,8 @@ class StateStoreFacade(Generic[MODEL_T]):
         Durable stores return a reconnect handle. Non-durable storage has no
         sync snapshot here; `InMemoryStateStore` overrides this.
         """
-        if isinstance(self._storage, StateStorage):
-            return self._storage.to_handle()
+        if self._durable is not None:
+            return self._durable.to_handle()
         raise NotImplementedError("Use await snapshot(serializer) for async storage")
 
 
@@ -872,6 +900,11 @@ class _InMemoryStateStorage:
 
     async def save(self, record: StateRecord) -> None:
         self._record = record.model_copy()
+
+    @asynccontextmanager
+    async def session(self) -> AsyncGenerator[_InMemoryStateStorage, None]:
+        # No per-call connections: the storage scopes itself.
+        yield self
 
     def load_sync(self) -> StateRecord | None:
         return self._record.model_copy() if self._record is not None else None
@@ -931,12 +964,14 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
             JsonSerializer(),
         )
 
-    async def _load_state_for_edit(self) -> MODEL_T:
+    async def _load_state_for_edit(
+        self, storage: _StateStorage | None = None
+    ) -> MODEL_T:
         # The live record IS the committed state. Hand `edit_state` a deep
         # copy so lockless readers keep seeing the committed state until
         # the block commits (matching durable backends, where each load
         # decodes a fresh instance from the committed row).
-        state = await self._load_state()
+        state = await self._load_state(storage)
         return state.model_copy(deep=True)
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
@@ -960,8 +995,12 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         state = cast(MODEL_T, record.data) if record is not None else self.state_type()
         return create_in_memory_payload(state, serializer).model_dump()
 
-    async def _write_state(self, state: BaseModel) -> None:
-        # Live-model record: no encoding, value identity preserved.
+    async def _write_state(
+        self, state: BaseModel, storage: _StateStorage | None = None
+    ) -> None:
+        # Live-model record: no encoding, value identity preserved. The
+        # in-memory session yields the storage itself, so writes always
+        # land in self._memory_storage.
         await self._memory_storage.save(_live_record(state))
 
     @classmethod

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -85,7 +85,7 @@ class _StateStorage(Protocol):
 class StateStorage(_StateStorage, Protocol):
     """Durable storage: state outlives the process and supports reconnect handles.
 
-    Backends implement genuine I/O only; the seed lifecycle, locking, and
+    Backends implement raw I/O only; the seed lifecycle, locking, and
     save-path encoding live in [StateStoreFacade][workflows.context.state_store.StateStoreFacade].
     """
 
@@ -134,15 +134,14 @@ def string_record_from_state(
     serializer: BaseSerializer,
     known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
 ) -> StateRecord:
-    """Encode a state model into a storage record with string data."""
-    state_data, state_type_name, state_module = encode_state_to_str(
-        state, serializer, known_unserializable_keys
-    )
-    return StateRecord(
-        data=state_data,
-        state_type=state_type_name,
-        state_module=state_module,
-    )
+    """Encode a state model into a storage record with string data.
+
+    For durable stores that persist a single string column.
+    """
+    record = _record_from_state(state, serializer, known_unserializable_keys)
+    if not isinstance(record.data, str):
+        record.data = json.dumps(record.data)
+    return record
 
 
 def parse_in_memory_state(
@@ -219,20 +218,6 @@ def encode_state(
         state_data = serializer.serialize(state)
 
     return state_data, type(state).__name__, type(state).__module__
-
-
-def encode_state_to_str(
-    state: BaseModel,
-    serializer: BaseSerializer,
-    known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
-) -> tuple[str, str, str]:
-    """Encode state for durable stores that persist a single string column."""
-    state_data, state_type_name, state_module = encode_state(
-        state, serializer, known_unserializable_keys
-    )
-    if not isinstance(state_data, str):
-        state_data = json.dumps(state_data)
-    return state_data, state_type_name, state_module
 
 
 def decode_state(
@@ -837,6 +822,15 @@ class StateStoreFacade(Generic[MODEL_T]):
         raise NotImplementedError("Use await snapshot(serializer) for async storage")
 
 
+def _live_record(state: BaseModel) -> StateRecord:
+    """Record wrapping a live model: in-memory state keeps value identity."""
+    return StateRecord(
+        data=state,
+        state_type=type(state).__name__,
+        state_module=type(state).__module__,
+    )
+
+
 class _InMemoryStateStorage:
     """Raw in-process storage for workflow state."""
 
@@ -898,13 +892,7 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
     state_type: type[MODEL_T]
 
     def __init__(self, initial_state: MODEL_T):
-        self._memory_storage = _InMemoryStateStorage(
-            StateRecord(
-                data=initial_state,
-                state_type=type(initial_state).__name__,
-                state_module=type(initial_state).__module__,
-            )
-        )
+        self._memory_storage = _InMemoryStateStorage(_live_record(initial_state))
         super().__init__(
             self._memory_storage,
             type(initial_state),
@@ -954,23 +942,12 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         record = self._memory_storage.load_sync()
         if record is None:
             # Reads are pure: return a default record without persisting it.
-            state = self.state_type()
-            record = StateRecord(
-                data=state,
-                state_type=type(state).__name__,
-                state_module=type(state).__module__,
-            )
+            record = _live_record(self.state_type())
         return record
 
     async def _write_state(self, state: BaseModel) -> None:
-        # Live-model record: in-memory state keeps value identity, no encoding.
-        await self._memory_storage.save(
-            StateRecord(
-                data=state,
-                state_type=type(state).__name__,
-                state_module=type(state).__module__,
-            )
-        )
+        # Live-model record: no encoding, value identity preserved.
+        await self._memory_storage.save(_live_record(state))
 
     @classmethod
     def from_dict(

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -16,6 +16,7 @@ from typing import (
     Generic,
     Literal,
     Protocol,
+    cast,
     runtime_checkable,
 )
 
@@ -25,7 +26,7 @@ from typing_extensions import TypeVar
 from workflows.decorators import StepConfig
 from workflows.events import DictLikeModel
 
-from .serializers import BaseSerializer
+from .serializers import BaseSerializer, JsonSerializer
 from .utils import import_module_from_qualified_name
 
 if TYPE_CHECKING:
@@ -54,6 +55,63 @@ class InMemorySerializedState(BaseModel):
         if isinstance(data, dict) and "store_type" not in data:
             data = {**data, "store_type": "in_memory"}
         return data
+
+
+class StoredStateRecord(BaseModel):
+    """Raw state record loaded and saved by a storage backend."""
+
+    data: Any
+    state_type: str | None = None
+    state_module: str | None = None
+
+
+@runtime_checkable
+class StateStorage(Protocol):
+    """Internal persistence boundary for workflow state."""
+
+    async def load(self) -> StoredStateRecord | None:
+        """Load a raw state record, or None when no state exists yet."""
+        ...
+
+    async def save(self, record: StoredStateRecord) -> None:
+        """Persist a raw state record."""
+        ...
+
+    def to_handle(self) -> dict[str, Any]:
+        """Return backend-specific reconnect metadata."""
+        ...
+
+
+def record_from_state(
+    state: BaseModel,
+    serializer: BaseSerializer,
+    known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
+) -> StoredStateRecord:
+    """Encode a state model into a raw storage record."""
+    state_data, state_type_name, state_module = encode_state(
+        state, serializer, known_unserializable_keys
+    )
+    return StoredStateRecord(
+        data=state_data,
+        state_type=state_type_name,
+        state_module=state_module,
+    )
+
+
+def string_record_from_state(
+    state: BaseModel,
+    serializer: BaseSerializer,
+    known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
+) -> StoredStateRecord:
+    """Encode a state model into a storage record with string data."""
+    state_data, state_type_name, state_module = encode_state_to_str(
+        state, serializer, known_unserializable_keys
+    )
+    return StoredStateRecord(
+        data=state_data,
+        state_type=state_type_name,
+        state_module=state_module,
+    )
 
 
 def parse_in_memory_state(
@@ -176,6 +234,9 @@ def decode_state(
     serializer: BaseSerializer,
 ) -> BaseModel:
     """Decode a state model using the persisted type metadata."""
+    if isinstance(state_data, BaseModel):
+        return state_data
+
     state_type = _resolve_state_type(state_type_name, state_module, serializer)
 
     if state_type is not None and issubclass(state_type, DictState):
@@ -479,8 +540,153 @@ class StateStore(Protocol[MODEL_T]):
         """Serialize state for persistence."""
         ...
 
+    async def snapshot(self, serializer: "BaseSerializer") -> dict[str, Any]:
+        """Serialize portable state data."""
+        ...
 
-class InMemoryStateStore(Generic[MODEL_T]):
+    def handle(self) -> dict[str, Any]:
+        """Serialize reconnect metadata for durable storage."""
+        ...
+
+
+class TypedStateStore(Generic[MODEL_T]):
+    """Typed public StateStore facade over raw storage."""
+
+    state_type: type[MODEL_T]
+
+    def __init__(
+        self,
+        storage: StateStorage,
+        state_type: type[MODEL_T],
+        serializer: BaseSerializer,
+        *,
+        to_dict_mode: Literal["snapshot", "handle"] = "snapshot",
+    ) -> None:
+        self._storage = storage
+        self.state_type = state_type
+        self._serializer = serializer
+        self._to_dict_mode = to_dict_mode
+
+    @functools.cached_property
+    def _lock(self) -> asyncio.Lock:
+        """Lazy lock initialization for Python 3.14+ compatibility."""
+        return asyncio.Lock()
+
+    def _create_default_state(self) -> MODEL_T:
+        return create_cleared_state(self.state_type)
+
+    async def _load_state_or_none(self) -> MODEL_T | None:
+        record = await self._storage.load()
+        if record is None:
+            return None
+        return cast(
+            MODEL_T,
+            decode_state(
+                record.data,
+                record.state_type,
+                record.state_module,
+                self._serializer,
+            ),
+        )
+
+    async def _load_state(self) -> MODEL_T:
+        state = await self._load_state_or_none()
+        if state is not None:
+            return state
+        state = self._create_default_state()
+        await self._save_state(state)
+        return state
+
+    async def _save_state(self, state: BaseModel) -> None:
+        await self._storage.save(record_from_state(state, self._serializer))
+
+    async def get_state(self) -> MODEL_T:
+        """Return a copy of the current state model."""
+        state = await self._load_state()
+        return state.model_copy()
+
+    async def set_state(self, state: MODEL_T) -> None:
+        """Replace or merge into the current state model."""
+        async with self._lock:
+            current = await self._load_state_or_none()
+            merged: BaseModel = (
+                state if current is None else merge_state(current, state)
+            )
+            await self._save_state(merged)
+
+    async def get(self, path: str, default: Any = Ellipsis) -> Any:
+        """Get a nested value using dot-separated paths."""
+        async with self._lock:
+            return get_by_path(await self._load_state(), path, default)
+
+    async def set(self, path: str, value: Any) -> None:
+        """Set a nested value using dot-separated paths."""
+        async with self.edit_state() as state:
+            set_by_path(state, path, value)
+
+    async def clear(self) -> None:
+        """Reset the state to its type defaults."""
+        await self.set_state(create_cleared_state(self.state_type))
+
+    @asynccontextmanager
+    async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
+        """Edit state transactionally under a lock."""
+        async with self._lock:
+            state = await self._load_state()
+            yield state
+            await self._save_state(state)
+
+    async def snapshot(self, serializer: BaseSerializer) -> dict[str, Any]:
+        """Serialize portable state data."""
+        state = await self._load_state()
+        return create_in_memory_payload(state, serializer).model_dump()
+
+    def handle(self) -> dict[str, Any]:
+        """Serialize reconnect metadata for durable storage."""
+        return self._storage.to_handle()
+
+    def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
+        """Serialize state for legacy callers."""
+        if self._to_dict_mode == "handle":
+            return self.handle()
+        record = self._sync_snapshot_record()
+        return InMemorySerializedState(
+            state_type=record.state_type or "DictState",
+            state_module=record.state_module or "workflows.context.state_store",
+            state_data=record.data,
+        ).model_dump()
+
+    def _sync_snapshot_record(self) -> StoredStateRecord:
+        raise NotImplementedError("Use await snapshot(serializer) for async storage")
+
+
+class InMemoryStateStorage:
+    """Raw in-process storage for workflow state."""
+
+    def __init__(self, record: StoredStateRecord | None = None) -> None:
+        self._record = record
+
+    async def load(self) -> StoredStateRecord | None:
+        return self._record.model_copy(deep=True) if self._record is not None else None
+
+    async def save(self, record: StoredStateRecord) -> None:
+        self._record = record.model_copy(deep=True)
+
+    def load_sync(self) -> StoredStateRecord | None:
+        return self._record.model_copy(deep=True) if self._record is not None else None
+
+    def to_handle(self) -> dict[str, Any]:
+        record = self.load_sync()
+        if record is None:
+            return InMemorySerializedState().model_dump()
+        return InMemorySerializedState(
+            state_type=record.state_type or "DictState",
+            state_module=record.state_module or "workflows.context.state_store",
+            state_data=record.data,
+        ).model_dump()
+
+
+class InMemoryStateStore(TypedStateStore[MODEL_T]):
     """
     Default in-memory implementation of the [StateStore][workflows.context.state_store.StateStore] protocol.
 
@@ -525,46 +731,19 @@ class InMemoryStateStore(Generic[MODEL_T]):
     state_type: type[MODEL_T]
 
     def __init__(self, initial_state: MODEL_T):
-        self._state = initial_state
-        self.state_type = type(initial_state)
-
-    @functools.cached_property
-    def _lock(self) -> asyncio.Lock:
-        """Lazy lock initialization for Python 3.14+ compatibility.
-
-        asyncio.Lock() requires a running event loop in Python 3.14+.
-        Using cached_property defers creation to first use in async context.
-        """
-        return asyncio.Lock()
-
-    async def get_state(self) -> MODEL_T:
-        """Return a shallow copy of the current state model.
-
-        Returns:
-            MODEL_T: A `.model_copy()` of the internal Pydantic model.
-        """
-        return self._state.model_copy()
-
-    async def set_state(self, state: MODEL_T) -> None:
-        """Replace or merge into the current state model.
-
-        If the provided state is the exact type of the current state, it replaces
-        the state entirely. If the provided state is a parent type (i.e., the
-        current state type is a subclass of the provided state type), the fields
-        from the parent are merged onto the current state, preserving any child
-        fields that aren't present in the parent.
-
-        This enables workflow inheritance where a base workflow step can call
-        set_state with a base state type without obliterating child state fields.
-
-        Args:
-            state (MODEL_T): New state, either the same type or a parent type.
-
-        Raises:
-            ValueError: If the types are not compatible (neither same nor parent).
-        """
-        async with self._lock:
-            self._state = merge_state(self._state, state)
+        self._memory_storage = InMemoryStateStorage(
+            StoredStateRecord(
+                data=initial_state,
+                state_type=type(initial_state).__name__,
+                state_module=type(initial_state).__module__,
+            )
+        )
+        super().__init__(
+            self._memory_storage,
+            type(initial_state),
+            JsonSerializer(),
+            to_dict_mode="snapshot",
+        )
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
         """Serialize the state and model metadata for persistence.
@@ -581,8 +760,36 @@ class InMemoryStateStore(Generic[MODEL_T]):
             dict[str, Any]: A payload suitable for
             [from_dict][workflows.context.state_store.InMemoryStateStore.from_dict].
         """
-        payload = create_in_memory_payload(self._state, serializer)
+        record = self._sync_snapshot_record()
+        state = decode_state(
+            record.data,
+            record.state_type,
+            record.state_module,
+            JsonSerializer(),
+        )
+        payload = create_in_memory_payload(state, serializer)
         return payload.model_dump()
+
+    def _sync_snapshot_record(self) -> StoredStateRecord:
+        record = self._memory_storage.load_sync()
+        if record is None:
+            state = self.state_type()
+            record = StoredStateRecord(
+                data=state,
+                state_type=type(state).__name__,
+                state_module=type(state).__module__,
+            )
+            self._memory_storage._record = record
+        return record
+
+    async def _save_state(self, state: BaseModel) -> None:
+        await self._memory_storage.save(
+            StoredStateRecord(
+                data=state,
+                state_type=type(state).__name__,
+                state_module=type(state).__module__,
+            )
+        )
 
     @classmethod
     def from_dict(
@@ -606,63 +813,6 @@ class InMemoryStateStore(Generic[MODEL_T]):
 
         state_instance = decode_seed_state(serialized_state, serializer)
         return cls(state_instance)  # type: ignore[arg-type]
-
-    @asynccontextmanager
-    async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
-        """Edit state transactionally under a lock.
-
-        Yields the mutable model and writes it back on exit. This pattern avoids
-        read-modify-write races and keeps updates atomic.
-
-        Yields:
-            MODEL_T: The current state model for in-place mutation.
-        """
-        async with self._lock:
-            state = self._state
-
-            yield state
-
-            self._state = state
-
-    async def get(self, path: str, default: Any = Ellipsis) -> Any:
-        """Get a nested value using dot-separated paths.
-
-        Args:
-            path (str): Dot-separated path, e.g. "user.profile.name".
-            default (Any): If provided, return this when the path does not
-                exist; otherwise, raise `ValueError`.
-
-        Returns:
-            Any: The resolved value.
-
-        Raises:
-            ValueError: If the path is invalid and no default is provided or if
-                the path depth exceeds limits.
-        """
-        async with self._lock:
-            return get_by_path(self._state, path, default)
-
-    async def set(self, path: str, value: Any) -> None:
-        """Set a nested value using dot-separated paths.
-
-        Args:
-            path (str): Dot-separated path to write.
-            value (Any): Value to assign.
-
-        Raises:
-            ValueError: If the path is empty or exceeds the maximum depth.
-        """
-        async with self._lock:
-            set_by_path(self._state, path, value)
-
-    async def clear(self) -> None:
-        """Reset the state to its type defaults.
-
-        Raises:
-            ValueError: If the model type cannot be instantiated from defaults
-                (i.e., fields missing default values).
-        """
-        await self.set_state(create_cleared_state(self._state.__class__))
 
 
 def deserialize_dict_state_data(

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -654,13 +654,13 @@ class _InMemoryStateStorage:
         self._record = record
 
     async def load(self) -> _StateRecord | None:
-        return self._record.model_copy(deep=True) if self._record is not None else None
+        return self._record.model_copy() if self._record is not None else None
 
     async def save(self, record: _StateRecord) -> None:
-        self._record = record.model_copy(deep=True)
+        self._record = record.model_copy()
 
     def load_sync(self) -> _StateRecord | None:
-        return self._record.model_copy(deep=True) if self._record is not None else None
+        return self._record.model_copy() if self._record is not None else None
 
     def to_handle(self) -> dict[str, Any]:
         record = self.load_sync()
@@ -822,7 +822,16 @@ def deserialize_dict_state_data(
     deserialized_data = {}
     for key, value in _data_serialized.items():
         try:
-            deserialized_data[key] = serializer.deserialize(value)
+            if isinstance(value, str):
+                try:
+                    deserialized_data[key] = serializer.deserialize(value)
+                except (TypeError, ValueError):
+                    deserialized_data[key] = value
+            else:
+                deserialize_value = getattr(serializer, "deserialize_value", None)
+                deserialized_data[key] = (
+                    deserialize_value(value) if callable(deserialize_value) else value
+                )
         except Exception as e:
             raise ValueError(f"Failed to deserialize state value for key {key}: {e}")
     return DictState(_data=deserialized_data)

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -57,7 +57,7 @@ class InMemorySerializedState(BaseModel):
         return data
 
 
-class StoredStateRecord(BaseModel):
+class _StateRecord(BaseModel):
     """Raw state record loaded and saved by a storage backend."""
 
     data: Any
@@ -66,14 +66,14 @@ class StoredStateRecord(BaseModel):
 
 
 @runtime_checkable
-class StateStorage(Protocol):
+class _StateStorage(Protocol):
     """Internal persistence boundary for workflow state."""
 
-    async def load(self) -> StoredStateRecord | None:
+    async def load(self) -> _StateRecord | None:
         """Load a raw state record, or None when no state exists yet."""
         ...
 
-    async def save(self, record: StoredStateRecord) -> None:
+    async def save(self, record: _StateRecord) -> None:
         """Persist a raw state record."""
         ...
 
@@ -82,32 +82,32 @@ class StateStorage(Protocol):
         ...
 
 
-def record_from_state(
+def _record_from_state(
     state: BaseModel,
     serializer: BaseSerializer,
     known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
-) -> StoredStateRecord:
+) -> _StateRecord:
     """Encode a state model into a raw storage record."""
     state_data, state_type_name, state_module = encode_state(
         state, serializer, known_unserializable_keys
     )
-    return StoredStateRecord(
+    return _StateRecord(
         data=state_data,
         state_type=state_type_name,
         state_module=state_module,
     )
 
 
-def string_record_from_state(
+def _string_record_from_state(
     state: BaseModel,
     serializer: BaseSerializer,
     known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
-) -> StoredStateRecord:
+) -> _StateRecord:
     """Encode a state model into a storage record with string data."""
     state_data, state_type_name, state_module = encode_state_to_str(
         state, serializer, known_unserializable_keys
     )
-    return StoredStateRecord(
+    return _StateRecord(
         data=state_data,
         state_type=state_type_name,
         state_module=state_module,
@@ -490,20 +490,15 @@ MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore
 
 @runtime_checkable
 class StateStore(Protocol[MODEL_T]):
-    """Protocol defining the async state store interface.
+    """Protocol defining the public async state store interface.
 
     State stores hold a single Pydantic model instance representing global
     workflow state. Implementations must be async-safe and support both
     atomic operations and transactional edits.
 
-    This protocol enables runtime plugins to provide custom state store
-    implementations (e.g., backed by databases, Redis, or external services)
-    while maintaining API compatibility with the default
+    Runtime plugins can provide custom implementations while maintaining API
+    compatibility with the default
     [InMemoryStateStore][workflows.context.state_store.InMemoryStateStore].
-
-    For remote state stores, `to_dict`/`from_dict` should serialize non-secret
-    connection info (e.g., URL, table name) rather than the full state contents,
-    since the actual state lives in the external service.
 
     See Also:
         - [InMemoryStateStore][workflows.context.state_store.InMemoryStateStore]
@@ -537,26 +532,18 @@ class StateStore(Protocol[MODEL_T]):
         ...
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
-        """Serialize state for persistence."""
-        ...
-
-    async def snapshot(self, serializer: "BaseSerializer") -> dict[str, Any]:
-        """Serialize portable state data."""
-        ...
-
-    def handle(self) -> dict[str, Any]:
-        """Serialize reconnect metadata for durable storage."""
+        """Serialize state for legacy persistence."""
         ...
 
 
-class TypedStateStore(Generic[MODEL_T]):
-    """Typed public StateStore facade over raw storage."""
+class _TypedStateStore(Generic[MODEL_T]):
+    """Typed StateStore facade over raw storage."""
 
     state_type: type[MODEL_T]
 
     def __init__(
         self,
-        storage: StateStorage,
+        storage: _StateStorage,
         state_type: type[MODEL_T],
         serializer: BaseSerializer,
         *,
@@ -598,7 +585,7 @@ class TypedStateStore(Generic[MODEL_T]):
         return state
 
     async def _save_state(self, state: BaseModel) -> None:
-        await self._storage.save(record_from_state(state, self._serializer))
+        await self._storage.save(_record_from_state(state, self._serializer))
 
     async def get_state(self) -> MODEL_T:
         """Return a copy of the current state model."""
@@ -656,23 +643,23 @@ class TypedStateStore(Generic[MODEL_T]):
             state_data=record.data,
         ).model_dump()
 
-    def _sync_snapshot_record(self) -> StoredStateRecord:
+    def _sync_snapshot_record(self) -> _StateRecord:
         raise NotImplementedError("Use await snapshot(serializer) for async storage")
 
 
-class InMemoryStateStorage:
+class _InMemoryStateStorage:
     """Raw in-process storage for workflow state."""
 
-    def __init__(self, record: StoredStateRecord | None = None) -> None:
+    def __init__(self, record: _StateRecord | None = None) -> None:
         self._record = record
 
-    async def load(self) -> StoredStateRecord | None:
+    async def load(self) -> _StateRecord | None:
         return self._record.model_copy(deep=True) if self._record is not None else None
 
-    async def save(self, record: StoredStateRecord) -> None:
+    async def save(self, record: _StateRecord) -> None:
         self._record = record.model_copy(deep=True)
 
-    def load_sync(self) -> StoredStateRecord | None:
+    def load_sync(self) -> _StateRecord | None:
         return self._record.model_copy(deep=True) if self._record is not None else None
 
     def to_handle(self) -> dict[str, Any]:
@@ -686,7 +673,7 @@ class InMemoryStateStorage:
         ).model_dump()
 
 
-class InMemoryStateStore(TypedStateStore[MODEL_T]):
+class InMemoryStateStore(_TypedStateStore[MODEL_T]):
     """
     Default in-memory implementation of the [StateStore][workflows.context.state_store.StateStore] protocol.
 
@@ -731,8 +718,8 @@ class InMemoryStateStore(TypedStateStore[MODEL_T]):
     state_type: type[MODEL_T]
 
     def __init__(self, initial_state: MODEL_T):
-        self._memory_storage = InMemoryStateStorage(
-            StoredStateRecord(
+        self._memory_storage = _InMemoryStateStorage(
+            _StateRecord(
                 data=initial_state,
                 state_type=type(initial_state).__name__,
                 state_module=type(initial_state).__module__,
@@ -770,11 +757,11 @@ class InMemoryStateStore(TypedStateStore[MODEL_T]):
         payload = create_in_memory_payload(state, serializer)
         return payload.model_dump()
 
-    def _sync_snapshot_record(self) -> StoredStateRecord:
+    def _sync_snapshot_record(self) -> _StateRecord:
         record = self._memory_storage.load_sync()
         if record is None:
             state = self.state_type()
-            record = StoredStateRecord(
+            record = _StateRecord(
                 data=state,
                 state_type=type(state).__name__,
                 state_module=type(state).__module__,
@@ -784,7 +771,7 @@ class InMemoryStateStore(TypedStateStore[MODEL_T]):
 
     async def _save_state(self, state: BaseModel) -> None:
         await self._memory_storage.save(
-            StoredStateRecord(
+            _StateRecord(
                 data=state,
                 state_type=type(state).__name__,
                 state_module=type(state).__module__,
@@ -811,7 +798,7 @@ class InMemoryStateStore(TypedStateStore[MODEL_T]):
         if not serialized_state:
             return cls(DictState())  # type: ignore[arg-type]
 
-        state_instance = decode_seed_state(serialized_state, serializer)
+        state_instance = _decode_seed_state(serialized_state, serializer)
         return cls(state_instance)  # type: ignore[arg-type]
 
 
@@ -869,7 +856,7 @@ def deserialize_state_from_dict(
     )
 
 
-def decode_seed_state(
+def _decode_seed_state(
     serialized_state: dict[str, Any],
     serializer: "BaseSerializer",
 ) -> BaseModel:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -550,7 +550,14 @@ class StateStore(Protocol[MODEL_T]):
 
 
 class _TypedStateStore(Generic[MODEL_T]):
-    """Typed StateStore facade over raw storage."""
+    """Typed StateStore facade over raw storage.
+
+    Concurrency contract: the internal lock serializes read-modify-write
+    operations within one process *through the same facade instance*.
+    Workflow stores memoize one facade per run so in-process writers share
+    that lock. Writers in other processes or replicas are not serialized;
+    cross-replica consistency requires backend-level atomicity.
+    """
 
     state_type: type[MODEL_T]
 

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import json
 import warnings
 from contextlib import asynccontextmanager
 from typing import (
@@ -25,6 +26,7 @@ from workflows.decorators import StepConfig
 from workflows.events import DictLikeModel
 
 from .serializers import BaseSerializer
+from .utils import import_module_from_qualified_name
 
 if TYPE_CHECKING:
     from workflows.workflow import Workflow
@@ -114,6 +116,64 @@ def serialize_dict_state_data(
     return {"_data": serialized_data}
 
 
+def _resolve_state_type(
+    state_type_name: str | None,
+    state_module: str | None,
+    serializer: BaseSerializer,
+) -> type[BaseModel]:
+    if not state_type_name or not state_module:
+        return DictState
+
+    qualified_name = f"{state_module}.{state_type_name}"
+    validate_qualified_name = getattr(serializer, "_validate_qualified_name", None)
+    if callable(validate_qualified_name):
+        validate_qualified_name(qualified_name)
+
+    try:
+        resolved = import_module_from_qualified_name(qualified_name)
+    except Exception:
+        return DictState
+
+    if isinstance(resolved, type) and issubclass(resolved, BaseModel):
+        return resolved
+    return DictState
+
+
+def encode_state(
+    state: BaseModel,
+    serializer: BaseSerializer,
+    known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
+) -> tuple[Any, str, str]:
+    """Encode a state model and its self-describing metadata."""
+    if isinstance(state, DictState):
+        state_data = serialize_dict_state_data(
+            state, serializer, known_unserializable_keys
+        )
+    else:
+        state_data = serializer.serialize(state)
+
+    return state_data, type(state).__name__, type(state).__module__
+
+
+def decode_state(
+    state_data: Any,
+    state_type_name: str | None,
+    state_module: str | None,
+    serializer: BaseSerializer,
+) -> BaseModel:
+    """Decode a state model using the persisted type metadata."""
+    state_type = _resolve_state_type(state_type_name, state_module, serializer)
+
+    if issubclass(state_type, DictState):
+        if isinstance(state_data, str):
+            state_data = json.loads(state_data)
+        if not isinstance(state_data, dict):
+            state_data = {}
+        return deserialize_dict_state_data(state_data, serializer)
+
+    return serializer.deserialize(state_data)
+
+
 def create_in_memory_payload(
     state: BaseModel,
     serializer: BaseSerializer,
@@ -129,16 +189,13 @@ def create_in_memory_payload(
     Returns:
         InMemorySerializedState containing the serialized data.
     """
-    if isinstance(state, DictState):
-        state_data = serialize_dict_state_data(
-            state, serializer, known_unserializable_keys
-        )
-    else:
-        state_data = serializer.serialize(state)
+    state_data, state_type_name, state_module = encode_state(
+        state, serializer, known_unserializable_keys
+    )
 
     return InMemorySerializedState(
-        state_type=type(state).__name__,
-        state_module=type(state).__module__,
+        state_type=state_type_name,
+        state_module=state_module,
         state_data=state_data,
     )
 
@@ -615,7 +672,6 @@ def deserialize_dict_state_data(
 def deserialize_state_from_dict(
     serialized_state: dict[str, Any],
     serializer: "BaseSerializer",
-    state_type: type[BaseModel] | None = None,
 ) -> BaseModel:
     """Deserialize state from a serialized payload.
 
@@ -626,9 +682,6 @@ def deserialize_state_from_dict(
         serialized_state: The payload from to_dict(), containing state_data,
             state_type, and state_module.
         serializer: Strategy to decode stored values.
-        state_type: Optional explicit state type. When provided, uses
-            issubclass to determine if it's DictState. When omitted, falls
-            back to reading state_type from the dict.
 
     Returns:
         The deserialized state model instance.
@@ -636,22 +689,12 @@ def deserialize_state_from_dict(
     Raises:
         ValueError: If deserialization fails for any key.
     """
-    state_data = serialized_state.get("state_data", {})
-    state_type_name = serialized_state.get("state_type", "DictState")
-
-    if state_type_name == "DictState":
-        _data_serialized = state_data.get("_data", {})
-        deserialized_data = {}
-        for key, value in _data_serialized.items():
-            try:
-                deserialized_data[key] = serializer.deserialize(value)
-            except Exception as e:
-                raise ValueError(
-                    f"Failed to deserialize state value for key {key}: {e}"
-                )
-        return DictState(_data=deserialized_data)
-    else:
-        return serializer.deserialize(state_data)
+    return decode_state(
+        serialized_state.get("state_data", {}),
+        serialized_state.get("state_type"),
+        serialized_state.get("state_module"),
+        serializer,
+    )
 
 
 def infer_state_type(workflow: "Workflow") -> type[BaseModel]:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -56,8 +56,12 @@ class InMemorySerializedState(BaseModel):
         return data
 
 
-class _StateRecord(BaseModel):
-    """Raw state record loaded and saved by a storage backend."""
+class StateRecord(BaseModel):
+    """Raw state record loaded and saved by a storage backend.
+
+    ``state_type``/``state_module`` are written for debugging only; decoding
+    dispatches on the payload shape, so loads may leave them ``None``.
+    """
 
     data: Any
     state_type: str | None = None
@@ -66,32 +70,39 @@ class _StateRecord(BaseModel):
 
 @runtime_checkable
 class _StateStorage(Protocol):
-    """Internal persistence boundary for workflow state."""
+    """Minimal persistence boundary for workflow state: load and save."""
 
-    async def load(self) -> _StateRecord | None:
+    async def load(self) -> StateRecord | None:
         """Load a raw state record, or None when no state exists yet."""
         ...
 
-    async def save(self, record: _StateRecord) -> None:
+    async def save(self, record: StateRecord) -> None:
         """Persist a raw state record."""
         ...
 
 
 @runtime_checkable
-class _DurableStateStorage(_StateStorage, Protocol):
-    """Storage whose state outlives the process and can emit a reconnect handle."""
+class StateStorage(_StateStorage, Protocol):
+    """Durable storage: state outlives the process and supports reconnect handles.
+
+    Backends implement genuine I/O only; the seed lifecycle, locking, and
+    save-path encoding live in [StateStoreFacade][workflows.context.state_store.StateStoreFacade].
+    """
 
     def to_handle(self) -> dict[str, Any]:
         """Return backend-specific reconnect metadata."""
         ...
 
+    def parse_own_handle(self, payload: dict[str, Any]) -> Any | None:
+        """Parse a serialized payload into this backend's handle, or None.
 
-@runtime_checkable
-class _SeededStateStorage(Protocol):
-    """Internal storage lifecycle hook for lazy seed materialization."""
+        Must be sync and pure (no I/O). Returns None when the payload is not
+        a handle this backend produced.
+        """
+        ...
 
-    async def ensure_seeded(self) -> None:
-        """Materialize any deferred seed before observable storage operations."""
+    async def copy_from_handle(self, handle: Any) -> None:
+        """Copy state from another target of this backend into this one."""
         ...
 
 
@@ -106,28 +117,28 @@ def _record_from_state(
     state: BaseModel,
     serializer: BaseSerializer,
     known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
-) -> _StateRecord:
+) -> StateRecord:
     """Encode a state model into a raw storage record."""
     state_data, state_type_name, state_module = encode_state(
         state, serializer, known_unserializable_keys
     )
-    return _StateRecord(
+    return StateRecord(
         data=state_data,
         state_type=state_type_name,
         state_module=state_module,
     )
 
 
-def _string_record_from_state(
+def string_record_from_state(
     state: BaseModel,
     serializer: BaseSerializer,
     known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
-) -> _StateRecord:
+) -> StateRecord:
     """Encode a state model into a storage record with string data."""
     state_data, state_type_name, state_module = encode_state_to_str(
         state, serializer, known_unserializable_keys
     )
-    return _StateRecord(
+    return StateRecord(
         data=state_data,
         state_type=state_type_name,
         state_module=state_module,
@@ -234,10 +245,18 @@ def decode_state(
     drive module imports. Typed payloads self-describe through the serializer
     (which validates the embedded qualified name before importing anything);
     DictState payloads are recognized by their ``{"_data": ...}`` wrapper.
+
+    Decoding is strict: ``None`` means a blank store (default empty state);
+    any other unrecognized shape raises ``ValueError`` instead of silently
+    degrading to an empty state.
     """
     if isinstance(state_data, BaseModel):
         # Live model from an in-process handoff.
         return state_data
+
+    if state_data is None:
+        # Blank-store handoffs serialize as state_data=None.
+        return DictState()
 
     if isinstance(state_data, str):
         try:
@@ -245,17 +264,22 @@ def decode_state(
         except ValueError:
             parsed = None
         if isinstance(parsed, dict) and "_data" in parsed:
-            state_data = parsed
-        else:
-            # Non-JSON strings (e.g. pickled payloads) and JSON-encoded typed
-            # payloads both reconstruct through the serializer, which fails
-            # closed on disallowed embedded types.
-            deserialized = serializer.deserialize(state_data)
-            if isinstance(deserialized, BaseModel):
-                return deserialized
-            state_data = deserialized
+            return deserialize_dict_state_data(parsed, serializer)
+        # Non-JSON strings (e.g. pickled payloads) and JSON-encoded typed
+        # payloads both reconstruct through the serializer, which fails
+        # closed on disallowed embedded types.
+        deserialized = serializer.deserialize(state_data)
+        if isinstance(deserialized, BaseModel):
+            return deserialized
+        raise ValueError(
+            "Unrecognized state payload: string decoding to "
+            f"{type(deserialized).__name__}; expected a typed model payload "
+            "or a {'_data': ...} DictState wrapper"
+        )
 
-    if isinstance(state_data, dict) and "_data" not in state_data:
+    if isinstance(state_data, dict):
+        if "_data" in state_data:
+            return deserialize_dict_state_data(state_data, serializer)
         # Already-parsed typed payload. JsonSerializer-style serializers can
         # reconstruct it from the embedded self-description.
         deserialize_value = getattr(serializer, "deserialize_value", None)
@@ -263,10 +287,15 @@ def decode_state(
             value = deserialize_value(state_data)
             if isinstance(value, BaseModel):
                 return value
+        raise ValueError(
+            "Unrecognized state payload: dict without a '_data' wrapper that "
+            "the serializer could not reconstruct into a model"
+        )
 
-    if not isinstance(state_data, dict):
-        state_data = {}
-    return deserialize_dict_state_data(state_data, serializer)
+    raise ValueError(
+        f"Unrecognized state payload of type {type(state_data).__name__}; "
+        "refusing to decode"
+    )
 
 
 def create_in_memory_payload(
@@ -549,17 +578,76 @@ class StateStore(Protocol[MODEL_T]):
         ...
 
 
-class _TypedStateStore(Generic[MODEL_T]):
+class _OwnerAwareLock:
+    """asyncio.Lock that records its holder task.
+
+    Writers acquire exclusively and fail loudly when the current task
+    already holds the lock; reads pass through in that case so reads
+    inside an `edit_state` block work.
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._holder: asyncio.Task[Any] | None = None
+
+    def _held_by_current_task(self) -> bool:
+        return self._holder is not None and self._holder is asyncio.current_task()
+
+    @asynccontextmanager
+    async def acquire_write(self) -> AsyncGenerator[None, None]:
+        if self._held_by_current_task():
+            raise RuntimeError(
+                "writer called inside edit_state: mutate the yielded state instead"
+            )
+        async with self._lock:
+            self._holder = asyncio.current_task()
+            try:
+                yield
+            finally:
+                self._holder = None
+
+    @asynccontextmanager
+    async def acquire_read(self) -> AsyncGenerator[None, None]:
+        if self._held_by_current_task():
+            yield
+            return
+        async with self._lock:
+            yield
+
+
+class _CopySeed:
+    """Pending seed: copy state from another target of the same backend."""
+
+    def __init__(self, handle: Any) -> None:
+        self.handle = handle
+
+
+class _PayloadSeed:
+    """Pending seed: portable in-memory payload to decode and save."""
+
+    def __init__(self, payload: dict[str, Any], serializer: BaseSerializer) -> None:
+        self.payload = payload
+        self.serializer = serializer
+
+
+class StateStoreFacade(Generic[MODEL_T]):
     """Typed StateStore facade over raw storage.
 
-    Concurrency contract: reads (`get_state`, `get`, `snapshot`) take no
-    lock; writers (`set_state`, `set`, `clear`, `edit_state`) take the
-    internal lock, which serializes read-modify-write cycles within one
-    process *through the same facade instance*. Calling a writer inside
-    an `edit_state` block deadlocks and is unsupported. Workflow stores
-    memoize one facade per run so in-process writers share that lock.
-    Writers in other processes or replicas are not serialized;
+    Concurrency contract: Writers serialize on the per-run lock; reads
+    return committed state — durable reads via the backend's committed row
+    (lockless), in-memory reads via the owner-aware lock; a task holding
+    the lock reads through without blocking, and nested writers raise.
+
+    Workflow stores memoize one facade per run so in-process writers share
+    that lock. Writers in other processes or replicas are not serialized;
     cross-replica consistency requires backend-level atomicity.
+
+    Reads are pure: an empty storage yields a default state instance
+    without persisting it; only writers (and seed materialization) save.
+
+    The facade also owns the seed lifecycle: `add_seed` validates a
+    serialized-state payload eagerly (sync, pure) and `ensure_seeded`
+    materializes it lazily on first async access or handoff.
     """
 
     state_type: type[MODEL_T]
@@ -569,26 +657,71 @@ class _TypedStateStore(Generic[MODEL_T]):
         storage: _StateStorage,
         state_type: type[MODEL_T],
         serializer: BaseSerializer,
-        *,
-        to_dict_mode: Literal["snapshot", "handle"] = "snapshot",
     ) -> None:
         self._storage = storage
         self.state_type = state_type
         self._serializer = serializer
-        self._to_dict_mode = to_dict_mode
+        self._pending_seed: _CopySeed | _PayloadSeed | None = None
 
     @functools.cached_property
-    def _lock(self) -> asyncio.Lock:
+    def _lock(self) -> _OwnerAwareLock:
+        """Lazy lock initialization for Python 3.14+ compatibility."""
+        return _OwnerAwareLock()
+
+    @functools.cached_property
+    def _seed_lock(self) -> asyncio.Lock:
         """Lazy lock initialization for Python 3.14+ compatibility."""
         return asyncio.Lock()
 
     def _create_default_state(self) -> MODEL_T:
         return create_cleared_state(self.state_type)
 
+    def add_seed(self, payload: dict[str, Any], serializer: BaseSerializer) -> None:
+        """Stage a serialized-state seed for lazy materialization.
+
+        Validation is eager, sync, and pure: empty payloads and durable
+        handles foreign to this storage raise immediately. I/O stays lazy —
+        the seed materializes on the first async access via `ensure_seeded`.
+        A pending seed wins over whatever already exists in storage.
+        """
+        if not payload:
+            raise ValueError("Cannot seed state store from an empty payload")
+        if isinstance(self._storage, StateStorage):
+            handle = self._storage.parse_own_handle(payload)
+            if handle is not None:
+                own = self._storage.parse_own_handle(self._storage.to_handle())
+                # Same target: state already lives in the backend, nothing
+                # to copy (and any previously staged seed is superseded).
+                self._pending_seed = None if handle == own else _CopySeed(handle)
+                return
+        if is_durable_serialized_state(payload):
+            raise ValueError(
+                "Cannot seed this state store from a durable handle with "
+                f"store_type '{payload.get('store_type')}'"
+            )
+        parse_in_memory_state(payload)  # eager shape validation, raises
+        self._pending_seed = _PayloadSeed(payload, serializer)
+
     async def ensure_seeded(self) -> None:
-        """Materialize any deferred storage seed."""
-        if isinstance(self._storage, _SeededStateStorage):
-            await self._storage.ensure_seeded()
+        """Materialize any pending seed exactly once (double-checked)."""
+        if self._pending_seed is None:
+            return
+        async with self._seed_lock:
+            seed = self._pending_seed
+            if seed is None:
+                return
+            if isinstance(seed, _CopySeed):
+                durable = cast(StateStorage, self._storage)
+                await durable.copy_from_handle(seed.handle)
+            else:
+                state = decode_seed_state(seed.payload, seed.serializer)
+                # Bypass _save_state: its ensure_seeded re-entry would
+                # deadlock on the seed lock we hold.
+                await self._write_state(state)
+            # Popped only after success so a failed materialization stays
+            # pending; concurrent readers block on the seed lock above
+            # until the seed is committed.
+            self._pending_seed = None
 
     async def _load_state_or_none(self) -> MODEL_T | None:
         await self.ensure_seeded()
@@ -601,22 +734,31 @@ class _TypedStateStore(Generic[MODEL_T]):
         state = await self._load_state_or_none()
         if state is not None:
             return state
-        state = self._create_default_state()
-        await self._save_state(state)
-        return state
+        # Reads are pure: return a default without persisting it.
+        return self._create_default_state()
 
     async def _save_state(self, state: BaseModel) -> None:
         await self.ensure_seeded()
-        await self._storage.save(_record_from_state(state, self._serializer))
+        await self._write_state(state)
+
+    async def _write_state(self, state: BaseModel) -> None:
+        """Single save chokepoint: durable rows persist string data."""
+        if isinstance(self._storage, StateStorage):
+            await self._storage.save(string_record_from_state(state, self._serializer))
+        else:
+            await self._storage.save(_record_from_state(state, self._serializer))
 
     async def get_state(self) -> MODEL_T:
-        """Return a copy of the current state model."""
+        """Return a copy of the current state model.
+
+        Durable reads are lockless (read-committed via the backend row).
+        """
         state = await self._load_state()
         return state.model_copy()
 
     async def set_state(self, state: MODEL_T) -> None:
         """Replace or merge into the current state model."""
-        async with self._lock:
+        async with self._lock.acquire_write():
             current = await self._load_state_or_none()
             merged: BaseModel = (
                 state if current is None else merge_state(current, state)
@@ -626,8 +768,7 @@ class _TypedStateStore(Generic[MODEL_T]):
     async def get(self, path: str, default: Any = Ellipsis) -> Any:
         """Get a nested value using dot-separated paths.
 
-        Lockless read, like `get_state`, so it stays safe inside
-        `edit_state`.
+        Durable reads are lockless (read-committed via the backend row).
         """
         return get_by_path(await self._load_state(), path, default)
 
@@ -644,20 +785,20 @@ class _TypedStateStore(Generic[MODEL_T]):
         too. Falls back to the construction-time `state_type` when storage
         is empty.
         """
-        async with self._lock:
+        async with self._lock.acquire_write():
             current = await self._load_state_or_none()
             target = type(current) if current is not None else self.state_type
             await self._save_state(create_cleared_state(target))
 
     @asynccontextmanager
     async def edit_state(self) -> AsyncGenerator[MODEL_T, None]:
-        """Edit state transactionally under a lock.
+        """Edit state transactionally under the writer lock.
 
         Reads (`get_state`, `get`, `snapshot`) are safe inside the block;
         calling a writer (`set_state`, `set`, `clear`, or a nested
-        `edit_state`) deadlocks and is unsupported.
+        `edit_state`) raises RuntimeError.
         """
-        async with self._lock:
+        async with self._lock.acquire_write():
             state = await self._load_state()
             yield state
             await self._save_state(state)
@@ -672,25 +813,19 @@ class _TypedStateStore(Generic[MODEL_T]):
 
         Durable stores return a reconnect handle (the state stays in the
         backend); in-memory stores return a portable, serializer-encoded
-        snapshot that round-trips through ``from_dict``.
+        snapshot that round-trips through ``from_dict``. Any pending seed
+        is materialized first so handles never point at unmaterialized
+        seeds.
         """
         await self.ensure_seeded()
-        if self._to_dict_mode == "handle":
-            return self._durable_storage().to_handle()
+        if isinstance(self._storage, StateStorage):
+            return self._storage.to_handle()
         return await self.snapshot(serializer)
-
-    def _durable_storage(self) -> _DurableStateStorage:
-        """Constructor invariant: handle mode implies durable storage."""
-        if not isinstance(self._storage, _DurableStateStorage):
-            raise TypeError(
-                "to_dict_mode='handle' requires storage implementing to_handle()"
-            )
-        return self._storage
 
     def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
         """Serialize state for legacy callers."""
-        if self._to_dict_mode == "handle":
-            return self._durable_storage().to_handle()
+        if isinstance(self._storage, StateStorage):
+            return self._storage.to_handle()
         record = self._sync_snapshot_record()
         return InMemorySerializedState(
             state_type=record.state_type or "DictState",
@@ -698,27 +833,27 @@ class _TypedStateStore(Generic[MODEL_T]):
             state_data=record.data,
         ).model_dump()
 
-    def _sync_snapshot_record(self) -> _StateRecord:
+    def _sync_snapshot_record(self) -> StateRecord:
         raise NotImplementedError("Use await snapshot(serializer) for async storage")
 
 
 class _InMemoryStateStorage:
     """Raw in-process storage for workflow state."""
 
-    def __init__(self, record: _StateRecord | None = None) -> None:
+    def __init__(self, record: StateRecord | None = None) -> None:
         self._record = record
 
-    async def load(self) -> _StateRecord | None:
+    async def load(self) -> StateRecord | None:
         return self._record.model_copy() if self._record is not None else None
 
-    async def save(self, record: _StateRecord) -> None:
+    async def save(self, record: StateRecord) -> None:
         self._record = record.model_copy()
 
-    def load_sync(self) -> _StateRecord | None:
+    def load_sync(self) -> StateRecord | None:
         return self._record.model_copy() if self._record is not None else None
 
 
-class InMemoryStateStore(_TypedStateStore[MODEL_T]):
+class InMemoryStateStore(StateStoreFacade[MODEL_T]):
     """
     Default in-memory implementation of the [StateStore][workflows.context.state_store.StateStore] protocol.
 
@@ -764,7 +899,7 @@ class InMemoryStateStore(_TypedStateStore[MODEL_T]):
 
     def __init__(self, initial_state: MODEL_T):
         self._memory_storage = _InMemoryStateStorage(
-            _StateRecord(
+            StateRecord(
                 data=initial_state,
                 state_type=type(initial_state).__name__,
                 state_module=type(initial_state).__module__,
@@ -774,8 +909,26 @@ class InMemoryStateStore(_TypedStateStore[MODEL_T]):
             self._memory_storage,
             type(initial_state),
             JsonSerializer(),
-            to_dict_mode="snapshot",
         )
+
+    async def get_state(self) -> MODEL_T:
+        """Return a shallow copy of the state, captured under the read lock.
+
+        The owner-aware lock keeps the copy from observing a half-applied
+        `edit_state` block; a task already holding the lock reads through.
+        """
+        async with self._lock.acquire_read():
+            return await super().get_state()
+
+    async def get(self, path: str, default: Any = Ellipsis) -> Any:
+        """Get a nested value, captured under the read lock."""
+        async with self._lock.acquire_read():
+            return await super().get(path, default)
+
+    async def snapshot(self, serializer: BaseSerializer) -> dict[str, Any]:
+        """Serialize portable state data, captured under the read lock."""
+        async with self._lock.acquire_read():
+            return await super().snapshot(serializer)
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
         """Serialize the state and model metadata for persistence.
@@ -797,21 +950,22 @@ class InMemoryStateStore(_TypedStateStore[MODEL_T]):
         payload = create_in_memory_payload(state, serializer)
         return payload.model_dump()
 
-    def _sync_snapshot_record(self) -> _StateRecord:
+    def _sync_snapshot_record(self) -> StateRecord:
         record = self._memory_storage.load_sync()
         if record is None:
+            # Reads are pure: return a default record without persisting it.
             state = self.state_type()
-            record = _StateRecord(
+            record = StateRecord(
                 data=state,
                 state_type=type(state).__name__,
                 state_module=type(state).__module__,
             )
-            self._memory_storage._record = record
         return record
 
-    async def _save_state(self, state: BaseModel) -> None:
+    async def _write_state(self, state: BaseModel) -> None:
+        # Live-model record: in-memory state keeps value identity, no encoding.
         await self._memory_storage.save(
-            _StateRecord(
+            StateRecord(
                 data=state,
                 state_type=type(state).__name__,
                 state_module=type(state).__module__,
@@ -838,7 +992,7 @@ class InMemoryStateStore(_TypedStateStore[MODEL_T]):
         if not serialized_state:
             return cls(DictState())  # type: ignore[arg-type]
 
-        state_instance = _decode_seed_state(serialized_state, serializer)
+        state_instance = decode_seed_state(serialized_state, serializer)
         return cls(state_instance)  # type: ignore[arg-type]
 
 
@@ -892,10 +1046,11 @@ def deserialize_state_from_dict(
     Raises:
         ValueError: If deserialization fails for any key.
     """
-    return decode_state(serialized_state.get("state_data", {}), serializer)
+    # Absent/None state data decodes to a default empty state.
+    return decode_state(serialized_state.get("state_data"), serializer)
 
 
-def _decode_seed_state(
+def decode_seed_state(
     serialized_state: dict[str, Any],
     serializer: "BaseSerializer",
 ) -> BaseModel:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import json
+import uuid
 import warnings
 from contextlib import asynccontextmanager
 from typing import (
@@ -89,6 +90,11 @@ class StateStorage(_StateStorage, Protocol):
     save-path encoding live in [StateStoreFacade][workflows.context.state_store.StateStoreFacade].
     """
 
+    @property
+    def run_id(self) -> str:
+        """Run id identifying this storage's target."""
+        ...
+
     def to_handle(self) -> dict[str, Any]:
         """Return backend-specific reconnect metadata."""
         ...
@@ -111,6 +117,15 @@ def is_durable_serialized_state(data: dict[str, Any] | None) -> bool:
     if not data:
         return False
     return data.get("store_type", "in_memory") != "in_memory"
+
+
+def restored_run_id(run_id: str | None, payload: dict[str, Any]) -> str:
+    """Resolve the target run id for a ``from_dict`` restore.
+
+    Explicit caller run id wins, then the payload's own run id, then a
+    fresh id for portable snapshots that carry none.
+    """
+    return run_id or payload.get("run_id") or str(uuid.uuid4())
 
 
 def _record_from_state(
@@ -640,13 +655,21 @@ class StateStoreFacade(Generic[MODEL_T]):
     def __init__(
         self,
         storage: _StateStorage,
-        state_type: type[MODEL_T],
-        serializer: BaseSerializer,
+        state_type: type[MODEL_T] | None = None,
+        serializer: BaseSerializer | None = None,
     ) -> None:
         self._storage = storage
-        self.state_type = state_type
-        self._serializer = serializer
+        self.state_type = state_type or DictState  # type: ignore[assignment]  # ty: ignore[invalid-assignment]
+        self._serializer = serializer or JsonSerializer()
         self._pending_seed: _CopySeed | _PayloadSeed | None = None
+
+    @property
+    def run_id(self) -> str:
+        """Run id of the durable storage target."""
+        storage = self._storage
+        if isinstance(storage, StateStorage):
+            return storage.run_id
+        raise AttributeError("run_id is only available on durable state stores")
 
     @functools.cached_property
     def _lock(self) -> _OwnerAwareLock:
@@ -808,17 +831,13 @@ class StateStoreFacade(Generic[MODEL_T]):
         return await self.snapshot(serializer)
 
     def to_dict(self, serializer: BaseSerializer) -> dict[str, Any]:
-        """Serialize state for legacy callers."""
+        """Serialize state for legacy callers.
+
+        Durable stores return a reconnect handle. Non-durable storage has no
+        sync snapshot here; `InMemoryStateStore` overrides this.
+        """
         if isinstance(self._storage, StateStorage):
             return self._storage.to_handle()
-        record = self._sync_snapshot_record()
-        return InMemorySerializedState(
-            state_type=record.state_type or "DictState",
-            state_module=record.state_module or "workflows.context.state_store",
-            state_data=record.data,
-        ).model_dump()
-
-    def _sync_snapshot_record(self) -> StateRecord:
         raise NotImplementedError("Use await snapshot(serializer) for async storage")
 
 
@@ -933,17 +952,11 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
             dict[str, Any]: A payload suitable for
             [from_dict][workflows.context.state_store.InMemoryStateStore.from_dict].
         """
-        record = self._sync_snapshot_record()
-        state = decode_state(record.data, JsonSerializer())
-        payload = create_in_memory_payload(state, serializer)
-        return payload.model_dump()
-
-    def _sync_snapshot_record(self) -> StateRecord:
         record = self._memory_storage.load_sync()
-        if record is None:
-            # Reads are pure: return a default record without persisting it.
-            record = _live_record(self.state_type())
-        return record
+        # Records always hold a live model here (see _write_state); when the
+        # storage is empty, snapshot a default without persisting it.
+        state = cast(MODEL_T, record.data) if record is not None else self.state_type()
+        return create_in_memory_payload(state, serializer).model_dump()
 
     async def _write_state(self, state: BaseModel) -> None:
         # Live-model record: no encoding, value identity preserved.

--- a/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from . import state_store as _state_store
+from .serializers import BaseSerializer
+
+StateRecord = _state_store._StateRecord
+StateStorage = _state_store._StateStorage
+StateStoreFacade = _state_store._TypedStateStore
+decode_seed_state = _state_store._decode_seed_state
+string_record_from_state = _state_store._string_record_from_state
+
+
+@runtime_checkable
+class StateStoreSnapshotter(Protocol):
+    """Integration protocol for stores that can emit portable state snapshots."""
+
+    async def snapshot(self, serializer: BaseSerializer) -> dict[str, Any]:
+        """Serialize portable state data."""
+        ...
+
+
+@runtime_checkable
+class StateStoreHandleProvider(Protocol):
+    """Integration protocol for durable stores that can emit reconnect handles."""
+
+    def handle(self) -> dict[str, Any]:
+        """Serialize reconnect metadata for durable storage."""
+        ...
+
+
+__all__ = [
+    "StateRecord",
+    "StateStorage",
+    "StateStoreFacade",
+    "StateStoreHandleProvider",
+    "StateStoreSnapshotter",
+    "decode_seed_state",
+    "string_record_from_state",
+]

--- a/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
@@ -3,16 +3,44 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Generic, Protocol, runtime_checkable
+
+from pydantic import BaseModel
+from typing_extensions import TypeVar
 
 from . import state_store as _state_store
 from .serializers import BaseSerializer
+from .state_store import DictState, StateStore
+
+MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
+
 
 StateRecord = _state_store._StateRecord
-StateStorage = _state_store._StateStorage
-StateStoreFacade = _state_store._TypedStateStore
-decode_seed_state = _state_store._decode_seed_state
-string_record_from_state = _state_store._string_record_from_state
+"""Raw state record loaded and saved by a storage backend."""
+
+
+@runtime_checkable
+class StateStorage(_state_store._StateStorage, Protocol):
+    """Integration protocol for raw workflow state persistence."""
+
+
+class StateStoreFacade(_state_store._TypedStateStore[MODEL_T], Generic[MODEL_T]):
+    """Typed state-store facade over raw persistence."""
+
+
+def decode_seed_state(
+    serialized_state: dict[str, Any], serializer: BaseSerializer
+) -> BaseModel:
+    """Decode a portable in-memory state seed."""
+    return _state_store._decode_seed_state(serialized_state, serializer)
+
+
+def string_record_from_state(
+    state: BaseModel, serializer: BaseSerializer
+) -> StateRecord:
+    """Encode state into the string-backed storage record format."""
+    record = _state_store._string_record_from_state(state, serializer)
+    return StateRecord.model_validate(record.model_dump())
 
 
 @runtime_checkable
@@ -33,12 +61,41 @@ class StateStoreHandleProvider(Protocol):
         ...
 
 
+@runtime_checkable
+class StateStorePreparer(Protocol):
+    """Integration protocol for stores with async lazy materialization."""
+
+    async def ensure_seeded(self) -> None:
+        """Prepare storage before exposing a durable handle."""
+        ...
+
+
+async def state_store_handoff(
+    store: StateStore[Any],
+    serializer: BaseSerializer,
+) -> dict[str, Any]:
+    """Serialize a store for runtime handoff.
+
+    Durable stores can return a reconnect handle. Snapshot-capable stores can
+    return a portable state payload. Legacy stores fall back to ``to_dict``.
+    """
+    if isinstance(store, StateStorePreparer):
+        await store.ensure_seeded()
+    if isinstance(store, StateStoreHandleProvider):
+        return store.handle()
+    if isinstance(store, StateStoreSnapshotter):
+        return await store.snapshot(serializer)
+    return store.to_dict(serializer)
+
+
 __all__ = [
     "StateRecord",
     "StateStorage",
     "StateStoreFacade",
     "StateStoreHandleProvider",
+    "StateStorePreparer",
     "StateStoreSnapshotter",
     "decode_seed_state",
+    "state_store_handoff",
     "string_record_from_state",
 ]

--- a/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
@@ -3,43 +3,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Generic, Protocol, runtime_checkable
+from typing import Any
 
-from pydantic import BaseModel
-from typing_extensions import TypeVar
-
-from . import state_store as _state_store
 from .serializers import BaseSerializer
-from .state_store import DictState, StateStore
-
-MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
-
-
-StateRecord = _state_store._StateRecord
-"""Raw state record loaded and saved by a storage backend."""
-
-
-@runtime_checkable
-class StateStorage(_state_store._DurableStateStorage, Protocol):
-    """Integration protocol for raw durable workflow state persistence."""
-
-
-class StateStoreFacade(_state_store._TypedStateStore[MODEL_T], Generic[MODEL_T]):
-    """Typed state-store facade over raw persistence."""
-
-
-def decode_seed_state(
-    serialized_state: dict[str, Any], serializer: BaseSerializer
-) -> BaseModel:
-    """Decode a portable in-memory state seed."""
-    return _state_store._decode_seed_state(serialized_state, serializer)
-
-
-def string_record_from_state(
-    state: BaseModel, serializer: BaseSerializer
-) -> StateRecord:
-    """Encode state into the string-backed storage record format."""
-    return _state_store._string_record_from_state(state, serializer)
+from .state_store import (
+    StateRecord,
+    StateStorage,
+    StateStore,
+    StateStoreFacade,
+    decode_seed_state,
+    string_record_from_state,
+)
 
 
 async def state_store_handoff(
@@ -52,7 +26,7 @@ async def state_store_handoff(
     (durable reconnect handle or portable snapshot, the store decides).
     Legacy third-party stores fall back to ``to_dict``.
     """
-    if isinstance(store, _state_store._TypedStateStore):
+    if isinstance(store, StateStoreFacade):
         return await store.serialize_for_handoff(serializer)
     return store.to_dict(serializer)
 

--- a/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
@@ -20,8 +20,8 @@ StateRecord = _state_store._StateRecord
 
 
 @runtime_checkable
-class StateStorage(_state_store._StateStorage, Protocol):
-    """Integration protocol for raw workflow state persistence."""
+class StateStorage(_state_store._DurableStateStorage, Protocol):
+    """Integration protocol for raw durable workflow state persistence."""
 
 
 class StateStoreFacade(_state_store._TypedStateStore[MODEL_T], Generic[MODEL_T]):
@@ -43,48 +43,19 @@ def string_record_from_state(
     return StateRecord.model_validate(record.model_dump())
 
 
-@runtime_checkable
-class StateStoreSnapshotter(Protocol):
-    """Integration protocol for stores that can emit portable state snapshots."""
-
-    async def snapshot(self, serializer: BaseSerializer) -> dict[str, Any]:
-        """Serialize portable state data."""
-        ...
-
-
-@runtime_checkable
-class StateStoreHandleProvider(Protocol):
-    """Integration protocol for durable stores that can emit reconnect handles."""
-
-    def handle(self) -> dict[str, Any]:
-        """Serialize reconnect metadata for durable storage."""
-        ...
-
-
-@runtime_checkable
-class StateStorePreparer(Protocol):
-    """Integration protocol for stores with async lazy materialization."""
-
-    async def ensure_seeded(self) -> None:
-        """Prepare storage before exposing a durable handle."""
-        ...
-
-
 async def state_store_handoff(
     store: StateStore[Any],
     serializer: BaseSerializer,
 ) -> dict[str, Any]:
     """Serialize a store for runtime handoff.
 
-    Durable stores can return a reconnect handle. Snapshot-capable stores can
-    return a portable state payload. Legacy stores fall back to ``to_dict``.
+    Facade-based stores self-describe through ``serialize_for_handoff``
+    (durable reconnect handle or portable snapshot, the store decides).
+    Legacy third-party stores fall back to ``to_dict``.
     """
-    if isinstance(store, StateStorePreparer):
-        await store.ensure_seeded()
-    if isinstance(store, StateStoreHandleProvider):
-        return store.handle()
-    if isinstance(store, StateStoreSnapshotter):
-        return await store.snapshot(serializer)
+    serialize = getattr(store, "serialize_for_handoff", None)
+    if callable(serialize):
+        return await serialize(serializer)
     return store.to_dict(serializer)
 
 
@@ -92,9 +63,6 @@ __all__ = [
     "StateRecord",
     "StateStorage",
     "StateStoreFacade",
-    "StateStoreHandleProvider",
-    "StateStorePreparer",
-    "StateStoreSnapshotter",
     "decode_seed_state",
     "state_store_handoff",
     "string_record_from_state",

--- a/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
@@ -12,6 +12,7 @@ from .state_store import (
     StateStore,
     StateStoreFacade,
     decode_seed_state,
+    restored_run_id,
     string_record_from_state,
 )
 
@@ -36,6 +37,7 @@ __all__ = [
     "StateStorage",
     "StateStoreFacade",
     "decode_seed_state",
+    "restored_run_id",
     "state_store_handoff",
     "string_record_from_state",
 ]

--- a/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
@@ -53,9 +53,8 @@ async def state_store_handoff(
     (durable reconnect handle or portable snapshot, the store decides).
     Legacy third-party stores fall back to ``to_dict``.
     """
-    serialize = getattr(store, "serialize_for_handoff", None)
-    if callable(serialize):
-        return await serialize(serializer)
+    if isinstance(store, _state_store._TypedStateStore):
+        return await store.serialize_for_handoff(serializer)
     return store.to_dict(serializer)
 
 

--- a/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store_integration.py
@@ -39,8 +39,7 @@ def string_record_from_state(
     state: BaseModel, serializer: BaseSerializer
 ) -> StateRecord:
     """Encode state into the string-backed storage record format."""
-    record = _state_store._string_record_from_state(state, serializer)
-    return StateRecord.model_validate(record.model_dump())
+    return _state_store._string_record_from_state(state, serializer)
 
 
 async def state_store_handoff(

--- a/packages/llama-index-workflows/src/workflows/plugins/basic.py
+++ b/packages/llama-index-workflows/src/workflows/plugins/basic.py
@@ -21,6 +21,7 @@ from workflows.context.state_store import (
     InMemoryStateStore,
     StateStore,
     infer_state_type,
+    is_durable_serialized_state,
 )
 from workflows.errors import WorkflowRuntimeError
 from workflows.events import Event, StartEvent, StopEvent
@@ -278,6 +279,12 @@ class BasicRuntime(Runtime):
         # Create state store from serialized state or infer type from workflow
         active_serializer = serializer or JsonSerializer()
         if serialized_state:
+            if is_durable_serialized_state(serialized_state):
+                store_type = serialized_state.get("store_type")
+                raise WorkflowRuntimeError(
+                    f"BasicRuntime cannot restore durable state store '{store_type}'. "
+                    "Use the matching durable runtime or pass an in-memory context snapshot."
+                )
             state_store = InMemoryStateStore.from_dict(
                 serialized_state, active_serializer
             )

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -750,7 +750,9 @@ def test_encode_decode_state_handles_dict_state() -> None:
 
 def test_encode_decode_state_handles_dict_state_subclass() -> None:
     serializer = JsonSerializer()
-    state = CustomDictState(answer=42, name="subclass")
+    state = CustomDictState()
+    state["answer"] = 42
+    state["name"] = "subclass"
 
     state_data, state_type, state_module = encode_state(state, serializer)
     result = decode_state(state_data, state_type, state_module, serializer)

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import gc
 import inspect
 import json
+import pickle
 import weakref
 from typing import cast
 
@@ -21,7 +23,7 @@ from workflows.context.context import (
 )
 from workflows.context.external_context import ExternalContext
 from workflows.context.internal_context import InternalContext
-from workflows.context.serializers import JsonSerializer
+from workflows.context.serializers import JsonSerializer, PickleSerializer
 from workflows.context.state_store import (
     DictState,
     InMemoryStateStore,
@@ -740,8 +742,8 @@ def test_encode_decode_state_handles_dict_state() -> None:
     serializer = JsonSerializer()
     state = DictState(answer=42, name="dict")
 
-    state_data, state_type, state_module = encode_state(state, serializer)
-    result = decode_state(state_data, state_type, state_module, serializer)
+    state_data, _, _ = encode_state(state, serializer)
+    result = decode_state(state_data, serializer)
 
     assert isinstance(result, DictState)
     assert result["answer"] == 42
@@ -754,8 +756,8 @@ def test_encode_decode_state_handles_dict_state_subclass() -> None:
     state["answer"] = 42
     state["name"] = "subclass"
 
-    state_data, state_type, state_module = encode_state(state, serializer)
-    result = decode_state(state_data, state_type, state_module, serializer)
+    state_data, _, _ = encode_state(state, serializer)
+    result = decode_state(state_data, serializer)
 
     assert isinstance(result, DictState)
     assert result["answer"] == 42
@@ -766,8 +768,8 @@ def test_encode_decode_state_handles_typed_state() -> None:
     serializer = JsonSerializer()
     state = TypedTestState(counter=7, name="typed")
 
-    state_data, state_type, state_module = encode_state(state, serializer)
-    result = decode_state(state_data, state_type, state_module, serializer)
+    state_data, _, _ = encode_state(state, serializer)
+    result = decode_state(state_data, serializer)
 
     assert isinstance(result, TypedTestState)
     assert result.counter == 7
@@ -777,42 +779,105 @@ def test_encode_decode_state_handles_typed_state() -> None:
 def test_decode_state_respects_json_serializer_allowed_types() -> None:
     serializer = JsonSerializer()
     state = TypedTestState(counter=7, name="typed")
-    state_data, state_type, state_module = encode_state(state, serializer)
+    state_data, _, _ = encode_state(state, serializer)
     restricted_serializer = JsonSerializer(allowed_types=[DictState])
 
     with pytest.raises(ValueError, match="Refusing to import disallowed"):
-        decode_state(state_data, state_type, state_module, restricted_serializer)
+        decode_state(state_data, restricted_serializer)
 
 
-def test_decode_state_uses_embedded_type_when_metadata_is_stale() -> None:
+def test_decode_state_allows_dict_state_under_restricted_allowlist() -> None:
+    """A restricted allowlist must not reject the default DictState container."""
+    serializer = JsonSerializer()
+    state = DictState()
+    state["inner"] = TypedTestState(counter=3, name="allowed")
+    state["plain"] = 42
+    state_data, _, _ = encode_state(state, serializer)
+    restricted_serializer = JsonSerializer(allowed_types=[TypedTestState])
+
+    result = decode_state(state_data, restricted_serializer)
+
+    assert isinstance(result, DictState)
+    assert isinstance(result["inner"], TypedTestState)
+    assert result["inner"].counter == 3
+    assert result["plain"] == 42
+
+
+def test_decode_state_typed_payload_self_describes() -> None:
+    """Typed payloads reconstruct from the serializer-embedded qualified name."""
     serializer = JsonSerializer()
     state = TypedTestState(counter=7, name="typed")
     state_data, _, _ = encode_state(state, serializer)
 
-    result = decode_state(state_data, "MovedState", "missing.module", serializer)
+    result = decode_state(state_data, serializer)
 
     assert isinstance(result, TypedTestState)
     assert result.counter == 7
     assert result.name == "typed"
 
 
-@pytest.mark.parametrize(
-    ("state_type_name", "state_module"),
-    [
-        (None, None),
-        ("MissingState", None),
-    ],
-)
-def test_decode_state_missing_metadata_falls_back_to_dict_state(
-    state_type_name: str | None, state_module: str | None
-) -> None:
+def test_decode_state_typed_payload_with_unimportable_type_raises() -> None:
+    serializer = JsonSerializer()
+    state_data = json.dumps(
+        {
+            "__is_pydantic": True,
+            "value": {"counter": 1, "name": "gone"},
+            "qualified_name": "missing.module.MovedState",
+        }
+    )
+
+    with pytest.raises(Exception):
+        decode_state(state_data, serializer)
+
+
+def test_decode_state_dict_wrapper_decodes_to_dict_state() -> None:
     serializer = JsonSerializer()
     state_data = {"_data": {"answer": serializer.serialize(42)}}
 
-    result = decode_state(state_data, state_type_name, state_module, serializer)
+    result = decode_state(state_data, serializer)
 
     assert isinstance(result, DictState)
     assert result["answer"] == 42
+
+
+def test_decode_state_dict_wrapper_string_decodes_to_dict_state() -> None:
+    """Durable rows persist the DictState wrapper as a JSON string."""
+    serializer = JsonSerializer()
+    state_data = json.dumps({"_data": {"answer": serializer.serialize(42)}})
+
+    result = decode_state(state_data, serializer)
+
+    assert isinstance(result, DictState)
+    assert result["answer"] == 42
+
+
+def test_decode_state_returns_live_model_unchanged() -> None:
+    serializer = JsonSerializer()
+    state = TypedTestState(counter=9, name="live")
+
+    assert decode_state(state, serializer) is state
+
+
+def test_decode_state_pickle_serializer_typed_payload_round_trips() -> None:
+    """PickleSerializer encodes JSON-incapable typed state as a base64 string."""
+    serializer = PickleSerializer()
+    state = TypedTestState(counter=5, name="pickled")
+    state_data = base64.b64encode(pickle.dumps(state)).decode("utf-8")
+
+    result = decode_state(state_data, serializer)
+
+    assert isinstance(result, TypedTestState)
+    assert result.counter == 5
+    assert result.name == "pickled"
+
+
+def test_decode_state_json_scalar_string_falls_back_to_dict_state() -> None:
+    serializer = JsonSerializer()
+
+    result = decode_state(json.dumps([1, 2, 3]), serializer)
+
+    assert isinstance(result, DictState)
+    assert len(list(result.items())) == 0
 
 
 def test_deserialize_state_from_dict_has_no_state_type_override() -> None:
@@ -882,28 +947,6 @@ def test_deserialize_state_from_dict_empty_dict_state() -> None:
 
     assert isinstance(result, DictState)
     assert len(list(result.items())) == 0
-
-
-def test_deserialize_state_from_dict_with_raw_dict_state_values() -> None:
-    serializer = JsonSerializer()
-    serialized = {
-        "state_data": {
-            "_data": {
-                "count": 5,
-                "state": {"nested": True},
-                "name": "raw",
-            }
-        },
-        "state_type": "DictState",
-        "state_module": "workflows.context.state_store",
-    }
-
-    result = deserialize_state_from_dict(serialized, serializer)
-
-    assert isinstance(result, DictState)
-    assert result["count"] == 5
-    assert result["state"] == {"nested": True}
-    assert result["name"] == "raw"
 
 
 # ============================================================================

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import inspect
 import json
 import weakref
 from typing import cast
@@ -24,7 +25,9 @@ from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import (
     DictState,
     InMemoryStateStore,
+    decode_state,
     deserialize_state_from_dict,
+    encode_state,
 )
 from workflows.decorators import step
 from workflows.errors import ContextStateError, WorkflowRuntimeError
@@ -727,6 +730,87 @@ class TypedTestState(BaseModel):
 
     counter: int = 0
     name: str = "default"
+
+
+class CustomDictState(DictState):
+    """DictState subclass for codec dispatch testing."""
+
+
+def test_encode_decode_state_handles_dict_state() -> None:
+    serializer = JsonSerializer()
+    state = DictState(answer=42, name="dict")
+
+    state_data, state_type, state_module = encode_state(state, serializer)
+    result = decode_state(state_data, state_type, state_module, serializer)
+
+    assert isinstance(result, DictState)
+    assert result["answer"] == 42
+    assert result["name"] == "dict"
+
+
+def test_encode_decode_state_handles_dict_state_subclass() -> None:
+    serializer = JsonSerializer()
+    state = CustomDictState(answer=42, name="subclass")
+
+    state_data, state_type, state_module = encode_state(state, serializer)
+    result = decode_state(state_data, state_type, state_module, serializer)
+
+    assert isinstance(result, DictState)
+    assert result["answer"] == 42
+    assert result["name"] == "subclass"
+
+
+def test_encode_decode_state_handles_typed_state() -> None:
+    serializer = JsonSerializer()
+    state = TypedTestState(counter=7, name="typed")
+
+    state_data, state_type, state_module = encode_state(state, serializer)
+    result = decode_state(state_data, state_type, state_module, serializer)
+
+    assert isinstance(result, TypedTestState)
+    assert result.counter == 7
+    assert result.name == "typed"
+
+
+def test_decode_state_respects_json_serializer_allowed_types() -> None:
+    serializer = JsonSerializer()
+    state = TypedTestState(counter=7, name="typed")
+    state_data, state_type, state_module = encode_state(state, serializer)
+    restricted_serializer = JsonSerializer(allowed_types=[DictState])
+
+    with pytest.raises(ValueError, match="Refusing to import disallowed"):
+        decode_state(state_data, state_type, state_module, restricted_serializer)
+
+
+def test_decode_state_missing_metadata_falls_back_to_dict_state() -> None:
+    serializer = JsonSerializer()
+    state_data = {"_data": {"answer": serializer.serialize(42)}}
+
+    result = decode_state(state_data, None, None, serializer)
+
+    assert isinstance(result, DictState)
+    assert result["answer"] == 42
+
+
+def test_decode_state_null_metadata_falls_back_to_dict_state() -> None:
+    serializer = JsonSerializer()
+    state_data = {"_data": {"answer": serializer.serialize(42)}}
+
+    result = decode_state(
+        state_data,
+        state_type_name=None,
+        state_module=None,
+        serializer=serializer,
+    )
+
+    assert isinstance(result, DictState)
+    assert result["answer"] == 42
+
+
+def test_deserialize_state_from_dict_has_no_state_type_override() -> None:
+    signature = inspect.signature(deserialize_state_from_dict)
+
+    assert "state_type" not in signature.parameters
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -906,10 +906,39 @@ def test_decode_state_pickle_serializer_typed_payload_round_trips() -> None:
     assert result.name == "pickled"
 
 
-def test_decode_state_json_scalar_string_falls_back_to_dict_state() -> None:
+def test_decode_state_json_list_string_raises() -> None:
     serializer = JsonSerializer()
 
-    result = decode_state(json.dumps([1, 2, 3]), serializer)
+    with pytest.raises(ValueError, match="state payload"):
+        decode_state(json.dumps([1, 2, 3]), serializer)
+
+
+def test_decode_state_json_scalar_string_raises() -> None:
+    serializer = JsonSerializer()
+
+    with pytest.raises(ValueError, match="state payload"):
+        decode_state(json.dumps("just a string"), serializer)
+
+
+def test_decode_state_dict_without_data_wrapper_raises() -> None:
+    serializer = JsonSerializer()
+
+    with pytest.raises(ValueError, match="state payload"):
+        decode_state({"foo": 1}, serializer)
+
+
+def test_decode_state_list_raises() -> None:
+    serializer = JsonSerializer()
+
+    with pytest.raises(ValueError, match="state payload"):
+        decode_state([1, 2, 3], serializer)
+
+
+def test_decode_state_none_yields_default_empty_state() -> None:
+    """Blank-store handoffs serialize as state_data=None and must stay valid."""
+    serializer = JsonSerializer()
+
+    result = decode_state(None, serializer)
 
     assert isinstance(result, DictState)
     assert len(list(result.items())) == 0

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -30,7 +30,7 @@ from workflows.context.state_store import (
     encode_state,
 )
 from workflows.decorators import step
-from workflows.errors import ContextStateError, WorkflowRuntimeError
+from workflows.errors import ContextSerdeError, ContextStateError, WorkflowRuntimeError
 from workflows.events import (
     Event,
     HumanResponseEvent,
@@ -1141,3 +1141,29 @@ def test_in_memory_state_store_from_dict_rejects_sql_format() -> None:
 
     with pytest.raises(ValueError, match="Cannot parse store_type 'sql'"):
         InMemoryStateStore.from_dict(sql_format, serializer)
+
+
+def test_pre_run_store_access_rejects_durable_state_handle(workflow: Workflow) -> None:
+    ctx = Context.from_dict(
+        workflow,
+        {"version": 1, "state": {"store_type": "sqlite", "run_id": "run-1"}},
+    )
+
+    with pytest.raises(ContextSerdeError, match="durable state store 'sqlite'"):
+        _ = ctx.store
+
+
+def test_basic_runtime_rejects_durable_state_handle(workflow: Workflow) -> None:
+    runtime = BasicRuntime()
+
+    with pytest.raises(
+        WorkflowRuntimeError,
+        match="BasicRuntime cannot restore durable state store 'postgres'",
+    ):
+        runtime.run_workflow(
+            "run-durable",
+            workflow,
+            BrokerState.from_workflow(workflow),
+            serialized_state={"store_type": "postgres", "run_id": "run-1"},
+            serializer=JsonSerializer(),
+        )

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -472,20 +472,6 @@ class ChildClearState(ParentClearState):
 
 
 @pytest.mark.asyncio
-async def test_get_inside_edit_state_does_not_deadlock() -> None:
-    """Reads are lockless: `get` must work inside an `edit_state` block."""
-    store = InMemoryStateStore(DictState())
-    await store.set("counter", 1)
-
-    async def nested_read() -> int:
-        async with store.edit_state() as state:
-            state["other"] = 2
-            return cast(int, await store.get("counter"))
-
-    assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
-
-
-@pytest.mark.asyncio
 async def test_clear_resets_subclass_fields() -> None:
     """Clear is a reset to the current state's type, not a merge."""
     store = InMemoryStateStore(ParentClearState())
@@ -838,19 +824,6 @@ def test_decode_state_allows_dict_state_under_restricted_allowlist() -> None:
     assert result["plain"] == 42
 
 
-def test_decode_state_typed_payload_self_describes() -> None:
-    """Typed payloads reconstruct from the serializer-embedded qualified name."""
-    serializer = JsonSerializer()
-    state = TypedTestState(counter=7, name="typed")
-    state_data, _, _ = encode_state(state, serializer)
-
-    result = decode_state(state_data, serializer)
-
-    assert isinstance(result, TypedTestState)
-    assert result.counter == 7
-    assert result.name == "typed"
-
-
 def test_decode_state_typed_payload_with_unimportable_type_raises() -> None:
     serializer = JsonSerializer()
     state_data = json.dumps(
@@ -906,32 +879,18 @@ def test_decode_state_pickle_serializer_typed_payload_round_trips() -> None:
     assert result.name == "pickled"
 
 
-def test_decode_state_json_list_string_raises() -> None:
-    serializer = JsonSerializer()
-
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param(json.dumps([1, 2, 3]), id="json-list-string"),
+        pytest.param(json.dumps("just a string"), id="json-scalar-string"),
+        pytest.param({"foo": 1}, id="dict-without-data-wrapper"),
+        pytest.param([1, 2, 3], id="list"),
+    ],
+)
+def test_decode_state_unrecognized_payload_raises(payload: object) -> None:
     with pytest.raises(ValueError, match="state payload"):
-        decode_state(json.dumps([1, 2, 3]), serializer)
-
-
-def test_decode_state_json_scalar_string_raises() -> None:
-    serializer = JsonSerializer()
-
-    with pytest.raises(ValueError, match="state payload"):
-        decode_state(json.dumps("just a string"), serializer)
-
-
-def test_decode_state_dict_without_data_wrapper_raises() -> None:
-    serializer = JsonSerializer()
-
-    with pytest.raises(ValueError, match="state payload"):
-        decode_state({"foo": 1}, serializer)
-
-
-def test_decode_state_list_raises() -> None:
-    serializer = JsonSerializer()
-
-    with pytest.raises(ValueError, match="state payload"):
-        decode_state([1, 2, 3], serializer)
+        decode_state(payload, JsonSerializer())
 
 
 def test_decode_state_none_yields_default_empty_state() -> None:

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -782,26 +782,32 @@ def test_decode_state_respects_json_serializer_allowed_types() -> None:
         decode_state(state_data, state_type, state_module, restricted_serializer)
 
 
-def test_decode_state_missing_metadata_falls_back_to_dict_state() -> None:
+def test_decode_state_uses_embedded_type_when_metadata_is_stale() -> None:
+    serializer = JsonSerializer()
+    state = TypedTestState(counter=7, name="typed")
+    state_data, _, _ = encode_state(state, serializer)
+
+    result = decode_state(state_data, "MovedState", "missing.module", serializer)
+
+    assert isinstance(result, TypedTestState)
+    assert result.counter == 7
+    assert result.name == "typed"
+
+
+@pytest.mark.parametrize(
+    ("state_type_name", "state_module"),
+    [
+        (None, None),
+        ("MissingState", None),
+    ],
+)
+def test_decode_state_missing_metadata_falls_back_to_dict_state(
+    state_type_name: str | None, state_module: str | None
+) -> None:
     serializer = JsonSerializer()
     state_data = {"_data": {"answer": serializer.serialize(42)}}
 
-    result = decode_state(state_data, None, None, serializer)
-
-    assert isinstance(result, DictState)
-    assert result["answer"] == 42
-
-
-def test_decode_state_null_metadata_falls_back_to_dict_state() -> None:
-    serializer = JsonSerializer()
-    state_data = {"_data": {"answer": serializer.serialize(42)}}
-
-    result = decode_state(
-        state_data,
-        state_type_name=None,
-        state_module=None,
-        serializer=serializer,
-    )
+    result = decode_state(state_data, state_type_name, state_module, serializer)
 
     assert isinstance(result, DictState)
     assert result["answer"] == 42

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -840,6 +840,17 @@ async def test_deserialize_state_from_dict_with_dict_state() -> None:
     assert result["name"] == "test-value"
 
 
+@pytest.mark.asyncio
+async def test_in_memory_get_preserves_mutable_value_identity() -> None:
+    store = InMemoryStateStore(DictState())
+    await store.set("state", {"items": []})
+
+    state = await store.get("state")
+    state["items"].append("persisted")
+
+    assert await store.get("state.items") == ["persisted"]
+
+
 def test_deserialize_state_from_dict_with_typed_state() -> None:
     """Test deserializing typed Pydantic model from to_dict() format."""
     serializer = JsonSerializer()
@@ -871,6 +882,28 @@ def test_deserialize_state_from_dict_empty_dict_state() -> None:
 
     assert isinstance(result, DictState)
     assert len(list(result.items())) == 0
+
+
+def test_deserialize_state_from_dict_with_raw_dict_state_values() -> None:
+    serializer = JsonSerializer()
+    serialized = {
+        "state_data": {
+            "_data": {
+                "count": 5,
+                "state": {"nested": True},
+                "name": "raw",
+            }
+        },
+        "state_type": "DictState",
+        "state_module": "workflows.context.state_store",
+    }
+
+    result = deserialize_state_from_dict(serialized, serializer)
+
+    assert isinstance(result, DictState)
+    assert result["count"] == 5
+    assert result["state"] == {"nested": True}
+    assert result["name"] == "raw"
 
 
 # ============================================================================

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import asyncio
 import base64
 import gc
-import inspect
 import json
 import pickle
 import weakref
@@ -464,6 +463,42 @@ async def test_clear(internal_ctx: Context) -> None:
     assert res is None
 
 
+class ParentClearState(BaseModel):
+    a: int = 0
+
+
+class ChildClearState(ParentClearState):
+    b: int = 0
+
+
+@pytest.mark.asyncio
+async def test_get_inside_edit_state_does_not_deadlock() -> None:
+    """Reads are lockless: `get` must work inside an `edit_state` block."""
+    store = InMemoryStateStore(DictState())
+    await store.set("counter", 1)
+
+    async def nested_read() -> int:
+        async with store.edit_state() as state:
+            state["other"] = 2
+            return cast(int, await store.get("counter"))
+
+    assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_subclass_fields() -> None:
+    """Clear is a reset to the current state's type, not a merge."""
+    store = InMemoryStateStore(ParentClearState())
+    await store.set_state(ChildClearState(a=1, b=7))
+
+    await store.clear()
+
+    state = await store.get_state()
+    assert isinstance(state, ChildClearState)
+    assert state.a == 0
+    assert state.b == 0
+
+
 @pytest.mark.asyncio
 async def test_running_steps_before_run_raises(workflow: Workflow) -> None:
     """Calling running_steps() before workflow.run() should raise ContextStateError."""
@@ -880,10 +915,17 @@ def test_decode_state_json_scalar_string_falls_back_to_dict_state() -> None:
     assert len(list(result.items())) == 0
 
 
-def test_deserialize_state_from_dict_has_no_state_type_override() -> None:
-    signature = inspect.signature(deserialize_state_from_dict)
+def test_deserialize_state_from_dict_accepts_deprecated_state_type_kwarg() -> None:
+    """Released llama-agents-dbos 0.3.x still passes state_type=; it must be ignored, not a TypeError."""
+    serializer = JsonSerializer()
+    store = InMemoryStateStore(TypedTestState(counter=3, name="kwarg"))
+    payload = store.to_dict(serializer)
 
-    assert "state_type" not in signature.parameters
+    with_kwarg = deserialize_state_from_dict(payload, serializer, state_type=DictState)
+    without_kwarg = deserialize_state_from_dict(payload, serializer)
+
+    assert isinstance(with_kwarg, TypedTestState)
+    assert with_kwarg == without_kwarg
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/context/test_state_store_facade.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_facade.py
@@ -106,6 +106,51 @@ async def test_concurrent_get_state_never_observes_torn_edit() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("durable", [False, True])
+async def test_concurrent_read_during_edit_returns_committed_state(
+    durable: bool,
+) -> None:
+    """Reads never block on an in-flight edit; they see the pre-edit state."""
+    store: Any = (
+        make_facade(FakeDurableStorage(), TwoFieldState)
+        if durable
+        else InMemoryStateStore(TwoFieldState())
+    )
+    await store.set_state(TwoFieldState(a=1, b=1))
+    mid_edit = asyncio.Event()
+    finish_edit = asyncio.Event()
+
+    async def editor() -> None:
+        async with store.edit_state() as state:
+            state.a = 2
+            mid_edit.set()
+            await finish_edit.wait()
+            state.b = 2
+
+    edit_task = asyncio.create_task(editor())
+    await asyncio.wait_for(mid_edit.wait(), timeout=2.0)
+    # The edit block is held open; the read must complete anyway.
+    observed = await asyncio.wait_for(store.get_state(), timeout=2.0)
+    assert (observed.a, observed.b) == (1, 1)
+    finish_edit.set()
+    await asyncio.wait_for(edit_task, timeout=2.0)
+    committed = await store.get_state()
+    assert (committed.a, committed.b) == (2, 2)
+
+
+@pytest.mark.asyncio
+async def test_edit_state_isolates_nested_mutables_until_commit() -> None:
+    """In-memory edits of nested containers must not leak before commit."""
+    store = InMemoryStateStore(DictState())
+    await store.set("nums", [1])
+    async with store.edit_state() as state:
+        state["nums"].append(2)
+        # Concurrent-style read while the block is open: committed value.
+        assert await store.get("nums") == [1]
+    assert await store.get("nums") == [1, 2]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("durable", [False, True])
 async def test_get_inside_edit_state(durable: bool) -> None:
     store: Any = (
         make_facade(FakeDurableStorage())

--- a/packages/llama-index-workflows/tests/context/test_state_store_facade.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_facade.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from typing import Any
 
 import pytest
@@ -40,6 +42,10 @@ class FakeDurableStorage:
     async def save(self, record: StateRecord) -> None:
         self.save_count += 1
         self.record = record.model_copy()
+
+    @asynccontextmanager
+    async def session(self) -> AsyncIterator[FakeDurableStorage]:
+        yield self
 
     def to_handle(self) -> dict[str, Any]:
         return {"store_type": "fake", "run_id": self.run_id}

--- a/packages/llama-index-workflows/tests/context/test_state_store_facade.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_facade.py
@@ -340,6 +340,26 @@ async def test_seed_materializes_exactly_once_under_concurrency(
 
 
 @pytest.mark.asyncio
+async def test_seed_staged_during_materialization_survives(
+    serializer: JsonSerializer,
+) -> None:
+    """A seed staged while another seed is materializing is not dropped."""
+    storage = GatedSaveStorage()
+    facade = make_facade(storage)
+    facade.add_seed(in_memory_seed_payload(serializer, counter=1), serializer)
+
+    first_read = asyncio.create_task(facade.get("counter"))
+    await asyncio.wait_for(storage.save_started.wait(), timeout=2.0)
+    # Re-stage mid-materialization, as a shared facade handed a fresh
+    # snapshot would.
+    facade.add_seed(in_memory_seed_payload(serializer, counter=2), serializer)
+    storage.release_save.set()
+    await asyncio.wait_for(first_read, timeout=2.0)
+
+    assert await asyncio.wait_for(facade.get("counter"), timeout=2.0) == 2
+
+
+@pytest.mark.asyncio
 async def test_seed_own_handle_same_target_is_noop(
     serializer: JsonSerializer,
 ) -> None:

--- a/packages/llama-index-workflows/tests/context/test_state_store_facade.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_facade.py
@@ -1,0 +1,388 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+from workflows.context.serializers import BaseSerializer, JsonSerializer
+from workflows.context.state_store import DictState, InMemoryStateStore
+from workflows.context.state_store_integration import (
+    StateRecord,
+    StateStoreFacade,
+)
+
+
+class TwoFieldState(BaseModel):
+    a: int = 0
+    b: int = 0
+
+
+class SeedState(BaseModel):
+    x: int = 0
+
+
+class FakeDurableStorage:
+    """Minimal durable StateStorage fake: counts saves, records copies."""
+
+    def __init__(self, run_id: str = "run-1") -> None:
+        self.run_id = run_id
+        self.record: StateRecord | None = None
+        self.save_count = 0
+        self.copied_handles: list[str] = []
+
+    async def load(self) -> StateRecord | None:
+        return self.record.model_copy() if self.record is not None else None
+
+    async def save(self, record: StateRecord) -> None:
+        self.save_count += 1
+        self.record = record.model_copy()
+
+    def to_handle(self) -> dict[str, Any]:
+        return {"store_type": "fake", "run_id": self.run_id}
+
+    def parse_own_handle(self, payload: dict[str, Any]) -> str | None:
+        if payload.get("store_type") == "fake":
+            return payload["run_id"]
+        return None
+
+    async def copy_from_handle(self, handle: str) -> None:
+        self.copied_handles.append(handle)
+
+
+@pytest.fixture()
+def serializer() -> JsonSerializer:
+    return JsonSerializer()
+
+
+def make_facade(
+    storage: FakeDurableStorage, state_type: type[BaseModel] = DictState
+) -> StateStoreFacade[Any]:
+    return StateStoreFacade(storage, state_type, JsonSerializer())
+
+
+def in_memory_seed_payload(serializer: BaseSerializer, **items: Any) -> dict[str, Any]:
+    return InMemoryStateStore(DictState(**items)).to_dict(serializer)
+
+
+# ============================================================================
+# Locking: torn reads, reads inside edit_state, nested writers
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_concurrent_get_state_never_observes_torn_edit() -> None:
+    """A concurrent reader must see both-old or both-new, never a half edit."""
+    store = InMemoryStateStore(TwoFieldState())
+    mid_edit = asyncio.Event()
+    finish_edit = asyncio.Event()
+
+    async def editor() -> None:
+        async with store.edit_state() as state:
+            state.a = 1
+            mid_edit.set()
+            await finish_edit.wait()
+            state.b = 1
+
+    async def reader() -> tuple[int, int]:
+        await mid_edit.wait()
+        state = await store.get_state()
+        return (state.a, state.b)
+
+    edit_task = asyncio.create_task(editor())
+    read_task = asyncio.create_task(reader())
+    await asyncio.wait_for(mid_edit.wait(), timeout=2.0)
+    # Give the reader a chance to run while the edit is mid-flight.
+    await asyncio.sleep(0)
+    finish_edit.set()
+    observed = await asyncio.wait_for(read_task, timeout=2.0)
+    await asyncio.wait_for(edit_task, timeout=2.0)
+
+    assert observed in {(0, 0), (1, 1)}
+
+
+@pytest.mark.asyncio
+async def test_get_inside_edit_state_in_memory() -> None:
+    store = InMemoryStateStore(DictState())
+    await store.set("counter", 1)
+
+    async def nested_read() -> Any:
+        async with store.edit_state() as state:
+            state["other"] = 2
+            return await store.get("counter")
+
+    assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_inside_edit_state_durable() -> None:
+    facade = make_facade(FakeDurableStorage())
+    await facade.set("counter", 1)
+
+    async def nested_read() -> Any:
+        async with facade.edit_state() as state:
+            state["other"] = 2
+            return await facade.get("counter")
+
+    assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("durable", [False, True])
+async def test_nested_writers_inside_edit_state_raise(durable: bool) -> None:
+    store: Any = (
+        make_facade(FakeDurableStorage())
+        if durable
+        else InMemoryStateStore(DictState())
+    )
+
+    async def run_nested_writers() -> None:
+        async with store.edit_state() as state:
+            state["touched"] = True
+            with pytest.raises(RuntimeError, match="edit_state"):
+                await store.set("foo", 1)
+            with pytest.raises(RuntimeError, match="edit_state"):
+                await store.set_state(DictState())
+            with pytest.raises(RuntimeError, match="edit_state"):
+                await store.clear()
+            with pytest.raises(RuntimeError, match="edit_state"):
+                async with store.edit_state():
+                    pass
+
+    await asyncio.wait_for(run_nested_writers(), timeout=2.0)
+    assert await store.get("touched") is True
+
+
+# ============================================================================
+# Reads are pure: no default-row persistence from the read path
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_read_on_empty_durable_storage_leaves_no_record() -> None:
+    storage = FakeDurableStorage()
+    facade = make_facade(storage)
+
+    state = await facade.get_state()
+    assert isinstance(state, DictState)
+    assert await facade.get("missing", default=None) is None
+
+    assert storage.save_count == 0
+    assert storage.record is None
+
+
+class FirstLoadGatedStorage(FakeDurableStorage):
+    """Captures the first load's result, then blocks until released."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.first_load_started = asyncio.Event()
+        self.release_first_load = asyncio.Event()
+        self._loads = 0
+
+    async def load(self) -> StateRecord | None:
+        result = await super().load()
+        self._loads += 1
+        if self._loads == 1:
+            self.first_load_started.set()
+            await self.release_first_load.wait()
+        return result
+
+
+@pytest.mark.asyncio
+async def test_read_racing_first_write_never_clobbers_the_write() -> None:
+    """A read that observed empty storage must not persist a default over a
+    write that committed while the read was in flight."""
+    storage = FirstLoadGatedStorage()
+    facade = make_facade(storage, SeedState)
+
+    read_task = asyncio.create_task(facade.get_state())
+    await asyncio.wait_for(storage.first_load_started.wait(), timeout=2.0)
+
+    await asyncio.wait_for(facade.set_state(SeedState(x=1)), timeout=2.0)
+    storage.release_first_load.set()
+    await asyncio.wait_for(read_task, timeout=2.0)
+
+    final = await facade.get_state()
+    assert final.x == 1
+
+
+# ============================================================================
+# Seed lifecycle
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_seed_foreign_durable_handle_raises_immediately(
+    serializer: JsonSerializer,
+) -> None:
+    facade = make_facade(FakeDurableStorage())
+    with pytest.raises(ValueError, match="sqlite"):
+        facade.add_seed({"store_type": "sqlite", "run_id": "other"}, serializer)
+
+
+@pytest.mark.asyncio
+async def test_add_seed_empty_payload_raises(serializer: JsonSerializer) -> None:
+    facade = make_facade(FakeDurableStorage())
+    with pytest.raises(ValueError):
+        facade.add_seed({}, serializer)
+
+
+@pytest.mark.asyncio
+async def test_add_seed_bad_in_memory_payload_raises_immediately(
+    serializer: JsonSerializer,
+) -> None:
+    facade = make_facade(FakeDurableStorage())
+    with pytest.raises(ValueError):
+        facade.add_seed(
+            {"store_type": "in_memory", "state_type": {"not": "a-string"}}, serializer
+        )
+
+
+@pytest.mark.asyncio
+async def test_in_memory_store_add_seed_rejects_durable_payload(
+    serializer: JsonSerializer,
+) -> None:
+    store = InMemoryStateStore(DictState())
+    with pytest.raises(ValueError, match="fake"):
+        store.add_seed({"store_type": "fake", "run_id": "run-1"}, serializer)
+
+
+@pytest.mark.asyncio
+async def test_seed_not_written_until_first_async_access(
+    serializer: JsonSerializer,
+) -> None:
+    storage = FakeDurableStorage()
+    facade = make_facade(storage)
+    facade.add_seed(in_memory_seed_payload(serializer, counter=42), serializer)
+
+    assert storage.save_count == 0
+
+    assert await facade.get("counter") == 42
+    assert storage.save_count == 1
+
+    # Subsequent access does not re-materialize.
+    assert await facade.get("counter") == 42
+    assert storage.save_count == 1
+
+
+class GatedSaveStorage(FakeDurableStorage):
+    """Save blocks until released, exposing the seed-materialization window."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.save_started = asyncio.Event()
+        self.release_save = asyncio.Event()
+
+    async def save(self, record: StateRecord) -> None:
+        self.save_started.set()
+        await self.release_save.wait()
+        await super().save(record)
+
+
+@pytest.mark.asyncio
+async def test_seed_materializes_exactly_once_under_concurrency(
+    serializer: JsonSerializer,
+) -> None:
+    storage = GatedSaveStorage()
+    facade = make_facade(storage)
+    facade.add_seed(in_memory_seed_payload(serializer, counter=42), serializer)
+
+    tasks = [asyncio.create_task(facade.get("counter")) for _ in range(5)]
+    await asyncio.wait_for(storage.save_started.wait(), timeout=2.0)
+    # Let the other readers reach ensure_seeded while the save is in flight.
+    await asyncio.sleep(0)
+    storage.release_save.set()
+
+    results = await asyncio.wait_for(asyncio.gather(*tasks), timeout=2.0)
+    assert results == [42] * 5
+    assert storage.save_count == 1
+
+
+@pytest.mark.asyncio
+async def test_seed_own_handle_same_target_is_noop(
+    serializer: JsonSerializer,
+) -> None:
+    storage = FakeDurableStorage(run_id="run-1")
+    facade = make_facade(storage)
+    facade.add_seed({"store_type": "fake", "run_id": "run-1"}, serializer)
+
+    await facade.get_state()
+
+    assert storage.copied_handles == []
+    assert storage.save_count == 0
+
+
+@pytest.mark.asyncio
+async def test_seed_own_handle_other_target_copies_once(
+    serializer: JsonSerializer,
+) -> None:
+    storage = FakeDurableStorage(run_id="run-1")
+    facade = make_facade(storage)
+    facade.add_seed({"store_type": "fake", "run_id": "run-2"}, serializer)
+
+    await facade.get_state()
+    await facade.get_state()
+
+    assert storage.copied_handles == ["run-2"]
+
+
+@pytest.mark.asyncio
+async def test_seed_wins_over_existing_row(serializer: JsonSerializer) -> None:
+    storage = FakeDurableStorage()
+    facade = make_facade(storage)
+    await facade.set("counter", 1)
+
+    facade.add_seed(in_memory_seed_payload(serializer, counter=99), serializer)
+
+    assert await facade.get("counter") == 99
+
+
+# ============================================================================
+# Handoff dispatch on storage durability
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_serialize_for_handoff_durable_returns_handle(
+    serializer: JsonSerializer,
+) -> None:
+    storage = FakeDurableStorage(run_id="run-7")
+    facade = make_facade(storage)
+
+    assert await facade.serialize_for_handoff(serializer) == {
+        "store_type": "fake",
+        "run_id": "run-7",
+    }
+    assert facade.to_dict(serializer) == {"store_type": "fake", "run_id": "run-7"}
+
+
+@pytest.mark.asyncio
+async def test_serialize_for_handoff_materializes_pending_seed(
+    serializer: JsonSerializer,
+) -> None:
+    storage = FakeDurableStorage()
+    facade = make_facade(storage)
+    facade.add_seed(in_memory_seed_payload(serializer, counter=5), serializer)
+
+    handle = await facade.serialize_for_handoff(serializer)
+
+    assert handle == {"store_type": "fake", "run_id": "run-1"}
+    assert storage.save_count == 1
+
+
+@pytest.mark.asyncio
+async def test_serialize_for_handoff_in_memory_returns_snapshot(
+    serializer: JsonSerializer,
+) -> None:
+    store = InMemoryStateStore(DictState())
+    await store.set("counter", 3)
+
+    payload = await store.serialize_for_handoff(serializer)
+
+    assert payload["store_type"] == "in_memory"
+    restored = InMemoryStateStore.from_dict(payload, serializer)
+    assert await restored.get("counter") == 3

--- a/packages/llama-index-workflows/tests/context/test_state_store_facade.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_facade.py
@@ -105,27 +105,19 @@ async def test_concurrent_get_state_never_observes_torn_edit() -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_inside_edit_state_in_memory() -> None:
-    store = InMemoryStateStore(DictState())
+@pytest.mark.parametrize("durable", [False, True])
+async def test_get_inside_edit_state(durable: bool) -> None:
+    store: Any = (
+        make_facade(FakeDurableStorage())
+        if durable
+        else InMemoryStateStore(DictState())
+    )
     await store.set("counter", 1)
 
     async def nested_read() -> Any:
         async with store.edit_state() as state:
             state["other"] = 2
             return await store.get("counter")
-
-    assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
-
-
-@pytest.mark.asyncio
-async def test_get_inside_edit_state_durable() -> None:
-    facade = make_facade(FakeDurableStorage())
-    await facade.set("counter", 1)
-
-    async def nested_read() -> Any:
-        async with facade.edit_state() as state:
-            state["other"] = 2
-            return await facade.get("counter")
 
     assert await asyncio.wait_for(nested_read(), timeout=2.0) == 1
 


### PR DESCRIPTION
Workflow state persistence on main has three copies of every contract. Sqlite, postgres, and agent-data each re-implement per-run store memoization, lazy seed materialization, the durable save path, and `from_dict` dispatch — with drift already visible (agent-data's cache misses the `DictState`→typed upgrade the others have; sqlite's save path skips seeding). On top of that, decode trusts persisted `state_type`/`state_module` row metadata to drive module imports, and the facade's locking is illusory because every `create_state_store` call builds a fresh facade with a fresh lock.

This branch centralizes each contract in exactly one place and fixes the concurrency bugs that fall out.

## Decode dispatches on payload shape, and is strict

`decode_state` never imports `{state_module}.{state_type}` from persisted rows; the only import path is the serializer's embedded qualified name, which is allowlist-validated and fails closed. The metadata columns are still written for debugging, but reads ignore them:

- live `BaseModel` → returned as-is (in-process handoff)
- `{"_data": ...}` dict or its JSON string → `DictState` with per-value deserialization
- serializer self-describing payload → typed model, qualified name validated
- `None` → default empty state (blank-store handoff)
- anything else → `ValueError` naming the payload shape

That last line is a behavior change: corrupt or foreign payloads previously decoded to an empty `DictState`, and the next save overwrote the only copy of the state. Now they raise — and seed validation happens eagerly at `create_state_store`/`from_dict` time, so a bad restore payload surfaces at submit time instead of mid-run.

## The facade owns locking, seeding, and the save path

`StateStoreFacade` (now public, with `StateRecord` and the durable `StateStorage` protocol) carries the whole concurrency contract:

> Writers serialize on the per-run lock; reads are lockless and read-committed on every backend — an in-flight `edit_state` block works on an isolated copy, so reads (including reads inside the block) return the pre-edit state until the block commits on exit.

Durable backends get the isolation for free (every load decodes a fresh instance from the committed row); the in-memory store hands `edit_state` a deep copy of its live record and commits it on block exit. That gets three fixes without ever blocking a reader:

- `get`/`get_state` inside an `edit_state` block works on every store (previously deadlocked on in-memory, by design gap)
- a nested writer inside `edit_state` raises `RuntimeError` instead of hanging
- concurrent in-memory readers can no longer observe a half-applied multi-field edit — they see the committed pre-edit state, exactly like a reader of a durable row

Reads are also pure now: a read on empty storage returns a default without persisting it, so a racing first read can't clobber a concurrent `set_state` with a default row.

Seeding moved into the facade: `add_seed` validates eagerly (sync, pure — foreign handles and malformed payloads raise), `ensure_seeded` materializes lazily on first async access or handoff, double-checked, in one place. A seed re-staged on a shared facade while another seed is mid-materialization survives for the next access instead of being silently dropped. Backends shrink to genuine I/O methods (`load`/`save`/`session`/`to_handle`/`parse_own_handle`/`copy_from_handle`); all the `ensure_seeded`/`_load_without_seed`/`_save_without_seed` shadow machinery is deleted. The durable save path is a single chokepoint that encodes string records, so the triplicated `json.dumps` coercion goes away too.

The facade decides durability exactly once, at construction (`isinstance(storage, StateStorage)`); every downstream path branches on that typed field instead of re-sniffing the protocol per call.

## Writers hold one connection

Each write (`set_state`, `clear`, `edit_state`) scopes its load+save pair to a single backend connection through the storage's `session()`. Previously sqlite opened two `sqlite3.connect`s per write and postgres checked out two pool connections — one for the load, one for the save. The session yields a *separate* conn-bound storage value rather than mutating the writer's storage, so lockless concurrent readers keep acquiring their own connections and can never observe a writer's uncommitted connection state.

## Agent-data reads cache the decoded model

Agent-data is a database over HTTP with single-process readers, so its facade subclass caches the decoded state model: reads after the first skip both the search round-trip and the JSON-parse/per-key decode, which is what keeps `ctx.store.get()` usable in hot paths. The cached instance is private — loads and saves exchange deep copies — and any materialized seed drops the cache, so a late re-staged restore is never masked by a stale read. The generic facade stays cache-free: sqlite/postgres reads always hit the backend (the storage-level raw-record cache is deleted), preserving correctness if writers ever exist in other processes.

## One memoization policy

`AbstractWorkflowStore.create_state_store` is now a concrete template method — cache, `DictState`→typed upgrade, and seed staging in one place — and backends implement a `_build_state_store` hook. A restore call hands the seed to the *existing* cached facade instead of rebuilding it, so a previously handed-out facade can no longer end up with a different lock than the restored one (two facades, two locks, concurrent `edit_state` races). The cache container stays per-backend: weak-valued by default, strong refs with terminal-event cleanup for agent-data and memory stores.

`start()` is on the ABC (default no-op), so DBOS drops its `isinstance`/`getattr` start probes, and seeds materialize via `ensure_seeded()` instead of a discarded `get_state()` round-trip. `PostgresWorkflowStore.start()` publishes its pool only after migrations and the LISTEN connection succeed — a concurrent late joiner previously could hit the unlocked fast path and query unmigrated tables. `close()` now closes the pool provider unconditionally (idempotent, no-op for borrowed pools), so a pool resolved during a failed `start()` can't leak.

## Handoff is explicit

Runtime handoff calls `await store.serialize_for_handoff(serializer)`: durable backends return a reconnect handle, in-memory stores return a portable serializer-encoded snapshot, after materializing any pending seed. The old `to_dict_mode` flag and protocol-sniffing are gone; handoff dispatches on the facade's construction-time durability decision.

## Versioning

`llama-index-workflows` is a minor release (integration contract change); runtime plugin packages bump their floor to match. `llama-agents-server` is also minor: `AbstractWorkflowStore` gained a required `_build_state_store` abstractmethod and a required `super().__init__()`, so third-party subclasses written against the previous release need changes. Already-released `llama-agents-dbos` 0.3.x keeps working: `deserialize_state_from_dict` retains its deprecated `state_type` kwarg as a no-op. The DBOS postgres workflow store no longer auto-migrates on start — deployments with `run_migrations_on_launch=False` must run migrations explicitly (changeset included).


