### PR TITLE
Ignore fresh handlers during startup resume

### DIFF
--- a/.changeset/fresh-handler-startup-resume.md
+++ b/.changeset/fresh-handler-startup-resume.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-server": patch
+---
+
+Fix startup resume incorrectly failing newly-created handlers before their first persisted tick

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -15,6 +15,7 @@ import logging
 import sqlite3
 from collections.abc import AsyncIterator, Coroutine
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from typing_extensions import override
@@ -307,12 +308,17 @@ class PersistenceDecorator(TickPersistenceDecorator):
 
     @override
     async def launch(self) -> None:
+        resume_started_at = datetime.now(timezone.utc)
         await super().launch()
         self.resume_task = self._spawn_task(
-            self._on_server_start(self._workflows_by_name)
+            self._on_server_start(self._workflows_by_name, resume_started_at)
         )
 
-    async def _on_server_start(self, registered_workflows: dict[str, Workflow]) -> None:
+    async def _on_server_start(
+        self,
+        registered_workflows: dict[str, Workflow],
+        resume_started_at: datetime,
+    ) -> None:
         """Resume previously running (non-idle) workflows from persistence."""
         handlers = await self._store.query(
             HandlerQuery(
@@ -322,6 +328,8 @@ class PersistenceDecorator(TickPersistenceDecorator):
             )
         )
         for persistent in handlers:
+            if _created_after(persistent.started_at, resume_started_at):
+                continue
             workflow = registered_workflows.get(persistent.workflow_name)
             if workflow is None:
                 continue
@@ -398,3 +406,13 @@ class PersistenceDecorator(TickPersistenceDecorator):
                 self.resume_task.cancel()
             except Exception:
                 pass
+
+
+def _created_after(created_at: datetime | None, cutoff: datetime) -> bool:
+    if created_at is None:
+        return False
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    if cutoff.tzinfo is None:
+        cutoff = cutoff.replace(tzinfo=timezone.utc)
+    return created_at > cutoff

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/persistence_runtime.py
@@ -15,7 +15,7 @@ import logging
 import sqlite3
 from collections.abc import AsyncIterator, Coroutine
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from typing_extensions import override
@@ -58,6 +58,7 @@ from .._store.abstract_workflow_store import (
 from .._store.sqlite.sqlite_state_store import SqliteStateStore
 
 logger = logging.getLogger(__name__)
+RESUME_FRESH_HANDLER_GRACE = timedelta(seconds=30)
 
 
 @dataclass
@@ -328,7 +329,7 @@ class PersistenceDecorator(TickPersistenceDecorator):
             )
         )
         for persistent in handlers:
-            if _created_after(persistent.started_at, resume_started_at):
+            if _created_within_resume_grace(persistent.started_at, resume_started_at):
                 continue
             workflow = registered_workflows.get(persistent.workflow_name)
             if workflow is None:
@@ -408,11 +409,13 @@ class PersistenceDecorator(TickPersistenceDecorator):
                 pass
 
 
-def _created_after(created_at: datetime | None, cutoff: datetime) -> bool:
+def _created_within_resume_grace(
+    created_at: datetime | None, resume_started_at: datetime
+) -> bool:
     if created_at is None:
         return False
     if created_at.tzinfo is None:
         created_at = created_at.replace(tzinfo=timezone.utc)
-    if cutoff.tzinfo is None:
-        cutoff = cutoff.replace(tzinfo=timezone.utc)
-    return created_at > cutoff
+    if resume_started_at.tzinfo is None:
+        resume_started_at = resume_started_at.replace(tzinfo=timezone.utc)
+    return created_at > resume_started_at - RESUME_FRESH_HANDLER_GRACE

--- a/packages/llama-agents-server/tests/server/test_durable_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_durable_runtime.py
@@ -344,6 +344,7 @@ async def test_on_server_start_finalizes_terminal_replay_as_completed(
     zombie.status = "running"
     zombie.result = None
     zombie.completed_at = None
+    zombie.started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     await memory_store.update(zombie)
 
     server2 = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
@@ -377,6 +378,7 @@ async def test_on_server_start_finalizes_terminal_replay_as_failed(
     zombie.status = "running"
     zombie.error = None
     zombie.completed_at = None
+    zombie.started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
     await memory_store.update(zombie)
 
     server2 = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)

--- a/packages/llama-agents-server/tests/server/test_durable_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_durable_runtime.py
@@ -283,6 +283,41 @@ async def test_on_server_start_marks_no_ticks_handler_as_failed(
 
 
 @pytest.mark.asyncio
+async def test_on_server_start_skips_handlers_created_after_resume_cutoff(
+    memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
+) -> None:
+    """A fresh request can create a running row before its first tick lands.
+
+    Startup resume should not classify those rows as crashed just because the
+    first tick is not persisted yet.
+    """
+    handler_id = "fresh-no-ticks-1"
+    run_id = "run-fresh-no-ticks-1"
+    resume_started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    await memory_store.update(
+        PersistentHandler(
+            handler_id=handler_id,
+            workflow_name="test",
+            status="running",
+            run_id=run_id,
+            started_at=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+        )
+    )
+
+    server = WorkflowServer(workflow_store=memory_store, idle_timeout=0.01)
+    server.add_workflow("test", simple_test_workflow)
+    persistence = _get_persistence(server)
+
+    await persistence._on_server_start(
+        {"test": simple_test_workflow}, resume_started_at
+    )
+
+    found = await memory_store.query(HandlerQuery(handler_id_in=[handler_id]))
+    assert found[0].status == "running"
+    assert found[0].error is None
+
+
+@pytest.mark.asyncio
 async def test_on_server_start_finalizes_terminal_replay_as_completed(
     memory_store: MemoryWorkflowStore,
 ) -> None:

--- a/packages/llama-agents-server/tests/server/test_durable_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_durable_runtime.py
@@ -283,24 +283,25 @@ async def test_on_server_start_marks_no_ticks_handler_as_failed(
 
 
 @pytest.mark.asyncio
-async def test_on_server_start_skips_handlers_created_after_resume_cutoff(
+async def test_on_server_start_skips_handlers_created_within_resume_grace(
     memory_store: MemoryWorkflowStore, simple_test_workflow: Workflow
 ) -> None:
     """A fresh request can create a running row before its first tick lands.
 
-    Startup resume should not classify those rows as crashed just because the
-    first tick is not persisted yet.
+    Startup resume should not classify recently-created rows as crashed just
+    because the first tick is not persisted yet. The grace window also covers
+    small clock drift around the launch cutoff.
     """
     handler_id = "fresh-no-ticks-1"
     run_id = "run-fresh-no-ticks-1"
-    resume_started_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    resume_started_at = datetime(2026, 1, 1, 0, 0, 30, tzinfo=timezone.utc)
     await memory_store.update(
         PersistentHandler(
             handler_id=handler_id,
             workflow_name="test",
             status="running",
             run_id=run_id,
-            started_at=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            started_at=datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc),
         )
     )
 


### PR DESCRIPTION
Startup resume currently queries every `running` handler after `launch()` and treats a no-tick row as a crashed zombie. A request can create that same no-tick shape before its workflow has persisted the first tick, so resume can mark a fresh handler failed and make later cancellation return `404 Handler not found`.

This captures when resume starts and skips handlers created within a 30s grace window around that cutoff. Existing older no-tick rows still go through the zombie classification path, and the new regression test covers the recent-row case.