### PR TITLE
Add list return fan-out syntax

### DIFF
--- a/.changeset/fan-out-syntax.md
+++ b/.changeset/fan-out-syntax.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": minor
+---
+
+Steps can return `list[E]` to emit one event per element.

--- a/packages/llama-index-workflows/src/workflows/decorators.py
+++ b/packages/llama-index-workflows/src/workflows/decorators.py
@@ -51,6 +51,14 @@ class StepConfig:
     resources: list[ResourceDefinition]
     context_state_type: type[BaseModel] | None = None
     skip_graph_checks: list[StepGraphCheck] = dataclasses.field(default_factory=list)
+    # Fan-out producer: True when the return annotation is ``list[E]``. Computed
+    # at decoration time from the return annotation; only an actual list return
+    # emits per element.
+    is_fan_out: bool = False
+    # Non-list members of a fan-out return union (``-> list[A] | B`` -> (B,)).
+    # A bare return of one of these types is ordinary dispatch; any other bare
+    # event under a list-returning annotation is a runtime error.
+    bare_return_types: tuple[Any, ...] = ()
     role: StepRole = "step"
     # Only meaningful when role == "catch_error".
     # None means wildcard — covers any step not claimed by a scoped handler.
@@ -213,6 +221,8 @@ def make_step_function(
         retry_policy=retry_policy,
         resources=spec.resources,
         skip_graph_checks=skip_graph_checks or [],
+        is_fan_out=spec.is_fan_out,
+        bare_return_types=tuple(spec.bare_return_types),
         accept_event_subclasses=accept_event_subclasses,
     )
 

--- a/packages/llama-index-workflows/src/workflows/representation/build.py
+++ b/packages/llama-index-workflows/src/workflows/representation/build.py
@@ -181,6 +181,21 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
     workflow_cls = workflow if isinstance(workflow, type) else type(workflow)
     steps: dict[str, StepFunction] = workflow_cls._get_steps_from_class()
 
+    # Map each produced event type (by class name) to the steps that declare it
+    # in their return signature. Collection returns (list[E]) are already
+    # flattened into return_types upstream.
+    produced_by_map: dict[str, list[str]] = {}
+    for step_name, step_func in steps.items():
+        for return_type in step_func._step_config.return_types:
+            if return_type is type(None):
+                continue
+            return_type_name = _get_type_name(return_type)
+            if return_type_name is None:
+                continue
+            producers = produced_by_map.setdefault(return_type_name, [])
+            if step_name not in producers:
+                producers.append(step_name)
+
     nodes: list[WorkflowGraphNode] = []
     edges: list[WorkflowGraphEdge] = []
     added_nodes: set[str] = set()  # Track added node IDs to avoid duplicates
@@ -313,6 +328,7 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
                         event_type=event_type_name,
                         event_types=_get_event_type_chain(event_type),
                         event_schema=_event_schema(event_type),
+                        produced_by=list(produced_by_map.get(event_type_name, [])),
                     )
                 )
                 added_nodes.add(event_type_name)
@@ -332,6 +348,7 @@ def get_workflow_representation(workflow: Workflow | type[Workflow]) -> Workflow
                         event_type=return_type_name,
                         event_types=_get_event_type_chain(return_type),
                         event_schema=_event_schema(return_type),
+                        produced_by=list(produced_by_map.get(return_type_name, [])),
                     )
                 )
                 added_nodes.add(return_type_name)

--- a/packages/llama-index-workflows/src/workflows/representation/types.py
+++ b/packages/llama-index-workflows/src/workflows/representation/types.py
@@ -47,6 +47,11 @@ class WorkflowEventNode(WorkflowNodeBase):
         default=None,
         description="Pydantic JSON schema for the event type",
     )
+    produced_by: list[str] = Field(
+        default_factory=list,
+        description="Names of steps whose declared return signature emits this "
+        "event type (including via list[E] returns).",
+    )
 
     def is_subclass_of(self, *type_names: str) -> bool:
         """Check if this node's event_type is a subclass of any of the given types."""

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -171,13 +171,12 @@ def as_step_worker_function(
         internal_context = Context._create_internal(workflow=workflow)
         returns = Returns(return_values=[])
 
-        token = StepWorkerStateContextVar.set(
-            StepWorkerContext(
-                state=state,
-                returns=returns,
-                retry=retry,
-            )
+        step_ctx = StepWorkerContext(
+            state=state,
+            returns=returns,
+            retry=retry,
         )
+        token = StepWorkerStateContextVar.set(step_ctx)
         ctx_token = InternalContextVar.set(weakref.ref(internal_context))
 
         try:
@@ -271,10 +270,51 @@ def as_step_worker_function(
                         raise captured_cancelled
                     if captured_waiting is not None:
                         raise captured_waiting
-                if result is not None and not isinstance(result, Event):
+                if isinstance(result, list) and config.is_fan_out:
+                    # A step that actually returned a list fans out: each
+                    # element is emitted as its own event. An empty list means
+                    # "no emission".
+                    for item in result:
+                        if not isinstance(item, Event):
+                            msg = (
+                                f"Step function {step_name} returned a list "
+                                f"containing {type(item).__name__} instead of an "
+                                "Event instance."
+                            )
+                            raise WorkflowRuntimeError(msg)
+                    if result:
+                        for item in result:
+                            returns.return_values.append(StepWorkerResult(result=item))
+                    else:
+                        returns.return_values.append(StepWorkerResult(result=None))
+                elif result is not None and not isinstance(result, Event):
                     msg = f"Step function {step_name} returned {type(result).__name__} instead of an Event instance."
                     raise WorkflowRuntimeError(msg)
-                returns.return_values.append(StepWorkerResult(result=result))
+                elif (
+                    config.is_fan_out
+                    and result is not None
+                    and not any(
+                        isinstance(t, type) and isinstance(result, t)
+                        for t in config.bare_return_types
+                    )
+                ):
+                    # A bare event under a list-returning annotation. A type
+                    # declared as a non-list union member (-> list[A] | B
+                    # returning B) is ordinary dispatch and handled below; an
+                    # undeclared bare element is an error, not a silent
+                    # one-element emission.
+                    msg = (
+                        f"Step function {step_name} returned a bare "
+                        f"{type(result).__name__} but its return annotation only "
+                        "declares it inside a list. Return a one-element list to "
+                        "fan out, or declare the bare type as a union member "
+                        "(e.g. -> list[A] | B) for ordinary dispatch."
+                    )
+                    raise WorkflowRuntimeError(msg)
+                else:
+                    # Ordinary dispatch — including a fan-out step's declared
+                    # non-list branch and its None (no emission) branch.
+                    returns.return_values.append(StepWorkerResult(result=result))
             except WaitingForEvent as e:
                 await asyncio.sleep(0)
                 returns.return_values.append(e.add)

--- a/packages/llama-index-workflows/src/workflows/utils.py
+++ b/packages/llama-index-workflows/src/workflows/utils.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import collections.abc as cabc
 import inspect
 import secrets
 import string
@@ -41,6 +42,12 @@ class StepSignatureSpec(BaseModel):
     context_parameter: str | None
     context_state_type: Any | None
     resources: list[Any]
+    # Fan-out producer: True when the return annotation is ``list[E]``.
+    is_fan_out: bool = False
+    # Non-list members of a fan-out return union (``-> list[A] | B`` -> [B]).
+    # A bare return of one of these types is ordinary dispatch; any other bare
+    # event under a list-returning annotation is a runtime error.
+    bare_return_types: list[Any] = []
 
 
 def inspect_signature(
@@ -67,6 +74,7 @@ def inspect_signature(
 
     sig = inspect.signature(fn)
     type_hints = _resolve_type_hints(fn, include_extras=True, localns=localns)
+    _reject_async_iterator_return(fn, type_hints.get("return"))
 
     accepted_events: dict[str, list[EventType]] = {}
     context_parameter = None
@@ -110,7 +118,7 @@ def inspect_signature(
             continue
 
         # Get name and type of the Context param (without state type)
-        if hasattr(annotation, "__name__") and annotation.__name__ == "Context":
+        if getattr(annotation, "__name__", None) == "Context":
             context_parameter = name
             continue
 
@@ -130,6 +138,8 @@ def inspect_signature(
         context_parameter=context_parameter,
         context_state_type=context_state_type,
         resources=resources,
+        is_fan_out=_is_fan_out_return(fn, localns=localns),
+        bare_return_types=_bare_return_types(fn, localns=localns),
     )
 
 
@@ -226,25 +236,157 @@ def _get_param_types(param: inspect.Parameter, type_hints: dict) -> list[Any]:
     return [typ]
 
 
+# Return-annotation origins whose single element type describes emitted events.
+# A step that returns ``list[E]`` declares produced events for validation and
+# graph representation. Async-iterator returns are rejected at decoration.
+_COLLECTION_RETURN_ORIGINS = (list,)
+
+# Async-iterator return origins, rejected at decoration with a pointer to
+# ``list[E]``.
+_ASYNC_ITERATOR_RETURN_ORIGINS = (
+    cabc.AsyncIterator,
+    cabc.AsyncIterable,
+    cabc.AsyncGenerator,
+)
+
+
+def _flatten_return_annotation(hint: Any) -> list[Any]:
+    """Flatten a return annotation into the set of produced event types.
+
+    Unwraps unions, ``Optional`` (``None`` is dropped), and the
+    emission-collection wrappers in ``_COLLECTION_RETURN_ORIGINS`` (``list[E]``).
+    The element ``E`` may itself be a union, which is flattened recursively.
+    ``NoneType`` never appears in the result; order is preserved and duplicates
+    are removed.
+    """
+    if hint is type(None):
+        return []
+
+    origin = get_origin(hint)
+    if origin in (Union, UnionType):
+        # Optional is Union[type, None] so it's covered here.
+        result: list[Any] = []
+        for arg in get_args(hint):
+            for t in _flatten_return_annotation(arg):
+                if t not in result:
+                    result.append(t)
+        return result
+
+    if origin in _COLLECTION_RETURN_ORIGINS:
+        args = get_args(hint)
+        if not args:
+            return []
+        # list[E] -> E
+        return _flatten_return_annotation(args[0])
+
+    return [hint]
+
+
 def _get_return_types(
     func: Callable, localns: dict[str, Any] | None = None
 ) -> list[Any]:
     """
     Extract the return type hints from a function.
 
-    Handles Union, Optional, and List types.
+    Handles Union, Optional, and the ``list[E]`` emission collection, which is
+    unwrapped to the event types it emits for validation and graph
+    representation.
     """
     type_hints = _resolve_type_hints(func, localns=localns)
     return_hint = type_hints.get("return")
     if return_hint is None:
         return []
 
+    flattened = _flatten_return_annotation(return_hint)
+    # Preserve the historical contract that a bare ``-> None`` reports
+    # ``[NoneType]`` (a truthy, annotated return) rather than an empty list,
+    # which validation treats as a missing annotation.
+    if not flattened:
+        return [type(None)]
+    return flattened
+
+
+def _reject_async_iterator_return(func: Callable, return_hint: Any) -> None:
+    """Reject async-iterator fan-out returns.
+
+    A step that is an async generator, or annotates its return as
+    ``AsyncIterator[E]`` / ``AsyncIterable[E]`` / ``AsyncGenerator[E, None]``,
+    The supported fan-out contract is a finite ``list[E]`` return. Async
+    iterators imply streaming member delivery, which the runtime does not model.
+    Producers should return ``list[E]`` or use ``ctx.send_event`` for ordinary
+    dispatch.
+    """
+    is_async_gen = inspect.isasyncgenfunction(
+        getattr(func, "__func__", func)
+    ) or inspect.isasyncgenfunction(func)
     origin = get_origin(return_hint)
+    if is_async_gen or origin in _ASYNC_ITERATOR_RETURN_ORIGINS:
+        raise WorkflowValidationError(
+            "Async-iterator fan-out (AsyncIterator[E] / AsyncGenerator[E, None] / "
+            "async generator steps) is not supported. Return list[E] for a "
+            "static collection, or emit incrementally with ctx.send_event."
+        )
+
+
+def _is_fan_out_return(func: Callable, localns: dict[str, Any] | None = None) -> bool:
+    """True if the return annotation declares per-element list emission.
+
+    A fan-out producer returns ``list[E]``. ``Optional[list[E]]``
+    (``list[E] | None``) also counts — it may emit a list or nothing. A plain
+    single-event or union-of-single-events return is NOT fan-out.
+    """
+    type_hints = _resolve_type_hints(func, localns=localns)
+    return_hint = type_hints.get("return")
+    if return_hint is None:
+        return False
+    return _return_hint_is_fan_out(return_hint)
+
+
+def _return_hint_is_fan_out(hint: Any) -> bool:
+    if hint is type(None):
+        return False
+    origin = get_origin(hint)
     if origin in (Union, UnionType):
-        # Optional is Union[type, None] so it's covered here
-        return [t for t in get_args(return_hint) if t is not type(None)]
-    else:
-        return [return_hint]
+        # Optional / unions: fan-out if any non-None member is a collection.
+        return any(
+            _return_hint_is_fan_out(arg)
+            for arg in get_args(hint)
+            if arg is not type(None)
+        )
+    return origin in _COLLECTION_RETURN_ORIGINS
+
+
+def _bare_return_types(
+    func: Callable, localns: dict[str, Any] | None = None
+) -> list[Any]:
+    """Non-list members of the return annotation.
+
+    For ``-> list[A] | B`` this is ``[B]``: a bare ``B`` return from a fan-out
+    step is ordinary dispatch rather than list emission. A pure ``-> list[A]``
+    has none, so any bare event return is a runtime error there. ``NoneType``
+    is dropped (a ``None`` return is the no-emission path).
+    """
+    type_hints = _resolve_type_hints(func, localns=localns)
+    return_hint = type_hints.get("return")
+    if return_hint is None:
+        return []
+    return _flatten_bare_members(return_hint)
+
+
+def _flatten_bare_members(hint: Any) -> list[Any]:
+    if hint is type(None):
+        return []
+    origin = get_origin(hint)
+    if origin in (Union, UnionType):
+        result: list[Any] = []
+        for arg in get_args(hint):
+            for t in _flatten_bare_members(arg):
+                if t not in result:
+                    result.append(t)
+        return result
+    if origin in _COLLECTION_RETURN_ORIGINS:
+        return []
+    return [hint]
 
 
 def _resolve_type_hints(

--- a/packages/llama-index-workflows/tests/test_fan_out_emission.py
+++ b/packages/llama-index-workflows/tests/test_fan_out_emission.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+from __future__ import annotations
+
+import pytest
+from workflows import Context, Workflow, step
+from workflows.errors import WorkflowRuntimeError
+from workflows.events import Event, StartEvent, StopEvent
+
+
+class Task(Event):
+    idx: int
+
+
+class Done(Event):
+    idx: int
+
+
+@pytest.mark.asyncio
+async def test_static_list_return_emits_each_element() -> None:
+    """A step returning ``list[Task]`` emits one event per element."""
+
+    class FanOutWorkflow(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return [Task(idx=i) for i in range(3)]
+
+        @step(num_workers=3)
+        async def process(self, ev: Task) -> Done:
+            return Done(idx=ev.idx)
+
+        @step
+        async def collect(self, ctx: Context, ev: Done) -> StopEvent | None:
+            done = ctx.collect_events(ev, [Done] * 3)
+            if done is None:
+                return None
+            return StopEvent(result=sorted(d.idx for d in done))
+
+    result = await FanOutWorkflow(timeout=10).run()
+    assert result == [0, 1, 2]
+
+
+@pytest.mark.asyncio
+async def test_empty_list_return_emits_nothing() -> None:
+    """Returning ``[]`` completes the step without emitting or raising."""
+
+    class EmptyFanOutWorkflow(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return []
+
+        @step
+        async def stop(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="ok")
+
+        @step
+        async def process(self, ev: Task) -> StopEvent | None:
+            # Should never run: the empty fan-out emits no Task.
+            return StopEvent(result="should-not-happen")
+
+    result = await EmptyFanOutWorkflow(timeout=10).run()
+    assert result == "ok"
+
+
+@pytest.mark.asyncio
+async def test_list_with_non_event_raises() -> None:
+    """A list element that is not an Event raises a runtime error."""
+
+    class BadFanOutWorkflow(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[Task]:
+            return ["not-an-event"]  # type: ignore
+
+        @step
+        async def process(self, ev: Task) -> StopEvent | None:
+            return StopEvent(result="done")
+
+    with pytest.raises(Exception):
+        await BadFanOutWorkflow(timeout=10).run()
+
+
+@pytest.mark.asyncio
+async def test_non_fan_out_list_return_raises() -> None:
+    """A runtime list only fans out when the signature declares list[E]."""
+
+    class BadReturnWorkflow(Workflow):
+        @step
+        async def start(self, ev: StartEvent) -> StopEvent:
+            return [StopEvent(result="not fan-out")]  # type: ignore[return-value]  # ty: ignore[invalid-return-type]
+
+    with pytest.raises(WorkflowRuntimeError, match="returned list"):
+        await BadReturnWorkflow(timeout=10).run()

--- a/packages/llama-index-workflows/tests/test_representation_utils.py
+++ b/packages/llama-index-workflows/tests/test_representation_utils.py
@@ -164,6 +164,33 @@ def test_truncated_label() -> None:
     assert node.truncated_label(17) == "my_long_step_name"
 
 
+class FannedOutTask(Event):
+    idx: int
+
+
+def test_produced_by_lists_producing_step() -> None:
+    """A step returning list[Task] records itself as Task's producer."""
+
+    class FanWorkflow(Workflow):
+        @step
+        async def fan_out(self, ev: StartEvent) -> list[FannedOutTask]:
+            return [FannedOutTask(idx=i) for i in range(3)]
+
+        @step
+        async def collect(self, ev: FannedOutTask) -> StopEvent | None:
+            return StopEvent(result=ev.idx)
+
+    graph = get_workflow_representation(FanWorkflow)
+
+    task_nodes = [
+        node
+        for node in graph.nodes
+        if isinstance(node, WorkflowEventNode) and node.event_type == "FannedOutTask"
+    ]
+    assert len(task_nodes) == 1
+    assert "fan_out" in task_nodes[0].produced_by
+
+
 def test_graph_serialization() -> None:
     """Test that WorkflowGraph serializes and restores node types."""
     graph = WorkflowGraph(

--- a/packages/llama-index-workflows/tests/test_utils.py
+++ b/packages/llama-index-workflows/tests/test_utils.py
@@ -2,14 +2,21 @@
 # Copyright (c) 2026 LlamaIndex Inc.
 
 import inspect
-from typing import Any, get_type_hints
+from typing import (
+    Any,
+    AsyncGenerator,
+    AsyncIterator,
+    List,
+    get_type_hints,
+)
 
 import pytest
 from workflows.context import Context
 from workflows.decorators import step
 from workflows.errors import WorkflowValidationError
-from workflows.events import StartEvent, StopEvent
+from workflows.events import Event, StartEvent, StopEvent
 from workflows.utils import (
+    _flatten_return_annotation,
     _get_param_types,
     _get_return_types,
     get_steps_from_class,
@@ -122,7 +129,7 @@ def test_validate_step_signature_too_many_params() -> None:
     def f1(self, ev: OneTestEvent, foo: OneTestEvent) -> None:  # noqa: ANN001
         pass
 
-    def f2(ev: OneTestEvent, foo: OneTestEvent) -> None:  # noqa: ANN001
+    def f2(ev: OneTestEvent, foo: OneTestEvent) -> None:
         pass
 
     with pytest.raises(
@@ -215,10 +222,12 @@ def test_get_return_types_optional() -> None:
 
 
 def test_get_return_types_list() -> None:
+    # list[E] is flattened to its element type for workflow validation and
+    # graph representation.
     def f(foo: int) -> list[str]:
         return [""]
 
-    assert _get_return_types(f) == [list[str]]
+    assert _get_return_types(f) == [str]
 
 
 def test_is_free_function() -> None:
@@ -233,3 +242,81 @@ def test_is_free_function() -> None:
 def test_inspect_signature_raises_if_not_callable() -> None:
     with pytest.raises(TypeError, match="Expected a callable object, got str"):
         inspect_signature("foo")  # type: ignore
+
+
+class _EventA(Event):
+    pass
+
+
+class _EventB(Event):
+    pass
+
+
+def test_return_type_list_is_flattened() -> None:
+    def f(ev: StartEvent) -> list[_EventA]:
+        return [_EventA()]
+
+    spec = inspect_signature(f)
+    assert spec.return_types == [_EventA]
+
+
+def test_async_iterator_return_is_rejected() -> None:
+    async def f(ev: StartEvent) -> AsyncIterator[_EventA]:
+        yield _EventA()
+
+    with pytest.raises(WorkflowValidationError, match="Async-iterator fan-out"):
+        inspect_signature(f)
+
+
+def test_async_generator_return_is_rejected() -> None:
+    async def f(ev: StartEvent) -> AsyncGenerator[_EventA, None]:
+        yield _EventA()
+
+    with pytest.raises(WorkflowValidationError, match="Async-iterator fan-out"):
+        inspect_signature(f)
+
+
+def test_return_type_list_of_union_is_flattened() -> None:
+    def f(ev: StartEvent) -> list[_EventA | _EventB]:
+        return [_EventA()]
+
+    spec = inspect_signature(f)
+    assert spec.return_types == [_EventA, _EventB]
+
+
+def test_return_type_optional_list_strips_none() -> None:
+    def f(ev: StartEvent) -> list[_EventA] | None:
+        return None
+
+    spec = inspect_signature(f)
+    assert spec.return_types == [_EventA]
+
+
+def test_return_type_bare_event_unchanged() -> None:
+    def f(ev: StartEvent) -> _EventA:
+        return _EventA()
+
+    spec = inspect_signature(f)
+    assert spec.return_types == [_EventA]
+
+
+def test_return_type_bare_none_reports_nonetype() -> None:
+    def f(ev: StartEvent) -> None:
+        return None
+
+    spec = inspect_signature(f)
+    assert spec.return_types == [type(None)]
+
+
+def test_validate_step_signature_accepts_list_return() -> None:
+    def f(ev: StartEvent) -> list[_EventA]:
+        return [_EventA()]
+
+    spec = inspect_signature(f)
+    # Should not raise: list[E] flattens to a real event return type.
+    validate_step_signature(spec)
+
+
+def test_flatten_return_annotation_unparameterized_collection_returns_empty() -> None:
+    # A collection origin with no type args (bare ``typing.List``) flattens to no types.
+    assert _flatten_return_annotation(List) == []


### PR DESCRIPTION
Workflow steps currently have to use imperative `ctx.send_event` loops when one invocation produces multiple same-shaped events. That hides the produced event type from validation and graph representation.

This adds a finite fan-out return shape: a step can declare `-> list[Task]` and return a list; the runtime emits one event per element.

```python
@step
async def fan_out(self, ev: StartEvent) -> list[Task]:
    return [Task(idx=i) for i in range(3)]
```

`return []` means no emission. Runtime lists only fan out when the return annotation declares `list[E]`; returning a list from an ordinary single-event step still errors. `AsyncIterator` and async generator returns are rejected because the runtime only models a finite collection return here.

Workflow representation now records which steps produce an event type, including event types produced through `list[E]` returns.