### PR TITLE
Upgrade basedpyright hook to 1.39.7 so pre-commit works on Python 3.14

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
         entry: uv run ty check packages/
         pass_filenames: false
   - repo: https://github.com/DetachHead/basedpyright-pre-commit-mirror
-    rev: 1.31.1
+    rev: 1.39.7
     hooks:
       - id: basedpyright
         exclude: "scripts/"

--- a/packages/llama-agents-appserver/tests/test_app_server_start.py
+++ b/packages/llama-agents-appserver/tests/test_app_server_start.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import webbrowser
 from pathlib import Path
 from typing import Any, Callable
 
@@ -159,7 +160,7 @@ def test_start_server_open_browser_triggers(
 ) -> None:
     opened = {"count": 0}
     monkeypatch.setattr(
-        app_mod.webbrowser,
+        webbrowser,
         "open",
         lambda *a, **k: opened.__setitem__("count", opened["count"] + 1),
     )

--- a/packages/llama-agents-control-plane/tests/code_repo/test_git_server.py
+++ b/packages/llama-agents-control-plane/tests/code_repo/test_git_server.py
@@ -21,7 +21,6 @@ from dulwich.repo import Repo
 from fastapi import FastAPI, Request
 from fastapi.responses import Response
 from httpx import ASGITransport
-from llama_agents.control_plane.code_repo import git_server as git_server_module
 from llama_agents.control_plane.code_repo.git_server import (
     handle_git_request,
     handle_git_request_readonly,
@@ -470,14 +469,14 @@ async def test_handle_git_request_closes_repo_handles(
         await storage.upload_repo("test-deploy", repo_path)
 
         close_calls = 0
-        original_close = git_server_module.Repo.close
+        original_close = Repo.close
 
         def _spy_close(self: Repo) -> None:
             nonlocal close_calls
             close_calls += 1
             original_close(self)
 
-        monkeypatch.setattr(git_server_module.Repo, "close", _spy_close)
+        monkeypatch.setattr(Repo, "close", _spy_close)
 
         app = _make_test_app(storage)
 
@@ -508,14 +507,14 @@ async def test_handle_git_request_readonly_closes_repo_after_response(
         await storage.upload_repo("test-deploy", repo_path)
 
         close_calls = 0
-        original_close = git_server_module.Repo.close
+        original_close = Repo.close
 
         def _spy_close(self: Repo) -> None:
             nonlocal close_calls
             close_calls += 1
             original_close(self)
 
-        monkeypatch.setattr(git_server_module.Repo, "close", _spy_close)
+        monkeypatch.setattr(Repo, "close", _spy_close)
 
         app = _make_test_app(storage, readonly=True)
 

--- a/packages/llama-agents-control-plane/tests/deployments/test_deployments_service.py
+++ b/packages/llama-agents-control-plane/tests/deployments/test_deployments_service.py
@@ -8,7 +8,6 @@ import pytest
 from fastapi import HTTPException
 from fastapi.responses import Response
 from llama_agents.control_plane.manage_api.deployments_service import (
-    DeploymentNotFoundError,
     deployments_service,
 )
 from llama_agents.core import schema
@@ -16,6 +15,7 @@ from llama_agents.core.schema.deployments import (
     INTERNAL_CODE_REPO_SCHEME,
     DeploymentResponse,
 )
+from llama_agents.core.server.manage_api import DeploymentNotFoundError
 
 
 def _make_deployment(

--- a/packages/llama-index-workflows/src/workflows/runtime/verbose.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/verbose.py
@@ -23,7 +23,7 @@ from workflows.runtime.runtime_decorators import (
     BaseInternalRunAdapterDecorator,
     BaseRuntimeDecorator,
 )
-from workflows.runtime.types.plugin import InternalRunAdapter, Runtime, WorkflowTick
+from workflows.runtime.types.plugin import InternalRunAdapter, Runtime
 from workflows.runtime.types.results import StepWorkerResult
 from workflows.runtime.types.ticks import (
     TickAddEvent,
@@ -33,6 +33,7 @@ from workflows.runtime.types.ticks import (
     TickStepResult,
     TickTimeout,
     TickWaiterTimeout,
+    WorkflowTick,
 )
 from workflows.workflow import Workflow
 

--- a/packages/llama-index-workflows/tests/test_verbose_decorator.py
+++ b/packages/llama-index-workflows/tests/test_verbose_decorator.py
@@ -9,7 +9,7 @@ import logging
 import pytest
 from workflows import Workflow, step
 from workflows.events import Event, StartEvent, StepState, StepStateChanged, StopEvent
-from workflows.runtime.types.plugin import InternalRunAdapter, WaitResult, WorkflowTick
+from workflows.runtime.types.plugin import InternalRunAdapter, WaitResult
 from workflows.runtime.types.results import StepWorkerResult
 from workflows.runtime.types.ticks import (
     TickAddEvent,
@@ -19,6 +19,7 @@ from workflows.runtime.types.ticks import (
     TickStepResult,
     TickTimeout,
     TickWaiterTimeout,
+    WorkflowTick,
 )
 from workflows.runtime.verbose import _VerboseInternalRunAdapter
 from workflows.testing import WorkflowTestRunner

--- a/packages/llamactl/src/llama_agents/cli/config/auth_service.py
+++ b/packages/llamactl/src/llama_agents/cli/config/auth_service.py
@@ -1,10 +1,11 @@
 import asyncio
 
+import httpx
 from llama_agents.cli.auth.client import PlatformAuthClient, RefreshMiddleware
-from llama_agents.cli.config._config import Auth, ConfigManager, Environment
-from llama_agents.cli.config.schema import DeviceOIDC
+from llama_agents.cli.config._config import ConfigManager
+from llama_agents.cli.config.schema import Auth, DeviceOIDC, Environment
 from llama_agents.cli.utils.redact import redact_api_key
-from llama_agents.core.client.manage_client import ControlPlaneClient, httpx
+from llama_agents.core.client.manage_client import ControlPlaneClient
 from llama_agents.core.schema import VersionResponse
 from llama_agents.core.schema.projects import ProjectSummary
 

--- a/packages/llamactl/tests/test_environments_cli.py
+++ b/packages/llamactl/tests/test_environments_cli.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 from click.testing import CliRunner
 from llama_agents.cli.app import app
-from llama_agents.cli.config._config import Environment
+from llama_agents.cli.config.schema import Environment
 
 _INTERACTIVE_PATCH = "llama_agents.cli.commands.environments.is_interactive_session"
 


### PR DESCRIPTION
basedpyright 1.31.1 (the current pre-commit rev) can't parse Python 3.14's stdlib `string/templatelib.py` (t-strings). With a 3.14 project venv, every file-scoped run — i.e. what pre-commit does on `git commit` — reports `Cannot access attribute "interpolations" for class "str"` against templatelib for *any* changed file, blocking commits unless you `--no-verify`. Full `pre-commit run -a` and CI don't hit it (CI resolves ubuntu's system 3.12), so it only bites local dev on newer interpreters.

This bumps the mirror rev to 1.39.7 and fixes the 12 errors the newer version legitimately flags, all `reportPrivateImportUsage` — symbols imported through modules that only re-export them transitively:

- `WorkflowTick` now imported from `workflows.runtime.types.ticks` instead of `.plugin`
- `Auth`/`Environment` from `llama_agents.cli.config.schema` instead of `._config`
- `httpx` imported directly instead of through `manage_client`
- `DeploymentNotFoundError` from `llama_agents.core.server.manage_api` (its public export) instead of through the control-plane service module
- tests patch `dulwich.repo.Repo` and stdlib `webbrowser` directly instead of reaching through the module under test (same objects, so identical behavior)

1.39.7 also warns on the wildcard imports in the `llama_deploy` back-compat shims; those are intentional re-exports and warnings don't fail the hook, so they're left alone.

Verified the hook passes both file-scoped and full runs under 3.12, 3.13, and 3.14 venvs.

Open question for reviewers: `lint.yml` doesn't pin a Python for `setup-uv`, so CI lint type-checks against whatever ubuntu ships (currently 3.12). Worth pinning for determinism, but not done here.