### PR TITLE
Resolve dynamic state keys before mapping methods in store path lookups

### DIFF
--- a/.changeset/state-store-method-named-keys.md
+++ b/.changeset/state-store-method-named-keys.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Fix ctx.store.get() returning bound dict methods instead of stored values for state keys named items, keys, values, or get

--- a/packages/llama-agents-integration-tests/tests/test_state_store_matrix.py
+++ b/packages/llama-agents-integration-tests/tests/test_state_store_matrix.py
@@ -282,6 +282,17 @@ async def test_get_missing_raises(state_store: StateStore[DictState]) -> None:
 
 
 @pytest.mark.asyncio
+async def test_method_named_keys(state_store: StateStore[DictState]) -> None:
+    """Keys colliding with mapping method names return stored values, not bound methods."""
+    await state_store.set("items", [1, 2, 3])
+    await state_store.set("keys", "abc")
+
+    assert await state_store.get("items") == [1, 2, 3]
+    assert await state_store.get("keys") == "abc"
+    assert await state_store.get("values", default=None) is None
+
+
+@pytest.mark.asyncio
 async def test_nested_get_set(state_store: StateStore[DictState]) -> None:
     """Test nested path access with dot notation."""
     await state_store.set("nested", {"a": "b"})

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -333,6 +333,16 @@ def create_in_memory_payload(
     )
 
 
+def is_declared_model_path_segment(obj: DictLikeModel, segment: str) -> bool:
+    """Return whether a path segment names a declared model attribute."""
+    cls = type(obj)
+    return (
+        segment in cls.model_fields
+        or segment in cls.model_computed_fields
+        or isinstance(getattr(cls, segment, None), property)
+    )
+
+
 def traverse_path_step(obj: Any, segment: str) -> Any:
     """Follow one segment into obj (dict key, list index, or attribute).
 
@@ -355,12 +365,7 @@ def traverse_path_step(obj: Any, segment: str) -> Any:
     if isinstance(obj, DictLikeModel):
         if segment in obj:  # __contains__ checks _data
             return obj[segment]
-        cls = type(obj)
-        if (
-            segment in cls.model_fields
-            or segment in cls.model_computed_fields
-            or isinstance(getattr(cls, segment, None), property)
-        ):
+        if is_declared_model_path_segment(obj, segment):
             return getattr(obj, segment)
         raise KeyError(segment)
 

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -349,6 +349,21 @@ def traverse_path_step(obj: Any, segment: str) -> Any:
     if isinstance(obj, dict):
         return obj[segment]
 
+    # DictLikeModel dynamic keys live in _data and are shadowed by mapping
+    # methods (items/keys/values/get, ...) under plain getattr, so check _data
+    # first and never resolve methods as values.
+    if isinstance(obj, DictLikeModel):
+        if segment in obj:  # __contains__ checks _data
+            return obj[segment]
+        cls = type(obj)
+        if (
+            segment in cls.model_fields
+            or segment in cls.model_computed_fields
+            or isinstance(getattr(cls, segment, None), property)
+        ):
+            return getattr(obj, segment)
+        raise KeyError(segment)
+
     # Attempt list/tuple index
     try:
         idx = int(segment)
@@ -370,6 +385,13 @@ def assign_path_step(obj: Any, segment: str, value: Any) -> None:
     """
     if isinstance(obj, dict):
         obj[segment] = value
+        return
+
+    # DictLikeModel: __setattr__ routes declared field names to the field and
+    # everything else into _data. Handling it before the int-index attempt
+    # keeps numeric segments stored under string keys, matching reads.
+    if isinstance(obj, DictLikeModel):
+        setattr(obj, segment, value)
         return
 
     # Attempt list/tuple index assignment

--- a/packages/llama-index-workflows/tests/test_state_manager.py
+++ b/packages/llama-index-workflows/tests/test_state_manager.py
@@ -13,7 +13,13 @@ These tests provide fast feedback during development of the base package.
 from __future__ import annotations
 
 import pytest
-from workflows.context.state_store import DictState, InMemoryStateStore
+from workflows.context.state_store import (
+    DictState,
+    InMemoryStateStore,
+    get_by_path,
+    set_by_path,
+)
+from workflows.events import DictLikeModel, StopEvent
 
 
 @pytest.mark.asyncio
@@ -46,3 +52,81 @@ async def test_in_memory_edit_state() -> None:
         state["counter"] = 1
 
     assert await store.get("counter") == 1
+
+
+@pytest.mark.asyncio
+async def test_state_keys_named_after_mapping_methods() -> None:
+    """Keys colliding with DictLikeModel method names return stored values, not bound methods."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+
+    for key, value in {
+        "items": [1, 2, 3],
+        "keys": "abc",
+        "values": {"x": 1},
+        "get": 42,
+        "model_dump": "shadowed",
+    }.items():
+        await store.set(key, value)
+        assert await store.get(key) == value
+
+
+@pytest.mark.asyncio
+async def test_missing_method_named_key_is_missing() -> None:
+    """An unset key that collides with a method name behaves like any missing key."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+
+    assert await store.get("items", default=None) is None
+    with pytest.raises(ValueError):
+        await store.get("keys")
+
+
+@pytest.mark.asyncio
+async def test_nested_set_through_method_named_segment() -> None:
+    """Setting a nested path under a method-named key creates the intermediate dict."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+
+    await store.set("items.nested", 1)
+    assert await store.get("items.nested") == 1
+    assert await store.get("items") == {"nested": 1}
+
+
+@pytest.mark.asyncio
+async def test_numeric_string_key_roundtrip() -> None:
+    """Numeric string keys on DictState round-trip through set/get."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+
+    await store.set("0", "zero")
+    assert await store.get("0") == "zero"
+
+
+def test_get_by_path_typed_dict_like_model() -> None:
+    """Declared fields and properties on DictLikeModel subclasses stay reachable."""
+
+    class TypedModel(DictLikeModel):
+        foo: int = 7
+
+    model = TypedModel()
+    model["dynamic"] = "bar"
+    assert get_by_path(model, "foo") == 7
+    assert get_by_path(model, "dynamic") == "bar"
+
+    # StopEvent.result is a @property backed by a private attr
+    state = DictState()
+    set_by_path(state, "ev", StopEvent(result=42))
+    assert get_by_path(state, "ev.result") == 42
+
+    # A dynamic key written over a property name wins on path reads
+    set_by_path(state, "ev.result", 7)
+    assert get_by_path(state, "ev.result") == 7
+
+
+def test_set_by_path_typed_field_assigns_field() -> None:
+    """set_by_path writes declared fields as fields, not shadow _data entries."""
+
+    class TypedModel(DictLikeModel):
+        foo: int = 7
+
+    model = TypedModel()
+    set_by_path(model, "foo", 9)
+    assert model.foo == 9
+    assert "foo" not in model._data


### PR DESCRIPTION
Fixes #667.

`ctx.store.get("items")` after `ctx.store.set("items", [1, 2, 3])` returns `<bound method DictLikeModel.items>` instead of the list. `traverse_path_step` falls back to `getattr(obj, segment)`, and `DictLikeModel` keeps dynamic keys in `_data` behind `__getattr__` — which Python skips for any name that exists on the class. So keys named `items`, `keys`, `values`, `get`, `model_dump`, etc. silently resolve to the method. Writes were fine (`__setattr__` routes non-field names into `_data`); only reads hit it. Nested writes under such a key were also broken: `set("items.nested", 1)` traversed to the bound method without raising and then failed with `AttributeError` on assignment.

`traverse_path_step` now handles `DictLikeModel` explicitly: `_data` keys win, then declared fields, computed fields, and properties resolve via `getattr` (this keeps `StopEvent.result` reachable by path), and anything else raises `KeyError` — so a missing key that happens to collide with a method name behaves like any missing key (default / `ValueError`) instead of returning the method. The `KeyError` also feeds `set_by_path`'s intermediate-dict creation, fixing the nested-write case.

`assign_path_step` gets a matching branch (plain `setattr` ahead of the list-index attempt) so numeric string keys round-trip: previously `set("0", v)` stored `_data[0]` via the int-index path while the new read branch looks up `"0"`.

All store implementations (in-memory, sqlite, postgres, agent-data) share these helpers, so the fix covers each; the matrix test gains a regression case across backends.