### PR TITLE
Add multi-parameter fan-in steps

### DIFF
--- a/.changeset/fan-out-groundwork.md
+++ b/.changeset/fan-out-groundwork.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": minor
+---
+
+Steps can declare multiple single-event parameters to fire once when one of each has arrived.

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -75,6 +75,8 @@ class SerializedEventAttempt(BaseModel):
 
     # The event being processed (as serializer-encoded string)
     event: str
+    # Pre-bound fan-in parameters for static multi-event steps.
+    bound_events: dict[str, str] | None = None
     # Number of times this event has been attempted (0 for first attempt)
     attempts: int = 0
     # Unix timestamp of first attempt, or None if not yet attempted
@@ -125,11 +127,13 @@ class SerializedStepWorkerState(BaseModel):
     # Queue of events waiting to be processed (with retry info)
     queue: list[SerializedEventAttempt] = Field(default_factory=list)
     # Events currently being processed. Serialized with full retry info so a
-    # resumed run re-queues them without losing attempt counts.
+    # resumed run re-queues them without losing attempt counts or fan-in bindings.
     in_progress: list[SerializedEventAttempt] = Field(default_factory=list)
     # Collected events for ctx.collect_events(), keyed by buffer_id -> [event, ...]
     # Events are serialized strings
     collected_events: dict[str, list[str]] = Field(default_factory=dict)
+    # Pending static multi-parameter fan-in events.
+    static_collect_events: list[str] = Field(default_factory=list)
     # Active waiters created by ctx.wait_for_event()
     collected_waiters: list[SerializedWaiter] = Field(default_factory=list)
 

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -101,6 +101,8 @@ class SerializedWaiter(BaseModel):
     waiter_id: str
     # The original event that triggered the wait (serialized)
     event: str
+    # Pre-bound fan-in parameters from the original worker invocation.
+    bound_events: dict[str, str] | None = None
     # Fully qualified name of the event type being waited for (e.g. "mymodule.MyEvent")
     waiting_for_event: str
     # Requirements dict for matching the waited-for event

--- a/packages/llama-index-workflows/src/workflows/decorators.py
+++ b/packages/llama-index-workflows/src/workflows/decorators.py
@@ -51,6 +51,11 @@ class StepConfig:
     resources: list[ResourceDefinition]
     context_state_type: type[BaseModel] | None = None
     skip_graph_checks: list[StepGraphCheck] = dataclasses.field(default_factory=list)
+    # Heterogeneous fan-in: when a step declares more than one event parameter,
+    # this is the ordered list of (parameter_name, event_type) it collects. The
+    # step fires once when one event of each type has arrived. None for the
+    # ordinary single-event-trigger model.
+    collect_params: list[tuple[str, Any]] | None = None
     # Fan-out producer: True when the return annotation is ``list[E]``. Computed
     # at decoration time from the return annotation; only an actual list return
     # emits per element.
@@ -210,6 +215,16 @@ def make_step_function(
 
     event_name, accepted_events = next(iter(spec.accepted_events.items()))
 
+    # Collect-mode (multi-slot fan-in): more than one event parameter. The step
+    # accepts every declared event type for routing, then collects by
+    # declaration order before firing once.
+    collect_params: list[tuple[str, Any]] | None = None
+    if len(spec.accepted_events) > 1:
+        collect_params = [
+            (name, param_types[0]) for name, param_types in spec.accepted_events.items()
+        ]
+        accepted_events = [event_type for _, event_type in collect_params]
+
     casted = cast(StepFunction[P, R], func)
     casted._step_config = StepConfig(
         accepted_events=accepted_events,
@@ -221,6 +236,7 @@ def make_step_function(
         retry_policy=retry_policy,
         resources=spec.resources,
         skip_graph_checks=skip_graph_checks or [],
+        collect_params=collect_params,
         is_fan_out=spec.is_fan_out,
         bare_return_types=tuple(spec.bare_return_types),
         accept_event_subclasses=accept_event_subclasses,

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -903,6 +903,8 @@ def _process_step_result_tick(
                 state.is_running = False
                 # Clear collected_events and collected_waiters since workflow is complete
                 for worker in state.workers.values():
+                    worker.queue.clear()
+                    worker.in_progress.clear()
                     worker.collected_events.clear()
                     worker.static_collect_events.clear()
                     worker.collected_waiters.clear()
@@ -1128,7 +1130,8 @@ def _process_step_result_tick(
                 )
             ),
         )
-        worker_state.in_progress.remove(this_execution)
+        if this_execution in worker_state.in_progress:
+            worker_state.in_progress.remove(this_execution)
     # enqueue next events if there are any
     if not is_completed:
         commands.extend(_drain_eligible_queue(step_id, worker_state, now_seconds))

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -230,6 +230,7 @@ class _ControlLoopRunner:
                     step_name=step_name,
                     event=command.event,
                     workflow=self.workflow,
+                    bound_events=command.bound_events,
                     retry=RetryAttempt(
                         retry_number=worker.attempts,
                         first_attempt_at=worker.first_attempt_at,
@@ -313,6 +314,7 @@ class _ControlLoopRunner:
                 TickAddEvent(
                     event=command.event,
                     step_id=command.step_id,
+                    bound_events=command.bound_events,
                     attempts=command.attempts,
                     first_attempt_at=command.first_attempt_at,
                     last_exception=command.last_exception,
@@ -824,6 +826,7 @@ def rewind_in_progress(
                 0,
                 EventAttempt(
                     event=in_progress.event,
+                    bound_events=in_progress.bound_events,
                     attempts=in_progress.attempts,
                     first_attempt_at=in_progress.first_attempt_at,
                     last_exception=in_progress.last_exception,
@@ -960,6 +963,7 @@ def _process_step_result_tick(
                     0,
                     EventAttempt(
                         event=tick.event,
+                        bound_events=this_execution.bound_events,
                         attempts=this_execution.attempts + 1,
                         first_attempt_at=first_attempt_at,
                         last_exception=result.exception,
@@ -1129,6 +1133,67 @@ def _process_step_result_tick(
     return state, commands
 
 
+def _static_collect_events(
+    event: Event,
+    worker_state: InternalStepWorkerState,
+) -> dict[str, Event] | None:
+    """Buffer a statically routed fan-in event until every declared slot is filled."""
+    collect_params = worker_state.config.collect_params
+    if collect_params is None:
+        return None
+
+    worker_state.static_collect_events.append(event)
+    selected_indices = _select_static_collect_batch(
+        events=worker_state.static_collect_events,
+        collect_params=collect_params,
+        allow_subclasses=worker_state.config.accept_event_subclasses,
+    )
+    if selected_indices is None:
+        return None
+
+    binding = {
+        param_name: worker_state.static_collect_events[event_index]
+        for (param_name, _), event_index in zip(collect_params, selected_indices)
+    }
+    selected = set(selected_indices)
+    worker_state.static_collect_events = [
+        pending
+        for index, pending in enumerate(worker_state.static_collect_events)
+        if index not in selected
+    ]
+    return binding
+
+
+def _select_static_collect_batch(
+    events: list[Event],
+    collect_params: list[tuple[str, Any]],
+    allow_subclasses: bool,
+) -> list[int] | None:
+    def search(param_index: int, used: set[int]) -> list[int] | None:
+        if param_index == len(collect_params):
+            return []
+
+        _, event_type = collect_params[param_index]
+        for event_index, candidate in enumerate(events):
+            if event_index in used:
+                continue
+            if not event_matches(
+                candidate,
+                event_type,
+                allow_subclasses=allow_subclasses,
+            ):
+                continue
+
+            used.add(event_index)
+            rest = search(param_index + 1, used)
+            used.remove(event_index)
+            if rest is not None:
+                return [event_index, *rest]
+        return None
+
+    return search(0, set())
+
+
 def _add_or_enqueue_event(
     event: EventAttempt,
     step_id: StepId,
@@ -1161,6 +1226,7 @@ def _add_or_enqueue_event(
         state.in_progress.append(
             InProgressState(
                 event=event.event,
+                bound_events=event.bound_events,
                 worker_id=id,
                 shared_state=shared_state,
                 attempts=event.attempts or 0,
@@ -1170,7 +1236,14 @@ def _add_or_enqueue_event(
                 recovery_counts=dict(event.recovery_counts),
             )
         )
-        commands.append(CommandRunWorker(step_id=step_id, event=event.event, id=id))
+        commands.append(
+            CommandRunWorker(
+                step_id=step_id,
+                event=event.event,
+                id=id,
+                bound_events=event.bound_events,
+            )
+        )
         commands.append(
             CommandPublishEvent(
                 StepStateChanged(
@@ -1251,9 +1324,18 @@ def _process_add_event_tick(
         ):
             handled = True
             _consume_superseded_delayed_attempt(tick, state.workers[step_name])
+            bound_events = tick.bound_events
+            if bound_events is None and state.workers[step_name].config.collect_params:
+                bound_events = _static_collect_events(
+                    event=tick.event,
+                    worker_state=state.workers[step_name],
+                )
+                if bound_events is None:
+                    continue
             subcommands = _add_or_enqueue_event(
                 EventAttempt(
                     event=tick.event,
+                    bound_events=bound_events,
                     attempts=tick.attempts,
                     first_attempt_at=tick.first_attempt_at,
                     last_exception=tick.last_exception,

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -904,6 +904,7 @@ def _process_step_result_tick(
                 # Clear collected_events and collected_waiters since workflow is complete
                 for worker in state.workers.values():
                     worker.collected_events.clear()
+                    worker.static_collect_events.clear()
                     worker.collected_waiters.clear()
                 commands.append(CommandCompleteRun(result=result.result))
             elif isinstance(result.result, Event):
@@ -1058,6 +1059,7 @@ def _process_step_result_tick(
                     CommandRunWorker(
                         step_id=step_id,
                         event=result.event,
+                        bound_events=this_execution.bound_events,
                         id=this_execution.worker_id,
                     )
                 )
@@ -1080,6 +1082,7 @@ def _process_step_result_tick(
             new_waiter = StepWorkerWaiter(
                 waiter_id=result.waiter_id,
                 event=this_execution.event,
+                bound_events=this_execution.bound_events,
                 waiting_for_event=result.event_type,
                 requirements=result.requirements,
                 has_requirements=bool(len(result.requirements)),
@@ -1301,7 +1304,10 @@ def _process_add_event_tick(
                 waiter_resolved_steps.add(step_name)
                 wait_condition.resolved_event = tick.event
                 subcommands = _add_or_enqueue_event(
-                    EventAttempt(event=wait_condition.event),
+                    EventAttempt(
+                        event=wait_condition.event,
+                        bound_events=wait_condition.bound_events,
+                    ),
                     step_id,
                     state.workers[step_name],
                     now_seconds,
@@ -1484,7 +1490,7 @@ def _process_waiter_timeout_tick(
         return state, commands
     waiter.timed_out = True
     subcommands = _add_or_enqueue_event(
-        EventAttempt(event=waiter.event),
+        EventAttempt(event=waiter.event, bound_events=waiter.bound_events),
         step_id,
         worker_state,
         now_seconds,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
@@ -27,12 +27,14 @@ class CommandRunWorker:
     step_id: StepId
     event: Event
     id: int
+    bound_events: dict[str, Event] | None = None
 
 
 @dataclass(frozen=True)
 class CommandQueueEvent:
     event: Event
     step_id: StepId | None = None
+    bound_events: dict[str, Event] | None = None
     attempts: int | None = None
     first_attempt_at: float | None = None
     last_exception: Exception | None = None

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -101,7 +101,11 @@ class BrokerState:
             ):
                 if waiter.has_requirements and not waiter.requirements:
                     commands.append(
-                        TickAddEvent(event=waiter.event, step_id=StepId.root(step_name))
+                        TickAddEvent(
+                            event=waiter.event,
+                            step_id=StepId.root(step_name),
+                            bound_events=waiter.bound_events,
+                        )
                     )
         return commands
 
@@ -160,6 +164,12 @@ class BrokerState:
                 SerializedWaiter(
                     waiter_id=waiter.waiter_id,
                     event=serializer.serialize(waiter.event),
+                    bound_events={
+                        name: serializer.serialize(event)
+                        for name, event in waiter.bound_events.items()
+                    }
+                    if waiter.bound_events is not None
+                    else None,
                     waiting_for_event=f"{waiter.waiting_for_event.__module__}.{waiter.waiting_for_event.__name__}",
                     has_requirements=bool(len(waiter.requirements))
                     or waiter.has_requirements,
@@ -253,6 +263,12 @@ class BrokerState:
                     StepWorkerWaiter(
                         waiter_id=waiter_data.waiter_id,
                         event=serializer.deserialize(waiter_data.event),
+                        bound_events={
+                            name: serializer.deserialize(event)
+                            for name, event in waiter_data.bound_events.items()
+                        }
+                        if waiter_data.bound_events is not None
+                        else None,
                         waiting_for_event=waiting_for_event,
                         requirements={},
                         has_requirements=waiter_data.has_requirements,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -83,6 +83,7 @@ class BrokerState:
                     config=step_func._step_config,
                     in_progress=[],
                     collected_events={},
+                    static_collect_events=[],
                     collected_waiters=[],
                 )
                 for name, step_func in workflow._get_steps().items()
@@ -113,6 +114,12 @@ class BrokerState:
             queue = [
                 SerializedEventAttempt(
                     event=serializer.serialize(attempt.event),
+                    bound_events={
+                        name: serializer.serialize(event)
+                        for name, event in attempt.bound_events.items()
+                    }
+                    if attempt.bound_events is not None
+                    else None,
                     attempts=attempt.attempts or 0,
                     first_attempt_at=attempt.first_attempt_at,
                     last_exception=attempt.last_exception,
@@ -123,11 +130,16 @@ class BrokerState:
                 for attempt in worker_state.queue
             ]
 
-            # Serialize in-progress events with full retry info so they can be
-            # re-queued on resume without restarting from attempt 0.
+            # Serialize in-progress attempts, including retry and fan-in binding state.
             in_progress = [
                 SerializedEventAttempt(
                     event=serializer.serialize(ip.event),
+                    bound_events={
+                        name: serializer.serialize(event)
+                        for name, event in ip.bound_events.items()
+                    }
+                    if ip.bound_events is not None
+                    else None,
                     attempts=ip.attempts or 0,
                     first_attempt_at=ip.first_attempt_at,
                     last_exception=ip.last_exception,
@@ -162,6 +174,10 @@ class BrokerState:
                 queue=queue,
                 in_progress=in_progress,
                 collected_events=collected_events,
+                static_collect_events=[
+                    serializer.serialize(ev)
+                    for ev in worker_state.static_collect_events
+                ],
                 collected_waiters=waiters,
             )
 
@@ -202,6 +218,12 @@ class BrokerState:
             worker.queue = [
                 EventAttempt(
                     event=serializer.deserialize(attempt.event),
+                    bound_events={
+                        name: serializer.deserialize(event)
+                        for name, event in attempt.bound_events.items()
+                    }
+                    if attempt.bound_events is not None
+                    else None,
                     attempts=attempt.attempts,
                     first_attempt_at=attempt.first_attempt_at,
                     last_exception=attempt.last_exception,
@@ -217,6 +239,9 @@ class BrokerState:
                 buffer_id: [serializer.deserialize(ev) for ev in events]
                 for buffer_id, events in worker_data.collected_events.items()
             }
+            worker.static_collect_events = [
+                serializer.deserialize(ev) for ev in worker_data.static_collect_events
+            ]
 
             # Restore waiters
             worker.collected_waiters = []
@@ -309,6 +334,7 @@ class EventAttempt:
     """
 
     event: Event
+    bound_events: dict[str, Event] | None = None
     attempts: int | None = None
     first_attempt_at: float | None = None
     last_exception: Exception | None = None
@@ -338,6 +364,7 @@ class InternalStepWorkerState:
     in_progress: list[InProgressState]
     collected_events: dict[str, list[Event]]
     collected_waiters: list[StepWorkerWaiter]
+    static_collect_events: list[Event] = field(default_factory=list)
 
     def _deepcopy(self) -> InternalStepWorkerState:
         return InternalStepWorkerState(
@@ -345,6 +372,7 @@ class InternalStepWorkerState:
             config=self.config,
             in_progress=[x._deepcopy() for x in self.in_progress],
             collected_events={k: list(v) for k, v in self.collected_events.items()},
+            static_collect_events=list(self.static_collect_events),
             collected_waiters=[dataclasses.replace(x) for x in self.collected_waiters],
         )
 
@@ -377,10 +405,12 @@ class InProgressState:
     last_exception: Exception | None = None
     last_failed_at: float | None = None
     recovery_counts: dict[str, int] = field(default_factory=dict)
+    bound_events: dict[str, Event] | None = None
 
     def _deepcopy(self) -> InProgressState:
         return InProgressState(
             event=self.event,
+            bound_events=dict(self.bound_events) if self.bound_events else None,
             worker_id=self.worker_id,
             shared_state=self.shared_state._deepcopy(),
             attempts=self.attempts,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -99,6 +99,8 @@ class StepWorkerWaiter(Generic[EventType]):
     has_requirements: bool
     # set to true when the waiting event has been resolved, such that the step can retrieve it
     resolved_event: EventType | None
+    # pre-bound fan-in parameters from the original worker invocation
+    bound_events: dict[str, Event] | None = None
     # set to true when the waiter has timed out, such that the step raises asyncio.TimeoutError
     timed_out: bool = False
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -109,6 +109,7 @@ class StepWorkerFunction(Protocol):
         step_name: str,
         event: Event,
         workflow: Workflow,
+        bound_events: dict[str, Event] | None = None,
         retry: RetryAttempt = RetryAttempt(),
     ) -> Awaitable[list[StepFunctionResult]]: ...
 
@@ -119,9 +120,13 @@ async def partial(
     event: Event,
     context: Context,
     workflow: Workflow,
+    collected_events: dict[str, Event] | None = None,
 ) -> Callable[[], Any]:
     kwargs: dict[str, Any] = {}
-    kwargs[step_config.event_name] = event
+    if collected_events is not None:
+        kwargs.update(collected_events)
+    else:
+        kwargs[step_config.event_name] = event
     if step_config.context_parameter:
         # Convert to internal face for step execution
         kwargs[step_config.context_parameter] = context
@@ -164,6 +169,7 @@ def as_step_worker_function(
         step_name: str,
         event: Event,
         workflow: Workflow,
+        bound_events: dict[str, Event] | None = None,
         retry: RetryAttempt = RetryAttempt(),
     ) -> list[StepFunctionResult]:
         from workflows.context.context import Context
@@ -247,6 +253,7 @@ def as_step_worker_function(
                 event=event,
                 context=internal_context,
                 workflow=workflow,
+                collected_events=bound_events,
             )
 
             try:

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -45,6 +45,7 @@ class TickAddEvent(BaseModel):
     type: Literal["add_event"] = "add_event"
     event: SerializableEvent
     step_id: StepId | None = Field(default=None, validation_alias="step_name")
+    bound_events: dict[str, SerializableEvent] | None = None
     attempts: int | None = None
     first_attempt_at: float | None = None
     last_exception: SerializableOptionalException = None

--- a/packages/llama-index-workflows/src/workflows/utils.py
+++ b/packages/llama-index-workflows/src/workflows/utils.py
@@ -122,6 +122,19 @@ def inspect_signature(
             context_parameter = name
             continue
 
+        # A ``list[E]`` parameter is reserved for collection fan-in over
+        # ``list[E]`` returns, which is not supported yet. Reject it with a
+        # pointer at the supported alternatives instead of falling through to
+        # the misleading "no Event parameter" error.
+        if _event_list_element_types(annotation) is not None:
+            msg = (
+                f"Parameter {name!r} is annotated as list[E] of Event types. "
+                "Collection fan-in parameters are not supported yet; declare "
+                "multiple single-event parameters for a multi-slot join, or "
+                "use ctx.collect_events() to gather events."
+            )
+            raise WorkflowValidationError(msg)
+
         # Collect name and types of the event param
         param_types = _get_param_types(t, type_hints)
         if all(
@@ -143,6 +156,37 @@ def inspect_signature(
     )
 
 
+def _event_list_element_types(annotation: Any) -> list[Any] | None:
+    """Element event types of a ``list[E]`` annotation, or None if not one."""
+    if get_origin(annotation) in (Union, UnionType):
+        members = [a for a in get_args(annotation) if a is not type(None)]
+        list_members = [a for a in members if get_origin(a) is list]
+        # Only unwrap the unambiguous ``list[E] | None`` shape: exactly one list
+        # member and no other non-None members.
+        if len(list_members) == 1 and len(members) == 1:
+            annotation = list_members[0]
+    if get_origin(annotation) is not list:
+        return None
+
+    element_types: list[Any] = []
+    for arg in get_args(annotation):
+        if get_origin(arg) in (Union, UnionType):
+            members = [a for a in get_args(arg) if a is not type(None)]
+        else:
+            members = [arg]
+        for member in members:
+            if member not in element_types:
+                element_types.append(member)
+    if not element_types:
+        return None
+    if all(
+        et is Event or (inspect.isclass(et) and issubclass(et, Event))
+        for et in element_types
+    ):
+        return element_types
+    return None
+
+
 def validate_step_signature(spec: StepSignatureSpec) -> None:
     """
     Validate that a step signature specification meets workflow requirements.
@@ -158,9 +202,20 @@ def validate_step_signature(spec: StepSignatureSpec) -> None:
     if num_of_events == 0:
         msg = "Step signature must have at least one parameter annotated as type Event"
         raise WorkflowValidationError(msg)
-    elif num_of_events > 1:
-        msg = f"Step signature must contain exactly one parameter of type Event but found {num_of_events}."
-        raise WorkflowValidationError(msg)
+    if num_of_events > 1:
+        # Collect-mode (multi-slot fan-in): a step with more than one
+        # event-shaped parameter fires once every declared slot is filled. Each
+        # parameter must name exactly one concrete event type; union-typed
+        # collect parameters (e.g. ``x: A | B``) are rejected.
+        for name, param_types in spec.accepted_events.items():
+            if len(param_types) != 1:
+                msg = (
+                    "Collect-mode steps (more than one event parameter) require "
+                    f"each event parameter to declare a single event type, but "
+                    f"parameter {name!r} declares {len(param_types)}. Union-typed "
+                    "collect parameters are not supported."
+                )
+                raise WorkflowValidationError(msg)
 
     if not spec.return_types:
         msg = "Return types of workflows step functions must be annotated with their type."

--- a/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
+++ b/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+from __future__ import annotations
+
+import pytest
+from workflows import Context, Workflow, step
+from workflows.context.internal_context import InternalContext
+from workflows.context.serializers import JsonSerializer
+from workflows.decorators import step as free_step
+from workflows.errors import WorkflowValidationError
+from workflows.events import Event, StartEvent, StopEvent
+from workflows.runtime.types.internal_state import BrokerState, EventAttempt
+
+
+class Header(Event):
+    value: str
+
+
+class Body(Event):
+    value: str
+
+
+class Footer(Event):
+    value: str
+
+
+class HeaderChild(Header):
+    pass
+
+
+class BodyChild(Body):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_three_param_heterogeneous_join_fires_once() -> None:
+    class AssembleWorkflow(Workflow):
+        @step
+        async def emit(
+            self, ctx: Context, ev: StartEvent
+        ) -> Header | Body | Footer | None:
+            ctx.send_event(Header(value="h"))
+            ctx.send_event(Body(value="b"))
+            ctx.send_event(Footer(value="f"))
+            return None
+
+        @step
+        async def assemble(self, h: Header, b: Body, f: Footer) -> StopEvent:
+            return StopEvent(result=f"{h.value}{b.value}{f.value}")
+
+    result = await AssembleWorkflow(timeout=10).run()
+    assert result == "hbf"
+
+
+@pytest.mark.asyncio
+async def test_heterogeneous_join_binds_by_parameter_type() -> None:
+    seen: dict[str, str] = {}
+
+    class OrderWorkflow(Workflow):
+        @step
+        async def emit(
+            self, ctx: Context, ev: StartEvent
+        ) -> Header | Body | Footer | None:
+            ctx.send_event(Footer(value="F"))
+            ctx.send_event(Header(value="H"))
+            ctx.send_event(Body(value="B"))
+            return None
+
+        @step
+        async def assemble(self, h: Header, b: Body, f: Footer) -> StopEvent:
+            seen["h"] = h.value
+            seen["b"] = b.value
+            seen["f"] = f.value
+            return StopEvent(result="ok")
+
+    await OrderWorkflow(timeout=10).run()
+    assert seen == {"h": "H", "b": "B", "f": "F"}
+
+
+@pytest.mark.asyncio
+async def test_heterogeneous_join_with_context_param() -> None:
+    class CtxWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> Header | Body | None:
+            ctx.send_event(Header(value="x"))
+            ctx.send_event(Body(value="y"))
+            return None
+
+        @step
+        async def assemble(self, ctx: Context, h: Header, b: Body) -> StopEvent:
+            await ctx.store.set("joined", h.value + b.value)
+            return StopEvent(result=await ctx.store.get("joined"))
+
+    result = await CtxWorkflow(timeout=10).run()
+    assert result == "xy"
+
+
+@pytest.mark.asyncio
+async def test_same_type_join_binds_by_arrival_order() -> None:
+    class SameTypeWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> Header | None:
+            ctx.send_event(Header(value="first"))
+            ctx.send_event(Header(value="second"))
+            return None
+
+        @step
+        async def assemble(self, first: Header, second: Header) -> StopEvent:
+            return StopEvent(result=f"{first.value},{second.value}")
+
+    result = await SameTypeWorkflow(timeout=10).run()
+    assert result == "first,second"
+
+
+@pytest.mark.asyncio
+async def test_same_type_join_releases_repeated_batches() -> None:
+    pairs: list[tuple[str, str]] = []
+
+    class SameTypeBatchWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> Header | None:
+            for value in ["a", "b", "c", "d"]:
+                ctx.send_event(Header(value=value))
+            return None
+
+        @step
+        async def assemble(self, first: Header, second: Header, ctx: Context) -> Body:
+            pairs.append((first.value, second.value))
+            count = await ctx.store.get("count", default=0) + 1
+            await ctx.store.set("count", count)
+            return Body(value=str(count))
+
+        @step
+        async def finish(self, ev: Body) -> StopEvent | None:
+            if ev.value == "2":
+                return StopEvent(result=list(pairs))
+            return None
+
+    result = await SameTypeBatchWorkflow(timeout=10).run()
+    assert result == [("a", "b"), ("c", "d")]
+
+
+@pytest.mark.asyncio
+async def test_collect_mode_honors_accept_event_subclasses() -> None:
+    class SubclassWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> Header | Body | None:
+            ctx.send_event(BodyChild(value="B"))
+            ctx.send_event(HeaderChild(value="H"))
+            return None
+
+        @step(accept_event_subclasses=True)
+        async def assemble(self, h: Header, b: Body) -> StopEvent:
+            return StopEvent(result=f"{h.value}{b.value}")
+
+    result = await SubclassWorkflow(timeout=10).run()
+    assert result == "HB"
+
+
+@pytest.mark.asyncio
+async def test_collect_mode_subclass_matching_handles_overlapping_slots() -> None:
+    class OverlapWorkflow(Workflow):
+        @step
+        async def emit(
+            self, ctx: Context, ev: StartEvent
+        ) -> Header | HeaderChild | None:
+            ctx.send_event(Header(value="parent"))
+            ctx.send_event(HeaderChild(value="child"))
+            return None
+
+        @step(accept_event_subclasses=True)
+        async def assemble(self, parent: Header, child: HeaderChild) -> StopEvent:
+            return StopEvent(result=f"{parent.value},{child.value}")
+
+    result = await OverlapWorkflow(timeout=10).run()
+    assert result == "parent,child"
+
+
+@pytest.mark.asyncio
+async def test_collect_mode_uses_private_buffer() -> None:
+    class BufferWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> Header | Body | None:
+            ctx.send_event(Header(value="h"))
+            ctx.send_event(Body(value="b"))
+            return None
+
+        @step
+        async def assemble(self, ctx: Context, h: Header, b: Body) -> StopEvent:
+            user_buffer = ctx.collect_events(b, [Header, Body])
+            return StopEvent(result=user_buffer is None)
+
+    result = await BufferWorkflow(timeout=10).run()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_collect_mode_does_not_call_collect_events(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_collect_events(*args: object, **kwargs: object) -> None:
+        raise AssertionError("static fan-in should not call collect_events")
+
+    monkeypatch.setattr(InternalContext, "collect_events", fail_collect_events)
+
+    class StaticFanInWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> Header | Body | None:
+            ctx.send_event(Header(value="h"))
+            ctx.send_event(Body(value="b"))
+            return None
+
+        @step
+        async def assemble(self, h: Header, b: Body) -> StopEvent:
+            return StopEvent(result=f"{h.value}{b.value}")
+
+    result = await StaticFanInWorkflow(timeout=10).run()
+    assert result == "hb"
+
+
+def test_collect_mode_state_serializes_static_buffers() -> None:
+    class SerializeWorkflow(Workflow):
+        @step
+        async def start(self, ev: StartEvent) -> None:
+            return None
+
+        @step
+        async def assemble(self, h: Header, b: Body) -> StopEvent:
+            return StopEvent(result=f"{h.value}{b.value}")
+
+    workflow = SerializeWorkflow()
+    serializer = JsonSerializer()
+    state = BrokerState.from_workflow(workflow)
+    worker = state.workers["assemble"]
+    worker.static_collect_events.append(Header(value="pending"))
+    worker.queue.append(
+        EventAttempt(
+            event=Body(value="trigger"),
+            bound_events={
+                "h": Header(value="bound-h"),
+                "b": Body(value="bound-b"),
+            },
+        )
+    )
+
+    restored = BrokerState.from_serialized(
+        state.to_serialized(serializer),
+        workflow,
+        serializer,
+    )
+    restored_worker = restored.workers["assemble"]
+
+    assert restored_worker.static_collect_events == [Header(value="pending")]
+    assert restored_worker.queue[0].bound_events == {
+        "h": Header(value="bound-h"),
+        "b": Body(value="bound-b"),
+    }
+
+
+def test_union_collect_param_rejected() -> None:
+    class _UnionWorkflow(Workflow):
+        pass
+
+    with pytest.raises(WorkflowValidationError, match="single event type"):
+
+        @free_step(workflow=_UnionWorkflow)
+        async def assemble(h: Header, b: Body | Footer) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+
+def test_list_event_param_rejected_with_forward_pointing_error() -> None:
+    class _ListWorkflow(Workflow):
+        pass
+
+    with pytest.raises(WorkflowValidationError, match="not supported yet"):
+
+        @free_step(workflow=_ListWorkflow)
+        async def collect(events: list[Header]) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")

--- a/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
+++ b/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
@@ -32,6 +32,14 @@ class BodyChild(Body):
     pass
 
 
+class Ping(Event):
+    value: str = ""
+
+
+class Done(Event):
+    pass
+
+
 @pytest.mark.asyncio
 async def test_three_param_heterogeneous_join_fires_once() -> None:
     class AssembleWorkflow(Workflow):
@@ -216,6 +224,71 @@ async def test_collect_mode_does_not_call_collect_events(
 
     result = await StaticFanInWorkflow(timeout=10).run()
     assert result == "hb"
+
+
+@pytest.mark.asyncio
+async def test_collect_mode_waiter_resume_preserves_static_bindings() -> None:
+    class WaiterWorkflow(Workflow):
+        @step
+        async def emit(
+            self, ctx: Context, ev: StartEvent
+        ) -> Header | Body | Ping | None:
+            ctx.send_event(Header(value="a"))
+            ctx.send_event(Body(value="b"))
+            ctx.send_event(Ping(value="p"))
+            return None
+
+        @step
+        async def join(self, ctx: Context, a: Header, b: Body) -> StopEvent:
+            ping = await ctx.wait_for_event(Ping)
+            return StopEvent(result=f"{a.value}{b.value}{ping.value}")
+
+    result = await WaiterWorkflow(timeout=10, disable_validation=True).run()
+    assert result == "abp"
+
+
+@pytest.mark.asyncio
+async def test_completed_run_clears_static_collect_events() -> None:
+    mode = {"run": 1}
+    joined: list[tuple[str, str]] = []
+
+    class CompletionWorkflow(Workflow):
+        @step
+        async def emit(
+            self, ctx: Context, ev: StartEvent
+        ) -> Header | Body | Done | None:
+            if mode["run"] == 1:
+                ctx.send_event(Header(value="old-h"))
+            else:
+                ctx.send_event(Body(value="new-b"))
+            ctx.send_event(Done())
+            return None
+
+        @step
+        async def incomplete_join(self, h: Header, b: Body) -> None:
+            joined.append((h.value, b.value))
+            return None
+
+        @step
+        async def finish(self, ev: Done) -> StopEvent:
+            return StopEvent(result=f"done-{mode['run']}")
+
+    workflow = CompletionWorkflow(timeout=10)
+    first = workflow.run()
+    assert await first == "done-1"
+    first_static_events = first.ctx.to_dict()["workers"]["incomplete_join"][
+        "static_collect_events"
+    ]
+    assert first_static_events == []
+
+    mode["run"] = 2
+    second = workflow.run(ctx=first.ctx)
+    assert await second == "done-2"
+    assert joined == []
+    second_static_events = second.ctx.to_dict()["workers"]["incomplete_join"][
+        "static_collect_events"
+    ]
+    assert second_static_events == []
 
 
 def test_collect_mode_state_serializes_static_buffers() -> None:

--- a/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
+++ b/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2026 LlamaIndex Inc.
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from workflows import Context, Workflow, step
 from workflows.context.internal_context import InternalContext
@@ -289,6 +291,50 @@ async def test_completed_run_clears_static_collect_events() -> None:
         "static_collect_events"
     ]
     assert second_static_events == []
+
+
+@pytest.mark.asyncio
+async def test_completed_run_clears_queued_and_in_progress_static_batches() -> None:
+    mode = {"run": 1}
+    joined: list[tuple[int, str, str]] = []
+
+    class CompletionWorkflow(Workflow):
+        @step
+        async def emit(
+            self, ctx: Context, ev: StartEvent
+        ) -> Header | Body | Done | None:
+            if mode["run"] == 1:
+                ctx.send_event(Header(value="h1"))
+                ctx.send_event(Body(value="b1"))
+                ctx.send_event(Header(value="h2"))
+                ctx.send_event(Body(value="b2"))
+            ctx.send_event(Done())
+            return None
+
+        @step(num_workers=1)
+        async def join(self, h: Header, b: Body) -> None:
+            joined.append((mode["run"], h.value, b.value))
+            await asyncio.sleep(0.05)
+            return None
+
+        @step
+        async def finish(self, ev: Done) -> StopEvent:
+            return StopEvent(result=f"done-{mode['run']}")
+
+    workflow = CompletionWorkflow(timeout=10)
+    first = workflow.run()
+    assert await first == "done-1"
+    first_worker = first.ctx.to_dict()["workers"]["join"]
+    assert first_worker["queue"] == []
+    assert first_worker["in_progress"] == []
+
+    mode["run"] = 2
+    second = workflow.run(ctx=first.ctx)
+    assert await second == "done-2"
+    assert joined == [(1, "h1", "b1")]
+    second_worker = second.ctx.to_dict()["workers"]["join"]
+    assert second_worker["queue"] == []
+    assert second_worker["in_progress"] == []
 
 
 def test_collect_mode_state_serializes_static_buffers() -> None:

--- a/packages/llama-index-workflows/tests/test_utils.py
+++ b/packages/llama-index-workflows/tests/test_utils.py
@@ -16,6 +16,7 @@ from workflows.decorators import step
 from workflows.errors import WorkflowValidationError
 from workflows.events import Event, StartEvent, StopEvent
 from workflows.utils import (
+    _event_list_element_types,
     _flatten_return_annotation,
     _get_param_types,
     _get_return_types,
@@ -125,24 +126,23 @@ def test_validate_step_signature_no_events() -> None:
         validate_step_signature(inspect_signature(f))
 
 
-def test_validate_step_signature_too_many_params() -> None:
+def test_validate_step_signature_multiple_single_event_params_is_collect_mode() -> None:
     def f1(self, ev: OneTestEvent, foo: OneTestEvent) -> None:  # noqa: ANN001
         pass
 
     def f2(ev: OneTestEvent, foo: OneTestEvent) -> None:
         pass
 
-    with pytest.raises(
-        WorkflowValidationError,
-        match="Step signature must contain exactly one parameter of type Event but found 2.",
-    ):
-        validate_step_signature(inspect_signature(f1))
+    validate_step_signature(inspect_signature(f1))
+    validate_step_signature(inspect_signature(f2))
 
-    with pytest.raises(
-        WorkflowValidationError,
-        match="Step signature must contain exactly one parameter of type Event but found 2.",
-    ):
-        validate_step_signature(inspect_signature(f2))
+
+def test_validate_step_signature_union_collect_param_rejected() -> None:
+    def f(ev: OneTestEvent, foo: AnotherTestEvent | OneTestEvent) -> StopEvent:
+        return StopEvent()
+
+    with pytest.raises(WorkflowValidationError, match="single event type"):
+        validate_step_signature(inspect_signature(f))
 
 
 def test_get_steps_from() -> None:
@@ -315,6 +315,26 @@ def test_validate_step_signature_accepts_list_return() -> None:
     spec = inspect_signature(f)
     # Should not raise: list[E] flattens to a real event return type.
     validate_step_signature(spec)
+
+
+def test_step_rejects_list_event_param_with_explicit_message() -> None:
+    with pytest.raises(WorkflowValidationError, match="not supported yet"):
+
+        @step
+        async def f(events: list[_EventA], ev: _EventB) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+
+def test_event_list_element_types_union_without_event_members_returns_none() -> None:
+    assert _event_list_element_types(list[int | str]) is None
+
+
+def test_event_list_element_types_mixed_members_returns_none() -> None:
+    assert _event_list_element_types(list[StartEvent | int]) is None
+
+
+def test_event_list_element_types_pure_event_list_is_recognized() -> None:
+    assert _event_list_element_types(list[StartEvent]) == [StartEvent]
 
 
 def test_flatten_return_annotation_unparameterized_collection_returns_empty() -> None:


### PR DESCRIPTION
Steps that need a fixed heterogeneous join currently have to accept a union event and call `ctx.collect_events` manually inside the step body. That makes the signature less precise and pushes the join shape out of validation.

This lets a step declare multiple single-event parameters and run once one event for each slot has arrived:

```python
@step
async def assemble(self, h: Header, b: Body, f: Footer) -> StopEvent:
    ...
```

The decorator records the ordered parameter slots on `StepConfig`, and routing sends each declared event type to the step. Static multi-parameter fan-in is resolved in the control loop: incoming events accumulate in a per-step fan-in buffer, and the worker is started only after the reducer can bind every declared slot. The worker receives the pre-bound parameter map and invokes user code directly, so this path does not call `ctx.collect_events` or use its retry/settling mechanics.

Repeated event types are supported by arrival order, and subclass-aware routing uses the shared event-matching helper so `accept_event_subclasses=True` applies consistently to route checks and slot binding. The static fan-in buffer and pre-bound worker inputs serialize through the current v2 context format, so partial joins, waiter resumes, and in-progress batches survive context persistence without adding another versioned in-progress field.

Completed runs clear pending queues, in-progress attempts, static fan-in buffers, collected events, and waiters, so a reused context cannot carry work from a prior completed run into a later run.

Union-typed collect parameters are rejected for now, and `list[E]` parameters fail with an explicit error because stream collection is not implemented here.