### PR TITLE
Join fan-out streams with list[E] parameters

### DIFF
--- a/.changeset/fan-out-fan-in.md
+++ b/.changeset/fan-out-fan-in.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": minor
+---
+
+Add `list[E]` fan-out returns and `list[E]` fan-in joins.

--- a/.changeset/fan-out-syntax.md
+++ b/.changeset/fan-out-syntax.md
@@ -1,5 +1,0 @@
----
-"llama-index-workflows": minor
----
-
-Steps can return `list[E]` to emit one event per element.

--- a/packages/llama-index-workflows/src/workflows/__init__.py
+++ b/packages/llama-index-workflows/src/workflows/__init__.py
@@ -3,7 +3,6 @@
 
 from pkgutil import extend_path
 
-from .collect import All, Cardinality, Collect, Take
 from .context import Context
 from .decorators import catch_error, step
 from .workflow import Workflow
@@ -12,11 +11,7 @@ __path__ = extend_path(__path__, __name__)
 
 
 __all__ = [
-    "All",
-    "Cardinality",
-    "Collect",
     "Context",
-    "Take",
     "Workflow",
     "catch_error",
     "step",

--- a/packages/llama-index-workflows/src/workflows/__init__.py
+++ b/packages/llama-index-workflows/src/workflows/__init__.py
@@ -3,6 +3,7 @@
 
 from pkgutil import extend_path
 
+from .collect import All, Cardinality, Collect, Take
 from .context import Context
 from .decorators import catch_error, step
 from .workflow import Workflow
@@ -11,7 +12,11 @@ __path__ = extend_path(__path__, __name__)
 
 
 __all__ = [
+    "All",
+    "Cardinality",
+    "Collect",
     "Context",
+    "Take",
     "Workflow",
     "catch_error",
     "step",

--- a/packages/llama-index-workflows/src/workflows/_stream_levels.py
+++ b/packages/llama-index-workflows/src/workflows/_stream_levels.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Static stream-level type traversal.
+
+A ``list[E]`` fan-out execution opens a *stream level*: the level contains the
+member types it emits plus everything reachable from them through 1:1 steps
+without crossing into another level. A nested fan-out consumer opens a child
+level; what it contributes back to the current level is the output of the
+collect steps bound to that child stream — collapsed recursively when a collect
+step itself fans out.
+
+This single traversal feeds both static validation
+(:mod:`workflows.representation.validate`) and runtime binding computation
+(:mod:`workflows.runtime.types.internal_state`); keep them on this one
+implementation so they cannot drift.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from workflows._event_matching import step_accepts_type
+from workflows.decorators import StepConfig
+from workflows.events import Event
+
+
+def event_types(types: Iterable[Any]) -> list[type[Event]]:
+    """Filter a type sequence down to concrete Event subclasses."""
+    return [t for t in types if isinstance(t, type) and issubclass(t, Event)]
+
+
+def same_level_types(
+    steps: dict[str, StepConfig],
+    seed_types: Iterable[Any],
+    guard: frozenset[str],
+) -> set[type[Event]]:
+    """Event types reachable from ``seed_types`` without changing stream level.
+
+    The ``guard`` holds producer step names already on the recursion path so
+    self-feeding fan-out loops terminate. Collect steps never continue the
+    walk directly: their members are absorbed at this level, and their outputs
+    surface one level up (handled by the caller's collapse).
+    """
+    collects: dict[str, tuple[Any, ...]] = {
+        name: cfg.collection_param[1]
+        for name, cfg in steps.items()
+        if cfg.collection_param is not None
+    }
+
+    def collapsed_outputs(producer: str, guard: frozenset[str]) -> set[type[Event]]:
+        """Types a fan-out execution surfaces at the level that triggered it.
+
+        Its members live in a child stream; what comes back to the trigger
+        level is the output of collect steps bound to that child stream. A
+        collect step that itself fans out opens yet another child stream, so
+        its contribution collapses recursively instead of injecting its raw
+        member types at this level.
+        """
+        child = walk(steps[producer].return_types, guard | {producer})
+        out: set[type[Event]] = set()
+        for collect_name, collect_event_types in collects.items():
+            collect_cfg = steps[collect_name]
+            if not any(
+                step_accepts_type(
+                    produced,
+                    collect_event_types,
+                    allow_subclasses=collect_cfg.accept_event_subclasses,
+                )
+                for produced in child
+            ):
+                continue
+            if collect_cfg.is_fan_out:
+                if collect_name not in guard:
+                    out |= collapsed_outputs(collect_name, guard | {collect_name})
+            else:
+                out |= set(event_types(collect_cfg.return_types))
+        return out
+
+    def walk(seeds: Iterable[Any], guard: frozenset[str]) -> set[type[Event]]:
+        seen: set[type[Event]] = set()
+        frontier: list[type[Event]] = list(event_types(seeds))
+        while frontier:
+            event_type = frontier.pop()
+            if event_type in seen:
+                continue
+            seen.add(event_type)
+            for name, cfg in steps.items():
+                if not step_accepts_type(
+                    event_type,
+                    cfg.accepted_events,
+                    allow_subclasses=cfg.accept_event_subclasses,
+                ):
+                    continue
+                if cfg.collection_param is not None:
+                    continue
+                if cfg.is_fan_out:
+                    if name in guard:
+                        continue
+                    frontier.extend(collapsed_outputs(name, guard))
+                    continue
+                frontier.extend(event_types(cfg.return_types))
+        return seen
+
+    return walk(seed_types, guard)
+
+
+def stream_level_types_by_producer(
+    steps: dict[str, StepConfig],
+) -> dict[str, set[type[Event]]]:
+    """Event types produced inside each returned-list producer's stream level."""
+    return {
+        name: same_level_types(steps, cfg.return_types, frozenset({name}))
+        for name, cfg in steps.items()
+        if cfg.is_fan_out
+    }

--- a/packages/llama-index-workflows/src/workflows/collect.py
+++ b/packages/llama-index-workflows/src/workflows/collect.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Collect selection algebra.
+
+The ``Collect`` marker and ``Cardinality`` hierarchy let a step declare *how* a
+collection fan-in parameter is released. They are used inside ``Annotated`` on a
+``list[E]`` parameter::
+
+    async def fastest(
+        events: Annotated[list[Result], Collect(Take(1))],
+    ) -> StopEvent: ...
+
+A bare ``list[E]`` parameter is exactly equivalent to ``Collect(All())`` — fire
+once when the stream closes with every collected event. ``Annotated[list[E],
+Collect()]`` is an explicit, grep-able synonym for the same default.
+
+Only ``All`` and ``Take`` are supported; any other cardinality raises a
+validation error instead of silently picking the wrong semantics. ``Collect``
+takes keyword-style construction, so future selection knobs can be added
+without breaking existing signatures.
+
+Semantics worth knowing:
+
+- Streams are runtime facts: a stream exists only for an execution that
+  actually returned a list. ``return []`` opens (and immediately closes) an
+  empty stream, so downstream joins fire once with ``[]``. ``return None``
+  (under ``list[E] | None``) emits nothing — no stream opens and joins do not
+  fire; the branch is dead like any other step returning ``None``.
+- A union producer (``-> list[A] | B``) returning a bare ``B`` is ordinary
+  dispatch; ``list[A]`` joins do not fire for that execution. When a type
+  appears both listed and bare (``-> list[A] | A``), a bare return is the
+  declared single member, not a one-element stream. A bare event whose type is
+  only declared inside the list (``-> list[A]`` returning ``A``) is a runtime
+  error.
+- ``ctx.send_event`` cannot add members to a collection stream. An untargeted
+  send that merely overlaps an open stream is ignored with a warning (it may
+  be legitimate traffic for other steps); a send *targeted* at the collect
+  step via ``step=...`` is an explicit instruction the runtime cannot honor
+  and raises a ``WorkflowRuntimeError``. The static validation error only
+  applies when no ``list[E]`` producer exists for the collect step at all.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class Cardinality:
+    """Base class for a collection-collect release strategy.
+
+    Subclasses describe *when* a collect-mode step fires and *which* members it
+    receives. Instantiate one of ``All`` / ``Take`` — the base class itself is
+    not a usable strategy.
+    """
+
+
+@dataclass(frozen=True)
+class All(Cardinality):
+    """Fire once when the stream closes, with every collected event (default)."""
+
+
+@dataclass(frozen=True)
+class Take(Cardinality):
+    """Fire once on the ``n``-th arrival with the first ``n`` events.
+
+    The remaining siblings keep running but never reach this step. If the stream
+    closes before ``n`` members arrive, the step fires once with whatever did
+    arrive.
+    """
+
+    n: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.n, int) or self.n < 1:
+            raise ValueError("Take(n) requires an integer n >= 1")
+
+
+@dataclass(frozen=True)
+class Collect:
+    """Marker for a collection fan-in parameter's selection behavior.
+
+    Wrap it around a ``list[E]`` parameter via ``Annotated``::
+
+        events: Annotated[list[E], Collect(Take(1))]
+
+    Attributes:
+        cardinality: When to release and which members to deliver. Defaults to
+            ``All()`` (fire on stream close with everything).
+    """
+
+    cardinality: Cardinality = field(default_factory=All)

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 from typing import Any
 
@@ -13,8 +15,9 @@ MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore
 # Serialization format version.
 #   v0: legacy nested-JSON-string format (SerializedContextV0).
 #   v1: structured format; per-worker ``in_progress`` was a list of event strings.
-#   v2: ``in_progress`` carries full attempts (retry counts and timestamps), so
-#       a resumed run does not silently restart in-flight work from attempt 0.
+#   v2: per-worker ``in_progress`` carries full attempts (retry counts and
+#       timestamps); collection stream attempts carry ``scope_path`` and collect
+#       invocations carry explicit release payloads.
 CURRENT_SERIALIZED_VERSION = 2
 
 
@@ -92,6 +95,20 @@ class SerializedEventAttempt(BaseModel):
     # be dispatched (retry delay), or None if eligible immediately. Additive:
     # older payloads validate with the default.
     not_before: float | None = None
+    # Collection stream scope path (innermost stream id last).
+    scope_path: list[str] = Field(default_factory=list)
+    # Explicit collect invocation payload, serialized only for queued/in-progress
+    # list[E] collect executions.
+    collection_release_payload: SerializedCollectionReleasePayload | None = None
+
+
+class SerializedCollectionReleasePayload(BaseModel):
+    """Serialized list-collect invocation payload."""
+
+    binding_id: str
+    stream_id: str
+    events: list[str] = Field(default_factory=list)
+    output_scope_path: list[str] = Field(default_factory=list)
 
 
 class SerializedWaiter(BaseModel):
@@ -109,6 +126,11 @@ class SerializedWaiter(BaseModel):
     has_requirements: bool = Field(default=False)
     # Resolved event if available (serialized), None otherwise
     resolved_event: str | None = None
+    # Originating work record: collection stream scope of the suspended work
+    # item (innermost stream id last).
+    scope_path: list[str] = Field(default_factory=list)
+    # For a suspended collect invocation, the release batch to re-invoke with.
+    collection_release_payload: SerializedCollectionReleasePayload | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -128,8 +150,8 @@ class SerializedStepWorkerState(BaseModel):
 
     # Queue of events waiting to be processed (with retry info)
     queue: list[SerializedEventAttempt] = Field(default_factory=list)
-    # Events currently being processed. Serialized with full retry info so a
-    # resumed run re-queues them without losing attempt counts or fan-in bindings.
+    # Events currently being processed. Serialized with full retry + stream scope
+    # so a resumed run re-queues them without losing collection liveness.
     in_progress: list[SerializedEventAttempt] = Field(default_factory=list)
     # Collected events for ctx.collect_events(), keyed by buffer_id -> [event, ...]
     # Events are serialized strings
@@ -138,6 +160,25 @@ class SerializedStepWorkerState(BaseModel):
     static_collect_events: list[str] = Field(default_factory=list)
     # Active waiters created by ctx.wait_for_event()
     collected_waiters: list[SerializedWaiter] = Field(default_factory=list)
+
+
+class SerializedCollectionStreamInstance(BaseModel):
+    """Serialized representation of an open collection stream."""
+
+    stream_id: str
+    source_step: str
+    scope_path: list[str] = Field(default_factory=list)
+    open_work_items: int = 0
+    accepting_binding_ids: list[str] = Field(default_factory=list)
+
+
+class SerializedCollectionReleaseState(BaseModel):
+    """Serialized release state for one binding inside one stream."""
+
+    binding_id: str
+    stream_id: str
+    buffer: list[str] = Field(default_factory=list)
+    released: bool = False
 
 
 class SerializedContext(BaseModel):
@@ -158,6 +199,14 @@ class SerializedContext(BaseModel):
     # Per-step worker state with queues, in-progress events, collected events, and waiters
     # Maps step_name -> SerializedStepWorkerState
     workers: dict[str, SerializedStepWorkerState] = Field(default_factory=dict)
+
+    # Monotonic stream-id counter. Persisted so a resumed run keeps minting
+    # unique, deterministic stream ids.
+    stream_seq: int = Field(default=0)
+    streams: dict[str, SerializedCollectionStreamInstance] = Field(default_factory=dict)
+    collection_release_states: dict[str, SerializedCollectionReleaseState] = Field(
+        default_factory=dict
+    )
 
     @staticmethod
     def from_v0(v0: SerializedContextV0) -> "SerializedContext":
@@ -233,7 +282,7 @@ class SerializedContext(BaseModel):
 
         v1 serialized each worker's ``in_progress`` as a list of event strings.
         v2 serializes them as full SerializedEventAttempt entries so a resumed
-        run keeps retry counts.
+        run keeps retry counts and stream scope.
         """
         migrated = dict(data)
         migrated["version"] = CURRENT_SERIALIZED_VERSION
@@ -257,7 +306,7 @@ class SerializedContext(BaseModel):
         A missing ``version`` routes to the legacy V0 parser. An unrecognized
         version, newer than this library supports, or not an int, fails
         loudly: routing it to an older parser would "succeed" while silently
-        dropping state.
+        dropping state (workers, streams).
         """
         version = data.get("version")
         if version is None:

--- a/packages/llama-index-workflows/src/workflows/context/internal_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/internal_context.py
@@ -160,9 +160,8 @@ class InternalContext(Generic[MODEL_T]):
 
         recovery_counts: dict[str, int] = {}
         try:
-            recovery_counts = dict(
-                StepWorkerStateContextVar.get().retry.recovery_counts
-            )
+            step_ctx = StepWorkerStateContextVar.get()
+            recovery_counts = dict(step_ctx.retry.recovery_counts)
         except LookupError:
             pass
 

--- a/packages/llama-index-workflows/src/workflows/decorators.py
+++ b/packages/llama-index-workflows/src/workflows/decorators.py
@@ -20,6 +20,7 @@ from typing import (
 
 from pydantic import BaseModel
 
+from .collect import Collect
 from .errors import WorkflowValidationError
 from .events import StepFailedEvent
 from .resource import ResourceDefinition
@@ -56,14 +57,26 @@ class StepConfig:
     # step fires once when one event of each type has arrived. None for the
     # ordinary single-event-trigger model.
     collect_params: list[tuple[str, Any]] | None = None
-    # Fan-out producer: True when the return annotation is ``list[E]``. Computed
-    # at decoration time from the return annotation; only an actual list return
-    # emits per element.
+    # Fan-out producer: True when the return annotation is ``list[E]``. Such
+    # a step MAY mint a fresh stream per execution — whether it does is a
+    # runtime fact: only an actual list return opens a stream. Computed at
+    # decoration time from the return annotation; used for binding computation
+    # and validation.
     is_fan_out: bool = False
     # Non-list members of a fan-out return union (``-> list[A] | B`` -> (B,)).
     # A bare return of one of these types is ordinary dispatch; any other bare
     # event under a list-returning annotation is a runtime error.
     bare_return_types: tuple[Any, ...] = ()
+    # Collection-stream fan-in: set to ``(parameter_name, element_event_types)``
+    # when the step declares a single ``list[E]`` parameter. The element types are
+    # a tuple — ``list[Done]`` -> ``(Done,)``; a union flat list ``list[A | B]`` ->
+    # ``(A, B)`` (every member routes to the step). The step buffers incoming
+    # members by innermost stream id and releases per ``collection_policy``.
+    collection_param: tuple[str, tuple[Any, ...]] | None = None
+    # The resolved ``Collect`` marker for the collection parameter. A bare
+    # ``list[E]`` parameter resolves to ``Collect()`` (``All``). None for steps
+    # without a collection parameter.
+    collection_policy: Collect | None = None
     role: StepRole = "step"
     # Only meaningful when role == "catch_error".
     # None means wildcard — covers any step not claimed by a scoped handler.
@@ -239,6 +252,8 @@ def make_step_function(
         collect_params=collect_params,
         is_fan_out=spec.is_fan_out,
         bare_return_types=tuple(spec.bare_return_types),
+        collection_param=spec.collection_param,
+        collection_policy=spec.collection_policy,
         accept_event_subclasses=accept_event_subclasses,
     )
 
@@ -378,12 +393,7 @@ def _capture_decorator_localns() -> dict[str, Any]:
         return {}
 
     try:
-        decorator_frame = frame.f_back
-        localns: dict[str, Any] = {}
-        localns.update(decorator_frame.f_locals)
-        if decorator_frame.f_back is not None:
-            localns.update(decorator_frame.f_back.f_locals)
-        return localns
+        return _merge_ancestor_locals(frame.f_back, depth=4)
     finally:
         del frame
 
@@ -394,11 +404,20 @@ def _capture_callsite_localns() -> dict[str, Any]:
         return {}
 
     try:
-        callsite_frame = frame.f_back.f_back
-        localns: dict[str, Any] = {}
-        localns.update(callsite_frame.f_locals)
-        if callsite_frame.f_back is not None:
-            localns.update(callsite_frame.f_back.f_locals)
-        return localns
+        return _merge_ancestor_locals(frame.f_back.f_back, depth=3)
     finally:
         del frame
+
+
+def _merge_ancestor_locals(start: Any, depth: int) -> dict[str, Any]:
+    frames: list[Any] = []
+    f = start
+    for _ in range(depth):
+        if f is None:
+            break
+        frames.append(f)
+        f = f.f_back
+    localns: dict[str, Any] = {}
+    for fr in reversed(frames):
+        localns.update(fr.f_locals)
+    return localns

--- a/packages/llama-index-workflows/src/workflows/events.py
+++ b/packages/llama-index-workflows/src/workflows/events.py
@@ -374,8 +374,11 @@ class WorkflowFailedEvent(StopEvent):
         step_name: The name of the step that failed.
         exception: The raised exception. ``__traceback__`` is present only
             in-process; ``None`` after a replay.
-        attempts: The total number of attempts made before giving up.
-        elapsed_seconds: Time in seconds from first attempt to final failure.
+        attempts: The total number of attempts made before giving up, or
+            ``None`` when the failure is not an exhausted step attempt (e.g.
+            a runtime-detected stuck run).
+        elapsed_seconds: Time in seconds from first attempt to final failure,
+            or ``None`` when not applicable.
 
     Examples:
         ```python
@@ -388,8 +391,26 @@ class WorkflowFailedEvent(StopEvent):
 
     step_name: str
     exception: SerializableException
-    attempts: int
-    elapsed_seconds: float
+    attempts: int | None = None
+    elapsed_seconds: float | None = None
+
+
+class CollectionReleaseEvent(Event):
+    """Internal: invokes a collect step with one released batch.
+
+    This is the trigger event of a collect-step invocation work item — never a
+    member of the stream itself. The authoritative record of the batch is the
+    work item's collection release payload; the runtime derives this event from
+    that payload at every (re)delivery so the two cannot diverge.
+
+    Surfaces publicly as `StepFailedEvent.input_event` when a collect step
+    fails into a `@catch_error` handler: ``events`` is the real released batch
+    (possibly empty for an empty stream).
+    """
+
+    events: list[SerializableEvent] = Field(default_factory=list)
+    stream_id: str = ""
+    binding_id: str = ""
 
 
 class StepFailedEvent(Event):

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -7,6 +7,11 @@ from collections.abc import Iterable
 from dataclasses import dataclass, field
 
 from workflows._event_matching import is_subclass, step_accepts_type, type_matches
+from workflows._stream_levels import (
+    event_types,
+    same_level_types,
+    stream_level_types_by_producer,
+)
 from workflows.decorators import CatchErrorHandler, StepConfig, WorkflowGraphCheck
 from workflows.errors import WorkflowConfigurationError, WorkflowValidationError
 from workflows.events import (
@@ -634,6 +639,112 @@ class _WorkflowValidationResult:
     uses_hitl: bool
 
 
+def _validate_collection_bindings(steps: dict[str, StepConfig]) -> None:
+    """Require list[E] fan-in to bind to a static returned-list producer."""
+
+    level_types_by_producer = stream_level_types_by_producer(steps)
+    errors: list[str] = []
+    for step_name, cfg in steps.items():
+        if cfg.collection_param is None:
+            continue
+        param_name, element_types = cfg.collection_param
+        missing = [
+            event_type
+            for event_type in event_types(element_types)
+            if not any(
+                type_matches(
+                    produced,
+                    event_type,
+                    allow_subclasses=cfg.accept_event_subclasses,
+                )
+                for level_types in level_types_by_producer.values()
+                for produced in level_types
+            )
+        ]
+        if missing:
+            names = ", ".join(sorted(t.__name__ for t in missing))
+            errors.append(
+                f"Step '{step_name}' parameter '{param_name}' collects "
+                f"list[{names}], but no returned-list producer creates a stream "
+                "for those event types. list[E] fan-in only consumes events "
+                "from steps annotated as returning list[E]; use ctx.collect_events "
+                "for unstreamed ctx.send_event flows."
+            )
+    if errors:
+        raise WorkflowValidationError("\n".join(errors))
+
+
+def _validate_multi_slot_levels(
+    steps: dict[str, StepConfig],
+    start_event_class: type[StartEvent],
+) -> None:
+    """Reject multi-slot joins whose slots cannot fill at one stream level.
+
+    A multi-slot step fires when one event of each declared type has arrived,
+    and its output continues at the scope of its inputs. That is only
+    well-defined when every slot type is producible at a common stream level
+    (the top level, or one returned-list producer's stream). Mixing levels
+    would strand work items: a slot filled at one level waits forever for a
+    slot that only fills at another.
+
+    Rejected shape:
+
+        fan_out(StartEvent) -> list[A]      # A is inside fan_out's stream
+        emit_b(StartEvent) -> B             # B is top-level
+        join(a: A, b: B) -> C               # no single level contains A and B
+    """
+    multi_slot = {
+        name: cfg.collect_params
+        for name, cfg in steps.items()
+        if cfg.collect_params is not None
+    }
+    if not multi_slot:
+        return
+
+    external_seeds = [
+        event_type
+        for cfg in steps.values()
+        for event_type in cfg.accepted_events
+        if isinstance(event_type, type) and issubclass(event_type, HumanResponseEvent)
+    ]
+    levels: dict[str, set[type[Event]]] = {
+        "the top level": same_level_types(
+            steps, [start_event_class, *external_seeds], frozenset()
+        )
+    }
+    for producer, level_types in stream_level_types_by_producer(steps).items():
+        levels[f"the stream of step '{producer}'"] = level_types
+
+    errors: list[str] = []
+    for step_name, slots in multi_slot.items():
+        slot_types = {slot_type for _, slot_type in slots or []}
+        if any(slot_types <= level_types for level_types in levels.values()):
+            continue
+        slot_levels = "; ".join(
+            f"'{param_name}' ({slot_type.__name__}) is produced at "
+            + (
+                ", ".join(
+                    sorted(
+                        level_name
+                        for level_name, level_types in levels.items()
+                        if slot_type in level_types
+                    )
+                )
+                or "no level"
+            )
+            for param_name, slot_type in slots or []
+        )
+        errors.append(
+            f"Step '{step_name}' joins event parameters that are never produced "
+            f"at a common stream level: {slot_levels}. A multi-slot join only "
+            "fires when all of its inputs originate at the same level. To gate "
+            "in-stream work on input from another level, use ctx.wait_for_event "
+            "inside the producing step instead."
+        )
+    if errors:
+        raise WorkflowValidationError("\n".join(errors))
+
+
 def _validate_workflow(
     steps: dict[str, StepConfig],
     workflow_cls_name: str,
@@ -658,6 +769,9 @@ def _validate_workflow(
 
     start_event_class = _ensure_start_event_class(steps, workflow_cls_name)
     stop_event_class = _ensure_stop_event_class(steps, workflow_cls_name)
+
+    _validate_collection_bindings(steps)
+    _validate_multi_slot_levels(steps, start_event_class)
 
     uses_hitl = _validate_event_connectivity(steps, start_event_class)
 

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -12,9 +12,15 @@ import time
 from collections.abc import AsyncIterable
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
-from workflows._event_matching import event_matches, step_accepts_event
+from workflows._event_matching import (
+    event_matches,
+    step_accepts_event,
+    step_accepts_type,
+)
+from workflows.collect import Collect, Take
 from workflows.errors import (
     WorkflowCancelledByUser,
     WorkflowRuntimeError,
@@ -51,6 +57,9 @@ from workflows.runtime.types.commands import (
 )
 from workflows.runtime.types.internal_state import (
     BrokerState,
+    CollectionBinding,
+    CollectionReleaseState,
+    CollectionStreamInstance,
     EventAttempt,
     InProgressState,
     InternalStepWorkerState,
@@ -70,6 +79,7 @@ from workflows.runtime.types.plugin import (
 from workflows.runtime.types.results import (
     AddCollectedEvent,
     AddWaiter,
+    CollectionReleasePayload,
     DeleteCollectedEvent,
     DeleteWaiter,
     RetryAttempt,
@@ -314,12 +324,8 @@ class _ControlLoopRunner:
                 TickAddEvent(
                     event=command.event,
                     step_id=command.step_id,
-                    bound_events=command.bound_events,
-                    attempts=command.attempts,
-                    first_attempt_at=command.first_attempt_at,
-                    last_exception=command.last_exception,
-                    last_failed_at=command.last_failed_at,
                     recovery_counts=dict(command.recovery_counts),
+                    scope_path=command.scope_path,
                 )
             )
             return None
@@ -428,7 +434,7 @@ class _ControlLoopRunner:
                 raise
 
         # Initialize pull task (single-iteration)
-        pull_task: asyncio.Task[WorkflowTick | None] | None = None
+        pull_task: asyncio.Task[list[WorkflowTick]] | None = None
 
         # Main event loop
         try:
@@ -728,6 +734,22 @@ def _reduce_tick(
     elif isinstance(tick, TickIdleCheck):
         # Return early — idle check ticks don't schedule further idle checks
         if _check_idle_state(init):
+            stuck = _detect_stuck_streams(init)
+            if stuck is not None:
+                stuck_step, stuck_error = stuck
+                state = init.deepcopy()
+                state.is_running = False
+                return state, [
+                    CommandPublishEvent(
+                        event=WorkflowFailedEvent(
+                            step_name=stuck_step,
+                            exception=stuck_error,
+                        )
+                    ),
+                    CommandFailWorkflow(
+                        step_id=StepId.root(stuck_step), exception=stuck_error
+                    ),
+                ]
             return init, [CommandPublishEvent(WorkflowIdleEvent())]
         return init, []
     elif isinstance(tick, TickWakeup):
@@ -835,6 +857,8 @@ def rewind_in_progress(
                     last_exception=in_progress.last_exception,
                     last_failed_at=in_progress.last_failed_at,
                     recovery_counts=dict(in_progress.recovery_counts),
+                    scope_path=in_progress.scope_path,
+                    collection_release_payload=in_progress.shared_state.collection_release_payload,
                 ),
             )
         step_state.in_progress = []
@@ -871,6 +895,264 @@ def _collect_buffer_diverged(live: list[Event], snapshot: list[Event]) -> bool:
     """True when a live ctx.collect_events() buffer no longer matches a snapshot."""
     return len(live) != len(snapshot) or any(a is not b for a, b in zip(live, snapshot))
 
+
+def _detect_stuck_streams(
+    state: BrokerState,
+) -> tuple[str, WorkflowRuntimeError] | None:
+    """Detect a provably-stuck run while the state is quiescent.
+
+    Two conditions, returned as ``(step_name, error)``:
+
+    - An unreleased release-state whose stream no longer exists. The close
+      path fires releases inline within the same reduce, so this should be
+      impossible; if it ever appears (corrupted or version-skewed persisted
+      state), the release can never fire — fail loudly instead of hanging.
+    - Open streams with no unresolved waiter *inside any of them*. A pending
+      in-stream waiter represents scoped work that can still resume and close
+      the stream. Without runnable work or such a waiter, an open stream can
+      never reach zero open work items: the run would hang to timeout (or
+      forever).
+    """
+    orphaned = next(
+        (
+            release
+            for release in state.collection_release_states.values()
+            if not release.released and release.stream_id not in state.streams
+        ),
+        None,
+    )
+    if orphaned is not None:
+        binding = state.config.collection_bindings.get(orphaned.binding_id)
+        step_name = binding.target_step if binding is not None else "<unknown>"
+        return step_name, WorkflowRuntimeError(
+            f"Workflow is idle with a pending collect release for step "
+            f"{step_name!r} (binding {orphaned.binding_id!r}) whose stream "
+            f"{orphaned.stream_id!r} no longer exists, so the release can "
+            "never fire. This indicates corrupted persisted state (e.g. a "
+            "snapshot written by an incompatible library version)."
+        )
+    if not state.streams:
+        return None
+    has_in_stream_waiter = any(
+        waiter.resolved_event is None
+        and not waiter.timed_out
+        and any(sid in state.streams for sid in waiter.scope_path)
+        for worker_state in state.workers.values()
+        for waiter in worker_state.collected_waiters
+    )
+    if has_in_stream_waiter:
+        return None
+    first_leaked = next(iter(state.streams.values()))
+    details = "; ".join(
+        f"stream {stream.stream_id!r} opened by step {stream.source_step!r} "
+        f"with {stream.open_work_items} open work item(s)"
+        for stream in state.streams.values()
+    )
+    return first_leaked.source_step, WorkflowRuntimeError(
+        "Workflow is idle but collection streams are still open, so the run "
+        f"can never complete: {details}. No queued, running, or resumable "
+        "scoped work remains that can close the stream. This indicates "
+        "corrupted persisted state, incompatible workflow/runtime changes "
+        "since the run was snapshotted, or a runtime stream-accounting bug."
+    )
+
+
+def _mint_stream_id(
+    state: BrokerState, scope_path: tuple[str, ...], step_name: str
+) -> str:
+    seq = state.stream_seq
+    state.stream_seq = seq + 1
+    path = ">".join(scope_path)
+    digest = hashlib.sha256(f"{path}:{step_name}:{seq}".encode()).hexdigest()
+    return f"stream-{digest[:16]}"
+
+
+def _clear_collection_state(state: BrokerState) -> None:
+    state.streams.clear()
+    state.collection_release_states.clear()
+
+
+def _count_accepting_steps(state: BrokerState, event_type: type) -> int:
+    """Number of steps that accept ``event_type`` — the work-item fan-out factor.
+
+    An event routed at a stream level becomes one work item per accepting step
+    (1:1 *and* collect steps count). This is the per-emission birth count for the
+    open_work_items set: a single emitted event accepted by N steps is N work
+    items. Must mirror the routing predicate in ``_process_add_event_tick``
+    exactly (including subclass-aware acceptance) — a birth count that differs
+    from the delivery count drifts the stream counter.
+    """
+    return sum(
+        1
+        for cfg in state.config.steps.values()
+        if step_accepts_type(
+            event_type,
+            cfg.accepted_events,
+            allow_subclasses=cfg.accept_event_subclasses,
+        )
+    )
+
+
+def _apply_stream_work_delta(
+    state: BrokerState, stream_id: str | None, delta: int, now_seconds: float
+) -> list[WorkflowCommand]:
+    if stream_id is None:
+        return []
+    stream = state.streams.get(stream_id)
+    if stream is None:
+        if delta < 0:
+            logger.warning(
+                "Stream accounting: ignoring a work-item decrement for "
+                "unknown or already-closed stream %r.",
+                stream_id,
+            )
+        return []
+    stream.open_work_items += delta
+    if stream.open_work_items < 0:
+        # Provably corrupt accounting. Log loudly and let the <= 0 close
+        # below fail fast instead of wedging the stream open.
+        logger.error(
+            "Stream accounting: open_work_items went negative (%d) for "
+            "stream %r from step %r. This is a runtime accounting bug.",
+            stream.open_work_items,
+            stream_id,
+            stream.source_step,
+        )
+    if stream.open_work_items <= 0:
+        return _close_collection_stream(state, stream_id, now_seconds)
+    return []
+
+
+def _close_collection_stream(
+    state: BrokerState, stream_id: str, now_seconds: float
+) -> list[WorkflowCommand]:
+    """Close a zero-count stream and release any buffered collection batches."""
+    stream = state.streams.pop(stream_id, None)
+    if stream is None:
+        return []
+    commands: list[WorkflowCommand] = []
+    for binding in state.config.bindings_for_source(stream.source_step):
+        worker_state = state.workers.get(binding.target_step)
+        if worker_state is None or worker_state.config.collection_param is None:
+            continue
+        key = _release_state_key(stream_id, binding.id)
+        release_state = state.collection_release_states.pop(
+            key,
+            CollectionReleaseState(
+                binding_id=binding.id,
+                stream_id=stream_id,
+            ),
+        )
+        release = _release_on_close(binding, release_state)
+        if release is None:
+            continue
+        commands.extend(
+            _fire_collection_release(
+                binding,
+                stream_id,
+                worker_state,
+                release,
+                tuple(stream.scope_path),
+                now_seconds,
+            )
+        )
+    return commands
+
+
+def _queue_catch_error_event(
+    this_execution: InProgressState,
+    *,
+    event: Event,
+    step_id: StepId,
+    recovery_counts: dict[str, int],
+) -> CommandQueueEvent:
+    """Build a catch_error dispatch in the failed work item's stream scope."""
+    return CommandQueueEvent(
+        event=event,
+        step_id=step_id,
+        recovery_counts=recovery_counts,
+        scope_path=this_execution.scope_path,
+    )
+
+
+def _take_threshold(collect: Collect | None) -> int | None:
+    if collect is None:
+        return None
+    card = collect.cardinality
+    if isinstance(card, Take):
+        return card.n
+    return None
+
+
+class WorkDisposition(Enum):
+    """What happened to a work item when its execution finished.
+
+    Stream accounting hinges on answering this exactly once per finished
+    execution: COMPLETED and ABSORBED consume the item (adjusting the
+    enclosing stream's open-work counter), FANNED_OUT consumes it into a
+    child stream, STILL_LIVE and RUN_ENDING leave the counter untouched.
+    """
+
+    # Consumed; same-scope successors (one per accepting step per emitted
+    # event) replace it in the enclosing stream.
+    COMPLETED = "completed"
+    # Consumed; the execution returned a list and opened a child stream.
+    FANNED_OUT = "fanned_out"
+    # Not consumed: the same work item re-delivers later (collect-buffer
+    # rerun, scheduled retry, catch_error handler routing, or a waiter
+    # suspension that resumes it whole).
+    STILL_LIVE = "still_live"
+    # Consumed; the invocation only buffered its trigger into a multi-slot
+    # join (or silently dropped a duplicate arrival) and emitted nothing.
+    ABSORBED = "absorbed"
+    # The run is over (StopEvent, halt, or workflow failure); accounting moot.
+    RUN_ENDING = "run_ending"
+
+
+def _classify_work_item(
+    tick: TickStepResult,
+    commands: list[WorkflowCommand],
+    *,
+    rerun_scheduled: bool,
+    redelivery_scheduled: bool,
+    fanned_out: bool,
+) -> WorkDisposition:
+    """Classify a finished execution's work item, positively, in one place.
+
+    Every case matches on what *did* happen (results returned, commands
+    emitted). An unrecognized combination raises instead of falling into a
+    residual bucket — a silently misclassified work item drifts the stream
+    counter and wedges or prematurely closes the stream.
+    """
+    did_complete_step = any(isinstance(x, StepWorkerResult) for x in tick.result)
+    step_failed = any(isinstance(x, StepWorkerFailed) for x in tick.result)
+    added_waiter = any(isinstance(x, AddWaiter) for x in tick.result)
+    step_name = _root_step_key(tick.step_id)
+
+    if any(indicates_exit(c) for c in commands):
+        return WorkDisposition.RUN_ENDING
+    if rerun_scheduled:
+        # The same invocation reruns against a fresh collect-buffer snapshot;
+        # only its final completion may consume the work item.
+        return WorkDisposition.STILL_LIVE
+    if step_failed and redelivery_scheduled:
+        # Retry attempts may live directly in BrokerState, so the reducer tells
+        # us explicitly when the failed work item was re-delivered.
+        return WorkDisposition.STILL_LIVE
+    if did_complete_step:
+        return WorkDisposition.FANNED_OUT if fanned_out else WorkDisposition.COMPLETED
+    if added_waiter:
+        return WorkDisposition.STILL_LIVE
+    if all(isinstance(x, AddCollectedEvent) for x in tick.result):
+        # Only buffer writes (or no recorded results at all — a duplicate
+        # arrival for an already-filled slot): the invocation is over and
+        # emitted nothing.
+        return WorkDisposition.ABSORBED
+    raise WorkflowRuntimeError(
+        f"Cannot classify finished execution of step {step_name!r} for "
+        f"stream accounting: results={[type(r).__name__ for r in tick.result]}. "
+        "This is a runtime bug."
+    )
 
 def _process_step_result_tick(
     tick: TickStepResult,
@@ -924,10 +1206,28 @@ def _process_step_result_tick(
 
     output_event_name: str | None = None
 
-    did_complete_step = bool(
-        [x for x in tick.result if isinstance(x, StepWorkerResult)]
-    )
+    did_complete_step = any(isinstance(x, StepWorkerResult) for x in tick.result)
     step_no_longer_in_progress = True
+    redelivery_scheduled = False
+
+    # Collection stream scope. The trigger path is carried on the in-progress
+    # state. Streams are runtime facts: an execution that actually returned a
+    # list (worker-reported via ``fanned_out``) mints ONE fresh stream id,
+    # stamps every event it emits, then closes the stream. An execution of a
+    # fan-out-annotated step that took a non-list branch (None or a declared
+    # bare union member) mints nothing. A 1:1 step's outputs inherit the
+    # trigger stack verbatim.
+    trigger_stack = this_execution.scope_path
+    fanned_out = any(
+        isinstance(x, StepWorkerResult) and x.fanned_out for x in tick.result
+    )
+    fan_out_stream_id: str | None = None
+    if fanned_out:
+        fan_out_stream_id = _mint_stream_id(state, trigger_stack, step_name)
+    if fan_out_stream_id is not None:
+        emit_stack: tuple[str, ...] = trigger_stack + (fan_out_stream_id,)
+    else:
+        emit_stack = trigger_stack
 
     for result in tick.result:
         if isinstance(result, StepWorkerResult):
@@ -945,6 +1245,8 @@ def _process_step_result_tick(
                     worker.collected_events.clear()
                     worker.static_collect_events.clear()
                     worker.collected_waiters.clear()
+                # Drop open collection state; no release can fire after the run ends.
+                _clear_collection_state(state)
                 commands.append(CommandCompleteRun(result=result.result))
             elif isinstance(result.result, Event):
                 # queue any subsequent events
@@ -955,6 +1257,7 @@ def _process_step_result_tick(
                     CommandQueueEvent(
                         event=result.result,
                         recovery_counts=dict(this_execution.recovery_counts),
+                        scope_path=emit_stack,
                     )
                 )
             elif result.result is None:
@@ -1002,7 +1305,7 @@ def _process_step_result_tick(
                 worker_state.queue.insert(
                     0,
                     EventAttempt(
-                        event=tick.event,
+                        event=this_execution.event,
                         bound_events=this_execution.bound_events,
                         attempts=this_execution.attempts + 1,
                         first_attempt_at=first_attempt_at,
@@ -1010,10 +1313,13 @@ def _process_step_result_tick(
                         last_failed_at=result.failed_at,
                         recovery_counts=dict(this_execution.recovery_counts),
                         not_before=not_before,
+                        scope_path=this_execution.scope_path,
+                        collection_release_payload=this_execution.shared_state.collection_release_payload,
                     ),
                 )
                 if not_before is not None:
                     commands.append(CommandScheduleWakeup(at_time=not_before))
+                redelivery_scheduled = True
             else:
                 exception = result.exception
                 total_attempts = this_execution.attempts + 1
@@ -1047,8 +1353,14 @@ def _process_step_result_tick(
                             result.failed_at, tz=timezone.utc
                         ),
                     )
+                    # The recovered branch continues at the same stream level:
+                    # the handler event inherits the failing work item's scope
+                    # so its output stays in-stream and the stream can still
+                    # close. It routes to the handler step, so it must not
+                    # carry the collect payload.
                     commands.append(
-                        CommandQueueEvent(
+                        _queue_catch_error_event(
+                            this_execution,
                             event=step_failed_event,
                             step_id=StepId.root(handler.step_name),
                             recovery_counts={
@@ -1057,6 +1369,7 @@ def _process_step_result_tick(
                             },
                         )
                     )
+                    redelivery_scheduled = True
                 else:
                     # Publish a WorkflowFailedEvent to inform stream consumers about the failure
                     state.is_running = False
@@ -1079,10 +1392,10 @@ def _process_step_result_tick(
                 result.event_id, []
             )
             # the events snapshot that was sent with the step function execution that yielded this result
-            sent_events = this_execution.shared_state.collected_events.get(
+            snapshot_events = this_execution.shared_state.collected_events.get(
                 result.event_id, []
             )
-            if len(collected_events) > len(sent_events):
+            if len(collected_events) > len(snapshot_events):
                 # rerun it, and don't append now to ensure serializability
                 # updating the run state
                 step_no_longer_in_progress = False
@@ -1126,6 +1439,10 @@ def _process_step_result_tick(
                 requirements=result.requirements,
                 has_requirements=bool(len(result.requirements)),
                 resolved_event=None,
+                # Store the suspended work item's record so resume re-delivers
+                # it whole: same stream scope, same collect batch.
+                scope_path=this_execution.scope_path,
+                collection_release_payload=this_execution.shared_state.collection_release_payload,
             )
             if existing is not None:
                 worker_state.collected_waiters[existing] = new_waiter
@@ -1153,7 +1470,65 @@ def _process_step_result_tick(
         else:
             raise ValueError(f"Unknown result type: {type(result)}")
 
-    is_completed = len([x for x in commands if indicates_exit(x)]) > 0
+    # Resolve this work item in its enclosing stream. Completion removes this
+    # item and adds same-scope successors. Stream close is driven only by
+    # source exhaustion plus ``open_work_items == 0``. Classification happens
+    # once, before any counter mutation.
+    emitted_non_stop = [
+        x.result
+        for x in tick.result
+        if isinstance(x, StepWorkerResult)
+        and isinstance(x.result, Event)
+        and not isinstance(x.result, StopEvent)
+    ]
+    enclosing = trigger_stack[-1] if trigger_stack else None
+    disposition = _classify_work_item(
+        tick,
+        commands,
+        rerun_scheduled=not step_no_longer_in_progress,
+        redelivery_scheduled=redelivery_scheduled,
+        fanned_out=fanned_out,
+    )
+
+    if disposition is WorkDisposition.FANNED_OUT and fan_out_stream_id is not None:
+        bindings = state.config.bindings_for_source(step_name)
+        accepting_binding_ids = tuple(binding.id for binding in bindings)
+        seed = sum(_count_accepting_steps(state, type(m)) for m in emitted_non_stop)
+        state.streams[fan_out_stream_id] = CollectionStreamInstance(
+            stream_id=fan_out_stream_id,
+            source_step=step_name,
+            scope_path=trigger_stack,
+            accepting_binding_ids=accepting_binding_ids,
+            open_work_items=seed,
+        )
+        # The parent work item now waits for each child collection release.
+        commands.extend(
+            _apply_stream_work_delta(
+                state, enclosing, len(accepting_binding_ids) - 1, now_seconds
+            )
+        )
+        if seed == 0:
+            commands.extend(
+                _close_collection_stream(state, fan_out_stream_id, now_seconds)
+            )
+    elif disposition is WorkDisposition.COMPLETED:
+        # Same-level resolution (1:1 step, or a collect step firing its
+        # summary). Remove this work item and add its same-level successors: one
+        # work item per accepting step per emitted event. A step that returns
+        # None adds zero successors and simply leaves the set.
+        successors = sum(
+            _count_accepting_steps(state, type(ev)) for ev in emitted_non_stop
+        )
+        commands.extend(
+            _apply_stream_work_delta(state, enclosing, successors - 1, now_seconds)
+        )
+    elif disposition is WorkDisposition.ABSORBED:
+        # Consumed once per work item, no matter how many slot buffers the
+        # invocation touched.
+        commands.extend(_apply_stream_work_delta(state, enclosing, -1, now_seconds))
+    # STILL_LIVE re-delivers and resolves later; RUN_ENDING needs no accounting.
+
+    is_completed = any(indicates_exit(c) for c in commands)
     if step_no_longer_in_progress:
         commands.insert(
             0,
@@ -1265,6 +1640,10 @@ def _add_or_enqueue_event(
             step_name=step_name,
             collected_events=state_copy.collected_events,
             collected_waiters=state_copy.collected_waiters,
+            collection_release_payload=event.collection_release_payload._copy()
+            if event.collection_release_payload is not None
+            else None,
+            scope_path=event.scope_path,
         )
         state.in_progress.append(
             InProgressState(
@@ -1277,6 +1656,7 @@ def _add_or_enqueue_event(
                 last_exception=event.last_exception,
                 last_failed_at=event.last_failed_at,
                 recovery_counts=dict(event.recovery_counts),
+                scope_path=event.scope_path,
             )
         )
         commands.append(
@@ -1322,6 +1702,40 @@ def _process_add_event_tick(
     if isinstance(tick.event, StartEvent):
         state.is_running = True
 
+    # A payload-carrying tick is a re-delivered collect invocation (retry,
+    # waiter re-ping after resume, serialized requeue). It routes directly to
+    # the binding's target step — before waiter matching, before the
+    # member-arrival path — so it can never be swallowed as a stream member or
+    # resolve an unrelated waiter. The event is derived from the payload, the
+    # authoritative work record.
+    if tick.collection_release_payload is not None:
+        payload = tick.collection_release_payload
+        binding = state.config.collection_bindings.get(payload.binding_id)
+        if binding is None:
+            raise WorkflowRuntimeError(
+                f"Collect invocation re-delivered for unknown binding "
+                f"{payload.binding_id!r} (stream {payload.stream_id!r}). "
+                "Workflow state is corrupt."
+            )
+        commands.extend(
+            _add_or_enqueue_event(
+                EventAttempt(
+                    event=payload.as_event(),
+                    attempts=tick.attempts,
+                    first_attempt_at=tick.first_attempt_at,
+                    last_exception=tick.last_exception,
+                    last_failed_at=tick.last_failed_at,
+                    recovery_counts=dict(tick.recovery_counts),
+                    scope_path=tuple(tick.scope_path),
+                    collection_release_payload=payload,
+                ),
+                StepId.root(binding.target_step),
+                state.workers[binding.target_step],
+                now_seconds,
+            )
+        )
+        return state, commands
+
     # First, check if the event resolves any waiters. Track which steps were
     # woken via waiter resolution so we don't also route the event to them
     # as a normal accepted event (which would cause duplicate processing).
@@ -1343,10 +1757,14 @@ def _process_add_event_tick(
                 handled = True
                 waiter_resolved_steps.add(step_name)
                 wait_condition.resolved_event = tick.event
+                # Resume re-delivers the suspended work item whole from the
+                # waiter record: original trigger, stream scope, collect batch.
                 subcommands = _add_or_enqueue_event(
                     EventAttempt(
                         event=wait_condition.event,
                         bound_events=wait_condition.bound_events,
+                        scope_path=wait_condition.scope_path,
+                        collection_release_payload=wait_condition.collection_release_payload,
                     ),
                     step_id,
                     state.workers[step_name],
@@ -1358,25 +1776,121 @@ def _process_add_event_tick(
     # via waiter resolution above.
     for step_name, step_config in state.config.steps.items():
         step_id = StepId.root(step_name)
-        if step_name in waiter_resolved_steps:
-            continue
         is_accepted = step_accepts_event(
             tick.event,
             step_config.accepted_events,
             allow_subclasses=step_config.accept_event_subclasses,
         )
-        if is_accepted and (
-            tick.step_id is None or _root_step_key(tick.step_id) == step_name
-        ):
+        is_targeted = tick.step_id is None or _root_step_key(tick.step_id) == step_name
+        if step_name in waiter_resolved_steps:
+            if is_accepted and is_targeted and tick.scope_path:
+                # The waiter swallowed a delivery this step would otherwise
+                # have received. The delivery was birth-counted as a work item
+                # in its stream, so consume it here — otherwise the stream can
+                # never close. This covers both 1:1 steps and collect steps
+                # parked on wait_for_event of their own member type (the
+                # swallowed member never joins the batch; the waiter consumed
+                # it).
+                commands.extend(
+                    _apply_stream_work_delta(
+                        state, tick.scope_path[-1], -1, now_seconds
+                    )
+                )
+            continue
+        if is_accepted and is_targeted:
             handled = True
-            _consume_superseded_delayed_attempt(tick, state.workers[step_name])
+            worker_state = state.workers[step_name]
+            if worker_state.config.collection_param is not None:
+                if not tick.scope_path:
+                    # Scope-less events (ctx.send_event, external sends) can
+                    # never join a collect batch — members reach a collect step
+                    # only by being emitted inside a fan-out stream.
+                    if tick.step_id is not None:
+                        # A targeted send is an explicit instruction the
+                        # runtime cannot honor; dropping it silently loses
+                        # data, so fail the run loudly instead.
+                        error = WorkflowRuntimeError(
+                            f"{type(tick.event).__name__} was sent to collect "
+                            f"step {step_name!r} via send_event(step=...), but "
+                            "a collect step cannot receive targeted events: it "
+                            "only collects events emitted inside a fan-out "
+                            "stream."
+                        )
+                        state.is_running = False
+                        commands.append(
+                            CommandPublishEvent(
+                                event=WorkflowFailedEvent(
+                                    step_name=step_name, exception=error
+                                )
+                            )
+                        )
+                        commands.append(
+                            CommandFailWorkflow(step_id=step_id, exception=error)
+                        )
+                        return state, commands
+                    # An untargeted send may be legitimate traffic for other
+                    # steps that merely overlaps an open stream — warn.
+                    logger.warning(
+                        "Ignoring %s for collect step %r: it was sent "
+                        "outside any collection stream (e.g. via "
+                        "ctx.send_event) so it cannot join a batch.",
+                        type(tick.event).__name__,
+                        step_name,
+                    )
+                    continue
+                stream_id = tick.scope_path[-1]
+                binding = state.config.binding_for_target(
+                    stream_id, step_name, state.streams
+                )
+                if binding is None:
+                    # Dropped member: its nearest stream has no binding to this
+                    # collect step. Balance the stream accounting for the dead
+                    # work item and say so.
+                    logger.warning(
+                        "Dropping %s for collect step %r: its enclosing "
+                        "stream %r has no collection binding targeting that "
+                        "step, so it can never join a batch.",
+                        type(tick.event).__name__,
+                        step_name,
+                        stream_id,
+                    )
+                    commands.extend(
+                        _apply_stream_work_delta(state, stream_id, -1, now_seconds)
+                    )
+                    continue
+                release_state = _release_state_for(state, stream_id, binding)
+                if not release_state.released:
+                    release_state.buffer.append(tick.event)
+                    release = _release_on_item(binding, release_state)
+                    if release is not None:
+                        commands.extend(
+                            _fire_collection_release(
+                                binding,
+                                stream_id,
+                                worker_state,
+                                release,
+                                tuple(tick.scope_path[:-1]),
+                                now_seconds,
+                            )
+                        )
+                commands.extend(
+                    _apply_stream_work_delta(state, stream_id, -1, now_seconds)
+                )
+                continue
+            _consume_superseded_delayed_attempt(tick, worker_state)
             bound_events = tick.bound_events
-            if bound_events is None and state.workers[step_name].config.collect_params:
+            if bound_events is None and worker_state.config.collect_params:
                 bound_events = _static_collect_events(
                     event=tick.event,
-                    worker_state=state.workers[step_name],
+                    worker_state=worker_state,
                 )
                 if bound_events is None:
+                    if tick.scope_path:
+                        commands.extend(
+                            _apply_stream_work_delta(
+                                state, tick.scope_path[-1], -1, now_seconds
+                            )
+                        )
                     continue
             subcommands = _add_or_enqueue_event(
                 EventAttempt(
@@ -1387,6 +1901,7 @@ def _process_add_event_tick(
                     last_exception=tick.last_exception,
                     last_failed_at=tick.last_failed_at,
                     recovery_counts=dict(tick.recovery_counts),
+                    scope_path=tuple(tick.scope_path),
                 ),
                 step_id,
                 state.workers[step_name],
@@ -1465,6 +1980,7 @@ def _process_timeout_tick(
 ) -> tuple[BrokerState, list[WorkflowCommand]]:
     state = init.deepcopy()
     state.is_running = False
+    _clear_collection_state(state)
     active_steps = [
         step_name
         for step_name, worker_state in init.workers.items()
@@ -1529,11 +2045,83 @@ def _process_waiter_timeout_tick(
     if waiter is None or waiter.resolved_event is not None:
         return state, commands
     waiter.timed_out = True
+    # Timeout resumes the suspended work item whole, like waiter resolution.
     subcommands = _add_or_enqueue_event(
-        EventAttempt(event=waiter.event, bound_events=waiter.bound_events),
+        EventAttempt(
+            event=waiter.event,
+            bound_events=waiter.bound_events,
+            scope_path=waiter.scope_path,
+            collection_release_payload=waiter.collection_release_payload,
+        ),
         step_id,
         worker_state,
         now_seconds,
     )
     commands.extend(subcommands)
     return state, commands
+
+
+def _release_state_key(stream_id: str, binding_id: str) -> str:
+    return f"{stream_id}:{binding_id}"
+
+
+def _release_state_for(
+    state: BrokerState, stream_id: str, binding: CollectionBinding
+) -> CollectionReleaseState:
+    key = _release_state_key(stream_id, binding.id)
+    release_state = state.collection_release_states.get(key)
+    if release_state is None:
+        release_state = CollectionReleaseState(
+            binding_id=binding.id,
+            stream_id=stream_id,
+        )
+        state.collection_release_states[key] = release_state
+    return release_state
+
+
+def _release_on_item(
+    binding: CollectionBinding, release_state: CollectionReleaseState
+) -> list[Event] | None:
+    threshold = _take_threshold(binding.policy)
+    if threshold is None or len(release_state.buffer) < threshold:
+        return None
+    release_state.released = True
+    return list(release_state.buffer[:threshold])
+
+
+def _release_on_close(
+    binding: CollectionBinding, release_state: CollectionReleaseState
+) -> list[Event] | None:
+    if release_state.released:
+        return None
+    release_state.released = True
+    threshold = _take_threshold(binding.policy)
+    if threshold is not None:
+        return list(release_state.buffer[:threshold])
+    return list(release_state.buffer)
+
+
+def _fire_collection_release(
+    binding: CollectionBinding,
+    stream_id: str,
+    worker_state: InternalStepWorkerState,
+    events: list[Event],
+    output_stack: tuple[str, ...],
+    now_seconds: float,
+) -> list[WorkflowCommand]:
+    payload = CollectionReleasePayload(
+        binding_id=binding.id,
+        stream_id=stream_id,
+        events=list(events),
+        output_scope_path=output_stack,
+    )
+    return _add_or_enqueue_event(
+        EventAttempt(
+            event=payload.as_event(),
+            scope_path=output_stack,
+            collection_release_payload=payload,
+        ),
+        StepId.root(binding.target_step),
+        worker_state,
+        now_seconds,
+    )

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -1154,6 +1154,7 @@ def _classify_work_item(
         "This is a runtime bug."
     )
 
+
 def _process_step_result_tick(
     tick: TickStepResult,
     init: BrokerState,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
@@ -34,12 +34,8 @@ class CommandRunWorker:
 class CommandQueueEvent:
     event: Event
     step_id: StepId | None = None
-    bound_events: dict[str, Event] | None = None
-    attempts: int | None = None
-    first_attempt_at: float | None = None
-    last_exception: Exception | None = None
-    last_failed_at: float | None = None
     recovery_counts: dict[str, int] = field(default_factory=dict)
+    scope_path: tuple[str, ...] = field(default_factory=tuple)
 
 
 @dataclass(frozen=True)
@@ -89,7 +85,7 @@ class CommandScheduleIdleCheck:
     Returned by the reducer when state looks quiescent after processing a tick.
     The runner appends a TickIdleCheck to tick_buffer so that idle is confirmed
     on the next loop iteration, after an asyncio.sleep(0) yield gives in-flight
-    ctx.send_event() calls a chance to drain.
+    ctx.send_event() calls a chance to deliver.
     """
 
     pass

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -8,8 +8,14 @@ import importlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
+from workflows._event_matching import step_accepts_type
+from workflows._stream_levels import event_types, stream_level_types_by_producer
+from workflows.collect import Collect, Take
 from workflows.context.context_types import (
     CURRENT_SERIALIZED_VERSION,
+    SerializedCollectionReleasePayload,
+    SerializedCollectionReleaseState,
+    SerializedCollectionStreamInstance,
     SerializedContext,
     SerializedEventAttempt,
     SerializedStepWorkerState,
@@ -19,14 +25,73 @@ from workflows.context.serializers import JsonSerializer
 from workflows.decorators import CatchErrorHandler, StepConfig
 from workflows.events import Event
 from workflows.retry_policy import RetryPolicy
-from workflows.runtime.types.results import StepWorkerState, StepWorkerWaiter
+from workflows.runtime.types.results import (
+    CollectionReleasePayload,
+    StepWorkerState,
+    StepWorkerWaiter,
+)
 from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import TickAddEvent, WorkflowTick
 from workflows.workflow import Workflow
 
 if TYPE_CHECKING:
-    from workflows.context.context_types import SerializedContext
     from workflows.context.serializers import BaseSerializer
+
+
+@dataclass(frozen=True)
+class CollectionBinding:
+    """
+    Static typed stream binding from a finite list source to a collect step.
+
+    Bindings are computed once from step signatures and stored in BrokerConfig.
+    At runtime, each CollectionStreamInstance records the binding ids that may
+    accept events produced inside that stream.
+    """
+
+    id: str
+    source_step: str
+    target_step: str
+    item_types: tuple[type[Event], ...]
+    policy: Collect
+
+
+@dataclass()
+class CollectionStreamInstance:
+    """
+    One execution of a collection-producing step.
+
+    A returned ``list[E]`` opens one stream instance. Work emitted inside that
+    stream carries ``scope_path`` so downstream completions can decrement the
+    right open-work counter and close the nearest enclosing stream.
+    """
+
+    stream_id: str
+    source_step: str
+    scope_path: tuple[str, ...]
+    open_work_items: int = 0
+    accepting_binding_ids: tuple[str, ...] = ()
+
+    def _copy(self) -> CollectionStreamInstance:
+        return dataclasses.replace(self)
+
+
+@dataclass()
+class CollectionReleaseState:
+    """
+    Release state for one binding within one stream instance.
+
+    ``buffer`` stores member events until the binding's Collect policy releases
+    them. ``released`` makes the release fire-once: Take(n) sets it on the
+    n-th arrival, and stream close sets it for All() (or an unmet Take).
+    """
+
+    binding_id: str
+    stream_id: str
+    buffer: list[Event] = field(default_factory=list)
+    released: bool = False
+
+    def _copy(self) -> CollectionReleaseState:
+        return dataclasses.replace(self, buffer=list(self.buffer))
 
 
 @dataclass()
@@ -40,11 +105,19 @@ class BrokerState:
     Attributes:
         config: Immutable configuration for the workflow and all steps
         workers: Mutable state for each step's worker pool, queues, and in-progress executions
+        stream_seq: Monotonic counter used to mint deterministic collection stream ids
+        streams: Open collection streams keyed by stream id
+        collection_release_states: Per-binding release buffers keyed by stream and binding
     """
 
     is_running: bool
     config: BrokerConfig
     workers: dict[str, InternalStepWorkerState]
+    stream_seq: int = 0
+    streams: dict[str, CollectionStreamInstance] = field(default_factory=dict)
+    collection_release_states: dict[str, CollectionReleaseState] = field(
+        default_factory=dict
+    )
 
     def deepcopy(self) -> BrokerState:
         """
@@ -56,6 +129,12 @@ class BrokerState:
             workers={
                 name: worker_state._deepcopy()
                 for name, worker_state in self.workers.items()
+            },
+            stream_seq=self.stream_seq,
+            streams={sid: stream._copy() for sid, stream in self.streams.items()},
+            collection_release_states={
+                key: state._copy()
+                for key, state in self.collection_release_states.items()
             },
         )
 
@@ -76,6 +155,7 @@ class BrokerState:
                 timeout=workflow._timeout,
                 catch_error_handlers=dict(workflow._catch_error_handlers),
                 handler_for_step=dict(workflow._handler_for_step),
+                collection_bindings=_compute_collection_bindings(workflow),
             ),
             workers={
                 name: InternalStepWorkerState(
@@ -100,11 +180,16 @@ class BrokerState:
                 worker_state.collected_waiters, key=lambda x: x.waiter_id
             ):
                 if waiter.has_requirements and not waiter.requirements:
+                    # Re-ping the step with its whole work record so the
+                    # re-registered waiter keeps its stream scope and any
+                    # collect batch.
                     commands.append(
                         TickAddEvent(
                             event=waiter.event,
                             step_id=StepId.root(step_name),
                             bound_events=waiter.bound_events,
+                            scope_path=waiter.scope_path,
+                            collection_release_payload=waiter.collection_release_payload,
                         )
                     )
         return commands
@@ -114,7 +199,7 @@ class BrokerState:
 
         workers_dict = {}
         for step_name, worker_state in self.workers.items():
-            # Serialize queue with retry info
+            # Serialize queue with retry and stream scope info
             queue = [
                 SerializedEventAttempt(
                     event=serializer.serialize(attempt.event),
@@ -130,11 +215,14 @@ class BrokerState:
                     last_failed_at=attempt.last_failed_at,
                     recovery_counts=dict(attempt.recovery_counts),
                     not_before=attempt.not_before,
+                    scope_path=list(attempt.scope_path),
+                    collection_release_payload=_serialize_release_payload(
+                        attempt.collection_release_payload, serializer
+                    ),
                 )
                 for attempt in worker_state.queue
             ]
-
-            # Serialize in-progress attempts, including retry and fan-in binding state.
+            # Serialize in-progress attempts so they can be re-queued on resume.
             in_progress = [
                 SerializedEventAttempt(
                     event=serializer.serialize(ip.event),
@@ -149,6 +237,10 @@ class BrokerState:
                     last_exception=ip.last_exception,
                     last_failed_at=ip.last_failed_at,
                     recovery_counts=dict(ip.recovery_counts),
+                    scope_path=list(ip.scope_path),
+                    collection_release_payload=_serialize_release_payload(
+                        ip.shared_state.collection_release_payload, serializer
+                    ),
                 )
                 for ip in worker_state.in_progress
             ]
@@ -176,6 +268,10 @@ class BrokerState:
                     resolved_event=serializer.serialize(waiter.resolved_event)
                     if waiter.resolved_event
                     else None,
+                    scope_path=list(waiter.scope_path),
+                    collection_release_payload=_serialize_release_payload(
+                        waiter.collection_release_payload, serializer
+                    ),
                 )
                 for waiter in worker_state.collected_waiters
             ]
@@ -196,6 +292,26 @@ class BrokerState:
             state={},  # State is filled separately by the state store
             is_running=self.is_running,
             workers=workers_dict,
+            stream_seq=self.stream_seq,
+            streams={
+                sid: SerializedCollectionStreamInstance(
+                    stream_id=stream.stream_id,
+                    source_step=stream.source_step,
+                    scope_path=list(stream.scope_path),
+                    open_work_items=stream.open_work_items,
+                    accepting_binding_ids=list(stream.accepting_binding_ids),
+                )
+                for sid, stream in self.streams.items()
+            },
+            collection_release_states={
+                key: SerializedCollectionReleaseState(
+                    binding_id=release.binding_id,
+                    stream_id=release.stream_id,
+                    buffer=[serializer.serialize(ev) for ev in release.buffer],
+                    released=release.released,
+                )
+                for key, release in self.collection_release_states.items()
+            },
         )
 
     @staticmethod
@@ -213,6 +329,26 @@ class BrokerState:
         # Unfortunately, important to preserve this state, since the workflow needs to know this to decide
         # whether to create a start_event from kwargs (it only constructs and passes a start event if not already running)
         base_state.is_running = serialized.is_running
+        base_state.stream_seq = serialized.stream_seq
+        base_state.streams = {
+            sid: CollectionStreamInstance(
+                stream_id=stream.stream_id,
+                source_step=stream.source_step,
+                scope_path=tuple(stream.scope_path),
+                open_work_items=stream.open_work_items,
+                accepting_binding_ids=tuple(stream.accepting_binding_ids),
+            )
+            for sid, stream in serialized.streams.items()
+        }
+        base_state.collection_release_states = {
+            key: CollectionReleaseState(
+                binding_id=release.binding_id,
+                stream_id=release.stream_id,
+                buffer=[serializer.deserialize(ev) for ev in release.buffer],
+                released=release.released,
+            )
+            for key, release in serialized.collection_release_states.items()
+        }
 
         # Restore worker state (queues, collected events, waiters)
         # We do this regardless of is_running state so workflows can resume from where they left off
@@ -222,25 +358,11 @@ class BrokerState:
 
             worker = base_state.workers[step_name]
 
-            # Restore queue with retry info.
+            # Restore queue with retry and stream scope info.
             # in_progress events are moved to the queue on deserialization;
             # they will be restarted when the workflow runs.
             worker.queue = [
-                EventAttempt(
-                    event=serializer.deserialize(attempt.event),
-                    bound_events={
-                        name: serializer.deserialize(event)
-                        for name, event in attempt.bound_events.items()
-                    }
-                    if attempt.bound_events is not None
-                    else None,
-                    attempts=attempt.attempts,
-                    first_attempt_at=attempt.first_attempt_at,
-                    last_exception=attempt.last_exception,
-                    last_failed_at=attempt.last_failed_at,
-                    recovery_counts=dict(attempt.recovery_counts),
-                    not_before=attempt.not_before,
-                )
+                _deserialize_event_attempt(attempt, serializer)
                 for attempt in [*worker_data.queue, *worker_data.in_progress]
             ]
 
@@ -256,20 +378,27 @@ class BrokerState:
             # Restore waiters
             worker.collected_waiters = []
             for waiter_data in worker_data.collected_waiters:
-                # Import the event type
-                waiting_for_event = _import_event_type(waiter_data.waiting_for_event)
-
+                waiter_payload = _deserialize_release_payload(
+                    waiter_data.collection_release_payload, serializer
+                )
                 worker.collected_waiters.append(
                     StepWorkerWaiter(
                         waiter_id=waiter_data.waiter_id,
-                        event=serializer.deserialize(waiter_data.event),
                         bound_events={
                             name: serializer.deserialize(event)
                             for name, event in waiter_data.bound_events.items()
                         }
                         if waiter_data.bound_events is not None
                         else None,
-                        waiting_for_event=waiting_for_event,
+                        # For a suspended collect invocation the payload is the
+                        # authoritative record; the trigger event is derived
+                        # from it so the two cannot diverge on resume.
+                        event=waiter_payload.as_event()
+                        if waiter_payload is not None
+                        else serializer.deserialize(waiter_data.event),
+                        waiting_for_event=_import_event_type(
+                            waiter_data.waiting_for_event
+                        ),
                         requirements={},
                         has_requirements=waiter_data.has_requirements,
                         resolved_event=serializer.deserialize(
@@ -277,10 +406,45 @@ class BrokerState:
                         )
                         if waiter_data.resolved_event
                         else None,
+                        scope_path=tuple(waiter_data.scope_path),
+                        collection_release_payload=waiter_payload,
                     )
                 )
 
         return base_state
+
+
+def _deserialize_event_attempt(
+    attempt: SerializedEventAttempt, serializer: BaseSerializer
+) -> EventAttempt:
+    """Restore one queued work item.
+
+    For a collect invocation the persisted payload is the authoritative
+    record; the trigger event is derived from it so the two cannot diverge
+    across a serialize/resume boundary.
+    """
+    payload = _deserialize_release_payload(
+        attempt.collection_release_payload, serializer
+    )
+    return EventAttempt(
+        event=payload.as_event()
+        if payload is not None
+        else serializer.deserialize(attempt.event),
+        bound_events={
+            name: serializer.deserialize(event)
+            for name, event in attempt.bound_events.items()
+        }
+        if attempt.bound_events is not None
+        else None,
+        attempts=attempt.attempts,
+        first_attempt_at=attempt.first_attempt_at,
+        last_exception=attempt.last_exception,
+        last_failed_at=attempt.last_failed_at,
+        recovery_counts=dict(attempt.recovery_counts),
+        not_before=attempt.not_before,
+        scope_path=tuple(attempt.scope_path),
+        collection_release_payload=payload,
+    )
 
 
 def _import_event_type(qualified_name: str) -> type[Event]:
@@ -295,6 +459,62 @@ def _import_event_type(qualified_name: str) -> type[Event]:
     return getattr(module, class_name)
 
 
+def _binding_id(
+    source_step: str,
+    target_step: str,
+    item_types: tuple[type[Event], ...],
+    policy: Collect,
+) -> str:
+    """Build a stable id for one static source-to-collect-step binding."""
+    type_names = ",".join(f"{t.__module__}.{t.__qualname__}" for t in item_types)
+    card = policy.cardinality
+    card_repr = f"Take({card.n})" if isinstance(card, Take) else type(card).__name__
+    return f"{source_step}->{target_step}:{type_names}:{card_repr}:nearest"
+
+
+def _compute_collection_bindings(workflow: Workflow) -> dict[str, CollectionBinding]:
+    """
+    Compute static list[E] stream bindings from the workflow graph.
+
+    A fan-out source binds to a collection step when the collection step's item
+    type appears at the same stream level reachable from the source (see
+    :mod:`workflows._stream_levels` for the level traversal, shared with static
+    validation).
+    """
+    steps = {name: fn._step_config for name, fn in workflow._get_steps().items()}
+    collects: dict[str, tuple[Any, ...]] = {
+        name: cfg.collection_param[1]
+        for name, cfg in steps.items()
+        if cfg.collection_param is not None
+    }
+
+    bindings: dict[str, CollectionBinding] = {}
+    for source_step, level_types in stream_level_types_by_producer(steps).items():
+        for target_step, collect_types in collects.items():
+            item_types = tuple(event_types(collect_types))
+            if not any(
+                step_accepts_type(
+                    produced,
+                    item_types,
+                    allow_subclasses=steps[target_step].accept_event_subclasses,
+                )
+                for produced in level_types
+            ):
+                continue
+            policy = steps[target_step].collection_policy
+            if policy is None:
+                continue
+            binding = CollectionBinding(
+                id=_binding_id(source_step, target_step, item_types, policy),
+                source_step=source_step,
+                target_step=target_step,
+                item_types=item_types,
+                policy=policy,
+            )
+            bindings[binding.id] = binding
+    return bindings
+
+
 @dataclass(frozen=True)
 class BrokerConfig:
     """
@@ -307,12 +527,36 @@ class BrokerConfig:
         timeout: Maximum seconds before the workflow times out, or None for no timeout
         catch_error_handlers: handler step name -> CatchErrorHandler descriptor
         handler_for_step: step name -> handler step name that owns it
+        collection_bindings: Static list[E] stream bindings keyed by binding id
     """
 
     steps: dict[str, InternalStepConfig]
     timeout: float | None
     catch_error_handlers: dict[str, CatchErrorHandler] = field(default_factory=dict)
     handler_for_step: dict[str, str] = field(default_factory=dict)
+    collection_bindings: dict[str, CollectionBinding] = field(default_factory=dict)
+
+    def bindings_for_source(self, source_step: str) -> tuple[CollectionBinding, ...]:
+        return tuple(
+            binding
+            for binding in self.collection_bindings.values()
+            if binding.source_step == source_step
+        )
+
+    def binding_for_target(
+        self,
+        stream_id: str,
+        target_step: str,
+        streams: dict[str, CollectionStreamInstance],
+    ) -> CollectionBinding | None:
+        stream = streams.get(stream_id)
+        if stream is None:
+            return None
+        for binding_id in stream.accepting_binding_ids:
+            binding = self.collection_bindings.get(binding_id)
+            if binding is not None and binding.target_step == target_step:
+                return binding
+        return None
 
 
 @dataclass()
@@ -347,6 +591,9 @@ class EventAttempt:
         last_failed_at: Unix timestamp of the most recent failure, or None.
         not_before: Absolute adapter-get_now time before which this attempt
             must not be dispatched (retry delay), or None if eligible now.
+        recovery_counts: Per-handler recovery counts on this event's lineage.
+        scope_path: Collection stream scope path, innermost stream id last.
+        collection_release_payload: Explicit payload for queued list[E] collect invocations.
     """
 
     event: Event
@@ -357,6 +604,8 @@ class EventAttempt:
     last_failed_at: float | None = None
     recovery_counts: dict[str, int] = field(default_factory=dict)
     not_before: float | None = None
+    scope_path: tuple[str, ...] = field(default_factory=tuple)
+    collection_release_payload: CollectionReleasePayload | None = None
 
 
 @dataclass()
@@ -411,6 +660,8 @@ class InProgressState:
         first_attempt_at: Unix timestamp when this event was first attempted
         last_exception: Most recent exception from the prior attempt, or None if this is the first attempt.
         last_failed_at: Unix timestamp of the most recent failure, or None.
+        recovery_counts: Per-handler recovery counts on this event's lineage.
+        scope_path: Collection stream scope path for the worker's current event.
     """
 
     event: Event
@@ -422,6 +673,7 @@ class InProgressState:
     last_failed_at: float | None = None
     recovery_counts: dict[str, int] = field(default_factory=dict)
     bound_events: dict[str, Event] | None = None
+    scope_path: tuple[str, ...] = field(default_factory=tuple)
 
     def _deepcopy(self) -> InProgressState:
         return InProgressState(
@@ -434,4 +686,33 @@ class InProgressState:
             last_exception=self.last_exception,
             last_failed_at=self.last_failed_at,
             recovery_counts=dict(self.recovery_counts),
+            scope_path=self.scope_path,
         )
+
+
+def _serialize_release_payload(
+    payload: CollectionReleasePayload | None, serializer: BaseSerializer
+) -> SerializedCollectionReleasePayload | None:
+    """Serialize a queued list[E] collect invocation payload."""
+    if payload is None:
+        return None
+    return SerializedCollectionReleasePayload(
+        binding_id=payload.binding_id,
+        stream_id=payload.stream_id,
+        events=[serializer.serialize(ev) for ev in payload.events],
+        output_scope_path=list(payload.output_scope_path),
+    )
+
+
+def _deserialize_release_payload(
+    payload: SerializedCollectionReleasePayload | None, serializer: BaseSerializer
+) -> CollectionReleasePayload | None:
+    """Deserialize a queued list[E] collect invocation payload."""
+    if payload is None:
+        return None
+    return CollectionReleasePayload(
+        binding_id=payload.binding_id,
+        stream_id=payload.stream_id,
+        events=[serializer.deserialize(ev) for ev in payload.events],
+        output_scope_path=tuple(payload.output_scope_path),
+    )

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -8,14 +8,24 @@ import weakref
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import (
+    Annotated,
     Any,
     Generic,
     Literal,
     TypeVar,
 )
 
-from pydantic import BaseModel, ConfigDict, model_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    PlainSerializer,
+    PlainValidator,
+    TypeAdapter,
+    model_serializer,
+    model_validator,
+)
 from workflows.events import (
+    CollectionReleaseEvent,
     Event,
     SerializableEvent,
     SerializableEventType,
@@ -39,8 +49,8 @@ class RetryAttempt:
     is 0-based (0 = first run, 1 = first retry). ``last_exception`` /
     ``last_failed_at`` are ``None`` on the first attempt. ``recovery_counts``
     carries the per-``@catch_error``-handler invocation counts on the running
-    event's lineage so ``ctx.send_event`` can tag emitted events and nested
-    failures route to the same handlers.
+    event's lineage so nested failures and ``ctx.send_event`` emissions route to
+    the same handlers.
     """
 
     retry_number: int = 0
@@ -72,13 +82,86 @@ class StepWorkerState:
     step_name: str
     collected_events: dict[str, list[Event]]
     collected_waiters: list[StepWorkerWaiter]
+    collection_release_payload: CollectionReleasePayload | None = None
+    scope_path: tuple[str, ...] = ()
 
     def _deepcopy(self) -> StepWorkerState:
         return StepWorkerState(
             step_name=self.step_name,
             collected_events={k: list(v) for k, v in self.collected_events.items()},
             collected_waiters=[dataclasses.replace(x) for x in self.collected_waiters],
+            collection_release_payload=self.collection_release_payload._copy()
+            if self.collection_release_payload is not None
+            else None,
+            scope_path=self.scope_path,
         )
+
+
+@dataclass(frozen=True)
+class CollectionReleasePayload:
+    """List payload supplied to a collection step invocation."""
+
+    binding_id: str
+    stream_id: str
+    events: list[Event]
+    output_scope_path: tuple[str, ...]
+
+    def _copy(self) -> CollectionReleasePayload:
+        return CollectionReleasePayload(
+            binding_id=self.binding_id,
+            stream_id=self.stream_id,
+            events=list(self.events),
+            output_scope_path=self.output_scope_path,
+        )
+
+    def as_event(self) -> CollectionReleaseEvent:
+        """Derive the invocation trigger event for this release.
+
+        The payload is the authoritative work record; the event is rebuilt from
+        it at every (re)delivery so the two cannot diverge across retries,
+        waiter resumes, or serialize/resume.
+        """
+        return CollectionReleaseEvent(
+            events=list(self.events),
+            stream_id=self.stream_id,
+            binding_id=self.binding_id,
+        )
+
+
+# Tick wire format for the payload's member events: the same SerializableEvent
+# codec every other tick/result event field uses (events.py).
+_payload_events_adapter: TypeAdapter[list[Event]] = TypeAdapter(list[SerializableEvent])
+
+
+def _serialize_release_payload_value(
+    payload: CollectionReleasePayload | None,
+) -> Any:
+    if payload is None:
+        return None
+    return {
+        "binding_id": payload.binding_id,
+        "stream_id": payload.stream_id,
+        "events": _payload_events_adapter.dump_python(payload.events),
+        "output_scope_path": list(payload.output_scope_path),
+    }
+
+
+def _deserialize_release_payload_value(data: Any) -> CollectionReleasePayload | None:
+    if data is None or isinstance(data, CollectionReleasePayload):
+        return data
+    return CollectionReleasePayload(
+        binding_id=data["binding_id"],
+        stream_id=data["stream_id"],
+        events=_payload_events_adapter.validate_python(data["events"]),
+        output_scope_path=tuple(data["output_scope_path"]),
+    )
+
+
+SerializableCollectionReleasePayload = Annotated[
+    CollectionReleasePayload | None,
+    PlainSerializer(_serialize_release_payload_value, return_type=Any),
+    PlainValidator(_deserialize_release_payload_value),
+]
 
 
 @dataclass()
@@ -103,6 +186,11 @@ class StepWorkerWaiter(Generic[EventType]):
     bound_events: dict[str, Event] | None = None
     # set to true when the waiter has timed out, such that the step raises asyncio.TimeoutError
     timed_out: bool = False
+    # Originating work record: stream scope of the suspended work item, restored
+    # whole on resume so the resumed attempt still closes its stream.
+    scope_path: tuple[str, ...] = ()
+    # For a suspended collect invocation, the release batch to re-invoke with.
+    collection_release_payload: CollectionReleasePayload | None = None
 
 
 @dataclass()
@@ -150,6 +238,12 @@ class StepWorkerResult(BaseModel):
     model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
     type: Literal["result"] = "result"
     result: SerializableOptionalEvent = None
+    # True when this execution actually returned a list (stream emission). A
+    # fan-out-annotated step that takes a non-list branch (None, or a declared
+    # bare union member) does not fan out: no stream is minted and downstream
+    # joins do not fire. An empty list return carries fanned_out=True with
+    # result=None — an empty stream whose joins fire with [].
+    fanned_out: bool = False
 
 
 class RetryDecision(BaseModel):

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -121,9 +121,14 @@ async def partial(
     context: Context,
     workflow: Workflow,
     collected_events: dict[str, Event] | None = None,
+    collection_events: dict[str, list[Event]] | None = None,
 ) -> Callable[[], Any]:
     kwargs: dict[str, Any] = {}
-    if collected_events is not None:
+    if collection_events is not None:
+        kwargs.update(collection_events)
+    elif collected_events is not None:
+        # Collect-mode (multi-slot fan-in): bind each declared event
+        # parameter to its collected event instead of a single trigger event.
         kwargs.update(collected_events)
     else:
         kwargs[step_config.event_name] = event
@@ -187,6 +192,24 @@ def as_step_worker_function(
 
         try:
             config = workflow._get_steps()[step_name]._step_config
+            collected_binding: dict[str, Event] | None = None
+            collection_binding: dict[str, list[Event]] | None = None
+            if config.collection_param is not None:
+                param_name, _ = config.collection_param
+                payload = state.collection_release_payload
+                if payload is None:
+                    # A collect invocation without its release payload is
+                    # corrupt state — fail loudly instead of re-running the
+                    # step with a fabricated empty batch.
+                    raise WorkflowRuntimeError(
+                        f"Collect step {step_name!r} was invoked without a "
+                        "collection release payload. This indicates a lost "
+                        "work record (runtime bug or corrupted serialized "
+                        "state)."
+                    )
+                collection_binding = {param_name: list(payload.events)}
+            else:
+                collected_binding = bound_events
             # Resolve callable at call time:
             # - If the workflow has an attribute with the step name, use it
             #   (this yields a bound method for instance-defined steps).
@@ -253,7 +276,8 @@ def as_step_worker_function(
                 event=event,
                 context=internal_context,
                 workflow=workflow,
-                collected_events=bound_events,
+                collected_events=collected_binding,
+                collection_events=collection_binding,
             )
 
             try:
@@ -279,8 +303,9 @@ def as_step_worker_function(
                         raise captured_waiting
                 if isinstance(result, list) and config.is_fan_out:
                     # A step that actually returned a list fans out: each
-                    # element is emitted as its own event. An empty list means
-                    # "no emission".
+                    # element is emitted as its own event into a fresh stream.
+                    # An empty list emits nothing but still opens (and
+                    # immediately closes) the stream, so joins fire with [].
                     for item in result:
                         if not isinstance(item, Event):
                             msg = (
@@ -291,9 +316,13 @@ def as_step_worker_function(
                             raise WorkflowRuntimeError(msg)
                     if result:
                         for item in result:
-                            returns.return_values.append(StepWorkerResult(result=item))
+                            returns.return_values.append(
+                                StepWorkerResult(result=item, fanned_out=True)
+                            )
                     else:
-                        returns.return_values.append(StepWorkerResult(result=None))
+                        returns.return_values.append(
+                            StepWorkerResult(result=None, fanned_out=True)
+                        )
                 elif result is not None and not isinstance(result, Event):
                     msg = f"Step function {step_name} returned {type(result).__name__} instead of an Event instance."
                     raise WorkflowRuntimeError(msg)
@@ -309,7 +338,7 @@ def as_step_worker_function(
                     # declared as a non-list union member (-> list[A] | B
                     # returning B) is ordinary dispatch and handled below; an
                     # undeclared bare element is an error, not a silent
-                    # one-element emission.
+                    # one-member stream.
                     msg = (
                         f"Step function {step_name} returned a bare "
                         f"{type(result).__name__} but its return annotation only "
@@ -320,7 +349,8 @@ def as_step_worker_function(
                     raise WorkflowRuntimeError(msg)
                 else:
                     # Ordinary dispatch — including a fan-out step's declared
-                    # non-list branch and its None (no emission) branch.
+                    # non-list branch and its None (no emission, no stream)
+                    # branch.
                     returns.return_values.append(StepWorkerResult(result=result))
             except WaitingForEvent as e:
                 await asyncio.sleep(0)

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -19,7 +19,10 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, TypeAdapter
 from workflows.events import SerializableEvent, SerializableOptionalException
-from workflows.runtime.types.results import StepFunctionResult
+from workflows.runtime.types.results import (
+    SerializableCollectionReleasePayload,
+    StepFunctionResult,
+)
 from workflows.runtime.types.step_id import StepId
 
 
@@ -51,6 +54,11 @@ class TickAddEvent(BaseModel):
     last_exception: SerializableOptionalException = None
     last_failed_at: float | None = None
     recovery_counts: dict[str, int] = Field(default_factory=dict)
+    scope_path: tuple[str, ...] = Field(default_factory=tuple)
+    # Collect-invocation work record. A payload-carrying tick is routed
+    # directly to the binding's target step, before waiter matching and the
+    # member-arrival path.
+    collection_release_payload: SerializableCollectionReleasePayload = None
 
 
 class TickCancelRun(BaseModel):
@@ -93,11 +101,11 @@ class TickWaiterTimeout(BaseModel):
 
 
 class TickIdleCheck(BaseModel):
-    """Scheduled after state appears idle, to re-check after async events drain.
+    """Scheduled after state appears idle, to re-check after async sends run.
 
     Appended to tick_buffer when the reducer sees quiescent state. Processed
     on the next loop iteration after asyncio.sleep(0), giving in-flight
-    ctx.send_event() calls a chance to deliver via the pull task.
+    ctx.send_event() calls a chance to deliver.
     """
 
     model_config = ConfigDict(frozen=True)

--- a/packages/llama-index-workflows/src/workflows/utils.py
+++ b/packages/llama-index-workflows/src/workflows/utils.py
@@ -27,6 +27,7 @@ from typing import Union
 
 from pydantic import BaseModel
 
+from .collect import All, Collect, Take
 from .errors import WorkflowValidationError
 from .events import Event, EventType
 from .resource import ResourceDefinition, ResourceDescriptor
@@ -42,6 +43,15 @@ class StepSignatureSpec(BaseModel):
     context_parameter: str | None
     context_state_type: Any | None
     resources: list[Any]
+    # Collection-stream fan-in: ``(parameter_name, element_event_types)`` when
+    # the step declares a single ``list[E]`` collect parameter, else None. The
+    # element types are a tuple — ``list[Done]`` -> ``(Done,)``; a union flat list
+    # ``list[A | B]`` -> ``(A, B)``.
+    collection_param: tuple[str, tuple[Any, ...]] | None = None
+    # The resolved ``Collect`` marker for the collection parameter. A bare
+    # ``list[E]`` parameter resolves to ``Collect()`` (``All`` cardinality).
+    # None for steps without a collection parameter.
+    collection_policy: Any | None = None
     # Fan-out producer: True when the return annotation is ``list[E]``.
     is_fan_out: bool = False
     # Non-list members of a fan-out return union (``-> list[A] | B`` -> [B]).
@@ -80,6 +90,8 @@ def inspect_signature(
     context_parameter = None
     context_state_type = None
     resources = []
+    collection_param: tuple[str, tuple[Any, ...]] | None = None
+    collection_policy: Collect | None = None
 
     # Inspect function parameters
     for name, t in sig.parameters.items():
@@ -102,12 +114,18 @@ def inspect_signature(
                     context_state_type = args[0]
                 continue
 
-        # Handle Annotated types for resources
+        # Handle Annotated types: resource descriptors and Collect markers. A
+        # ``Collect`` marker unwraps to the inner ``list[E]`` annotation and is
+        # carried forward to the collection-collect handling below; everything else
+        # (unknown metadata) is ignored.
+        collect_marker: Collect | None = None
         if get_origin(annotation) is Annotated:
             args = get_args(annotation)
             type_annotation = args[0] if args else None
-            descriptor = args[1] if len(args) > 1 else None
-            if descriptor is not None and isinstance(descriptor, ResourceDescriptor):
+            descriptor = next(
+                (a for a in args[1:] if isinstance(a, ResourceDescriptor)), None
+            )
+            if descriptor is not None:
                 # Pass localns to resource for nested annotation resolution
                 descriptor.set_localns(localns)
                 resources.append(
@@ -115,23 +133,43 @@ def inspect_signature(
                         name=name, resource=descriptor, type_annotation=type_annotation
                     )
                 )
-            continue
+                continue
+            collect_marker = next((a for a in args[1:] if isinstance(a, Collect)), None)
+            if collect_marker is None:
+                # Unknown Annotated metadata — ignore as before.
+                continue
+            annotation = type_annotation
 
         # Get name and type of the Context param (without state type)
         if getattr(annotation, "__name__", None) == "Context":
             context_parameter = name
             continue
 
-        # A ``list[E]`` parameter is reserved for collection fan-in over
-        # ``list[E]`` returns, which is not supported yet. Reject it with a
-        # pointer at the supported alternatives instead of falling through to
-        # the misleading "no Event parameter" error.
-        if _event_list_element_types(annotation) is not None:
+        # Collection-stream fan-in: a ``list[E]`` parameter (e.g.
+        # ``events: list[Done]``) is a collect step. It buffers incoming ``E`` by
+        # stream id and releases per its ``Collect`` cardinality. ``E`` may be a
+        # union (``list[A | B]``) — every member type routes to the step. A bare
+        # ``list[E]`` is exactly ``Annotated[list[E], Collect(All())]``.
+        element_types = _event_list_element_types(annotation)
+        if element_types is not None:
+            marker = collect_marker if collect_marker is not None else Collect()
+            _validate_collect_marker(marker, name)
+            if collection_param is not None:
+                msg = (
+                    "A step may declare at most one list[E] collection parameter, "
+                    f"but found both {collection_param[0]!r} and {name!r}. "
+                    "Multi-slot collects are not supported."
+                )
+                raise WorkflowValidationError(msg)
+            collection_param = (name, tuple(element_types))
+            collection_policy = marker
+            accepted_events[name] = list(element_types)
+            continue
+        if collect_marker is not None:
             msg = (
-                f"Parameter {name!r} is annotated as list[E] of Event types. "
-                "Collection fan-in parameters are not supported yet; declare "
-                "multiple single-event parameters for a multi-slot join, or "
-                "use ctx.collect_events() to gather events."
+                f"Parameter {name!r} carries a Collect marker but is not annotated "
+                "as list[E] of an Event subclass. Collect markers apply only to "
+                "collection fan-in (list[Event]) parameters."
             )
             raise WorkflowValidationError(msg)
 
@@ -151,13 +189,26 @@ def inspect_signature(
         context_parameter=context_parameter,
         context_state_type=context_state_type,
         resources=resources,
+        collection_param=collection_param,
+        collection_policy=collection_policy,
         is_fan_out=_is_fan_out_return(fn, localns=localns),
         bare_return_types=_bare_return_types(fn, localns=localns),
     )
 
 
 def _event_list_element_types(annotation: Any) -> list[Any] | None:
-    """Element event types of a ``list[E]`` annotation, or None if not one."""
+    """Element event types of a ``list[E]`` annotation, or None if not one.
+
+    ``list[Done]`` -> ``[Done]``; ``list[A | B]`` -> ``[A, B]`` (the single arg is
+    itself a union). ``None`` is dropped. Returns None when ``annotation`` is not
+    a ``list`` of ``Event`` subclasses (so the caller falls through to other
+    parameter handling). Order is preserved; duplicates are removed.
+
+    ``Optional[list[E]]`` / ``list[E] | None`` unwraps to the inner ``list[E]``,
+    mirroring the fan-out *return* side (which already unwraps Optional) so a
+    collect parameter declared optional is recognized rather than rejected with a
+    misleading "no Event parameter" error.
+    """
     if get_origin(annotation) in (Union, UnionType):
         members = [a for a in get_args(annotation) if a is not type(None)]
         list_members = [a for a in members if get_origin(a) is list]
@@ -187,6 +238,15 @@ def _event_list_element_types(annotation: Any) -> list[Any] | None:
     return None
 
 
+def _validate_collect_marker(marker: Collect, name: str) -> None:
+    """Reject Collect cardinalities outside the supported contract."""
+    if not isinstance(marker.cardinality, (All, Take)):
+        raise WorkflowValidationError(
+            f"Collect cardinality on {name!r} must be All() or Take(n). "
+            "Other cardinalities are not supported."
+        )
+
+
 def validate_step_signature(spec: StepSignatureSpec) -> None:
     """
     Validate that a step signature specification meets workflow requirements.
@@ -201,6 +261,15 @@ def validate_step_signature(spec: StepSignatureSpec) -> None:
     num_of_events = len(spec.accepted_events)
     if num_of_events == 0:
         msg = "Step signature must have at least one parameter annotated as type Event"
+        raise WorkflowValidationError(msg)
+    if spec.collection_param is not None and num_of_events > 1:
+        # A list[E] collection parameter alongside other event params is a
+        # multi-slot collect, which this contract does not support.
+        msg = (
+            "A list[E] collection parameter cannot be combined with other "
+            "event parameters. Use a single list[E] parameter, or multiple "
+            "single-event parameters for a multi-slot join."
+        )
         raise WorkflowValidationError(msg)
     if num_of_events > 1:
         # Collect-mode (multi-slot fan-in): a step with more than one
@@ -384,10 +453,10 @@ def _reject_async_iterator_return(func: Callable, return_hint: Any) -> None:
 
 
 def _is_fan_out_return(func: Callable, localns: dict[str, Any] | None = None) -> bool:
-    """True if the return annotation declares per-element list emission.
+    """True if the return annotation emits a finite collection stream.
 
     A fan-out producer returns ``list[E]``. ``Optional[list[E]]``
-    (``list[E] | None``) also counts — it may emit a list or nothing. A plain
+    (``list[E] | None``) also counts — it may emit a stream or nothing. A plain
     single-event or union-of-single-events return is NOT fan-out.
     """
     type_hints = _resolve_type_hints(func, localns=localns)
@@ -417,7 +486,7 @@ def _bare_return_types(
     """Non-list members of the return annotation.
 
     For ``-> list[A] | B`` this is ``[B]``: a bare ``B`` return from a fan-out
-    step is ordinary dispatch rather than list emission. A pure ``-> list[A]``
+    step is ordinary dispatch rather than stream emission. A pure ``-> list[A]``
     has none, so any bare event return is a runtime error there. ``NoneType``
     is dropped (a ``None`` return is the no-emission path).
     """

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop.py
@@ -441,7 +441,9 @@ async def test_control_loop_step_failure_publishes_stop_event(
         "Failed event exception should carry the message"
     )
     assert stop_event.attempts == 1, "Failed event should contain the attempt count"
-    assert stop_event.elapsed_seconds >= 0, "Failed event should contain elapsed time"
+    assert stop_event.elapsed_seconds is not None and stop_event.elapsed_seconds >= 0, (
+        "Failed event should contain elapsed time"
+    )
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/runtime/test_state.py
+++ b/packages/llama-index-workflows/tests/runtime/test_state.py
@@ -23,7 +23,7 @@ def _v1_payload(in_progress: list[str], queue: list[str]) -> dict:
     """A version-1 serialized context with one worker.
 
     v1 stored ``in_progress`` as bare event strings (queue entries were already
-    structured attempts).
+    structured attempts) and had none of the collection-stream fields.
     """
     return {
         "version": 1,
@@ -75,6 +75,11 @@ def test_from_dict_auto_migrates_v1_in_progress_strings() -> None:
     assert attempt.event == event
     assert attempt.attempts == 0
     assert attempt.not_before is None
+    # New stream fields fall back to empty defaults.
+    assert attempt.scope_path == []
+    assert result.stream_seq == 0
+    assert result.streams == {}
+    assert result.collection_release_states == {}
 
 
 def test_from_dict_auto_migrates_v1_with_empty_in_progress() -> None:
@@ -105,17 +110,23 @@ def test_from_dict_auto_passes_current_version_through() -> None:
                         "event": event,
                         "attempts": 1,
                         "first_attempt_at": None,
+                        "scope_path": ["b0"],
                     }
                 ],
                 "collected_events": {},
                 "collected_waiters": [],
             }
         },
+        "stream_seq": 3,
+        "streams": {},
+        "collection_release_states": {},
     }
     result = SerializedContext.from_dict_auto(payload)
 
     assert result.version == CURRENT_SERIALIZED_VERSION
+    assert result.stream_seq == 3
     attempt = result.workers["middle_step"].in_progress[0]
+    assert attempt.scope_path == ["b0"]
     assert attempt.attempts == 1
 
 

--- a/packages/llama-index-workflows/tests/test_collect_algebra.py
+++ b/packages/llama-index-workflows/tests/test_collect_algebra.py
@@ -1,0 +1,634 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Collect selection algebra.
+
+Covers the public ``Collect`` / ``Cardinality`` API, signature inference for
+collection fan-in parameters (bare ``list[E]``, the ``Annotated[..., Collect()]``
+synonym, union flat lists, and the ``Take(n)`` marker), the validation errors
+that keep mode determination legible, and ``Take(n)`` runtime release.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Any, Callable, cast
+
+import pytest
+from workflows import All, Cardinality, Collect, Context, Take, Workflow, step
+from workflows.decorators import StepConfig, StepFunction
+from workflows.decorators import step as free_step
+from workflows.errors import (
+    WorkflowCancelledByUser,
+    WorkflowRuntimeError,
+    WorkflowValidationError,
+)
+from workflows.events import Event, StartEvent, StopEvent, WorkflowIdleEvent
+
+
+class Task(Event):
+    n: int
+
+
+class Done(Event):
+    n: int
+
+
+class Skipped(Event):
+    n: int
+
+
+async def _run(wf: Workflow) -> object:
+    """Run a workflow to completion, draining its event stream first."""
+    handler = wf.run()
+    async for _ in handler.stream_events():
+        pass
+    return await handler
+
+
+# --------------------------------------------------------------------------- #
+# Public API: Cardinality / Collect dataclasses
+# --------------------------------------------------------------------------- #
+
+
+def test_collect_defaults_to_all_cardinality() -> None:
+    marker = Collect()
+    assert isinstance(marker.cardinality, All)
+
+
+def test_cardinality_hierarchy() -> None:
+    assert isinstance(All(), Cardinality)
+    assert isinstance(Take(1), Cardinality)
+    assert Take(3).n == 3
+
+
+def test_at_least_is_not_exported() -> None:
+    """The at-least cardinality is outside the supported set."""
+    import workflows
+
+    export_name = "".join(("At", "Least"))
+    assert not hasattr(workflows, export_name)
+
+
+@pytest.mark.parametrize("bad", [0, -1, 1.5, "2"])
+def test_take_rejects_bad_n(bad: Any) -> None:
+    with pytest.raises(ValueError):
+        Take(bad)
+
+
+# --------------------------------------------------------------------------- #
+# Inference matrix: signature -> StepConfig
+# --------------------------------------------------------------------------- #
+
+
+def _config_for(fn_builder: Callable[[type[Workflow]], StepFunction]) -> StepConfig:
+    """Decorate a free function step against a throwaway workflow, return config."""
+
+    class _W(Workflow):
+        pass
+
+    return fn_builder(_W)._step_config
+
+
+def test_bare_list_infers_collect_all() -> None:
+    def build(w: type[Workflow]) -> StepFunction:
+        @free_step(workflow=w)
+        async def join(events: list[Done]) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+        return join
+
+    cfg = _config_for(build)
+    assert cfg.collection_param == ("events", (Done,))
+    assert cfg.collection_policy is not None
+    assert isinstance(cfg.collection_policy.cardinality, All)
+
+
+def test_annotated_collect_is_synonym_for_bare_list() -> None:
+    def build(w: type[Workflow]) -> StepFunction:
+        @free_step(workflow=w)
+        async def join(events: Annotated[list[Done], Collect()]) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+        return join
+
+    cfg = _config_for(build)
+    assert cfg.collection_param == ("events", (Done,))
+    assert cfg.collection_policy is not None
+    assert isinstance(cfg.collection_policy.cardinality, All)
+
+
+def test_annotated_take_cardinality_inferred() -> None:
+    def build(w: type[Workflow]) -> StepFunction:
+        @free_step(workflow=w)
+        async def join(events: Annotated[list[Done], Collect(Take(2))]) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+        return join
+
+    cfg = _config_for(build)
+    assert cfg.collection_policy is not None
+    assert cfg.collection_policy.cardinality == Take(2)
+
+
+def test_union_flat_list_infers_all_member_types() -> None:
+    def build(w: type[Workflow]) -> StepFunction:
+        @free_step(workflow=w)
+        async def report(events: list[Done | Skipped]) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+        return report
+
+    cfg = _config_for(build)
+    assert cfg.collection_param is not None
+    assert cfg.collection_param[1] == (Done, Skipped)
+    assert Done in cfg.accepted_events
+    assert Skipped in cfg.accepted_events
+
+
+def test_single_event_param_is_not_collection_param() -> None:
+    def build(w: type[Workflow]) -> StepFunction:
+        @free_step(workflow=w)
+        async def work(ev: Task) -> Done:  # type: ignore[unused-ignore]
+            return Done(n=ev.n)
+
+        return work
+
+    cfg = _config_for(build)
+    assert cfg.collection_param is None
+    assert cfg.collection_policy is None
+
+
+# --------------------------------------------------------------------------- #
+# Validation: legible mode determination
+# --------------------------------------------------------------------------- #
+
+
+def test_unknown_cardinality_raises_clear_error() -> None:
+    class _W(Workflow):
+        pass
+
+    class Weird(Cardinality):
+        pass
+
+    with pytest.raises(WorkflowValidationError, match="All\\(\\) or Take\\(n\\)"):
+
+        @free_step(workflow=_W)
+        async def join(  # type: ignore[unused-ignore]
+            events: Annotated[list[Done], Collect(Weird())],
+        ) -> StopEvent:
+            return StopEvent(result="x")
+
+
+def test_collect_marker_on_non_list_param_raises() -> None:
+    class _W(Workflow):
+        pass
+
+    with pytest.raises(WorkflowValidationError, match="only to collection fan-in"):
+
+        @free_step(workflow=_W)
+        async def join(ev: Annotated[Done, Collect()]) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+
+def test_two_list_params_rejected_as_multi_slot() -> None:
+    class _W(Workflow):
+        pass
+
+    with pytest.raises(WorkflowValidationError, match=r"at most one list\[E\]"):
+
+        @free_step(workflow=_W)
+        async def merge(a: list[Done], b: list[Skipped]) -> StopEvent:  # type: ignore[unused-ignore]
+            return StopEvent(result="x")
+
+
+# --------------------------------------------------------------------------- #
+# Runtime: cardinality release
+# --------------------------------------------------------------------------- #
+
+
+async def test_take_one_fires_with_first_and_completes() -> None:
+    """`Take(1)` releases on the first arrival with a single event."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(5)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def fastest(
+            self, events: Annotated[list[Done], Collect(Take(1))]
+        ) -> StopEvent:
+            return StopEvent(result=len(events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == 1
+
+
+async def test_take_one_leaves_siblings_running() -> None:
+    """`Take(1)` fires once; the dropped siblings still run without error."""
+
+    work_calls: list[int] = []
+    join_calls: list[int] = []
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(4)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            work_calls.append(ev.n)
+            return Done(n=ev.n)
+
+        @step
+        async def fastest(
+            self, events: Annotated[list[Done], Collect(Take(1))]
+        ) -> StopEvent:
+            join_calls.append(len(events))
+            return StopEvent(result="done")
+
+    result = await _run(FanOut(timeout=10))
+    assert result == "done"
+    # The join fired exactly once with a single event.
+    assert join_calls == [1]
+
+
+async def test_take_two_fires_with_two() -> None:
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(6)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def first_two(
+            self, events: Annotated[list[Done], Collect(Take(2))]
+        ) -> StopEvent:
+            return StopEvent(result=len(events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == 2
+
+
+async def test_take_covers_quorum() -> None:
+    """Quorum (commit once N have arrived) is `Take(N)` in v1: release at N."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(5)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def commit(
+            self, acks: Annotated[list[Done], Collect(Take(3))]
+        ) -> StopEvent:
+            return StopEvent(result=len(acks))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == 3
+
+
+async def test_take_below_threshold_fires_on_close() -> None:
+    """`Take(n)` with fewer than n members fires on stream close, not early."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def commit(
+            self, events: Annotated[list[Done], Collect(Take(5))]
+        ) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == [0, 1, 2]
+
+
+async def test_take_inside_nested_stream_releases_per_inner_level() -> None:
+    """`Take(n)` on an inner join releases early within each inner stream and the
+    outer join still sees one summary per inner stream."""
+
+    class InnerTask(Event):
+        outer: int
+        inner: int
+
+    class InnerDone(Event):
+        outer: int
+        inner: int
+
+    class InnerSummary(Event):
+        outer: int
+        count: int
+
+    class FanOut(Workflow):
+        @step
+        async def outer(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=o) for o in range(2)]
+
+        @step
+        async def inner(self, ev: Task) -> list[InnerTask]:
+            return [InnerTask(outer=ev.n, inner=i) for i in range(4)]
+
+        @step
+        async def inner_work(self, ev: InnerTask) -> InnerDone:
+            return InnerDone(outer=ev.outer, inner=ev.inner)
+
+        @step
+        async def per_inner(
+            self, events: Annotated[list[InnerDone], Collect(Take(2))]
+        ) -> InnerSummary:
+            return InnerSummary(outer=events[0].outer, count=len(events))
+
+        @step
+        async def per_outer(self, events: list[InnerSummary]) -> StopEvent:
+            return StopEvent(result=sorted((s.outer, s.count) for s in events))
+
+    result = await _run(FanOut(timeout=10))
+    # Each inner stream releases exactly 2 (Take(2)); one summary per outer.
+    assert result == [(0, 2), (1, 2)], result
+
+
+async def test_union_flat_list_collects_all_member_types() -> None:
+    """`list[Done | Skipped]` collects both member types into one closed stream."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(6)]
+
+        @step
+        async def work(self, ev: Task) -> Done | Skipped:
+            return Done(n=ev.n) if ev.n % 2 == 0 else Skipped(n=ev.n)
+
+        @step
+        async def report(self, events: list[Done | Skipped]) -> StopEvent:
+            dones = sorted(e.n for e in events if isinstance(e, Done))
+            skips = sorted(e.n for e in events if isinstance(e, Skipped))
+            return StopEvent(result=(dones, skips))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == ([0, 2, 4], [1, 3, 5])
+
+
+async def test_annotated_all_runs_like_bare_list() -> None:
+    """`Annotated[list[E], Collect()]` behaves exactly like bare `list[E]`."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(4)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: Annotated[list[Done], Collect()]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == [0, 1, 2, 3]
+
+
+# --------------------------------------------------------------------------- #
+# Streams are runtime facts: only an actual list return mints a stream.
+# --------------------------------------------------------------------------- #
+
+
+class Round(Event):
+    i: int
+
+
+async def test_none_return_emits_no_stream_and_joins_do_not_fire() -> None:
+    """`return None` is a dead branch: no stream, no join firing.
+
+    The producer is kicked three times; only the execution that actually
+    returns a list opens a stream, so the join fires exactly once with its
+    members — never with a fabricated [] for the None executions.
+    """
+    join_calls: list[list[int]] = []
+    calls = {"n": 0}
+
+    class WF(Workflow):
+        @step
+        async def driver(self, ctx: Context, ev: StartEvent) -> Round:
+            ctx.send_event(Round(i=1))
+            ctx.send_event(Round(i=2))
+            return Round(i=0)
+
+        @step(num_workers=1)
+        async def produce(self, ev: Round) -> list[Task] | None:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                return None
+            return [Task(n=k) for k in range(2)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            join_calls.append(sorted(e.n for e in events))
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(WF(timeout=8))
+    assert result == [0, 1]
+    assert join_calls == [[0, 1]], join_calls
+
+
+async def test_bare_union_member_routes_ordinarily_and_join_idles() -> None:
+    """`-> list[A] | B` returning B never fires list[A] joins.
+
+    With the B lineage dying out, the run has no stream and nothing to do: it
+    idles (observably via WorkflowIdleEvent) instead of completing the join
+    with a fabricated [].
+    """
+    join_calls: list[list[int]] = []
+    singles: list[int] = []
+
+    class Single(Event):
+        n: int
+
+    class WF(Workflow):
+        @step
+        async def produce(self, ev: StartEvent) -> list[Task] | Single:
+            return Single(n=7)
+
+        @step
+        async def handle_single(self, ev: Single) -> None:
+            singles.append(ev.n)
+            return None
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            join_calls.append(sorted(e.n for e in events))
+            return StopEvent(result=None)
+
+    handler = WF(timeout=5).run()
+    saw_idle = False
+    async for ev in handler.stream_events(expose_internal=True):
+        if isinstance(ev, WorkflowIdleEvent):
+            saw_idle = True
+            break
+    await handler.cancel_run()
+    try:
+        await handler
+    except WorkflowCancelledByUser:
+        pass
+
+    assert saw_idle
+    assert singles == [7]
+    assert join_calls == [], join_calls
+
+
+async def test_bare_member_declared_both_listed_and_bare_is_single_dispatch() -> None:
+    """`-> list[A] | A` returning a bare A is the declared single member."""
+    join_calls: list[list[int]] = []
+
+    class WF(Workflow):
+        @step
+        async def produce(self, ev: StartEvent) -> list[Done] | Done:
+            return Done(n=5)
+
+        @step
+        async def handle(self, ev: Done) -> StopEvent:
+            return StopEvent(result=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            join_calls.append(sorted(e.n for e in events))
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(WF(timeout=5))
+    assert result == 5
+    assert join_calls == [], join_calls
+
+
+async def test_bare_element_under_pure_list_return_is_runtime_error() -> None:
+    """A bare element where only list[E] is declared fails loudly."""
+
+    class WF(Workflow):
+        @step
+        async def produce(self, ev: StartEvent) -> list[Done]:
+            return cast("list[Done]", Done(n=0))  # wrong shape on purpose
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=len(events))
+
+    with pytest.raises(WorkflowRuntimeError, match="bare"):
+        await _run(WF(timeout=5))
+
+
+# --------------------------------------------------------------------------- #
+# Re-fanning collect steps open a child stream, not a parent-level binding.
+# --------------------------------------------------------------------------- #
+
+
+async def test_refanning_collect_fires_join_once_per_refan_stream() -> None:
+    """A collect step that fans out again must not create a spurious binding.
+
+    outer -> inner fan-out -> collect_and_refan(list[D]) -> list[N] -> join.
+    The join is bound to each re-fan stream and fires once per instance with
+    its members — never an extra time with [] when the outer stream closes.
+    """
+    join_calls: list[list[tuple[int, int]]] = []
+
+    class Outer(Event):
+        o: int
+
+    class D(Event):
+        o: int
+        i: int
+
+    class N(Event):
+        o: int
+        i: int
+
+    class Total(Event):
+        o: int
+        count: int
+
+    class WF(Workflow):
+        @step
+        async def outer(self, ev: StartEvent) -> list[Outer]:
+            return [Outer(o=k) for k in range(2)]
+
+        @step
+        async def inner_fan(self, ev: Outer) -> list[D]:
+            return [D(o=ev.o, i=j) for j in range(2)]
+
+        @step
+        async def collect_and_refan(self, events: list[D]) -> list[N]:
+            return [N(o=e.o, i=e.i) for e in events]
+
+        @step
+        async def join(self, events: list[N]) -> Total:
+            join_calls.append(sorted((e.o, e.i) for e in events))
+            return Total(o=events[0].o if events else -1, count=len(events))
+
+        @step
+        async def total_join(self, events: list[Total]) -> StopEvent:
+            return StopEvent(result=sorted((t.o, t.count) for t in events))
+
+    result = await _run(WF(timeout=8))
+    assert result == [(0, 2), (1, 2)], result
+    assert sorted(len(c) for c in join_calls) == [2, 2], join_calls
+    assert all(c for c in join_calls), join_calls
+
+
+# --------------------------------------------------------------------------- #
+# Multi-slot joins must fill at one stream level.
+# --------------------------------------------------------------------------- #
+
+
+def test_mixed_level_multi_slot_join_rejected_at_init() -> None:
+    """Slots produced at different stream levels can never join."""
+
+    class A(Event):
+        n: int
+
+    class B(Event):
+        n: int
+
+    with pytest.raises(WorkflowValidationError, match="common stream level"):
+
+        class WF(Workflow):
+            @step
+            async def fan(self, ev: StartEvent) -> list[Task]:
+                return [Task(n=0)]
+
+            @step
+            async def work(self, ev: Task) -> A:
+                return A(n=ev.n)
+
+            @step
+            async def top(self, ev: StartEvent) -> B:
+                return B(n=1)
+
+            @step
+            async def pair(self, a: A, b: B) -> StopEvent:
+                return StopEvent(result=(a.n, b.n))
+
+        WF()._validate()

--- a/packages/llama-index-workflows/tests/test_collect_algebra.py
+++ b/packages/llama-index-workflows/tests/test_collect_algebra.py
@@ -13,7 +13,8 @@ from __future__ import annotations
 from typing import Annotated, Any, Callable, cast
 
 import pytest
-from workflows import All, Cardinality, Collect, Context, Take, Workflow, step
+from workflows import Context, Workflow, step
+from workflows.collect import All, Cardinality, Collect, Take
 from workflows.decorators import StepConfig, StepFunction
 from workflows.decorators import step as free_step
 from workflows.errors import (

--- a/packages/llama-index-workflows/tests/test_collection_stream_liveness_model.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_liveness_model.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Model test for the fan-out/fan-in stream liveness rule.
+
+Drives a synthetic stream through the transitions the reducer applies: seed at
+open, same-scope emission, collect delivery, nested fan-out, and close-on-empty.
+End-to-end coverage lives in
+``test_collection_stream_regressions.py``; this pins the invariant itself:
+**a stream closes exactly when its open work set empties, never before.**
+"""
+
+from __future__ import annotations
+
+import pytest
+from workflows import Workflow, step
+from workflows.context.serializers import JsonSerializer
+from workflows.errors import WorkflowRuntimeError
+from workflows.events import Event, StartEvent, StopEvent
+from workflows.runtime.control_loop import (
+    _apply_stream_work_delta,
+    _classify_work_item,
+    _close_collection_stream,
+    _count_accepting_steps,
+)
+from workflows.runtime.types.commands import (
+    CommandRunWorker,
+    WorkflowCommand,
+)
+from workflows.runtime.types.internal_state import (
+    BrokerState,
+    CollectionReleaseState,
+    CollectionStreamInstance,
+)
+from workflows.runtime.types.results import StepWorkerFailed
+from workflows.runtime.types.step_id import StepId
+from workflows.runtime.types.ticks import TickStepResult
+
+
+class Task(Event):
+    n: int
+
+
+class Done(Event):
+    n: int
+
+
+class _WF(Workflow):
+    @step
+    async def fan_out(self, ev: StartEvent) -> list[Task]:
+        return [Task(n=i) for i in range(3)]
+
+    @step
+    async def work(self, ev: Task) -> Done:
+        return Done(n=ev.n)
+
+    @step
+    async def collect_a(self, events: list[Done]) -> StopEvent:
+        return StopEvent(result=len(events))
+
+    @step
+    async def collect_b(self, events: list[Done]) -> None:
+        return None
+
+
+def _state() -> BrokerState:
+    return BrokerState.from_workflow(_WF())
+
+
+def _open_stream(state: BrokerState, open_work_items: int) -> CollectionStreamInstance:
+    stream = CollectionStreamInstance(
+        stream_id="stream-test",
+        source_step="fan_out",
+        scope_path=(),
+        accepting_binding_ids=tuple(
+            binding.id for binding in state.config.bindings_for_source("fan_out")
+        ),
+        open_work_items=open_work_items,
+    )
+    state.streams[stream.stream_id] = stream
+    return stream
+
+
+def test_count_accepting_steps_is_work_item_fan_out_factor() -> None:
+    state = _state()
+    # Task is accepted by exactly one step (work); Done by two collects.
+    assert _count_accepting_steps(state, Task) == 1
+    assert _count_accepting_steps(state, Done) == 2
+
+
+def _release_targets(commands: list[WorkflowCommand]) -> list[str]:
+    """Step names invoked by inline release-firing commands."""
+    return sorted(c.step_id.name for c in commands if isinstance(c, CommandRunWorker))
+
+
+def test_close_fires_exactly_when_live_empties() -> None:
+    state = _state()
+    _open_stream(state, open_work_items=1)
+    # A positive/neutral delta never closes.
+    assert _apply_stream_work_delta(state, "stream-test", +2, 0.0) == []
+    assert state.streams["stream-test"].open_work_items == 3
+    assert _apply_stream_work_delta(state, "stream-test", -2, 0.0) == []
+    assert state.streams["stream-test"].open_work_items == 1
+    # Reaching zero closes exactly once: the record is removed and both
+    # bindings' releases fire inline as collect invocations.
+    commands = _apply_stream_work_delta(state, "stream-test", -1, 0.0)
+    assert _release_targets(commands) == ["collect_a", "collect_b"]
+    assert "stream-test" not in state.streams
+    assert state.collection_release_states == {}
+
+
+def test_full_two_collect_stream_drains_to_close() -> None:
+    """Walk #1's accounting: 3 Tasks, each work emits Done to two collects.
+
+    Seed open work = sum of accepting-step counts per member. Each work resolves
+    (-1 + 2 successors); each of the 6 collect deliveries resolves (-1). The
+    stream closes precisely on the last delivery, never earlier.
+    """
+    state = _state()
+    members = [Task(n=i) for i in range(3)]
+    seed = sum(_count_accepting_steps(state, type(m)) for m in members)
+    _open_stream(state, open_work_items=seed)
+    assert seed == 3
+
+    # Three 1:1 work resolutions: -1 (death) + 2 (Done accepted by two collects).
+    for _ in range(3):
+        assert (
+            _apply_stream_work_delta(
+                state, "stream-test", _count_accepting_steps(state, Done) - 1, 0.0
+            )
+            == []
+        )
+    assert state.streams["stream-test"].open_work_items == 6
+
+    # Six collect deliveries (3 Done x 2 collects), each -1. Only the last
+    # closes, firing both bindings' releases inline.
+    closed: list[WorkflowCommand] = []
+    for _ in range(6):
+        closed.extend(_apply_stream_work_delta(state, "stream-test", -1, 0.0))
+    assert _release_targets(closed) == ["collect_a", "collect_b"]
+    assert "stream-test" not in state.streams
+
+
+def test_apply_delta_is_noop_for_missing_or_none_stream() -> None:
+    state = _state()
+    assert _apply_stream_work_delta(state, None, -1, 0.0) == []
+    assert _apply_stream_work_delta(state, "nonexistent", -1, 0.0) == []
+    assert _close_collection_stream(state, "nonexistent", 0.0) == []
+
+
+def test_failed_work_without_redelivery_is_not_classified_live() -> None:
+    tick = TickStepResult(
+        step_id=StepId.root("work"),
+        worker_id=0,
+        event=Task(n=0),
+        result=[StepWorkerFailed(exception=RuntimeError("boom"), failed_at=1.0)],
+    )
+
+    with pytest.raises(WorkflowRuntimeError, match="Cannot classify"):
+        _classify_work_item(
+            tick,
+            [],
+            rerun_scheduled=False,
+            redelivery_scheduled=False,
+            fanned_out=False,
+        )
+
+
+def test_unreleased_release_buffer_serializes_and_fires_on_close() -> None:
+    state = _state()
+    stream = _open_stream(state, open_work_items=1)
+    binding = next(
+        b
+        for b in state.config.bindings_for_source("fan_out")
+        if b.target_step == "collect_a"
+    )
+    key = f"{stream.stream_id}:{binding.id}"
+    state.collection_release_states[key] = CollectionReleaseState(
+        binding_id=binding.id,
+        stream_id=stream.stream_id,
+        buffer=[Done(n=7)],
+    )
+
+    serializer = JsonSerializer()
+    restored = BrokerState.from_serialized(
+        state.to_serialized(serializer), _WF(), serializer
+    )
+    restored_buffer = restored.collection_release_states[key].buffer
+    assert [event.n for event in restored_buffer] == [7]
+
+    commands = _close_collection_stream(restored, stream.stream_id, 0.0)
+    assert _release_targets(commands) == ["collect_a", "collect_b"]
+    payload = (
+        restored.workers["collect_a"]
+        .in_progress[0]
+        .shared_state.collection_release_payload
+    )
+    assert payload is not None
+    assert [event.n for event in payload.events] == [7]

--- a/packages/llama-index-workflows/tests/test_collection_stream_loudness.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_loudness.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Loudness around collection streams: drop warnings and the idle hang detector.
+
+An untargeted ``ctx.send_event`` of a collected type that can never join a
+batch warns; a *targeted* send at a collect step is an explicit instruction
+the runtime cannot honor and fails the run. A quiescent run with open streams
+and no pending waiter inside them is provably stuck and must fail with a
+diagnostic naming the leaked streams; an unresolved waiter scoped inside the
+stream (HITL) suppresses the detector.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+from workflows import Context, Workflow, step
+from workflows.errors import WorkflowRuntimeError
+from workflows.events import Event, StartEvent, StopEvent, WorkflowIdleEvent
+from workflows.runtime.control_loop import _reduce_tick
+from workflows.runtime.types.commands import (
+    CommandFailWorkflow,
+    CommandPublishEvent,
+)
+from workflows.runtime.types.internal_state import (
+    BrokerState,
+    CollectionReleaseState,
+    CollectionStreamInstance,
+)
+from workflows.runtime.types.results import StepWorkerWaiter
+from workflows.runtime.types.step_id import StepId
+from workflows.runtime.types.ticks import TickIdleCheck
+
+_CONTROL_LOOP_LOGGER = "workflows.runtime.control_loop"
+
+
+class Task(Event):
+    n: int
+
+
+class Done(Event):
+    n: int
+
+
+class Approval(Event):
+    pass
+
+
+class Waiting(Event):
+    pass
+
+
+async def _run(wf: Workflow, timeout: float = 8.0) -> object:
+    """Run a workflow to completion, draining its event stream first."""
+    handler = wf.run()
+    async for _ in handler.stream_events():
+        pass
+    return await asyncio.wait_for(handler, timeout=timeout)
+
+
+def _warnings(caplog: pytest.LogCaptureFixture, needle: str) -> list[str]:
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == _CONTROL_LOOP_LOGGER
+        and r.levelno == logging.WARNING
+        and needle in r.getMessage()
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Drop warnings
+# ---------------------------------------------------------------------------
+
+
+async def test_untargeted_send_of_collected_type_warns_and_is_ignored(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ctx: Context, ev: Task) -> Done:
+            if ev.n == 2:
+                ctx.send_event(Done(n=99))
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    with caplog.at_level(logging.WARNING, logger=_CONTROL_LOOP_LOGGER):
+        result = await _run(WF(timeout=6))
+
+    # The extra Done never joined the batch, and the drop was loud.
+    assert result == [0, 1, 2]
+    messages = _warnings(caplog, "sent outside any collection stream")
+    assert messages, caplog.text
+    assert "Done" in messages[0]
+    assert "'join'" in messages[0]
+
+
+async def test_targeted_send_at_collect_step_fails_run() -> None:
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ctx: Context, ev: Task) -> Done:
+            if ev.n == 0:
+                ctx.send_event(Done(n=99), step="join")
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    with pytest.raises(WorkflowRuntimeError, match="targeted events"):
+        await _run(WF(timeout=6))
+
+
+# ---------------------------------------------------------------------------
+# Idle hang detector (reducer level)
+# ---------------------------------------------------------------------------
+
+
+class _FanOutWF(Workflow):
+    @step
+    async def fan_out(self, ev: StartEvent) -> list[Task]:
+        return [Task(n=i) for i in range(2)]
+
+    @step
+    async def work(self, ev: Task) -> Done:
+        return Done(n=ev.n)
+
+    @step
+    async def join(self, events: list[Done]) -> StopEvent:
+        return StopEvent(result=len(events))
+
+
+def _leaked_stream_state() -> BrokerState:
+    """Quiescent running state with one open stream and nothing in flight."""
+    wf = _FanOutWF()
+    wf._validate()
+    state = BrokerState.from_workflow(wf)
+    state.is_running = True
+    state.streams["stream-x"] = CollectionStreamInstance(
+        stream_id="stream-x",
+        source_step="fan_out",
+        scope_path=("stream-x",),
+        open_work_items=1,
+    )
+    return state
+
+
+def test_idle_check_fails_run_on_leaked_open_stream() -> None:
+    state = _leaked_stream_state()
+    _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
+
+    failures = [c for c in commands if isinstance(c, CommandFailWorkflow)]
+    assert len(failures) == 1, commands
+    message = str(failures[0].exception)
+    assert "fan_out" in message
+    assert "stream-x" in message
+    assert failures[0].step_id == StepId.root("fan_out")
+
+
+def test_idle_check_fails_run_on_orphaned_unreleased_release_state() -> None:
+    """An unreleased release whose stream is gone fails loudly, never hangs.
+
+    Stream closes fire releases inline, so this state is unreachable in a
+    healthy run — it indicates corrupted or version-skewed persisted state.
+    The detector must flag it even with no open streams (the blind spot that
+    used to hang resumes silently).
+    """
+    wf = _FanOutWF()
+    wf._validate()
+    state = BrokerState.from_workflow(wf)
+    state.is_running = True
+    binding_id = next(iter(state.config.collection_bindings))
+    state.collection_release_states[f"stream-gone:{binding_id}"] = (
+        CollectionReleaseState(binding_id=binding_id, stream_id="stream-gone")
+    )
+
+    _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
+
+    failures = [c for c in commands if isinstance(c, CommandFailWorkflow)]
+    assert len(failures) == 1, commands
+    assert failures[0].step_id == StepId.root("join")
+    message = str(failures[0].exception)
+    assert "stream-gone" in message
+    assert "never fire" in message
+
+
+def _waiter(scope_path: tuple[str, ...]) -> StepWorkerWaiter:
+    return StepWorkerWaiter(
+        waiter_id="w1",
+        event=Task(n=0),
+        waiting_for_event=Approval,
+        requirements={},
+        has_requirements=False,
+        resolved_event=None,
+        timed_out=False,
+        scope_path=scope_path,
+    )
+
+
+def test_idle_check_with_in_stream_waiter_publishes_idle_not_failure() -> None:
+    state = _leaked_stream_state()
+    state.workers["work"].collected_waiters.append(_waiter(("stream-x",)))
+    _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
+
+    assert not any(isinstance(c, CommandFailWorkflow) for c in commands), commands
+    idle_publishes = [
+        c
+        for c in commands
+        if isinstance(c, CommandPublishEvent) and isinstance(c.event, WorkflowIdleEvent)
+    ]
+    assert len(idle_publishes) == 1, commands
+
+
+def test_idle_check_with_out_of_stream_waiter_still_fails_run() -> None:
+    """A HITL waiter elsewhere in the workflow must not mask a wedged stream.
+
+    Only a waiter whose scope places it inside an open stream (or a
+    descendant) can still feed that stream; one outside (empty scope here)
+    cannot, so detection proceeds. The failure event carries no fabricated
+    attempt counters — this is not an exhausted step attempt.
+    """
+    state = _leaked_stream_state()
+    state.workers["work"].collected_waiters.append(_waiter(()))
+    _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
+
+    failures = [c for c in commands if isinstance(c, CommandFailWorkflow)]
+    assert len(failures) == 1, commands
+    published = [
+        c.event
+        for c in commands
+        if isinstance(c, CommandPublishEvent) and hasattr(c.event, "attempts")
+    ]
+    assert published and published[0].attempts is None
+    assert published[0].elapsed_seconds is None
+
+
+# ---------------------------------------------------------------------------
+# Idle hang detector (end-to-end): a pending HITL waiter inside an open stream
+# must not trip the detector while the run waits.
+# ---------------------------------------------------------------------------
+
+
+async def test_open_stream_with_pending_waiter_does_not_fail_run() -> None:
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(2)]
+
+        @step
+        async def work(self, ctx: Context, ev: Task) -> Done:
+            if ev.n == 0:
+                await ctx.wait_for_event(
+                    Approval, waiter_event=Waiting(), waiter_id="gate", timeout=5
+                )
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    handler = WF(timeout=10).run()
+    sent = False
+    async for ev in handler.stream_events():
+        if isinstance(ev, Waiting) and not sent:
+            sent = True
+            # Linger in the quiescent waiting state: idle checks run here and
+            # must publish idle, not fail the run.
+            await asyncio.sleep(0.5)
+            assert not handler.is_done()
+            handler.ctx.send_event(Approval())
+    assert sent, "workflow never emitted the Waiting marker"
+    result = await asyncio.wait_for(handler, timeout=8)
+    assert result == [0, 1]

--- a/packages/llama-index-workflows/tests/test_collection_stream_redelivery.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_redelivery.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Re-delivery of collect-step invocations.
+
+A collect-step invocation is an internal ``CollectionReleaseEvent`` carrying
+the released batch, never a member event. The re-delivery kind x scope grid
+lives in test_collection_stream_redelivery_matrix.py; this file keeps the two
+cases outside that grid: a waiter for a member type is not spuriously resolved
+by a re-delivered release carrying that type, and ``@catch_error`` on an empty
+release sees the real (empty) batch on ``StepFailedEvent.input_event``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from workflows import Context, Workflow, catch_error, step
+from workflows.events import (
+    CollectionReleaseEvent,
+    Event,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+)
+from workflows.retry_policy import retry_policy, stop_after_attempt, wait_fixed
+
+_RETRY = retry_policy(wait=wait_fixed(0.05), stop=stop_after_attempt(3))
+
+
+class Task(Event):
+    n: int
+
+
+class Done(Event):
+    n: int
+
+
+async def _run(wf: Workflow, timeout: float = 8.0) -> object:
+    """Run a workflow to completion, draining its event stream first."""
+    handler = wf.run()
+    async for _ in handler.stream_events():
+        pass
+    return await asyncio.wait_for(handler, timeout=timeout)
+
+
+async def test_waiter_for_member_type_not_resolved_by_collect_redelivery() -> None:
+    """A pending waiter for type T must not resolve when a collect invocation
+    carrying T members is re-delivered (retry). Only a genuine external T does.
+
+    The watcher starts waiting only after the stream's real Done members have
+    already been collected, so the only Done-shaped traffic during the wait is
+    the retried release — which must stay a CollectionReleaseEvent, never a
+    member event.
+    """
+
+    class StartWatch(Event):
+        pass
+
+    batches: list[list[int]] = []
+    resolved: list[int] = []
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(2)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step(retry_policy=_RETRY)
+        async def join(self, ctx: Context, events: list[Done]) -> StartWatch | None:
+            batches.append(sorted(e.n for e in events))
+            if len(batches) == 1:
+                ctx.send_event(StartWatch())
+                raise RuntimeError("transient join failure")
+            return None
+
+        @step
+        async def watcher(self, ctx: Context, ev: StartWatch) -> StopEvent:
+            done = await ctx.wait_for_event(Done, timeout=5)
+            resolved.append(done.n)
+            return StopEvent(result=done.n)
+
+    handler = WF(timeout=10).run()
+    # Wait for the retried join invocation to have run with the same batch.
+    for _ in range(300):
+        if len(batches) == 2:
+            break
+        await asyncio.sleep(0.02)
+    assert batches == [[0, 1], [0, 1]], batches
+    # Give any spurious waiter resolution time to surface, then confirm the
+    # re-delivered release did not resolve the Done waiter.
+    await asyncio.sleep(0.2)
+    assert resolved == []
+
+    # A genuine externally-sent Done resolves it.
+    handler.ctx.send_event(Done(n=777))
+    async for _ in handler.stream_events():
+        pass
+    result = await asyncio.wait_for(handler, timeout=8)
+    assert result == 777
+    assert resolved == [777]
+
+
+# ---------------------------------------------------------------------------
+# catch_error on a collect step whose stream released EMPTY: the handler sees
+# the real empty batch (the matrix covers the non-empty release cell).
+# ---------------------------------------------------------------------------
+
+
+async def test_catch_error_on_empty_release_sees_empty_batch() -> None:
+    captured: dict[str, StepFailedEvent] = {}
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return []
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            raise RuntimeError("join exploded on empty batch")
+
+        @catch_error(for_steps=["join"])
+        async def recover(self, ev: StepFailedEvent) -> StopEvent:
+            captured["ev"] = ev
+            return StopEvent(result="recovered-empty")
+
+    result = await _run(WF(timeout=8))
+    assert result == "recovered-empty"
+    failed = captured["ev"]
+    assert isinstance(failed.input_event, CollectionReleaseEvent)
+    assert failed.input_event.events == []

--- a/packages/llama-index-workflows/tests/test_collection_stream_redelivery_matrix.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_redelivery_matrix.py
@@ -20,7 +20,8 @@ import asyncio
 from typing import Annotated
 
 import pytest
-from workflows import Collect, Context, Take, Workflow, catch_error, step
+from workflows import Context, Workflow, catch_error, step
+from workflows.collect import Collect, Take
 from workflows.events import (
     CollectionReleaseEvent,
     Event,

--- a/packages/llama-index-workflows/tests/test_collection_stream_redelivery_matrix.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_redelivery_matrix.py
@@ -1,0 +1,610 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Re-delivery matrix for collection-stream work items.
+
+A work item's record (event, scope_path, collection release payload, retry
+lineage) must travel WHOLE through every re-delivery path. This file crosses
+the three re-delivery kinds — retry, @catch_error routing, and wait_for_event
+resume — with the three places a work item can live: a top-level collect step,
+a nested (inner) collect step, and a 1:1 worker inside a fan-out branch. It
+then covers serialize/resume round-trips taken mid-flight and two interaction
+cells (Take(n) + retry, num_workers>1 overlapping releases + retry).
+
+Every cell asserts two things: the run completes with the correct batch, and
+each delivery of the target work item observed the *same* payload.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated
+
+import pytest
+from workflows import Collect, Context, Take, Workflow, catch_error, step
+from workflows.events import (
+    CollectionReleaseEvent,
+    Event,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+)
+from workflows.handler import WorkflowHandler
+from workflows.retry_policy import retry_policy, stop_after_attempt, wait_fixed
+
+
+class Task(Event):
+    n: int
+
+
+class Done(Event):
+    n: int
+
+
+class InnerTask(Event):
+    outer: int
+    inner: int
+
+
+class InnerDone(Event):
+    outer: int
+    inner: int
+
+
+class InnerSummary(Event):
+    outer: int
+    total: int
+
+
+class Approval(Event):
+    token: str
+
+
+class ApprovalRequired(Event):
+    """Waiter marker written to the event stream by a parked step."""
+
+    token: str
+
+
+_FAST_RETRY = retry_policy(wait=wait_fixed(0.01), stop=stop_after_attempt(3))
+
+_KINDS = ["retry", "catch_error", "waiter"]
+
+
+async def _run(wf: Workflow, timeout: float = 8.0) -> object:
+    """Run to completion, answering each ApprovalRequired marker exactly once.
+
+    Draining the published-event stream lets the in-memory runtime's pull task
+    finish cleanly; for waiter cells the drain doubles as the external approver.
+    """
+    handler = wf.run()
+
+    async def drive() -> object:
+        answered: set[str] = set()
+        async for ev in handler.stream_events():
+            if isinstance(ev, ApprovalRequired) and ev.token not in answered:
+                answered.add(ev.token)
+                handler.ctx.send_event(Approval(token=ev.token))
+        return await handler
+
+    return await asyncio.wait_for(drive(), timeout=timeout)
+
+
+async def _drain(handler: WorkflowHandler) -> None:
+    async for _ in handler.stream_events():
+        pass
+
+
+async def _snapshot_cancel(handler: WorkflowHandler) -> dict:
+    """Snapshot a live run, then cancel it (ignoring the cancellation error)."""
+    snapshot = handler.ctx.to_dict()
+    await handler.cancel_run()
+    try:
+        await asyncio.wait_for(handler, timeout=2)
+    except BaseException:
+        pass
+    return snapshot
+
+
+# ---------------------------------------------------------------------------
+# Matrix: re-delivery kind x scope. Each factory builds a workflow whose target
+# step is re-delivered once via `kind`, recording the payload seen by every
+# delivery so identity across deliveries is asserted, not just completion.
+# ---------------------------------------------------------------------------
+
+
+class _TopLevelBase(Workflow):
+    """Shared producers: fan out 4 members, 1:1 work, join defined per kind."""
+
+    @step
+    async def fan_out(self, ev: StartEvent) -> list[Task]:
+        return [Task(n=i) for i in range(4)]
+
+    @step
+    async def work(self, ev: Task) -> Done:
+        return Done(n=ev.n)
+
+
+def _make_top_level_join_wf(kind: str, batches: list[list[int]]) -> type[Workflow]:
+    """The re-delivered step is the top-level collect step itself."""
+    if kind == "retry":
+
+        class RetryWF(_TopLevelBase):
+            @step(retry_policy=_FAST_RETRY)
+            async def join(self, events: list[Done]) -> StopEvent:
+                batch = sorted(e.n for e in events)
+                batches.append(batch)
+                if len(batches) == 1:
+                    raise RuntimeError("transient join failure")
+                return StopEvent(result=batch)
+
+        return RetryWF
+
+    if kind == "catch_error":
+
+        class CatchWF(_TopLevelBase):
+            @step
+            async def join(self, events: list[Done]) -> StopEvent:
+                batches.append(sorted(e.n for e in events))
+                raise RuntimeError("terminal join failure")
+
+            @catch_error(for_steps=["join"])
+            async def recover(self, ev: StepFailedEvent) -> StopEvent:
+                release = ev.input_event
+                assert isinstance(release, CollectionReleaseEvent)
+                batch = sorted(e.n for e in release.events)
+                batches.append(batch)
+                return StopEvent(result=batch)
+
+        return CatchWF
+
+    class WaiterWF(_TopLevelBase):
+        @step
+        async def join(self, ctx: Context, events: list[Done]) -> StopEvent:
+            batch = sorted(e.n for e in events)
+            batches.append(batch)
+            await ctx.wait_for_event(
+                Approval,
+                waiter_event=ApprovalRequired(token="top-join"),
+                waiter_id="top-join",
+                timeout=3,
+            )
+            return StopEvent(result=batch)
+
+    return WaiterWF
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+async def test_top_level_join_redelivery_completes_with_full_batch(
+    kind: str,
+) -> None:
+    batches: list[list[int]] = []
+    result = await _run(_make_top_level_join_wf(kind, batches)(timeout=8))
+    assert result == [0, 1, 2, 3]
+    # Both deliveries of the collect invocation saw the identical batch.
+    assert batches == [[0, 1, 2, 3], [0, 1, 2, 3]], batches
+
+
+class _NestedBase(Workflow):
+    """Outer fan-out of 3, inner fan-out of 2; per_inner defined per kind."""
+
+    @step
+    async def outer(self, ev: StartEvent) -> list[Task]:
+        return [Task(n=o) for o in range(3)]
+
+    @step
+    async def inner(self, ev: Task) -> list[InnerTask]:
+        return [InnerTask(outer=ev.n, inner=i) for i in range(2)]
+
+    @step
+    async def inner_work(self, ev: InnerTask) -> InnerDone:
+        return InnerDone(outer=ev.outer, inner=ev.inner)
+
+    @step
+    async def per_outer(self, events: list[InnerSummary]) -> StopEvent:
+        return StopEvent(result=sorted((s.outer, s.total) for s in events))
+
+
+def _make_nested_join_wf(kind: str, batches: list[list[int]]) -> type[Workflow]:
+    """The re-delivered step is the inner collect step, for outer==1 only.
+
+    `batches` records the inner indices seen by each delivery of that one
+    invocation; the other outers run undisturbed.
+    """
+    if kind == "retry":
+
+        class RetryWF(_NestedBase):
+            @step(retry_policy=_FAST_RETRY)
+            async def per_inner(self, events: list[InnerDone]) -> InnerSummary:
+                outer = events[0].outer
+                if outer == 1:
+                    batches.append(sorted(e.inner for e in events))
+                    if len(batches) == 1:
+                        raise RuntimeError("transient inner join failure")
+                return InnerSummary(outer=outer, total=len(events))
+
+        return RetryWF
+
+    if kind == "catch_error":
+
+        class CatchWF(_NestedBase):
+            @step
+            async def per_inner(self, events: list[InnerDone]) -> InnerSummary:
+                outer = events[0].outer
+                if outer == 1:
+                    batches.append(sorted(e.inner for e in events))
+                    raise RuntimeError("terminal inner join failure")
+                return InnerSummary(outer=outer, total=len(events))
+
+            @catch_error(for_steps=["per_inner"])
+            async def recover(self, ev: StepFailedEvent) -> InnerSummary:
+                release = ev.input_event
+                assert isinstance(release, CollectionReleaseEvent)
+                members = release.events
+                batches.append(sorted(e.inner for e in members))
+                # The recovered summary must rejoin the OUTER stream so the
+                # outer collect still sees all three summaries.
+                return InnerSummary(outer=members[0].outer, total=len(members))
+
+        return CatchWF
+
+    class WaiterWF(_NestedBase):
+        @step
+        async def per_inner(
+            self, ctx: Context, events: list[InnerDone]
+        ) -> InnerSummary:
+            outer = events[0].outer
+            if outer == 1:
+                batches.append(sorted(e.inner for e in events))
+                await ctx.wait_for_event(
+                    Approval,
+                    waiter_event=ApprovalRequired(token="inner-1"),
+                    waiter_id="inner-1",
+                    timeout=3,
+                )
+            return InnerSummary(outer=outer, total=len(events))
+
+    return WaiterWF
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+async def test_nested_join_redelivery_completes_with_full_batch(kind: str) -> None:
+    batches: list[list[int]] = []
+    result = await _run(_make_nested_join_wf(kind, batches)(timeout=8))
+    assert result == [(0, 2), (1, 2), (2, 2)]
+    assert batches == [[0, 1], [0, 1]], batches
+
+
+class _BranchBase(Workflow):
+    """Fan-out of 3 with a plain join; the worker is defined per kind."""
+
+    @step
+    async def fan_out(self, ev: StartEvent) -> list[Task]:
+        return [Task(n=i) for i in range(3)]
+
+    @step
+    async def join(self, events: list[Done]) -> StopEvent:
+        return StopEvent(result=sorted(e.n for e in events))
+
+
+def _make_branch_member_wf(kind: str, deliveries: list[int]) -> type[Workflow]:
+    """The re-delivered step is the 1:1 worker for stream member n==1.
+
+    Its output must keep its scope so it still joins the stream.
+    """
+    if kind == "retry":
+
+        class RetryWF(_BranchBase):
+            @step(retry_policy=_FAST_RETRY)
+            async def work(self, ev: Task) -> Done:
+                if ev.n == 1:
+                    deliveries.append(ev.n)
+                    if len(deliveries) == 1:
+                        raise RuntimeError("transient member failure")
+                return Done(n=ev.n)
+
+        return RetryWF
+
+    if kind == "catch_error":
+
+        class CatchWF(_BranchBase):
+            @step
+            async def work(self, ev: Task) -> Done:
+                if ev.n == 1:
+                    deliveries.append(ev.n)
+                    raise RuntimeError("terminal member failure")
+                return Done(n=ev.n)
+
+            @catch_error(for_steps=["work"])
+            async def recover(self, ev: StepFailedEvent) -> Done:
+                failed = ev.input_event
+                assert isinstance(failed, Task)
+                deliveries.append(failed.n)
+                return Done(n=failed.n)
+
+        return CatchWF
+
+    class WaiterWF(_BranchBase):
+        @step
+        async def work(self, ctx: Context, ev: Task) -> Done:
+            if ev.n == 1:
+                deliveries.append(ev.n)
+                await ctx.wait_for_event(
+                    Approval,
+                    waiter_event=ApprovalRequired(token="member-1"),
+                    waiter_id="member-1",
+                    timeout=3,
+                )
+            return Done(n=ev.n)
+
+    return WaiterWF
+
+
+@pytest.mark.parametrize("kind", _KINDS)
+async def test_branch_member_redelivery_output_still_joins(kind: str) -> None:
+    deliveries: list[int] = []
+    result = await _run(_make_branch_member_wf(kind, deliveries)(timeout=8))
+    assert result == [0, 1, 2]
+    # Member 1 was delivered twice (original + re-delivery), same event.
+    assert deliveries == [1, 1], deliveries
+
+
+# ---------------------------------------------------------------------------
+# Serialize/resume round-trips mid-flight. Module-level gates/state survive the
+# first run's cancellation so the resumed run (same module event loop) can be
+# released and compared against the original deliveries.
+# ---------------------------------------------------------------------------
+
+
+def _waiter_branch_workflow() -> type[Workflow]:
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(4)]
+
+        @step(num_workers=8)
+        async def work(self, ctx: Context, ev: Task) -> Done:
+            if ev.n == 2:
+                await ctx.wait_for_event(
+                    Approval,
+                    waiter_event=ApprovalRequired(token="branch-2"),
+                    waiter_id="branch-2",
+                    timeout=8,
+                )
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    return WF
+
+
+async def test_resume_with_unresolved_waiter_in_branch() -> None:
+    """Snapshot while one branch is parked on wait_for_event, resume, approve."""
+    wf = _waiter_branch_workflow()(timeout=20)
+    handler = wf.run()
+    async for ev in handler.stream_events():
+        if isinstance(ev, ApprovalRequired):
+            break
+    await asyncio.sleep(0.2)  # let the other members settle into the join buffer
+    snapshot = await _snapshot_cancel(handler)
+
+    wf2 = _waiter_branch_workflow()(timeout=20)
+    restored = Context.from_dict(wf2, snapshot)
+    handler2 = wf2.run(ctx=restored)
+    drain = asyncio.create_task(_drain(handler2))
+    result_task: asyncio.Future[object] = asyncio.ensure_future(handler2)
+    # The waiter was restored from the snapshot; nudge it until it resolves.
+    for _ in range(50):
+        if result_task.done():
+            break
+        handler2.ctx.send_event(Approval(token="branch-2"))
+        await asyncio.sleep(0.1)
+    result = await asyncio.wait_for(result_task, timeout=5)
+    await asyncio.wait_for(drain, timeout=5)
+    assert result == [0, 1, 2, 3], result
+
+
+_MID_COLLECT_GATE = asyncio.Event()
+_MID_COLLECT_BATCHES: list[list[int]] = []
+
+
+def _gated_collect_workflow() -> type[Workflow]:
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(4)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            _MID_COLLECT_BATCHES.append(sorted(e.n for e in events))
+            await _MID_COLLECT_GATE.wait()  # hold the invocation open
+            return StopEvent(result=sorted(e.n for e in events))
+
+    return WF
+
+
+async def test_resume_mid_collect_invocation_preserves_payload() -> None:
+    """Snapshot while the collect invocation is in progress; resume re-fires it
+    with the identical batch (the release payload travels in the snapshot)."""
+    _MID_COLLECT_GATE.clear()
+    _MID_COLLECT_BATCHES.clear()
+
+    wf = _gated_collect_workflow()(timeout=20)
+    handler = wf.run()
+    for _ in range(300):
+        if _MID_COLLECT_BATCHES:
+            break
+        await asyncio.sleep(0.02)
+    assert _MID_COLLECT_BATCHES, "collect invocation never started"
+    snapshot = await _snapshot_cancel(handler)
+
+    _MID_COLLECT_GATE.set()
+    wf2 = _gated_collect_workflow()(timeout=20)
+    restored = Context.from_dict(wf2, snapshot)
+    result = await asyncio.wait_for(wf2.run(ctx=restored), timeout=8)
+    assert result == [0, 1, 2, 3], result
+    assert _MID_COLLECT_BATCHES == [[0, 1, 2, 3], [0, 1, 2, 3]], _MID_COLLECT_BATCHES
+
+
+_RETRY_COLLECT_GATE = asyncio.Event()
+_RETRY_COLLECT_BATCHES: list[list[int]] = []
+
+
+def _retrying_collect_workflow() -> type[Workflow]:
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(4)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step(retry_policy=_FAST_RETRY)
+        async def join(self, events: list[Done]) -> StopEvent:
+            _RETRY_COLLECT_BATCHES.append(sorted(e.n for e in events))
+            if len(_RETRY_COLLECT_BATCHES) == 1:
+                raise RuntimeError("transient join failure")
+            await _RETRY_COLLECT_GATE.wait()  # hold the retry attempt open
+            return StopEvent(result=sorted(e.n for e in events))
+
+    return WF
+
+
+async def test_resume_mid_collect_retry_preserves_payload_and_lineage() -> None:
+    """Snapshot while a collect invocation's RETRY attempt is in flight.
+
+    The retry re-runs the same work item; snapshotting mid-retry and resuming
+    must re-deliver the identical batch.
+
+    Note: a snapshot taken inside the retry *delay window* (between the failed
+    attempt and the rescheduled one) is NOT capturable today — the delayed
+    re-delivery lives only in the runner's in-memory scheduled-wakeups heap, so
+    the work item is absent from the serialized state and the resumed run
+    hangs. That gap is general to retry delays (not collect-specific), so this
+    test pins the in-flight-retry variant instead.
+    """
+    _RETRY_COLLECT_GATE.clear()
+    _RETRY_COLLECT_BATCHES.clear()
+
+    wf = _retrying_collect_workflow()(timeout=20)
+    handler = wf.run()
+    # Wait until the retry attempt (second delivery) has entered the step body.
+    for _ in range(300):
+        if len(_RETRY_COLLECT_BATCHES) >= 2:
+            break
+        await asyncio.sleep(0.02)
+    assert len(_RETRY_COLLECT_BATCHES) >= 2, "retry attempt never started"
+    snapshot = await _snapshot_cancel(handler)
+
+    _RETRY_COLLECT_GATE.set()
+    wf2 = _retrying_collect_workflow()(timeout=20)
+    restored = Context.from_dict(wf2, snapshot)
+    result = await asyncio.wait_for(wf2.run(ctx=restored), timeout=8)
+    assert result == [0, 1, 2, 3], result
+    # Failed attempt, gated retry attempt, resumed attempt: identical batches.
+    assert _RETRY_COLLECT_BATCHES == [[0, 1, 2, 3]] * 3, _RETRY_COLLECT_BATCHES
+
+
+# ---------------------------------------------------------------------------
+# Interaction cells.
+# ---------------------------------------------------------------------------
+
+
+async def test_take_two_collect_retry_redelivers_same_two_members() -> None:
+    """Take(2) releases the first two members; a retry re-fires with the SAME
+    two, not a re-evaluated window over later arrivals."""
+    batches: list[list[int]] = []
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(4)]
+
+        @step(num_workers=1)  # serialize members so "first two" is [0, 1]
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step(retry_policy=_FAST_RETRY)
+        async def first_two(
+            self, events: Annotated[list[Done], Collect(Take(2))]
+        ) -> StopEvent:
+            batch = sorted(e.n for e in events)
+            batches.append(batch)
+            if len(batches) == 1:
+                raise RuntimeError("transient take-two failure")
+            return StopEvent(result=batch)
+
+    result = await _run(WF(timeout=8))
+    assert result == [0, 1]
+    assert batches == [[0, 1], [0, 1]], batches
+
+
+class Seed(Event):
+    gid: int
+
+
+class Leaf(Event):
+    gid: int
+    k: int
+
+
+class Collected(Event):
+    gid: int
+    n: int
+
+
+async def test_overlapping_releases_num_workers_2_with_retry() -> None:
+    """Two independent streams release into a num_workers=2 collect step whose
+    invocations overlap; one invocation fails once. Both batches arrive intact
+    and the retried invocation re-fires with its own original batch."""
+    entered = 0
+    proceed = asyncio.Event()
+    failed: dict[int, bool] = {}
+    batches: list[tuple[int, list[int]]] = []
+    finished: list[tuple[int, int]] = []
+
+    class WF(Workflow):
+        @step
+        async def seed(self, ev: StartEvent) -> list[Seed]:
+            return [Seed(gid=0), Seed(gid=1)]
+
+        @step(num_workers=2)
+        async def fan_inner(self, ev: Seed) -> list[Leaf]:
+            return [Leaf(gid=ev.gid, k=k) for k in range(3)]
+
+        @step(num_workers=2, retry_policy=_FAST_RETRY)
+        async def collect(self, stream: list[Leaf]) -> Collected:
+            nonlocal entered
+            gid = stream[0].gid
+            batches.append((gid, sorted(b.k for b in stream)))
+            entered += 1
+            if entered >= 2:
+                proceed.set()
+            # One-shot rendezvous: the first two invocations overlap in time.
+            await asyncio.wait_for(proceed.wait(), timeout=5)
+            if gid == 0 and not failed.get(0):
+                failed[0] = True
+                raise RuntimeError("transient on gid 0")
+            return Collected(gid=gid, n=len(stream))
+
+        @step
+        async def finish(self, ev: Collected) -> StopEvent | None:
+            finished.append((ev.gid, ev.n))
+            if len(finished) < 2:
+                return None
+            return StopEvent(result=sorted(finished))
+
+    result = await _run(WF(timeout=10))
+    assert result == [(0, 3), (1, 3)]
+    # gid 0 delivered twice (original + retry) with the same batch; gid 1 once.
+    assert sorted(batches) == [
+        (0, [0, 1, 2]),
+        (0, [0, 1, 2]),
+        (1, [0, 1, 2]),
+    ], batches

--- a/packages/llama-index-workflows/tests/test_collection_stream_regressions.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_regressions.py
@@ -15,7 +15,8 @@ import logging
 from typing import Annotated, Callable
 
 import pytest
-from workflows import Collect, Context, Take, Workflow, catch_error, step
+from workflows import Context, Workflow, catch_error, step
+from workflows.collect import Collect, Take
 from workflows.errors import WorkflowValidationError
 from workflows.events import Event, StartEvent, StepFailedEvent, StopEvent
 from workflows.retry_policy import retry_policy, stop_after_attempt, wait_fixed

--- a/packages/llama-index-workflows/tests/test_collection_stream_regressions.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_regressions.py
@@ -1,0 +1,767 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Regression tests for the typed ``list[E]`` fan-out/fan-in stream accounting.
+
+Each case below is a minimal reproduction for a bug class that can silently
+truncate a joined stream or leave it waiting forever. Assertions stay on
+observable behavior: the run completes, the join sees the expected stream, and
+capacity limits are honored.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Annotated, Callable
+
+import pytest
+from workflows import Collect, Context, Take, Workflow, catch_error, step
+from workflows.errors import WorkflowValidationError
+from workflows.events import Event, StartEvent, StepFailedEvent, StopEvent
+from workflows.retry_policy import retry_policy, stop_after_attempt, wait_fixed
+
+_CONTROL_LOOP_LOGGER = "workflows.runtime.control_loop"
+
+# Counter-drift smells: a premature close shows up as decrements against an
+# already-closed stream or a negative counter, even when the run "succeeds".
+_ACCOUNTING_SMELLS = ("already-closed stream", "went negative")
+
+
+def _assert_clean_accounting(caplog: pytest.LogCaptureFixture) -> None:
+    smells = [
+        r.getMessage()
+        for r in caplog.records
+        if r.name == _CONTROL_LOOP_LOGGER
+        and any(needle in r.getMessage() for needle in _ACCOUNTING_SMELLS)
+    ]
+    assert not smells, smells
+
+
+class Task(Event):
+    n: int
+
+
+class Done(Event):
+    n: int
+
+
+async def _run(wf: Workflow, timeout: float = 6.0) -> object:
+    """Run to completion, failing loudly (not hanging) if a stream never closes."""
+    return await asyncio.wait_for(wf.run(), timeout=timeout)
+
+
+# ---------------------------------------------------------------------------
+# Member accounting: an event accepted by two steps is two work items. The join
+# must still see the full stream.
+# ---------------------------------------------------------------------------
+
+
+async def test_two_collects_same_type_see_full_stream() -> None:
+    """Two `list[Done]` joins on the same element type each see the whole stream."""
+    a_calls: list[list[int]] = []
+    b_calls: list[list[int]] = []
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def collect_a(self, events: list[Done]) -> StopEvent:
+            a_calls.append(sorted(e.n for e in events))
+            return StopEvent(result=sorted(e.n for e in events))
+
+        @step
+        async def collect_b(self, events: list[Done]) -> None:
+            b_calls.append(sorted(e.n for e in events))
+            return None
+
+    await _run(WF(timeout=8))
+    assert a_calls == [[0, 1, 2]], a_calls
+    assert b_calls == [[0, 1, 2]], b_calls
+
+
+async def test_event_routed_to_step_and_join_keeps_full_stream() -> None:
+    """A fanned-out event consumed by both a 1:1 step and a join loses no members."""
+
+    class Echo(Event):
+        n: int
+
+    join_calls: list[list[int]] = []
+    echoed: list[int] = []
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(5)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step(skip_graph_checks=["dead_end"])
+        async def passthrough(self, ev: Done) -> Echo:
+            return Echo(n=ev.n)
+
+        @step(skip_graph_checks=["dead_end"])
+        async def sink(self, ev: Echo) -> None:
+            echoed.append(ev.n)
+            return None
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            join_calls.append(sorted(e.n for e in events))
+            return StopEvent(result=sorted(e.n for e in events))
+
+    await _run(WF(timeout=8))
+    assert join_calls == [[0, 1, 2, 3, 4]], join_calls
+    assert sorted(echoed) == [0, 1, 2, 3, 4], echoed
+
+
+async def test_list_collect_honors_accept_event_subclasses() -> None:
+    class BaseDone(Event):
+        n: int
+
+    class DerivedDone(BaseDone):
+        pass
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[DerivedDone]:
+            return [DerivedDone(n=1), DerivedDone(n=2)]
+
+        @step(accept_event_subclasses=True)
+        async def join(self, events: list[BaseDone]) -> StopEvent:
+            return StopEvent(result=[type(e).__name__ for e in events])
+
+    result = await _run(WF(timeout=8))
+    assert result == ["DerivedDone", "DerivedDone"]
+
+
+async def test_distinct_fan_out_sources_share_collect_target_without_merging() -> None:
+    class Batch(Event):
+        nums: list[int]
+
+    batches: list[list[int]] = []
+
+    class WF(Workflow):
+        @step
+        async def fan_a(self, ev: StartEvent) -> list[Done]:
+            return [Done(n=0), Done(n=1)]
+
+        @step
+        async def fan_b(self, ev: StartEvent) -> list[Done]:
+            return [Done(n=10), Done(n=11)]
+
+        @step
+        async def join(self, events: list[Done]) -> Batch:
+            return Batch(nums=sorted(e.n for e in events))
+
+        @step
+        async def finish(self, ev: Batch) -> StopEvent | None:
+            batches.append(ev.nums)
+            if len(batches) < 2:
+                return None
+            return StopEvent(result=sorted(batches))
+
+    result = await _run(WF(timeout=8))
+    assert result == [[0, 1], [10, 11]]
+
+
+# ---------------------------------------------------------------------------
+# Error paths keep the work item's stream stack across retry and recovery.
+# ---------------------------------------------------------------------------
+
+
+async def test_catch_error_recovery_rejoins_stream() -> None:
+    """A member recovered by @catch_error rejoins the stream and makes the join.
+
+    The handler runs in the failed member's scope: the work item travels whole
+    to the handler invocation, and the handler's member-typed emission stays
+    in-stream. The join therefore always sees the recovered member — never a
+    truncated batch from the stream closing first.
+    """
+
+    class WF(Workflow):
+        @step
+        async def start(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            if ev.n == 1:
+                raise RuntimeError("boom on member 1")
+            return Done(n=ev.n)
+
+        @catch_error(for_steps=["work"], max_recoveries=2)
+        async def recover(self, ev: StepFailedEvent) -> Done:
+            return Done(n=1000 + getattr(ev.input_event, "n", -1))
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(WF(timeout=8), timeout=6)
+    assert result == [0, 2, 1001], result
+
+
+async def test_catch_error_successor_can_fan_out_inside_stream() -> None:
+    class RecoveryPiece(Event):
+        n: int
+
+    class WF(Workflow):
+        @step
+        async def start(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            if ev.n == 1:
+                raise RuntimeError("boom on member 1")
+            return Done(n=ev.n)
+
+        @catch_error(for_steps=["work"])
+        async def recover(self, ev: StepFailedEvent) -> list[RecoveryPiece]:
+            return [RecoveryPiece(n=1000), RecoveryPiece(n=1)]
+
+        @step
+        async def collect_recovery(self, events: list[RecoveryPiece]) -> Done:
+            return Done(n=sum(e.n for e in events))
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(WF(timeout=8), timeout=6)
+    assert result == [0, 2, 1001]
+
+
+# ---------------------------------------------------------------------------
+# Collection releases use the normal worker capacity path. Overlapping releases
+# must queue distinct payloads instead of aliasing in-progress state.
+# ---------------------------------------------------------------------------
+
+
+async def test_num_workers_1_collect_overlapping_streams() -> None:
+    class Seed(Event):
+        gid: int
+
+    class Leaf(Event):
+        gid: int
+        k: int
+
+    class Collected(Event):
+        gid: int
+        n: int
+
+    collected: list[tuple[int, int]] = []
+    active_collects = 0
+    max_active_collects = 0
+
+    class WF(Workflow):
+        @step
+        async def seed(self, ev: StartEvent) -> list[Seed]:
+            return [Seed(gid=0), Seed(gid=1)]
+
+        @step(num_workers=2)
+        async def fan_inner(self, ev: Seed) -> list[Leaf]:
+            return [Leaf(gid=ev.gid, k=k) for k in range(3)]
+
+        @step(num_workers=1)
+        async def collect(self, stream: list[Leaf]) -> Collected:
+            nonlocal active_collects, max_active_collects
+            active_collects += 1
+            max_active_collects = max(max_active_collects, active_collects)
+            await asyncio.sleep(0.2)
+            try:
+                gid = next(iter({b.gid for b in stream}))
+                return Collected(gid=gid, n=len(stream))
+            finally:
+                active_collects -= 1
+
+        @step
+        async def finish(self, ev: Collected) -> StopEvent | None:
+            collected.append((ev.gid, ev.n))
+            if len(collected) < 2:
+                return None
+            return StopEvent(result=sorted(collected))
+
+    await _run(WF(timeout=10), timeout=8)
+    assert sorted(collected) == [(0, 3), (1, 3)], collected
+    assert max_active_collects == 1
+
+
+# ---------------------------------------------------------------------------
+# Nested fan-out still summarizes when inner joins drop some or all branches.
+# ---------------------------------------------------------------------------
+
+
+class InnerTask(Event):
+    outer: int
+    inner: int
+
+
+class InnerDone(Event):
+    outer: int
+    inner: int
+
+
+class InnerSummary(Event):
+    outer: int
+    total: int
+
+
+def _nested_workflow(per_inner_drops: Callable[[int], bool]) -> type[Workflow]:
+    class Nested(Workflow):
+        @step
+        async def outer(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=o) for o in range(3)]
+
+        @step
+        async def inner(self, ev: Task) -> list[InnerTask]:
+            return [InnerTask(outer=ev.n, inner=i) for i in range(2)]
+
+        @step
+        async def inner_work(self, ev: InnerTask) -> InnerDone:
+            return InnerDone(outer=ev.outer, inner=ev.inner)
+
+        @step
+        async def per_inner(self, events: list[InnerDone]) -> InnerSummary | None:
+            outer = events[0].outer
+            if per_inner_drops(outer):
+                return None
+            return InnerSummary(outer=outer, total=len(events))
+
+        @step
+        async def per_outer(self, events: list[InnerSummary]) -> StopEvent:
+            return StopEvent(result=sorted((s.outer, s.total) for s in events))
+
+    return Nested
+
+
+async def test_nested_partial_inner_drop_sees_subset() -> None:
+    """One inner join drops, the outer join sees the survivors."""
+    wf = _nested_workflow(lambda outer: outer == 1)
+    result = await _run(wf(timeout=8))
+    assert result == [(0, 2), (2, 2)], result
+
+
+async def test_nested_all_inner_dropped_terminates() -> None:
+    """Every inner join drops; the outer join must still fire once with []."""
+    wf = _nested_workflow(lambda outer: True)
+    result = await _run(wf(timeout=8))
+    assert result == [], result
+
+
+# ---------------------------------------------------------------------------
+# Persistence: a snapshot taken mid-fan-out can resume without losing stream ids
+# or in-progress member scope.
+# ---------------------------------------------------------------------------
+
+
+_RESUME_GATE = asyncio.Event()
+_RESUME_SEEN: list[int] = []
+
+
+def _gated_fan_out_workflow() -> type[Workflow]:
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(5)]
+
+        @step(num_workers=8)
+        async def work(self, ev: Task) -> Done:
+            _RESUME_SEEN.append(ev.n)
+            await _RESUME_GATE.wait()  # hold the stream open at snapshot time
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    return FanOut
+
+
+async def test_resume_mid_open_stream_completes() -> None:
+    _RESUME_GATE.clear()
+    _RESUME_SEEN.clear()
+
+    wf = _gated_fan_out_workflow()(timeout=30)
+    handler = wf.run()
+    for _ in range(300):
+        if _RESUME_SEEN:
+            break
+        await asyncio.sleep(0.02)
+    assert _RESUME_SEEN, "workers never started"
+    await asyncio.sleep(0.2)  # let the rest of the stream settle into the queue
+
+    snapshot = handler.ctx.to_dict()
+    await handler.cancel_run()
+    try:
+        await asyncio.wait_for(handler, timeout=2)
+    except BaseException:
+        pass
+
+    _RESUME_GATE.set()
+    wf2 = _gated_fan_out_workflow()(timeout=30)
+    restored = Context.from_dict(wf2, snapshot)
+    result = await asyncio.wait_for(wf2.run(ctx=restored), timeout=10)
+    assert result == [0, 1, 2, 3, 4], result
+
+
+# ---------------------------------------------------------------------------
+# Signature validation rejects unsupported shapes with useful errors, while
+# supported multi-slot joins must consume one event per slot without hanging.
+# ---------------------------------------------------------------------------
+
+
+async def test_same_type_multi_slot_join_consumes_one_event_per_slot() -> None:
+    class A(Event):
+        value: str
+
+    class WF(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> A | None:
+            ctx.send_event(A(value="one"))
+            ctx.send_event(A(value="two"))
+            return None
+
+        @step
+        async def join(self, a: A, b: A) -> StopEvent:
+            return StopEvent(result=f"{a.value}+{b.value}")
+
+    assert await _run(WF(timeout=3), timeout=3) == "one+two"
+
+
+def test_optional_list_collect_param_not_generic_error() -> None:
+    """Fan-out return unwraps Optional/Union; the fan-in param side should too."""
+
+    def _build() -> None:
+        class WF(Workflow):
+            @step
+            async def fan(self, ev: StartEvent) -> Done:
+                return Done(n=0)
+
+            @step
+            async def collect(self, events: list[Done] | None) -> StopEvent:
+                return StopEvent(result=len(events or []))
+
+    try:
+        _build()
+    except WorkflowValidationError as e:
+        assert "at least one parameter annotated as type Event" not in str(e), str(e)
+
+
+# ---------------------------------------------------------------------------
+# ctx.send_event is ordinary dispatch, not stream membership. list[E] fan-in is
+# only for returned-list producer streams.
+# ---------------------------------------------------------------------------
+
+
+class Item(Event):
+    idx: int
+
+
+async def test_send_event_into_take_collect_rejected() -> None:
+    """Unstreamed send_event flows must use ctx.collect_events, not list[E]."""
+
+    class WF(Workflow):
+        @step
+        async def start(self, ctx: Context, ev: StartEvent) -> StopEvent | None:
+            for i in range(3):
+                ctx.send_event(Item(idx=i))
+            return None
+
+        @step
+        async def collect(
+            self, events: Annotated[list[Item], Collect(Take(3))]
+        ) -> StopEvent:
+            return StopEvent(result=sorted(e.idx for e in events))
+
+    with pytest.raises(WorkflowValidationError, match="returned-list producer"):
+        await _run(WF(timeout=10))
+
+
+async def test_send_event_into_all_collect_rejected() -> None:
+    class WF(Workflow):
+        @step
+        async def start(self, ctx: Context, ev: StartEvent) -> StopEvent | None:
+            for i in range(3):
+                ctx.send_event(Item(idx=i))
+            return None
+
+        @step
+        async def collect(self, events: list[Item]) -> StopEvent:
+            return StopEvent(result=sorted(e.idx for e in events))
+
+    with pytest.raises(WorkflowValidationError, match="returned-list producer"):
+        await _run(WF(timeout=10), timeout=5)
+
+
+async def test_send_event_only_inside_collection_param_rejected() -> None:
+    """A list[E] collect needs a returned-list producer binding."""
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ctx: Context, ev: Task) -> None:
+            ctx.send_event(Done(n=ev.n))
+            return None
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    with pytest.raises(WorkflowValidationError, match="returned-list producer"):
+        await _run(WF(timeout=6), timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Resume mid-stream with a member retrying. Combines the persist/resume path with
+# an in-flight retry: the snapshot must preserve both the open stream's live count
+# and the retrying member's scope_path, and the resumed run must not double- or
+# under-count the member when it re-runs.
+# ---------------------------------------------------------------------------
+
+
+_RETRY_RESUME_GATE = asyncio.Event()
+_RETRY_RESUME_SEEN: list[int] = []
+_RETRY_RESUME_FAILED: dict[int, bool] = {}
+
+
+def _gated_retry_fan_out_workflow() -> type[Workflow]:
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(5)]
+
+        @step(
+            num_workers=8,
+            retry_policy=retry_policy(
+                wait=wait_fixed(0.01), stop=stop_after_attempt(3)
+            ),
+        )
+        async def work(self, ev: Task) -> Done:
+            _RETRY_RESUME_SEEN.append(ev.n)
+            if ev.n == 3 and not _RETRY_RESUME_FAILED.get(3):
+                _RETRY_RESUME_FAILED[3] = True
+                raise RuntimeError("transient on member 3")
+            await _RETRY_RESUME_GATE.wait()  # hold the stream open at snapshot time
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    return FanOut
+
+
+async def test_resume_mid_stream_with_retry_in_flight_completes() -> None:
+    _RETRY_RESUME_GATE.clear()
+    _RETRY_RESUME_SEEN.clear()
+    _RETRY_RESUME_FAILED.clear()
+
+    wf = _gated_retry_fan_out_workflow()(timeout=30)
+    handler = wf.run()
+    # Wait until member 3 has failed once (its retry is now scheduled/in flight).
+    for _ in range(300):
+        if _RETRY_RESUME_FAILED.get(3):
+            break
+        await asyncio.sleep(0.02)
+    assert _RETRY_RESUME_FAILED.get(3), "member 3 never failed"
+    await asyncio.sleep(0.2)  # let the stream settle with the retry pending
+
+    snapshot = handler.ctx.to_dict()
+    await handler.cancel_run()
+    try:
+        await asyncio.wait_for(handler, timeout=2)
+    except BaseException:
+        pass
+
+    _RETRY_RESUME_GATE.set()
+    wf2 = _gated_retry_fan_out_workflow()(timeout=30)
+    restored = Context.from_dict(wf2, snapshot)
+    result = await asyncio.wait_for(wf2.run(ctx=restored), timeout=10)
+    assert result == [0, 1, 2, 3, 4], result
+
+
+# ---------------------------------------------------------------------------
+# Consume-once accounting for merge-shaped steps inside a stream. Each shape
+# below resolves every birth-counted delivery exactly once: a stale-snapshot
+# rerun is the same live work item (must not consume), a slot-buffering
+# invocation consumes its trigger, and a waiter that steals a delivery consumes
+# it on behalf of the step it woke.
+# ---------------------------------------------------------------------------
+
+
+async def test_in_stream_collect_events_default_workers_full_batch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """ctx.collect_events inside a fan-out branch sees the whole batch.
+
+    With the default num_workers, concurrent buffering invocations rerun on
+    stale snapshots; counting each rerun closed the stream early and released
+    the join with [] (silent data loss).
+    """
+
+    class Summed(Event):
+        total: int
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step  # num_workers default 4: buffering invocations overlap
+        async def gather(self, ctx: Context, ev: Task) -> Summed | None:
+            await asyncio.sleep(0.01)  # encourage overlapping snapshots
+            events = ctx.collect_events(ev, [Task] * 3)
+            if events is None:
+                return None
+            return Summed(total=sum(e.n for e in events))
+
+        @step
+        async def join(self, events: list[Summed]) -> StopEvent:
+            return StopEvent(result=[e.total for e in events])
+
+    with caplog.at_level(logging.WARNING, logger=_CONTROL_LOOP_LOGGER):
+        result = await _run(WF(timeout=8))
+
+    assert result == [3], result
+    _assert_clean_accounting(caplog)
+
+
+def _pair_join_workflow(task_count: int) -> tuple[type[Workflow], type[Event]]:
+    class A(Event):
+        n: int
+
+    class B(Event):
+        n: int
+
+    class C(Event):
+        n: int
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(task_count)]
+
+        @step
+        async def worker_a(self, ev: Task) -> A:
+            return A(n=ev.n)
+
+        @step
+        async def worker_b(self, ev: Task) -> B:
+            return B(n=ev.n + 10)
+
+        @step
+        async def pair_join(self, a: A, b: B) -> C:
+            return C(n=a.n + b.n)
+
+        @step
+        async def join(self, events: list[C]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    return WF, C
+
+
+async def test_in_stream_multi_slot_join_single_pair(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A two-slot join fed from inside a fan-out stream completes the stream.
+
+    The slot-buffering invocation must consume its work item; otherwise an
+    N-slot join leaks N-1 items per firing and the run dies with a stuck-stream
+    failure.
+    """
+    wf_cls, _ = _pair_join_workflow(1)
+
+    with caplog.at_level(logging.WARNING, logger=_CONTROL_LOOP_LOGGER):
+        result = await _run(wf_cls(timeout=8))
+
+    assert result == [10], result
+    _assert_clean_accounting(caplog)
+
+
+async def test_in_stream_multi_slot_join_many_members_completes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Multiple same-type members racing into a two-slot join still complete.
+
+    Slot pairing is by arrival order and a duplicate arrival for an
+    already-filled slot is dropped, so the batch size can vary — but every
+    delivery must be consumed exactly once: the run completes (no stuck-stream
+    failure) and the accounting stays clean.
+    """
+    wf_cls, _ = _pair_join_workflow(3)
+
+    with caplog.at_level(logging.WARNING, logger=_CONTROL_LOOP_LOGGER):
+        result = await _run(wf_cls(timeout=8))
+
+    assert isinstance(result, list)
+    assert 1 <= len(result) <= 3, result
+    _assert_clean_accounting(caplog)
+
+
+_STEAL_GATE = asyncio.Event()
+
+
+class _StealWaiting(Event):
+    pass
+
+
+async def test_waiter_steal_of_in_stream_member_completes(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A member that resolves a waiter on a step that also accepts it.
+
+    Waiter matching swallows the member's normal delivery to the woken step;
+    that birth-counted delivery must still be consumed or the stream never
+    closes. The stolen member never joins the woken step's processing — the
+    waiter consumed it — but the list[E] join still sees every member.
+    """
+    _STEAL_GATE.clear()
+
+    class WF(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            if ev.n == 2:
+                # Hold the resolving member until the waiter is registered.
+                await _STEAL_GATE.wait()
+            return Done(n=ev.n)
+
+        @step
+        async def observe(self, ctx: Context, ev: Done) -> None:
+            if ev.n == 0:
+                await ctx.wait_for_event(
+                    Done,
+                    requirements={"n": 2},
+                    waiter_event=_StealWaiting(),
+                    timeout=6,
+                )
+            return None
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    with caplog.at_level(logging.WARNING, logger=_CONTROL_LOOP_LOGGER):
+        handler = WF(timeout=10).run()
+        async for ev in handler.stream_events():
+            if isinstance(ev, _StealWaiting) and not _STEAL_GATE.is_set():
+                _STEAL_GATE.set()
+        result = await asyncio.wait_for(handler, timeout=8)
+
+    assert result == [0, 1, 2], result
+    _assert_clean_accounting(caplog)

--- a/packages/llama-index-workflows/tests/test_collection_streams.py
+++ b/packages/llama-index-workflows/tests/test_collection_streams.py
@@ -1,0 +1,374 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Collection-stream fan-out / fan-in.
+
+Covers the terse ``join(events: list[Done])`` form for static ``list[E]``
+producers, multi-level fan-out, replay equality of stream ids and grouping,
+empty streams, and branch death. Async-iterator producers are rejected at
+decoration because this path only supports finite returned-list streams.
+"""
+
+from __future__ import annotations
+
+from typing import AsyncIterator
+
+import pytest
+from workflows import Context, Workflow, step
+from workflows.errors import WorkflowValidationError
+from workflows.events import Event, StartEvent, StopEvent
+from workflows.runtime.control_loop import (
+    rebuild_state_from_ticks,
+    rebuild_state_from_ticks_stream,
+    replay_ticks_stream,
+)
+from workflows.runtime.types.internal_state import BrokerState
+from workflows.runtime.types.plugin import as_snapshottable_adapter
+from workflows.runtime.types.ticks import (
+    TickAddEvent,
+    WorkflowTick,
+)
+
+
+class Task(Event):
+    n: int
+
+
+class Done(Event):
+    n: int
+
+
+class InnerTask(Event):
+    outer: int
+    inner: int
+
+
+class InnerDone(Event):
+    outer: int
+    inner: int
+
+
+class InnerSummary(Event):
+    outer: int
+    total: int
+
+
+async def _stream(ticks: list[WorkflowTick]) -> AsyncIterator[WorkflowTick]:
+    for t in ticks:
+        yield t
+
+
+async def _run(wf: Workflow) -> object:
+    """Run a workflow to completion, draining its event stream first.
+
+    Draining the published-event stream lets the in-memory runtime's pull task
+    finish cleanly so it does not linger on a shared event loop between tests.
+    """
+    handler = wf.run()
+    async for _ in handler.stream_events():
+        pass
+    return await handler
+
+
+async def test_static_list_producer_join_fires_once_with_all() -> None:
+    """`join(events: list[Done])` fires once with the full stream, no ctx.store."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(5)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == [0, 1, 2, 3, 4]
+
+
+def test_async_generator_producer_rejected_at_decoration() -> None:
+    """Async-iterator fan-out is outside the returned-list stream contract."""
+
+    with pytest.raises(WorkflowValidationError, match="Async-iterator fan-out"):
+
+        class FanOut(Workflow):
+            @step
+            async def fan_out(self, ev: StartEvent) -> AsyncIterator[Task]:
+                for i in range(4):
+                    yield Task(n=i)
+
+            @step
+            async def join(self, events: list[Done]) -> StopEvent:
+                return StopEvent(result=sorted(e.n for e in events))
+
+
+async def test_join_fires_exactly_once() -> None:
+    """The join body executes exactly once per stream."""
+
+    calls: list[int] = []
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(3)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            calls.append(len(events))
+            return StopEvent(result=len(events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == 3
+    assert calls == [3]
+
+
+async def test_empty_stream_fires_join_once_with_empty_list() -> None:
+    """`return []` still closes the stream; the join fires once with `[]`."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return []
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=["empty", len(events)])
+
+    result = await _run(FanOut(timeout=10))
+    assert result == ["empty", 0]
+
+
+async def test_branch_death_join_sees_surviving_subset() -> None:
+    """A 1:1 worker returning None drops its branch; the join fires with the rest."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(6)]
+
+        @step
+        async def work(self, ev: Task) -> Done | None:
+            # Drop even branches.
+            if ev.n % 2 == 0:
+                return None
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == [1, 3, 5]
+
+
+async def test_multi_level_fan_out_joins_at_innermost_level() -> None:
+    """Nested fan-out: inner joins fire per outer task, then an outer join."""
+
+    class FanOut(Workflow):
+        @step
+        async def outer(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=o) for o in range(3)]
+
+        @step
+        async def inner(self, ev: Task) -> list[InnerTask]:
+            return [InnerTask(outer=ev.n, inner=i) for i in range(2)]
+
+        @step
+        async def inner_work(self, ev: InnerTask) -> InnerDone:
+            return InnerDone(outer=ev.outer, inner=ev.inner)
+
+        @step
+        async def per_inner(self, events: list[InnerDone]) -> InnerSummary:
+            outer = events[0].outer
+            return InnerSummary(outer=outer, total=len(events))
+
+        @step
+        async def per_outer(self, events: list[InnerSummary]) -> StopEvent:
+            return StopEvent(result=sorted((s.outer, s.total) for s in events))
+
+    result = await _run(FanOut(timeout=10))
+    # Three outer tasks, each producing a 2-member inner stream.
+    assert result == [(0, 2), (1, 2), (2, 2)]
+
+
+class _ReplayFanOut(Workflow):
+    """Single-level fan-out used by the replay-determinism test."""
+
+    @step
+    async def fan_out(self, ev: StartEvent) -> list[Task]:
+        return [Task(n=i) for i in range(4)]
+
+    @step
+    async def work(self, ev: Task) -> Done:
+        return Done(n=ev.n)
+
+    @step
+    async def join(self, events: list[Done]) -> StopEvent:
+        return StopEvent(result=sorted(e.n for e in events))
+
+
+async def _run_recording_ticks(
+    wf: Workflow,
+) -> tuple[object, list[WorkflowTick]]:
+    """Run ``wf`` to completion and return (result, recorded tick stream).
+
+    The in-memory runtime records every tick it reduces via ``on_tick`` and
+    exposes them through the run adapter's ``replay()``. That recorded stream is
+    exactly what persistence stores, so re-feeding it through
+    ``replay_ticks_stream`` must rebuild identical stream scopes.
+    """
+    handler = wf.run()
+    async for _ in handler.stream_events():
+        pass
+    result = await handler
+    adapter = wf._runtime.get_external_adapter(handler.run_id)
+    snapshottable = as_snapshottable_adapter(adapter)
+    assert snapshottable is not None, "in-memory runtime adapter is snapshottable"
+    ticks = list(snapshottable.replay())
+    return result, ticks
+
+
+def _done_stream_ids(ticks: list[WorkflowTick]) -> list[str]:
+    return [
+        t.scope_path[-1]
+        for t in ticks
+        if isinstance(t, TickAddEvent) and isinstance(t.event, Done) and t.scope_path
+    ]
+
+
+async def test_replay_reproduces_identical_stream_ids_and_grouping() -> None:
+    """Record a real fan-out run's tick stream, replay it, and assert identical
+    stream ids and grouping. Replay determinism lives in the reducer: stream ids
+    are a pure function of the producer path and stream sequence."""
+
+    wf = _ReplayFanOut()
+    result, ticks = await _run_recording_ticks(wf)
+    assert result == [0, 1, 2, 3]
+    assert ticks, "expected a recorded tick stream"
+
+    # The Done events all carry one stream id (single fan-out level).
+    done_ids = _done_stream_ids(ticks)
+    assert len(done_ids) == 4, done_ids
+    assert len(set(done_ids)) == 1, done_ids
+
+    # Replay the exact stream twice; both reproduce the same final state
+    # deterministically (the stream-id counter is a pure function of the stream).
+    replay1 = await replay_ticks_stream(BrokerState.from_workflow(wf), _stream(ticks))
+    replay2 = await replay_ticks_stream(BrokerState.from_workflow(wf), _stream(ticks))
+    assert replay1.state.stream_seq == replay2.state.stream_seq
+    assert replay1.state.stream_seq >= 1  # at least one stream was minted
+
+    rebuilt = await rebuild_state_from_ticks_stream(
+        BrokerState.from_workflow(wf), _stream(ticks)
+    )
+    assert rebuilt.stream_seq == replay1.state.stream_seq
+
+
+class _NestedReplayFanOut(Workflow):
+    """Two-level fan-out used by the snapshot-prefix invariant test."""
+
+    @step
+    async def outer(self, ev: StartEvent) -> list[Task]:
+        return [Task(n=o) for o in range(2)]
+
+    @step
+    async def inner(self, ev: Task) -> list[InnerTask]:
+        return [InnerTask(outer=ev.n, inner=i) for i in range(2)]
+
+    @step
+    async def inner_work(self, ev: InnerTask) -> InnerDone:
+        return InnerDone(outer=ev.outer, inner=ev.inner)
+
+    @step
+    async def per_inner(self, events: list[InnerDone]) -> InnerSummary:
+        return InnerSummary(outer=events[0].outer, total=len(events))
+
+    @step
+    async def per_outer(self, events: list[InnerSummary]) -> StopEvent:
+        return StopEvent(result=sorted((s.outer, s.total) for s in events))
+
+
+@pytest.mark.parametrize("wf_cls", [_ReplayFanOut, _NestedReplayFanOut])
+async def test_no_tick_prefix_strands_a_release(wf_cls: type[Workflow]) -> None:
+    """A snapshot at any tick boundary can resume: no prefix strands a release.
+
+    Stream closes fire their releases inline within the reduce, so there is no
+    state between two ticks where a stream is gone but its unreleased
+    release-state remains. Rebuild state from every prefix of a recorded run's
+    tick log and assert the invariant — an unreleased ``CollectionReleaseState``
+    always has its stream present.
+    """
+    wf = wf_cls()
+    _, ticks = await _run_recording_ticks(wf)
+    assert ticks
+
+    base = BrokerState.from_workflow(wf)
+    for prefix_len in range(len(ticks) + 1):
+        state = rebuild_state_from_ticks(base, ticks[:prefix_len])
+        stranded = [
+            key
+            for key, release in state.collection_release_states.items()
+            if not release.released and release.stream_id not in state.streams
+        ]
+        assert not stranded, (prefix_len, stranded)
+
+
+async def test_no_stream_state_remains_after_completion() -> None:
+    """A completed fan-out leaves no open streams or fan-in buffers in state."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(n=i) for i in range(4)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=sorted(e.n for e in events))
+
+    wf = FanOut(timeout=10)
+    handler = wf.run()
+    async for _ in handler.stream_events():
+        pass
+    await handler
+
+    serialized = handler.ctx.to_dict()
+    assert serialized.get("streams", {}) == {}, serialized.get("streams")
+    for step_name, worker in serialized.get("workers", {}).items():
+        assert not worker.get("collection_release_states"), (step_name, worker)
+        assert not worker.get("collection_released"), (step_name, worker)
+
+
+async def test_no_ctx_store_threading_needed() -> None:
+    """Sanity: the terse form needs neither ctx.store nor collect_events."""
+
+    class FanOut(Workflow):
+        @step
+        async def fan_out(self, ctx: Context, ev: StartEvent) -> list[Task]:
+            # Deliberately do NOT set any cardinality in ctx.store.
+            return [Task(n=i) for i in range(7)]
+
+        @step
+        async def work(self, ev: Task) -> Done:
+            return Done(n=ev.n)
+
+        @step
+        async def join(self, events: list[Done]) -> StopEvent:
+            return StopEvent(result=len(events))
+
+    result = await _run(FanOut(timeout=10))
+    assert result == 7

--- a/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
+++ b/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import asyncio
 
 import pytest
-from workflows import Context, Workflow, step
+from workflows import Context, Workflow, catch_error, step
 from workflows.context.internal_context import InternalContext
 from workflows.context.serializers import JsonSerializer
 from workflows.decorators import step as free_step
 from workflows.errors import WorkflowValidationError
-from workflows.events import Event, StartEvent, StopEvent
+from workflows.events import Event, StartEvent, StepFailedEvent, StopEvent
 from workflows.runtime.types.internal_state import BrokerState, EventAttempt
 
 
@@ -250,6 +250,32 @@ async def test_collect_mode_waiter_resume_preserves_static_bindings() -> None:
 
 
 @pytest.mark.asyncio
+async def test_collect_mode_catch_error_does_not_carry_static_bindings() -> None:
+    recovered: list[str] = []
+
+    class RecoverWorkflow(Workflow):
+        @step
+        async def emit(self, ctx: Context, ev: StartEvent) -> Header | Body | None:
+            ctx.send_event(Header(value="h"))
+            ctx.send_event(Body(value="b"))
+            return None
+
+        @step
+        async def assemble(self, h: Header, b: Body) -> StopEvent:
+            raise RuntimeError(f"{h.value}{b.value}")
+
+        @catch_error(for_steps=["assemble"])
+        async def recover(self, ev: StepFailedEvent) -> StopEvent:
+            assert isinstance(ev.input_event, Body)
+            recovered.append(str(ev.exception))
+            return StopEvent(result="recovered")
+
+    result = await RecoverWorkflow(timeout=10).run()
+    assert result == "recovered"
+    assert recovered == ["hb"]
+
+
+@pytest.mark.asyncio
 async def test_completed_run_clears_static_collect_events() -> None:
     mode = {"run": 1}
     joined: list[tuple[str, str]] = []
@@ -387,12 +413,37 @@ def test_union_collect_param_rejected() -> None:
             return StopEvent(result="x")
 
 
-def test_list_event_param_rejected_with_forward_pointing_error() -> None:
+def test_list_event_param_accepted_as_collection_param() -> None:
+    """A single ``list[E]`` parameter is a collection-collect step."""
+
     class _ListWorkflow(Workflow):
         pass
 
-    with pytest.raises(WorkflowValidationError, match="not supported yet"):
+    @free_step(workflow=_ListWorkflow)
+    async def collect(events: list[Header]) -> StopEvent:  # type: ignore[unused-ignore]
+        return StopEvent(result="x")
 
-        @free_step(workflow=_ListWorkflow)
-        async def collect(events: list[Header]) -> StopEvent:  # type: ignore[unused-ignore]
-            return StopEvent(result="x")
+    cfg = collect._step_config
+    assert cfg.collection_param is not None
+    assert cfg.collection_param[0] == "events"
+    assert cfg.collection_param[1] == (Header,)
+    # The step routes on the element event type.
+    assert Header in cfg.accepted_events
+
+
+def test_list_union_event_param_accepted_as_flat_stream() -> None:
+    """A ``list[A | B]`` collect parameter is a flat heterogeneous stream."""
+
+    class _ListUnionWorkflow(Workflow):
+        pass
+
+    @free_step(workflow=_ListUnionWorkflow)
+    async def collect(events: list[Header | Body]) -> StopEvent:  # type: ignore[unused-ignore]
+        return StopEvent(result="x")
+
+    cfg = collect._step_config
+    assert cfg.collection_param is not None
+    assert cfg.collection_param[1] == (Header, Body)
+    # Both member types route to the step.
+    assert Header in cfg.accepted_events
+    assert Body in cfg.accepted_events

--- a/packages/llama-index-workflows/tests/test_utils.py
+++ b/packages/llama-index-workflows/tests/test_utils.py
@@ -16,6 +16,7 @@ from workflows.decorators import step
 from workflows.errors import WorkflowValidationError
 from workflows.events import Event, StartEvent, StopEvent
 from workflows.utils import (
+    StepSignatureSpec,
     _event_list_element_types,
     _flatten_return_annotation,
     _get_param_types,
@@ -317,8 +318,24 @@ def test_validate_step_signature_accepts_list_return() -> None:
     validate_step_signature(spec)
 
 
-def test_step_rejects_list_event_param_with_explicit_message() -> None:
-    with pytest.raises(WorkflowValidationError, match="not supported yet"):
+def test_validate_step_signature_rejects_stream_param_with_other_events() -> None:
+    # A list[E] collection parameter cannot be combined with additional event params.
+    spec = StepSignatureSpec(
+        accepted_events={"a": [StartEvent], "b": [StopEvent]},
+        return_types=[StopEvent],
+        context_parameter=None,
+        context_state_type=None,
+        resources=[],
+        collection_param=("a", (StartEvent,)),
+        collection_policy=None,
+        is_fan_out=False,
+    )
+    with pytest.raises(WorkflowValidationError, match="cannot be combined with other"):
+        validate_step_signature(spec)
+
+
+def test_step_rejects_stream_param_with_other_event_params() -> None:
+    with pytest.raises(WorkflowValidationError, match="cannot be combined with other"):
 
         @step
         async def f(events: list[_EventA], ev: _EventB) -> StopEvent:  # type: ignore[unused-ignore]


### PR DESCRIPTION
Workflow steps can now fan out with `list[E]` returns, but on `main` there is no typed way to join the stream back together. Consumers still have to hand-roll buffering, counts, and resume behavior around individual events.

This adds signature-driven collection parameters: a step with a single `list[E]` parameter joins the finite stream opened by an upstream `list[E]` return.

```python
@step
async def fan_out(self, ev: StartEvent) -> list[Task]:
    return [Task(n=i) for i in range(5)]

@step
async def work(self, ev: Task) -> Done:
    return Done(n=ev.n)

@step
async def join(self, events: list[Done]) -> StopEvent:
    return StopEvent(result=[e.n for e in events])
```

Each returned list opens a collection stream. Events emitted inside that stream carry a scope path, and the runtime counts live work until the stream closes. A matching `list[E]` collect parameter then fires once with the collected batch. `Annotated[list[E], Collect(Take(n))]` releases on the nth member, `list[A | B]` collects a flat heterogeneous stream, `return []` still opens and closes an empty stream so joins fire with `[]`, and nested fan-outs create nested stream scopes.

The stream work record is persisted with the existing v2 context shape: queued and in-progress attempts carry scope paths, collect invocations carry their release payload, and open streams/release buffers serialize with the broker state. Retries, catch-error routing, `ctx.wait_for_event`, and snapshot/resume re-deliver the same batch instead of reconstructing it from mutable buffers.

The runtime now fails loudly for collection states that cannot complete: targeted sends into collect steps, stuck open streams at idle, orphaned release buffers, and static graph shapes where a collect step has no compatible returned-list producer or tries to join events from incompatible stream levels.