### PR TITLE
Rehydrate restored workflow waiters conservatively

### DIFF
--- a/.changeset/waiter-requirements-rehydrate.md
+++ b/.changeset/waiter-requirements-rehydrate.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Rehydrate restored workflow waiters with serialized requirements conservatively.

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -218,6 +218,7 @@ class BrokerState:
             for waiter_data in worker_data.collected_waiters:
                 # Import the event type
                 waiting_for_event = _import_event_type(waiter_data.waiting_for_event)
+                needs_rehydration = _serialized_waiter_needs_rehydration(waiter_data)
 
                 worker.collected_waiters.append(
                     StepWorkerWaiter(
@@ -225,7 +226,8 @@ class BrokerState:
                         event=serializer.deserialize(waiter_data.event),
                         waiting_for_event=waiting_for_event,
                         requirements={},
-                        has_requirements=waiter_data.has_requirements,
+                        has_requirements=waiter_data.has_requirements
+                        or needs_rehydration,
                         resolved_event=serializer.deserialize(
                             waiter_data.resolved_event
                         )
@@ -235,6 +237,26 @@ class BrokerState:
                 )
 
         return base_state
+
+
+def _serialized_waiter_needs_rehydration(waiter: SerializedWaiter) -> bool:
+    """Return whether a restored waiter should replay its owning step.
+
+    Requirements are intentionally not serialized because they may contain
+    application objects. New snapshots use ``has_requirements`` for this signal;
+    default waiter IDs also embed the requirements repr, so they provide a
+    backwards-compatible fallback when that flag is absent or stale.
+    """
+    if waiter.resolved_event is not None:
+        return False
+    return waiter.has_requirements or _default_waiter_id_has_requirements(
+        waiter.waiter_id
+    )
+
+
+def _default_waiter_id_has_requirements(waiter_id: str) -> bool:
+    """Detect default wait_for_event IDs generated with non-empty requirements."""
+    return waiter_id.startswith("waiter_") and not waiter_id.endswith("_{}")
 
 
 def _import_event_type(qualified_name: str) -> type[Event]:

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -243,20 +243,14 @@ def _serialized_waiter_needs_rehydration(waiter: SerializedWaiter) -> bool:
     """Return whether a restored waiter should replay its owning step.
 
     Requirements are intentionally not serialized because they may contain
-    application objects. New snapshots use ``has_requirements`` for this signal;
-    default waiter IDs also embed the requirements repr, so they provide a
-    backwards-compatible fallback when that flag is absent or stale.
+    application objects. New snapshots use ``has_requirements`` for this signal.
+    Legacy snapshots that omit the field do not have a reliable per-waiter
+    requirements signal, so unresolved legacy waiters are replayed
+    conservatively to reconstruct any requirements they owned.
     """
     if waiter.resolved_event is not None:
         return False
-    return waiter.has_requirements or _default_waiter_id_has_requirements(
-        waiter.waiter_id
-    )
-
-
-def _default_waiter_id_has_requirements(waiter_id: str) -> bool:
-    """Detect default wait_for_event IDs generated with non-empty requirements."""
-    return waiter_id.startswith("waiter_") and not waiter_id.endswith("_{}")
+    return waiter.has_requirements or "has_requirements" not in waiter.model_fields_set
 
 
 def _import_event_type(qualified_name: str) -> type[Event]:

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -369,7 +369,7 @@ class ApprovalResponseEvent(HumanResponseEvent):
 
 
 @pytest.mark.asyncio
-async def test_waiter_requirements_rehydrate_even_if_serialized_flag_is_false() -> None:
+async def test_waiter_requirements_rehydrate_from_legacy_snapshot() -> None:
     class ApprovalWorkflow(Workflow):
         @step
         async def review(self, ctx: Context, ev: StartEvent) -> StopEvent:
@@ -400,11 +400,12 @@ async def test_waiter_requirements_rehydrate_even_if_serialized_flag_is_false() 
     assert waiters[0]["has_requirements"] is True
     assert not waiters[0]["waiter_id"].endswith("_{}")
 
-    # Simulate a stale or tampered context snapshot that clears the serialized
-    # rehydration flag. The original requirements are intentionally not stored
-    # in the snapshot, so restore falls back to the default waiter id's embedded
-    # requirements signal and reconstructs them by replaying the waiting step.
-    waiters[0]["has_requirements"] = False
+    # Simulate a legacy context snapshot written before waiter requirement
+    # metadata was persisted. The original requirements are intentionally not
+    # stored in the snapshot, so restore falls back to the default waiter id's
+    # embedded requirements signal and reconstructs them by replaying the
+    # waiting step.
+    waiters[0].pop("has_requirements")
 
     new_handler = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))
     new_handler.ctx.send_event(ApprovalResponseEvent(response="unbound"))

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -398,13 +398,11 @@ async def test_waiter_requirements_rehydrate_from_legacy_snapshot() -> None:
     ]
     assert len(waiters) == 1
     assert waiters[0]["has_requirements"] is True
-    assert not waiters[0]["waiter_id"].endswith("_{}")
 
     # Simulate a legacy context snapshot written before waiter requirement
-    # metadata was persisted. The original requirements are intentionally not
-    # stored in the snapshot, so restore falls back to the default waiter id's
-    # embedded requirements signal and reconstructs them by replaying the
-    # waiting step.
+    # metadata was persisted. Since that format does not provide a reliable
+    # per-waiter requirement signal, restore conservatively replays unresolved
+    # legacy waiters to reconstruct any requirements they owned.
     waiters[0].pop("has_requirements")
 
     new_handler = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -359,6 +359,66 @@ async def test_wait_for_event_in_workflow_serialization() -> None:
     assert total_waiters == 0
 
 
+class ApprovalRequiredEvent(InputRequiredEvent):
+    prefix: str
+
+
+class ApprovalResponseEvent(HumanResponseEvent):
+    response: str
+    waiter_id: str | None = None
+
+
+@pytest.mark.asyncio
+async def test_waiter_requirements_rehydrate_even_if_serialized_flag_is_false() -> None:
+    class ApprovalWorkflow(Workflow):
+        @step
+        async def review(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            result = await ctx.wait_for_event(
+                ApprovalResponseEvent,
+                waiter_event=ApprovalRequiredEvent(prefix="approval"),
+                requirements={"waiter_id": "waiter_one"},
+            )
+            return StopEvent(result=result.response)
+
+    workflow = ApprovalWorkflow()
+    handler = workflow.run()
+    ctx_dict = None
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            ctx_dict = handler.ctx.to_dict()
+            await handler.cancel_run()
+            break
+
+    assert ctx_dict is not None
+    waiters = [
+        waiter
+        for worker in ctx_dict["workers"].values()
+        for waiter in worker["collected_waiters"]
+    ]
+    assert len(waiters) == 1
+    assert waiters[0]["has_requirements"] is True
+    assert not waiters[0]["waiter_id"].endswith("_{}")
+
+    # Simulate a stale or tampered context snapshot that clears the serialized
+    # rehydration flag. The original requirements are intentionally not stored
+    # in the snapshot, so restore falls back to the default waiter id's embedded
+    # requirements signal and reconstructs them by replaying the waiting step.
+    waiters[0]["has_requirements"] = False
+
+    new_handler = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))
+    new_handler.ctx.send_event(ApprovalResponseEvent(response="unbound"))
+
+    task = asyncio.ensure_future(new_handler)
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(asyncio.shield(task), timeout=0.2)
+
+    new_handler.ctx.send_event(
+        ApprovalResponseEvent(response="bound", waiter_id="waiter_one")
+    )
+    assert await task == "bound"
+
+
 class Waiter1(Event):
     msg: str
 

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -20,6 +20,7 @@ from workflows.context.context import (
 )
 from workflows.context.external_context import ExternalContext
 from workflows.context.internal_context import InternalContext
+from workflows.context.pre_context import PreContext
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import (
     DictState,
@@ -405,7 +406,14 @@ async def test_waiter_requirements_rehydrate_from_legacy_snapshot() -> None:
     # legacy waiters to reconstruct any requirements they owned.
     waiters[0].pop("has_requirements")
 
-    new_handler = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))
+    legacy_ctx = Context.from_dict(workflow, ctx_dict)
+    assert isinstance(legacy_ctx._face, PreContext)
+    legacy_state = BrokerState.from_serialized(
+        legacy_ctx._face.init_snapshot, workflow, JsonSerializer()
+    )
+    assert len(legacy_state.rehydrate_with_ticks()) == 1
+
+    new_handler = workflow.run(ctx=legacy_ctx)
     new_handler.ctx.send_event(ApprovalResponseEvent(response="unbound"))
 
     task = asyncio.ensure_future(new_handler)
@@ -416,6 +424,44 @@ async def test_waiter_requirements_rehydrate_from_legacy_snapshot() -> None:
         ApprovalResponseEvent(response="bound", waiter_id="waiter_one")
     )
     assert await task == "bound"
+
+
+@pytest.mark.asyncio
+async def test_waiter_without_requirements_does_not_rehydrate() -> None:
+    class ApprovalWorkflow(Workflow):
+        @step
+        async def review(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            result = await ctx.wait_for_event(
+                ApprovalResponseEvent,
+                waiter_event=ApprovalRequiredEvent(prefix="approval"),
+            )
+            return StopEvent(result=result.response)
+
+    workflow = ApprovalWorkflow()
+    handler = workflow.run()
+    ctx_dict = None
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            ctx_dict = handler.ctx.to_dict()
+            await handler.cancel_run()
+            break
+
+    assert ctx_dict is not None
+    waiters = [
+        waiter
+        for worker in ctx_dict["workers"].values()
+        for waiter in worker["collected_waiters"]
+    ]
+    assert len(waiters) == 1
+    assert waiters[0]["has_requirements"] is False
+
+    new_ctx = Context.from_dict(workflow, ctx_dict)
+    assert isinstance(new_ctx._face, PreContext)
+    current_state = BrokerState.from_serialized(
+        new_ctx._face.init_snapshot, workflow, JsonSerializer()
+    )
+    assert current_state.rehydrate_with_ticks() == []
 
 
 class Waiter1(Event):


### PR DESCRIPTION
## Summary

Rehydrates restored `wait_for_event` waiters when serialized metadata indicates that requirements need to be reconstructed, and handles legacy context snapshots that do not contain that metadata.

Requirements remain out of serialized context payloads, so non-serializable application-owned requirement values continue to be supported. New snapshots use `has_requirements`; legacy snapshots that omit that field replay unresolved waiters conservatively because the old payload format has no reliable per-waiter requirement signal.

## Why

`wait_for_event` requirements may contain application objects, so serialized context payloads store only metadata about whether requirements exist. A context snapshot written without that metadata falls back to the schema default of `has_requirements=False` during restore. If that waiter originally had requirements, it can be restored with an empty requirements dict.

Since an empty requirements dict is vacuously satisfied, an unbound event of the target type can satisfy the restored waiter before the original requirements are reconstructed. The fallback keeps current-format no-requirement waiters on their existing restore path, and only conservatively replays unresolved waiters for legacy snapshots where the `has_requirements` field was missing.

## Tests

- `uv run --project packages/llama-index-workflows pytest packages/llama-index-workflows/tests/context/test_context.py::test_waiter_requirements_rehydrate_from_legacy_snapshot packages/llama-index-workflows/tests/context/test_context.py::test_waiter_without_requirements_does_not_rehydrate -q`
- `uv run --package llama-agents-server pytest packages/llama-agents-server/tests/server/test_durable_runtime.py::test_multistep_hitl_broker_state_survives_restart packages/llama-agents-server/tests/server/test_durable_runtime.py::test_multistep_hitl_multiple_restarts_at_same_wait_point -q`
- `uv run --with ruff ruff check packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py packages/llama-index-workflows/tests/context/test_context.py`
- `uv run --with ruff ruff format --check packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py packages/llama-index-workflows/tests/context/test_context.py`
- `uv run --project packages/llama-index-workflows python -m py_compile packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py packages/llama-index-workflows/tests/context/test_context.py`
- `uv run ty check packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py packages/llama-index-workflows/tests/context/test_context.py`
- `uv run --with basedpyright basedpyright packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py packages/llama-index-workflows/tests/context/test_context.py`
- `git diff --check`
