### PR TITLE
Preserve in-progress retry state in serialized contexts

### DIFF
--- a/.changeset/in-progress-attempt-serialization.md
+++ b/.changeset/in-progress-attempt-serialization.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Preserve retry state for in-progress workflow steps across serialized context resume.

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -10,6 +10,13 @@ from workflows.events import SerializableOptionalException
 
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
+# Serialization format version.
+#   v0: legacy nested-JSON-string format (SerializedContextV0).
+#   v1: structured format; per-worker ``in_progress`` was a list of event strings.
+#   v2: ``in_progress`` carries full attempts (retry counts and timestamps), so
+#       a resumed run does not silently restart in-flight work from attempt 0.
+CURRENT_SERIALIZED_VERSION = 2
+
 
 class SerializedContextV0(BaseModel):
     """
@@ -117,8 +124,9 @@ class SerializedStepWorkerState(BaseModel):
 
     # Queue of events waiting to be processed (with retry info)
     queue: list[SerializedEventAttempt] = Field(default_factory=list)
-    # Events currently being processed (no retry info needed, will be re-queued on failure)
-    in_progress: list[str] = Field(default_factory=list)
+    # Events currently being processed. Serialized with full retry info so a
+    # resumed run re-queues them without losing attempt counts.
+    in_progress: list[SerializedEventAttempt] = Field(default_factory=list)
     # Collected events for ctx.collect_events(), keyed by buffer_id -> [event, ...]
     # Events are serialized strings
     collected_events: dict[str, list[str]] = Field(default_factory=dict)
@@ -132,8 +140,8 @@ class SerializedContext(BaseModel):
     This format better represents BrokerState needs including retry information and waiter state.
     """
 
-    # Version marker to distinguish from V0
-    version: int = Field(default=1)
+    # Serialization format version. See CURRENT_SERIALIZED_VERSION.
+    version: int = Field(default=CURRENT_SERIALIZED_VERSION)
 
     # Serialized state store payload (same format as V0)
     state: dict[str, Any] = Field(default_factory=dict)
@@ -207,19 +215,59 @@ class SerializedContext(BaseModel):
             )
 
         return SerializedContext(
-            version=1,
+            version=CURRENT_SERIALIZED_VERSION,
             state=v0.state,
             is_running=v0.is_running,
             workers=workers,
         )
 
     @staticmethod
+    def from_v1(data: dict[str, Any]) -> "SerializedContext":
+        """Migrate a v1 payload to the current format.
+
+        v1 serialized each worker's ``in_progress`` as a list of event strings.
+        v2 serializes them as full SerializedEventAttempt entries so a resumed
+        run keeps retry counts.
+        """
+        migrated = dict(data)
+        migrated["version"] = CURRENT_SERIALIZED_VERSION
+        workers: dict[str, Any] = {}
+        for step_name, worker in (data.get("workers") or {}).items():
+            worker = dict(worker)
+            worker["in_progress"] = [
+                {"event": ev, "attempts": 0, "first_attempt_at": None}
+                if isinstance(ev, str)
+                else ev
+                for ev in worker.get("in_progress", [])
+            ]
+            workers[step_name] = worker
+        migrated["workers"] = workers
+        return SerializedContext.model_validate(migrated)
+
+    @staticmethod
     def from_dict_auto(data: dict[str, Any]) -> "SerializedContext":
-        """Parse a dict as either V0 or V1 format and return V1."""
-        # Check if it has version field
-        if "version" in data and data["version"] == 1:
-            return SerializedContext.model_validate(data)
-        else:
-            # Assume V0 format
+        """Parse a dict as V0, v1, or current format and return the current format.
+
+        A missing ``version`` routes to the legacy V0 parser. An unrecognized
+        version, newer than this library supports, or not an int, fails
+        loudly: routing it to an older parser would "succeed" while silently
+        dropping state.
+        """
+        version = data.get("version")
+        if version is None:
             v0 = SerializedContextV0.model_validate(data)
             return SerializedContext.from_v0(v0)
+        if not isinstance(version, int) or version > CURRENT_SERIALIZED_VERSION:
+            raise ValueError(
+                f"Cannot load serialized workflow context with "
+                f"version={version!r}; this library supports up to version "
+                f"{CURRENT_SERIALIZED_VERSION}. The payload was likely written "
+                "by a newer version of llama-index-workflows."
+            )
+        if version == CURRENT_SERIALIZED_VERSION:
+            return SerializedContext.model_validate(data)
+        if version == 1:
+            return SerializedContext.from_v1(data)
+        # Older int version markers (e.g. an explicit 0): legacy V0 format.
+        v0 = SerializedContextV0.model_validate(data)
+        return SerializedContext.from_v0(v0)

--- a/packages/llama-index-workflows/src/workflows/context/pre_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/pre_context.py
@@ -56,7 +56,7 @@ class PreContext(Generic[MODEL_T]):
                 BrokerState.from_serialized(
                     previous_context_parsed, workflow, self._serializer
                 )
-            except ValidationError as e:
+            except (ValidationError, ValueError) as e:
                 raise ContextSerdeError(
                     f"Context dict specified in an invalid format: {e}"
                 ) from e

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from workflows.context.context_types import (
+    CURRENT_SERIALIZED_VERSION,
     SerializedContext,
     SerializedEventAttempt,
     SerializedStepWorkerState,
@@ -121,9 +122,18 @@ class BrokerState:
                 for attempt in worker_state.queue
             ]
 
-            # Serialize in-progress events (just the events, retry info tracked separately)
+            # Serialize in-progress events with full retry info so they can be
+            # re-queued on resume without restarting from attempt 0.
             in_progress = [
-                serializer.serialize(ip.event) for ip in worker_state.in_progress
+                SerializedEventAttempt(
+                    event=serializer.serialize(ip.event),
+                    attempts=ip.attempts or 0,
+                    first_attempt_at=ip.first_attempt_at,
+                    last_exception=ip.last_exception,
+                    last_failed_at=ip.last_failed_at,
+                    recovery_counts=dict(ip.recovery_counts),
+                )
+                for ip in worker_state.in_progress
             ]
 
             # Serialize collected events
@@ -155,7 +165,7 @@ class BrokerState:
             )
 
         return SerializedContext(
-            version=1,
+            version=CURRENT_SERIALIZED_VERSION,
             state={},  # State is filled separately by the state store
             is_running=self.is_running,
             workers=workers_dict,
@@ -185,7 +195,9 @@ class BrokerState:
 
             worker = base_state.workers[step_name]
 
-            # Restore queue with retry info
+            # Restore queue with retry info.
+            # in_progress events are moved to the queue on deserialization;
+            # they will be restarted when the workflow runs.
             worker.queue = [
                 EventAttempt(
                     event=serializer.deserialize(attempt.event),
@@ -196,19 +208,8 @@ class BrokerState:
                     recovery_counts=dict(attempt.recovery_counts),
                     not_before=attempt.not_before,
                 )
-                for attempt in worker_data.queue
+                for attempt in [*worker_data.queue, *worker_data.in_progress]
             ]
-
-            # in_progress events are moved to the queue on deserialization
-            # They will be restarted when the workflow runs
-            for event_str in worker_data.in_progress:
-                worker.queue.append(
-                    EventAttempt(
-                        event=serializer.deserialize(event_str),
-                        attempts=0,
-                        first_attempt_at=None,
-                    )
-                )
 
             # Restore collected events
             worker.collected_events = {

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -364,6 +364,20 @@ async def test_wait_for_event_in_workflow_serialization() -> None:
     assert total_waiters == 0
 
 
+def test_context_from_dict_rejects_future_version_as_context_serde_error(
+    workflow: Workflow,
+) -> None:
+    payload = {
+        "version": CURRENT_SERIALIZED_VERSION + 1,
+        "state": {},
+        "is_running": False,
+        "workers": {},
+    }
+
+    with pytest.raises(ContextSerdeError, match="newer version"):
+        Context.from_dict(workflow, payload)
+
+
 class TwoStepHITLWorkflow(Workflow):
     """The documented two-step HITL shape: emit InputRequiredEvent, consume HumanResponseEvent."""
 

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -20,6 +20,7 @@ from workflows.context.context import (
     _warn_get_result,
     _warn_is_running_in_step,
 )
+from workflows.context.context_types import CURRENT_SERIALIZED_VERSION
 from workflows.context.external_context import ExternalContext
 from workflows.context.internal_context import InternalContext
 from workflows.context.serializers import JsonSerializer, PickleSerializer
@@ -327,7 +328,7 @@ async def test_wait_for_event_in_workflow_serialization() -> None:
         if isinstance(ev, Event) and ev.msg == "foo":
             ctx_dict = handler.ctx.to_dict()
             # Check that at least one worker has waiters
-            assert ctx_dict["version"] == 1
+            assert ctx_dict["version"] == CURRENT_SERIALIZED_VERSION
             total_waiters = sum(
                 len(worker_data["collected_waiters"])
                 for worker_data in ctx_dict["workers"].values()

--- a/packages/llama-index-workflows/tests/runtime/test_state.py
+++ b/packages/llama-index-workflows/tests/runtime/test_state.py
@@ -1,8 +1,197 @@
 from json import JSONDecodeError
 
 import pytest
-from workflows.context.context_types import SerializedContext, SerializedContextV0
+from pydantic import ValidationError
+from workflows import step
+from workflows.context.context_types import (
+    CURRENT_SERIALIZED_VERSION,
+    SerializedContext,
+    SerializedContextV0,
+)
+from workflows.context.serializers import JsonSerializer
+from workflows.events import StartEvent, StopEvent
+from workflows.runtime.types.internal_state import (
+    BrokerState,
+    EventAttempt,
+    InProgressState,
+)
+from workflows.runtime.types.results import StepWorkerState
 from workflows.workflow import Workflow
+
+
+def _v1_payload(in_progress: list[str], queue: list[str]) -> dict:
+    """A version-1 serialized context with one worker.
+
+    v1 stored ``in_progress`` as bare event strings (queue entries were already
+    structured attempts).
+    """
+    return {
+        "version": 1,
+        "state": {},
+        "is_running": True,
+        "workers": {
+            "middle_step": {
+                "queue": [
+                    {"event": ev, "attempts": 0, "first_attempt_at": None}
+                    for ev in queue
+                ],
+                "in_progress": in_progress,
+                "collected_events": {},
+                "collected_waiters": [],
+            }
+        },
+    }
+
+
+class _RetryStateWorkflow(Workflow):
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="ok")
+
+
+def test_v1_in_progress_strings_fail_strict_validation() -> None:
+    """A v1 payload no longer validates against the current schema directly.
+
+    in_progress changed from list[str] to list[SerializedEventAttempt]; this is
+    why from_dict_auto must route v1 through a migration rather than straight
+    model_validate.
+    """
+    event = JsonSerializer().serialize(StartEvent())
+    with pytest.raises(ValidationError):
+        SerializedContext.model_validate(_v1_payload(in_progress=[event], queue=[]))
+
+
+def test_from_dict_auto_migrates_v1_in_progress_strings() -> None:
+    """from_dict_auto upgrades a v1 payload, lifting in_progress strings into attempts."""
+    event = JsonSerializer().serialize(StartEvent())
+    result = SerializedContext.from_dict_auto(
+        _v1_payload(in_progress=[event], queue=[])
+    )
+
+    assert result.version == CURRENT_SERIALIZED_VERSION
+    worker = result.workers["middle_step"]
+    assert len(worker.in_progress) == 1
+    attempt = worker.in_progress[0]
+    assert attempt.event == event
+    assert attempt.attempts == 0
+    assert attempt.not_before is None
+
+
+def test_from_dict_auto_migrates_v1_with_empty_in_progress() -> None:
+    """v1 payloads with no in-progress work still upgrade cleanly."""
+    queued = JsonSerializer().serialize(StartEvent())
+    result = SerializedContext.from_dict_auto(
+        _v1_payload(in_progress=[], queue=[queued])
+    )
+
+    assert result.version == CURRENT_SERIALIZED_VERSION
+    worker = result.workers["middle_step"]
+    assert worker.in_progress == []
+    assert [a.event for a in worker.queue] == [queued]
+
+
+def test_from_dict_auto_passes_current_version_through() -> None:
+    """A current-version payload is validated as-is, not migrated."""
+    event = JsonSerializer().serialize(StartEvent())
+    payload = {
+        "version": CURRENT_SERIALIZED_VERSION,
+        "state": {},
+        "is_running": False,
+        "workers": {
+            "middle_step": {
+                "queue": [],
+                "in_progress": [
+                    {
+                        "event": event,
+                        "attempts": 1,
+                        "first_attempt_at": None,
+                    }
+                ],
+                "collected_events": {},
+                "collected_waiters": [],
+            }
+        },
+    }
+    result = SerializedContext.from_dict_auto(payload)
+
+    assert result.version == CURRENT_SERIALIZED_VERSION
+    attempt = result.workers["middle_step"].in_progress[0]
+    assert attempt.attempts == 1
+
+
+def test_from_dict_auto_rejects_future_version() -> None:
+    """A payload from a newer library version fails loudly, not as near-empty V0."""
+    payload = {"version": CURRENT_SERIALIZED_VERSION + 1, "state": {}, "workers": {}}
+    with pytest.raises(ValueError, match="newer version"):
+        SerializedContext.from_dict_auto(payload)
+
+
+def test_from_dict_auto_rejects_non_int_version() -> None:
+    """A stringified version marker is unrecognized and fails loudly."""
+    payload = {"version": str(CURRENT_SERIALIZED_VERSION), "state": {}, "workers": {}}
+    with pytest.raises(ValueError, match="version"):
+        SerializedContext.from_dict_auto(payload)
+
+
+def test_from_dict_auto_missing_version_routes_to_v0() -> None:
+    """No version marker still parses as the legacy V0 format."""
+    result = SerializedContext.from_dict_auto({"state": {}, "is_running": False})
+    assert result.version == CURRENT_SERIALIZED_VERSION
+
+
+def test_in_progress_retry_state_survives_serialization() -> None:
+    """In-flight work is requeued with its retry state on resume."""
+    workflow = _RetryStateWorkflow()
+    state = BrokerState.from_workflow(workflow)
+    state.workers["start"].in_progress.append(
+        InProgressState(
+            event=StartEvent(),
+            worker_id=0,
+            shared_state=StepWorkerState(
+                step_name="start",
+                collected_events={},
+                collected_waiters=[],
+            ),
+            attempts=2,
+            first_attempt_at=100.0,
+            last_exception=ValueError("transient"),
+            last_failed_at=125.0,
+            recovery_counts={"handler": 1},
+        )
+    )
+
+    serializer = JsonSerializer()
+    serialized = state.to_serialized(serializer)
+    restored = BrokerState.from_serialized(serialized, workflow, serializer)
+    attempt = restored.workers["start"].queue[0]
+
+    assert serialized.version == CURRENT_SERIALIZED_VERSION
+    assert attempt.attempts == 2
+    assert attempt.first_attempt_at == 100.0
+    assert str(attempt.last_exception) == "transient"
+    assert attempt.last_failed_at == 125.0
+    assert attempt.recovery_counts == {"handler": 1}
+
+
+def test_queued_not_before_survives_serialization() -> None:
+    """The v2 change preserves the delayed-retry field added to queued attempts."""
+    workflow = _RetryStateWorkflow()
+    state = BrokerState.from_workflow(workflow)
+    state.workers["start"].queue.append(
+        EventAttempt(
+            event=StartEvent(),
+            attempts=1,
+            first_attempt_at=100.0,
+            not_before=150.0,
+        )
+    )
+
+    serializer = JsonSerializer()
+    serialized = state.to_serialized(serializer)
+    restored = BrokerState.from_serialized(serialized, workflow, serializer)
+
+    assert serialized.workers["start"].queue[0].not_before == 150.0
+    assert restored.workers["start"].queue[0].not_before == 150.0
 
 
 def test_deserialize_broken_state_raises_validation_error(workflow: Workflow) -> None:


### PR DESCRIPTION
Snapshots already preserve retry metadata for queued work, including delayed retries. In-flight work is different: `SerializedStepWorkerState.in_progress` is still a list of serialized event strings, so resume moves those events back to the queue as fresh attempts.

This changes the serialized context format to v2 and stores in-progress work as full `SerializedEventAttempt` entries:

```python
# v1
in_progress: list[str]

# v2
in_progress: list[SerializedEventAttempt]
```

On resume, queued attempts and in-progress attempts now flow through the same restore path, so attempts, first failure timing, last exception, and recovery lineage survive the restart. The delayed-retry `not_before` field on queued attempts is preserved unchanged.

Older v1 payloads still load through `from_dict_auto`; their in-progress event strings are lifted into attempt records with zeroed retry metadata because v1 never stored those fields. Unknown future versions now fail loudly instead of being parsed as legacy V0 and dropping worker state, and the public `Context.from_dict` restore path reports those incompatible payloads as `ContextSerdeError`.