### PR TITLE
Sanitize slashes in Mermaid execution step IDs

### DIFF
--- a/.changeset/sanitize-mermaid-step-slashes.md
+++ b/.changeset/sanitize-mermaid-step-slashes.md
@@ -1,0 +1,5 @@
+---
+"llama-index-utils-workflow": patch
+---
+
+Sanitize slashes in Mermaid execution diagram step IDs.

--- a/packages/llama-index-utils-workflow/src/llama_index/utils/workflow/__init__.py
+++ b/packages/llama-index-utils-workflow/src/llama_index/utils/workflow/__init__.py
@@ -185,7 +185,7 @@ def _determine_event_color(event_type: type) -> str:
 
 def _clean_id_for_mermaid(name: str) -> str:
     """Convert a name to a valid Mermaid ID."""
-    return name.replace(" ", "_").replace("-", "_").replace(".", "_")
+    return name.replace(" ", "_").replace("-", "_").replace(".", "_").replace("/", "_")
 
 
 def _get_mermaid_css_class(node: WorkflowGraphNode) -> str:
@@ -900,7 +900,8 @@ def draw_most_recent_execution_mermaid(
     mermaid_lines = ["flowchart TD"]
 
     cleaned_ids = {
-        node_id: node_id.replace(":", "_").replace("#", "_") for node_id in nodes.keys()
+        node_id: _clean_id_for_mermaid(node_id.replace(":", "_").replace("#", "_"))
+        for node_id in nodes.keys()
     }
 
     for node_id, (label, node_type, ev_type) in nodes.items():

--- a/packages/llama-index-utils-workflow/tests/test_drawing.py
+++ b/packages/llama-index-utils-workflow/tests/test_drawing.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Any, cast
 from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
@@ -15,6 +15,8 @@ from pydantic import BaseModel
 from workflows.decorators import step
 from workflows.events import StartEvent, StopEvent
 from workflows.resource import Resource, ResourceConfig
+from workflows.runtime.types.results import StepWorkerResult
+from workflows.runtime.types.ticks import TickStepResult
 from workflows.workflow import Workflow
 
 
@@ -308,6 +310,29 @@ async def test_draw_most_recent_execution_mermaid(workflow: Workflow) -> None:
         edge_lines = [line for line in lines if " --> " in line]
         assert len(node_lines) > 0
         assert len(edge_lines) > 0
+
+
+@pytest.mark.asyncio
+async def test_draw_most_recent_execution_mermaid_sanitizes_slash_step_ids(
+    workflow: Workflow,
+) -> None:
+    handler = workflow.run()
+    await handler
+
+    adapter = cast(Any, handler.ctx._face)._external_adapter
+    adapter._queues.ticks = [
+        TickStepResult(
+            step_name="parent/child",
+            worker_id=0,
+            event=StartEvent(),
+            result=[StepWorkerResult(result=StopEvent())],
+        )
+    ]
+
+    result = draw_most_recent_execution_mermaid(handler, filename="")
+
+    assert 'step_parent_child_1["parent/child#1"]:::stepStyle' in result
+    assert "step_parent/child_1" not in result
 
 
 # --- Resource node rendering tests ---


### PR DESCRIPTION
Mermaid execution diagrams only normalized `:` and `#` in tick-derived node IDs, so a slash in a step name was emitted into the Mermaid ID even though the visible label rendered fine.

The renderer now runs execution IDs through the shared Mermaid ID sanitizer, and that sanitizer also normalizes slashes for graph rendering.