### PR TITLE
Add typed runtime step ids

### DIFF
--- a/.changeset/step-id-runtime-identity.md
+++ b/.changeset/step-id-runtime-identity.md
@@ -1,0 +1,6 @@
+---
+"llama-index-workflows": patch
+"llama-index-utils-workflow": patch
+---
+
+Add typed runtime step identities while preserving root workflow tick compatibility

--- a/.changeset/step-id-runtime-identity.md
+++ b/.changeset/step-id-runtime-identity.md
@@ -1,6 +1,6 @@
 ---
-"llama-index-workflows": patch
-"llama-index-utils-workflow": patch
+"llama-index-workflows": minor
+"llama-index-utils-workflow": minor
 ---
 
-Add typed runtime step identities while preserving root workflow tick compatibility
+Add typed runtime step identities.

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -33,6 +33,7 @@ from workflows.events import Event, StartEvent, StopEvent
 from workflows.runtime.types.internal_state import BrokerState
 from workflows.runtime.types.named_task import WorkerTask
 from workflows.runtime.types.plugin import RegisteredWorkflow
+from workflows.runtime.types.step_id import StepId
 from workflows.testing import WorkflowTestRunner
 from workflows.workflow import Workflow
 
@@ -397,7 +398,7 @@ async def test_replay_wait_for_next_task_timeout_returns_none(
 
     try:
         result = await adapter.wait_for_next_task(
-            [WorkerTask("step_a", 0, task)],
+            [WorkerTask(StepId.root("step_a"), 0, task)],
             [],
             timeout=0.01,
         )

--- a/packages/llama-index-utils-workflow/pyproject.toml
+++ b/packages/llama-index-utils-workflow/pyproject.toml
@@ -21,7 +21,7 @@ authors = [{name = "Adrian Lyjak", email = "adrianlyjak@gmail.com"}]
 requires-python = ">=3.10"
 dependencies = [
   "llama-index-core>=0.14,<0.15.0",
-  "llama-index-workflows>=2.13.0,<3.0.0",
+  "llama-index-workflows>=2.22.0,<3.0.0",
   "pyvis>=0.3.2"
 ]
 

--- a/packages/llama-index-utils-workflow/src/llama_index/utils/workflow/__init__.py
+++ b/packages/llama-index-utils-workflow/src/llama_index/utils/workflow/__init__.py
@@ -515,10 +515,11 @@ def _extract_execution_graph(
             ev_id = ensure_event_node(t.event)
             edges.append((external_node_id, ev_id))
         elif isinstance(t, TickStepResult):
-            step_seq[t.step_name] = step_seq.get(t.step_name, 0) + 1
-            seq = step_seq[t.step_name]
-            step_node_id = f"step:{t.step_name}#{seq}"
-            step_label = f"{t.step_name}#{seq}"
+            step_name = str(t.step_id)
+            step_seq[step_name] = step_seq.get(step_name, 0) + 1
+            seq = step_seq[step_name]
+            step_node_id = f"step:{step_name}#{seq}"
+            step_label = f"{step_name}#{seq}"
             display_label = (
                 _truncate_label(step_label, max_label_length)
                 if max_label_length

--- a/packages/llama-index-utils-workflow/tests/test_drawing.py
+++ b/packages/llama-index-utils-workflow/tests/test_drawing.py
@@ -16,6 +16,7 @@ from workflows.decorators import step
 from workflows.events import StartEvent, StopEvent
 from workflows.resource import Resource, ResourceConfig
 from workflows.runtime.types.results import StepWorkerResult
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import TickStepResult
 from workflows.workflow import Workflow
 
@@ -322,7 +323,7 @@ async def test_draw_most_recent_execution_mermaid_sanitizes_slash_step_ids(
     adapter = cast(Any, handler.ctx._face)._external_adapter
     adapter._queues.ticks = [
         TickStepResult(
-            step_name="parent/child",
+            step_id=StepId.from_str("parent/child"),
             worker_id=0,
             event=StartEvent(),
             result=[StepWorkerResult(result=StopEvent())],

--- a/packages/llama-index-workflows/src/workflows/context/external_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/external_context.py
@@ -20,6 +20,7 @@ from workflows.runtime.types.plugin import (
     as_snapshottable_adapter,
     as_v2_runtime_compatibility_shim,
 )
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import TickAddEvent, TickCancelRun, WorkflowTick
 
 if TYPE_CHECKING:
@@ -120,7 +121,10 @@ class ExternalContext(Generic[MODEL_T, RunResultT]):
 
         self._execute_task(
             self._external_adapter.send_event(
-                TickAddEvent(event=message, step_name=step)
+                TickAddEvent(
+                    event=message,
+                    step_id=StepId.root(step) if step is not None else None,
+                )
             )
         )
 

--- a/packages/llama-index-workflows/src/workflows/context/internal_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/internal_context.py
@@ -22,6 +22,7 @@ from workflows.runtime.types.results import (
     StepWorkerStateContextVar,
     WaitingForEvent,
 )
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import TickAddEvent
 
 if TYPE_CHECKING:
@@ -169,7 +170,7 @@ class InternalContext(Generic[MODEL_T]):
             self._internal_adapter.send_event(
                 TickAddEvent(
                     event=message,
-                    step_name=step,
+                    step_id=StepId.root(step) if step is not None else None,
                     recovery_counts=recovery_counts,
                 )
             )

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop.py
@@ -80,6 +80,7 @@ from workflows.runtime.types.results import (
     StepWorkerState,
     StepWorkerWaiter,
 )
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickAddEvent,
     TickCancelRun,
@@ -124,6 +125,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _root_step_key(step_id: StepId) -> str:
+    return str(step_id)
+
+
 class _ControlLoopRunner:
     """
     Private class to encapsulate the async control loop runtime state and behavior.
@@ -161,8 +166,8 @@ class _ControlLoopRunner:
         self._wakeup_sequence = 0
         # Pull task sequence counter for deterministic journaling
         self._pull_sequence = 0
-        # Map from worker task to (step_name, worker_id) key
-        self._task_keys: dict[asyncio.Task[TickStepResult], tuple[str, int]] = {}
+        # Map from worker task to (step_id, worker_id) key
+        self._task_keys: dict[asyncio.Task[TickStepResult], tuple[StepId, int]] = {}
         # Whether a TickIdleCheck is currently in tick_buffer
         self._idle_check_pending = False
         # Pending worker coroutines not yet started (started by adapter in wait_for_next_task)
@@ -203,11 +208,12 @@ class _ControlLoopRunner:
 
         async def _run_worker() -> TickStepResult:
             worker: InProgressState | None = None
+            step_name = _root_step_key(command.step_id)
             try:
                 worker = next(
                     (
                         w
-                        for w in self.state.workers[command.step_name].in_progress
+                        for w in self.state.workers[step_name].in_progress
                         if w.worker_id == command.id
                     ),
                     None,
@@ -217,11 +223,11 @@ class _ControlLoopRunner:
                         f"Worker {command.id} not found in in_progress. This should not happen."
                     )
                 snapshot = worker.shared_state
-                step_fn: StepWorkerFunction = self.step_workers[command.step_name]
+                step_fn: StepWorkerFunction = self.step_workers[step_name]
 
                 result = await step_fn(
                     state=snapshot,
-                    step_name=command.step_name,
+                    step_name=step_name,
                     event=command.event,
                     workflow=self.workflow,
                     retry=RetryAttempt(
@@ -234,12 +240,10 @@ class _ControlLoopRunner:
                 )
                 # Return result for main loop to process
                 return TickStepResult(
-                    step_name=command.step_name,
+                    step_id=command.step_id,
                     worker_id=command.id,
                     event=command.event,
-                    result=self._stamp_retry_decisions(
-                        command.step_name, worker, result
-                    ),
+                    result=self._stamp_retry_decisions(command.step_id, worker, result),
                 )
             except Exception as e:
                 if _is_shutdown_error(e):
@@ -252,21 +256,21 @@ class _ControlLoopRunner:
                     exception=e, failed_at=await self.adapter.get_now()
                 )
                 return TickStepResult(
-                    step_name=command.step_name,
+                    step_id=command.step_id,
                     worker_id=command.id,
                     event=command.event,
                     result=self._stamp_retry_decisions(
-                        command.step_name, worker, [failed]
+                        command.step_id, worker, [failed]
                     ),
                 )
 
         self._pending_workers.append(
-            PendingWorker(command.step_name, command.id, _run_worker())
+            PendingWorker(command.step_id, command.id, _run_worker())
         )
 
     def _stamp_retry_decisions(
         self,
-        step_name: str,
+        step_id: StepId,
         worker: InProgressState | None,
         results: list[StepFunctionResult],
     ) -> list[StepFunctionResult]:
@@ -280,6 +284,7 @@ class _ControlLoopRunner:
         """
         if worker is None:
             return results
+        step_name = _root_step_key(step_id)
         policy = self.state.workers[step_name].config.retry_policy
         out: list[StepFunctionResult] = []
         for result in results:
@@ -307,7 +312,7 @@ class _ControlLoopRunner:
             self.tick_buffer.append(
                 TickAddEvent(
                     event=command.event,
-                    step_name=command.step_name,
+                    step_id=command.step_id,
                     attempts=command.attempts,
                     first_attempt_at=command.first_attempt_at,
                     last_exception=command.last_exception,
@@ -340,9 +345,7 @@ class _ControlLoopRunner:
         elif isinstance(command, CommandScheduleWaiterTimeout):
             now = await self.adapter.get_now()
             self.schedule_tick(
-                TickWaiterTimeout(
-                    step_name=command.step_name, waiter_id=command.waiter_id
-                ),
+                TickWaiterTimeout(step_id=command.step_id, waiter_id=command.waiter_id),
                 at_time=now + command.timeout,
             )
             return None
@@ -492,7 +495,7 @@ class _ControlLoopRunner:
                         pull_task = nt.task
                     elif isinstance(nt, WorkerTask):
                         self.worker_tasks.add(nt.task)
-                        self._task_keys[nt.task] = (nt.step_name, nt.worker_id)
+                        self._task_keys[nt.task] = (nt.step_id, nt.worker_id)
 
                 completed_task = result.completed
 
@@ -778,7 +781,7 @@ def _decide_retry_delay(
 
 
 def _drain_eligible_queue(
-    step_name: str,
+    step_id: StepId,
     state: InternalStepWorkerState,
     now_seconds: float,
 ) -> list[WorkflowCommand]:
@@ -797,7 +800,7 @@ def _drain_eligible_queue(
         if index is None:
             break
         attempt = state.queue.pop(index)
-        commands.extend(_add_or_enqueue_event(attempt, step_name, state, now_seconds))
+        commands.extend(_add_or_enqueue_event(attempt, step_id, state, now_seconds))
     return commands
 
 
@@ -815,6 +818,7 @@ def rewind_in_progress(
     state = state.deepcopy()
     commands: list[WorkflowCommand] = []
     for step_name, step_state in sorted(state.workers.items(), key=lambda x: x[0]):
+        step_id = StepId.root(step_name)
         for in_progress in step_state.in_progress:
             step_state.queue.insert(
                 0,
@@ -828,7 +832,7 @@ def rewind_in_progress(
                 ),
             )
         step_state.in_progress = []
-        commands.extend(_drain_eligible_queue(step_name, step_state, now_seconds))
+        commands.extend(_drain_eligible_queue(step_id, step_state, now_seconds))
         for attempt in step_state.queue:
             if attempt.not_before is not None:
                 commands.append(CommandScheduleWakeup(at_time=attempt.not_before))
@@ -868,7 +872,9 @@ def _process_step_result_tick(
     """
     state = init.deepcopy()
     commands: list[WorkflowCommand] = []
-    worker_state = state.workers[tick.step_name]
+    step_id = tick.step_id
+    step_name = _root_step_key(step_id)
+    worker_state = state.workers[step_name]
     # get the current execution details and mark it as no longer in progress
     this_execution = next(
         (w for w in worker_state.in_progress if w.worker_id == tick.worker_id), None
@@ -913,7 +919,7 @@ def _process_step_result_tick(
                 pass
             else:
                 logger.warning(
-                    f"Unknown result type returned from step function ({tick.step_name}): {type(result.result)}"
+                    f"Unknown result type returned from step function ({step_name}): {type(result.result)}"
                 )
         elif isinstance(result, StepWorkerFailed):
             # Schedule a retry if permitted, otherwise fail the workflow.
@@ -941,7 +947,7 @@ def _process_step_result_tick(
                     failures=this_execution.attempts + 1,
                     exception=result.exception,
                     run_id=run_id,
-                    step_name=tick.step_name,
+                    step_name=step_name,
                 )
             if delay is not None:
                 # Re-queue the attempt directly into persisted state, carrying
@@ -969,7 +975,7 @@ def _process_step_result_tick(
                 total_attempts = this_execution.attempts + 1
                 elapsed = result.failed_at - first_attempt_at
 
-                handler_name = state.config.handler_for_step.get(tick.step_name)
+                handler_name = state.config.handler_for_step.get(step_name)
                 handler = (
                     state.config.catch_error_handlers.get(handler_name)
                     if handler_name is not None
@@ -988,7 +994,7 @@ def _process_step_result_tick(
                     # Route to the catch-error handler. Keep workflow running so
                     # the handler can produce either a StopEvent or a new failure.
                     step_failed_event = StepFailedEvent(
-                        step_name=tick.step_name,
+                        step_name=step_name,
                         input_event=tick.event,
                         exception=exception,
                         attempts=total_attempts,
@@ -1000,7 +1006,7 @@ def _process_step_result_tick(
                     commands.append(
                         CommandQueueEvent(
                             event=step_failed_event,
-                            step_name=handler.step_name,
+                            step_id=StepId.root(handler.step_name),
                             recovery_counts={
                                 **this_execution.recovery_counts,
                                 handler.step_name: new_count,
@@ -1013,7 +1019,7 @@ def _process_step_result_tick(
                     commands.append(
                         CommandPublishEvent(
                             event=WorkflowFailedEvent(
-                                step_name=tick.step_name,
+                                step_name=step_name,
                                 exception=exception,
                                 attempts=total_attempts,
                                 elapsed_seconds=elapsed,
@@ -1021,15 +1027,13 @@ def _process_step_result_tick(
                         )
                     )
                     commands.append(
-                        CommandFailWorkflow(
-                            step_name=tick.step_name, exception=exception
-                        )
+                        CommandFailWorkflow(step_id=step_id, exception=exception)
                     )
         elif isinstance(result, AddCollectedEvent):
             # The current state of collected events.
-            collected_events = state.workers[
-                tick.step_name
-            ].collected_events.setdefault(result.event_id, [])
+            collected_events = state.workers[step_name].collected_events.setdefault(
+                result.event_id, []
+            )
             # the events snapshot that was sent with the step function execution that yielded this result
             sent_events = this_execution.shared_state.collected_events.get(
                 result.event_id, []
@@ -1042,15 +1046,13 @@ def _process_step_result_tick(
                     this_execution.shared_state,
                     collected_events={
                         x: list(y)
-                        for x, y in state.workers[
-                            tick.step_name
-                        ].collected_events.items()
+                        for x, y in state.workers[step_name].collected_events.items()
                     },
                 )
                 this_execution.shared_state = updated_state
                 commands.append(
                     CommandRunWorker(
-                        step_name=tick.step_name,
+                        step_id=step_id,
                         event=result.event,
                         id=this_execution.worker_id,
                     )
@@ -1060,9 +1062,7 @@ def _process_step_result_tick(
         elif isinstance(result, DeleteCollectedEvent):
             if did_complete_step:  # allow retries to grab the events
                 # indicates that a run has successfully collected its events, and they can be deleted from the collected events state
-                state.workers[tick.step_name].collected_events.pop(
-                    result.event_id, None
-                )
+                state.workers[step_name].collected_events.pop(result.event_id, None)
         elif isinstance(result, AddWaiter):
             # indicates that a run has added a waiter to the collected waiters state
             existing = next(
@@ -1090,7 +1090,7 @@ def _process_step_result_tick(
                 if result.timeout is not None:
                     commands.append(
                         CommandScheduleWaiterTimeout(
-                            step_name=tick.step_name,
+                            step_id=step_id,
                             waiter_id=result.waiter_id,
                             timeout=result.timeout,
                         )
@@ -1100,7 +1100,7 @@ def _process_step_result_tick(
             if did_complete_step:  # allow retries to grab the waiter events
                 # indicates that a run has obtained the waiting event, and it can be deleted from the collected waiters state
                 to_remove = result.waiter_id
-                waiters = state.workers[tick.step_name].collected_waiters
+                waiters = state.workers[step_name].collected_waiters
                 item = next(filter(lambda w: w.waiter_id == to_remove, waiters), None)
                 if item is not None:
                     waiters.remove(item)
@@ -1114,7 +1114,7 @@ def _process_step_result_tick(
             CommandPublishEvent(
                 StepStateChanged(
                     step_state=StepState.NOT_RUNNING,
-                    name=tick.step_name,
+                    name=step_name,
                     input_event_name=str(type(tick.event)),
                     output_event_name=output_event_name,
                     worker_id=str(tick.worker_id),
@@ -1124,16 +1124,14 @@ def _process_step_result_tick(
         worker_state.in_progress.remove(this_execution)
     # enqueue next events if there are any
     if not is_completed:
-        commands.extend(
-            _drain_eligible_queue(tick.step_name, worker_state, now_seconds)
-        )
+        commands.extend(_drain_eligible_queue(step_id, worker_state, now_seconds))
 
     return state, commands
 
 
 def _add_or_enqueue_event(
     event: EventAttempt,
-    step_name: str,
+    step_id: StepId,
     state: InternalStepWorkerState,
     now_seconds: float,
 ) -> list[WorkflowCommand]:
@@ -1142,6 +1140,7 @@ def _add_or_enqueue_event(
     Note! This mutates the state, assuming that its already been deepcopied in an outer scope.
     """
     commands: list[WorkflowCommand] = []
+    step_name = _root_step_key(step_id)
     # Determine if there is available capacity based on in_progress workers.
     # Delayed attempts (not_before set) are never dispatched here; they wait
     # in the queue without consuming a worker slot until a wakeup flips them.
@@ -1171,7 +1170,7 @@ def _add_or_enqueue_event(
                 recovery_counts=dict(event.recovery_counts),
             )
         )
-        commands.append(CommandRunWorker(step_name=step_name, event=event.event, id=id))
+        commands.append(CommandRunWorker(step_id=step_id, event=event.event, id=id))
         commands.append(
             CommandPublishEvent(
                 StepStateChanged(
@@ -1212,6 +1211,7 @@ def _process_add_event_tick(
     # as a normal accepted event (which would cause duplicate processing).
     waiter_resolved_steps: set[str] = set()
     for step_name, step_config in state.config.steps.items():
+        step_id = StepId.root(step_name)
         wait_conditions = state.workers[step_name].collected_waiters
         for wait_condition in wait_conditions:
             is_match = event_matches(
@@ -1229,7 +1229,7 @@ def _process_add_event_tick(
                 wait_condition.resolved_event = tick.event
                 subcommands = _add_or_enqueue_event(
                     EventAttempt(event=wait_condition.event),
-                    step_name,
+                    step_id,
                     state.workers[step_name],
                     now_seconds,
                 )
@@ -1238,6 +1238,7 @@ def _process_add_event_tick(
     # Then route to accepting steps, skipping any that were already woken
     # via waiter resolution above.
     for step_name, step_config in state.config.steps.items():
+        step_id = StepId.root(step_name)
         if step_name in waiter_resolved_steps:
             continue
         is_accepted = step_accepts_event(
@@ -1245,7 +1246,9 @@ def _process_add_event_tick(
             step_config.accepted_events,
             allow_subclasses=step_config.accept_event_subclasses,
         )
-        if is_accepted and (tick.step_name is None or tick.step_name == step_name):
+        if is_accepted and (
+            tick.step_id is None or _root_step_key(tick.step_id) == step_name
+        ):
             handled = True
             _consume_superseded_delayed_attempt(tick, state.workers[step_name])
             subcommands = _add_or_enqueue_event(
@@ -1257,7 +1260,7 @@ def _process_add_event_tick(
                     last_failed_at=tick.last_failed_at,
                     recovery_counts=dict(tick.recovery_counts),
                 ),
-                step_name,
+                step_id,
                 state.workers[step_name],
                 now_seconds,
             )
@@ -1273,7 +1276,7 @@ def _process_add_event_tick(
                     UnhandledEvent(
                         event_type=event_cls.__name__,
                         qualified_name=f"{event_cls.__module__}.{event_cls.__name__}",
-                        step_name=tick.step_name,
+                        step_name=str(tick.step_id) if tick.step_id else None,
                         idle=_check_idle_state(state),
                     )
                 )
@@ -1372,10 +1375,11 @@ def _process_wakeup_tick(
     state = init.deepcopy()
     commands: list[WorkflowCommand] = []
     for step_name, worker_state in sorted(state.workers.items(), key=lambda x: x[0]):
+        step_id = StepId.root(step_name)
         for attempt in worker_state.queue:
             if attempt.not_before is not None and attempt.not_before <= tick.due:
                 attempt.not_before = None
-        commands.extend(_drain_eligible_queue(step_name, worker_state, now_seconds))
+        commands.extend(_drain_eligible_queue(step_id, worker_state, now_seconds))
     return state, commands
 
 
@@ -1384,9 +1388,11 @@ def _process_waiter_timeout_tick(
 ) -> tuple[BrokerState, list[WorkflowCommand]]:
     state = init.deepcopy()
     commands: list[WorkflowCommand] = []
-    if tick.step_name not in state.workers:
+    step_id = tick.step_id
+    step_name = _root_step_key(step_id)
+    if step_name not in state.workers:
         return state, commands
-    worker_state = state.workers[tick.step_name]
+    worker_state = state.workers[step_name]
     waiter = next(
         (w for w in worker_state.collected_waiters if w.waiter_id == tick.waiter_id),
         None,
@@ -1397,7 +1403,7 @@ def _process_waiter_timeout_tick(
     waiter.timed_out = True
     subcommands = _add_or_enqueue_event(
         EventAttempt(event=waiter.event),
-        tick.step_name,
+        step_id,
         worker_state,
         now_seconds,
     )

--- a/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
@@ -19,11 +19,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 
 from workflows.events import Event, StopEvent
+from workflows.runtime.types.step_id import StepId
 
 
 @dataclass(frozen=True)
 class CommandRunWorker:
-    step_name: str
+    step_id: StepId
     event: Event
     id: int
 
@@ -31,7 +32,7 @@ class CommandRunWorker:
 @dataclass(frozen=True)
 class CommandQueueEvent:
     event: Event
-    step_name: str | None = None
+    step_id: StepId | None = None
     attempts: int | None = None
     first_attempt_at: float | None = None
     last_exception: Exception | None = None
@@ -51,7 +52,7 @@ class CommandCompleteRun:
 
 @dataclass(frozen=True)
 class CommandFailWorkflow:
-    step_name: str
+    step_id: StepId
     exception: Exception
 
 
@@ -62,7 +63,7 @@ class CommandPublishEvent:
 
 @dataclass(frozen=True)
 class CommandScheduleWaiterTimeout:
-    step_name: str
+    step_id: StepId
     waiter_id: str
     timeout: float
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -20,6 +20,7 @@ from workflows.decorators import CatchErrorHandler, StepConfig
 from workflows.events import Event
 from workflows.retry_policy import RetryPolicy
 from workflows.runtime.types.results import StepWorkerState, StepWorkerWaiter
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import TickAddEvent, WorkflowTick
 from workflows.workflow import Workflow
 
@@ -99,7 +100,7 @@ class BrokerState:
             ):
                 if waiter.has_requirements and not waiter.requirements:
                     commands.append(
-                        TickAddEvent(event=waiter.event, step_name=step_name)
+                        TickAddEvent(event=waiter.event, step_id=StepId.root(step_name))
                     )
         return commands
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/named_task.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/named_task.py
@@ -10,6 +10,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Coroutine
 
+from workflows.runtime.types.step_id import StepId
+
 # Key prefix for pull tasks
 PULL_PREFIX = "__pull__"
 
@@ -18,13 +20,13 @@ PULL_PREFIX = "__pull__"
 class WorkerTask:
     """An asyncio worker task with structured identity."""
 
-    step_name: str
+    step_id: StepId
     worker_id: int
     task: Task[Any]
 
     @property
     def key(self) -> str:
-        return f"{self.step_name}:{self.worker_id}"
+        return f"{self.step_id}:{self.worker_id}"
 
 
 @dataclass
@@ -89,17 +91,17 @@ def pick_highest_priority(
 class PendingWorker:
     """A worker coroutine that hasn't been started yet."""
 
-    step_name: str
+    step_id: StepId
     worker_id: int
     coro: Coroutine[Any, Any, Any]
 
     @property
     def key(self) -> str:
-        return f"{self.step_name}:{self.worker_id}"
+        return f"{self.step_id}:{self.worker_id}"
 
     def start(self, task: Task[Any]) -> WorkerTask:
         """Convert to a started WorkerTask."""
-        return WorkerTask(self.step_name, self.worker_id, task)
+        return WorkerTask(self.step_id, self.worker_id, task)
 
 
 @dataclass

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_id.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_id.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic_core import core_schema
+
+
+@dataclass(frozen=True)
+class StepId:
+    """Internal workflow runtime step identity."""
+
+    namespace: tuple[str, ...]
+    name: str
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("StepId name cannot be empty")
+        if any(not part for part in self.namespace):
+            raise ValueError("StepId namespace parts cannot be empty")
+
+    @classmethod
+    def root(cls, name: str) -> StepId:
+        return cls(namespace=(), name=name)
+
+    @classmethod
+    def from_str(cls, value: str) -> StepId:
+        parts = tuple(value.split("/"))
+        if len(parts) == 1:
+            return cls.root(value)
+        return cls(namespace=parts[:-1], name=parts[-1])
+
+    def __str__(self) -> str:
+        if not self.namespace:
+            return self.name
+        return "/".join((*self.namespace, self.name))
+
+    @classmethod
+    def _validate(cls, value: Any) -> StepId:
+        if isinstance(value, StepId):
+            return value
+        if isinstance(value, str):
+            return cls.from_str(value)
+        raise TypeError(f"Expected StepId or str, got {type(value).__name__}")
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls,
+        source_type: Any,
+        handler: Any,
+    ) -> core_schema.CoreSchema:
+        return core_schema.no_info_after_validator_function(
+            cls._validate,
+            core_schema.union_schema(
+                [core_schema.is_instance_schema(cls), core_schema.str_schema()]
+            ),
+            serialization=core_schema.plain_serializer_function_ser_schema(str),
+        )

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -20,14 +20,17 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, ConfigDict, Discriminator, Field, TypeAdapter
 from workflows.events import SerializableEvent, SerializableOptionalException
 from workflows.runtime.types.results import StepFunctionResult
+from workflows.runtime.types.step_id import StepId
 
 
 class TickStepResult(BaseModel):
     """When processed, executes a step function and publishes the result"""
 
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+    model_config = ConfigDict(
+        frozen=True, arbitrary_types_allowed=True, populate_by_name=True
+    )
     type: Literal["step_result"] = "step_result"
-    step_name: str
+    step_id: StepId = Field(validation_alias="step_name")
     worker_id: int
     event: SerializableEvent
     result: list[Annotated[StepFunctionResult, Discriminator("type")]]
@@ -36,10 +39,12 @@ class TickStepResult(BaseModel):
 class TickAddEvent(BaseModel):
     """When sent, adds an event to the workflow's event queue"""
 
-    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+    model_config = ConfigDict(
+        frozen=True, arbitrary_types_allowed=True, populate_by_name=True
+    )
     type: Literal["add_event"] = "add_event"
     event: SerializableEvent
-    step_name: str | None = None
+    step_id: StepId | None = Field(default=None, validation_alias="step_name")
     attempts: int | None = None
     first_attempt_at: float | None = None
     last_exception: SerializableOptionalException = None
@@ -80,9 +85,9 @@ class TickTimeout(BaseModel):
 class TickWaiterTimeout(BaseModel):
     """When processed, marks a specific waiter as timed out and replays the step."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, populate_by_name=True)
     type: Literal["waiter_timeout"] = "waiter_timeout"
-    step_name: str
+    step_id: StepId = Field(validation_alias="step_name")
     waiter_id: str
 
 

--- a/packages/llama-index-workflows/src/workflows/runtime/verbose.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/verbose.py
@@ -93,7 +93,7 @@ class _VerboseInternalRunAdapter(BaseInternalRunAdapterDecorator):
     async def on_tick(self, tick: WorkflowTick) -> None:
         if isinstance(tick, TickAddEvent):
             summary = summarize_event(tick.event)
-            target = f" -> {tick.step_name}" if tick.step_name else ""
+            target = f" -> {tick.step_id}" if tick.step_id else ""
             self._output(f"[tick] add: {summary}{target}")
         elif isinstance(tick, TickPublishEvent):
             self._output(f"[tick] publish: {summarize_event(tick.event)}")
@@ -101,7 +101,7 @@ class _VerboseInternalRunAdapter(BaseInternalRunAdapterDecorator):
             self._output(f"[tick] timeout: {tick.timeout}s")
         elif isinstance(tick, TickWaiterTimeout):
             self._output(
-                f"[tick] waiter timeout: step {tick.step_name} waiter {tick.waiter_id}"
+                f"[tick] waiter timeout: step {tick.step_id} waiter {tick.waiter_id}"
             )
         elif isinstance(tick, TickCancelRun):
             self._output("[tick] cancelled")

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -204,7 +204,7 @@ async def test_get_not_found(internal_ctx: Context) -> None:
 
 @pytest.mark.asyncio
 async def test_send_event_step_is_none() -> None:
-    """Test that external events create TickAddEvent with step_name=None.
+    """Test that external events create TickAddEvent with step_id=None.
 
     Uses a workflow that waits for the external event so we can verify
     the tick is logged before the workflow completes.
@@ -227,7 +227,7 @@ async def test_send_event_step_is_none() -> None:
         assert isinstance(external_face, ExternalContext)
 
         # Wait for event to appear in tick log (up to 1 second)
-        expected_tick = TickAddEvent(event=ev, step_name=None)
+        expected_tick = TickAddEvent(event=ev, step_id=None)
         for _ in range(100):
             if expected_tick in external_face._tick_log:
                 break

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop.py
@@ -46,6 +46,7 @@ from workflows.runtime.control_loop import _ControlLoopRunner, control_loop
 from workflows.runtime.types.internal_state import BrokerState
 from workflows.runtime.types.plugin import RunContext, run_context
 from workflows.runtime.types.step_function import as_step_worker_function
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickAddEvent,
     TickCancelRun,
@@ -636,7 +637,9 @@ async def test_control_loop_per_step_routing(test_plugin: MockRunAdapter) -> Non
     )
 
     # Route explicitly to the 'second' step with an accepted event type
-    await test_plugin.send_event(TickAddEvent(event=SomeEvent(), step_name="second"))
+    await test_plugin.send_event(
+        TickAddEvent(event=SomeEvent(), step_id=StepId.root("second"))
+    )
 
     result = await asyncio.wait_for(task, timeout=2.0)
     assert isinstance(result, StopEvent)

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
@@ -79,6 +79,7 @@ from workflows.runtime.types.results import (
     StepWorkerState,
     StepWorkerWaiter,
 )
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickAddEvent,
     TickCancelRun,
@@ -161,7 +162,7 @@ def add_worker(
 
 def test_add_event_unhandled_emits_internal_event(base_state: BrokerState) -> None:
     """Unhandled events should emit UnhandledEvent with idle status."""
-    tick = TickAddEvent(event=OtherEvent(data="unused"), step_name=None)
+    tick = TickAddEvent(event=OtherEvent(data="unused"), step_id=None)
     state, commands = _process_add_event_tick(tick, base_state, now_seconds=0.0)
 
     publish_events = [c.event for c in commands if isinstance(c, CommandPublishEvent)]
@@ -187,7 +188,7 @@ def test_add_event_input_required_does_not_emit_unhandled(
     InputRequiredEvent events are designed to be handled externally by human
     consumers, not by workflow steps. They should not trigger UnhandledEvent.
     """
-    tick = TickAddEvent(event=CustomInputRequired(prompt="test"), step_name=None)
+    tick = TickAddEvent(event=CustomInputRequired(prompt="test"), step_id=None)
     _, commands = _process_add_event_tick(tick, base_state, now_seconds=0.0)
 
     publish_events = [c.event for c in commands if isinstance(c, CommandPublishEvent)]
@@ -199,7 +200,7 @@ def test_add_event_base_input_required_does_not_emit_unhandled(
     base_state: BrokerState,
 ) -> None:
     """Base InputRequiredEvent should also NOT emit UnhandledEvent."""
-    tick = TickAddEvent(event=InputRequiredEvent(), step_name=None)
+    tick = TickAddEvent(event=InputRequiredEvent(), step_id=None)
     _, commands = _process_add_event_tick(tick, base_state, now_seconds=0.0)
 
     publish_events = [c.event for c in commands if isinstance(c, CommandPublishEvent)]
@@ -221,7 +222,7 @@ def test_add_event_matches_waiter_does_not_emit_unhandled(
             resolved_event=None,
         )
     )
-    tick = TickAddEvent(event=OtherEvent(data="hit"), step_name=None)
+    tick = TickAddEvent(event=OtherEvent(data="hit"), step_id=None)
     _, commands = _process_add_event_tick(tick, base_state, now_seconds=0.0)
 
     publish_events = [c.event for c in commands if isinstance(c, CommandPublishEvent)]
@@ -248,7 +249,7 @@ def test_step_worker_results(
     add_worker(base_state, event)
 
     tick = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerResult(result=result)],
@@ -278,7 +279,7 @@ def test_step_worker_failed_with_retry(base_state: BrokerState) -> None:
     add_worker(base_state, event)
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -308,7 +309,7 @@ def test_step_worker_failed_without_retry(base_state: BrokerState) -> None:
     add_worker(base_state, event)
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -327,7 +328,7 @@ def test_collected_events(base_state: BrokerState) -> None:
 
     # Add event
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[AddCollectedEvent(event_id="buf1", event=OtherEvent(data="e1"))],
@@ -338,7 +339,7 @@ def test_collected_events(base_state: BrokerState) -> None:
     # Delete event
     add_worker(new_state, event)
     tick = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -364,7 +365,7 @@ def test_waiters(base_state: BrokerState) -> None:
     )
     # Add waiter
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -377,7 +378,7 @@ def test_waiters(base_state: BrokerState) -> None:
     # Delete waiter
     add_worker(new_state, event)
     tick = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -404,7 +405,7 @@ def test_event_routing(base_state: BrokerState) -> None:
 
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert run_cmds[0].step_name == "test_step"
+    assert str(run_cmds[0].step_id) == "test_step"
 
 
 def test_per_step_explicit_routing_accepts_only_matching_types(
@@ -413,12 +414,12 @@ def test_per_step_explicit_routing_accepts_only_matching_types(
     """Explicit routing with step_name must still satisfy accepted event types."""
     # base_state only has test_step that accepts MyTestEvent and StartEvent
     # Explicitly target test_step with MyTestEvent → should run
-    tick_ok = TickAddEvent(event=MyTestEvent(value=1), step_name="test_step")
+    tick_ok = TickAddEvent(event=MyTestEvent(value=1), step_id=StepId.root("test_step"))
     _, cmds_ok = _process_add_event_tick(tick_ok, base_state, now_seconds=100.0)
     assert any(isinstance(c, CommandRunWorker) for c in cmds_ok)
 
     # Explicitly target an unknown step → should not run anything
-    tick_bad = TickAddEvent(event=MyTestEvent(value=1), step_name="unknown")
+    tick_bad = TickAddEvent(event=MyTestEvent(value=1), step_id=StepId.root("unknown"))
     _, cmds_bad = _process_add_event_tick(tick_bad, base_state, now_seconds=100.0)
     assert not any(isinstance(c, CommandRunWorker) for c in cmds_bad)
 
@@ -447,18 +448,18 @@ def test_explicit_routing_requires_acceptance(base_state: BrokerState) -> None:
     )
 
     # Try to route MyTestEvent explicitly to non-accepting step → should not start
-    tick = TickAddEvent(event=MyTestEvent(value=1), step_name="other_step")
+    tick = TickAddEvent(event=MyTestEvent(value=1), step_id=StepId.root("other_step"))
     _, commands = _process_add_event_tick(tick, base_state, now_seconds=100.0)
     assert not any(
-        isinstance(c, CommandRunWorker) and c.step_name == "other_step"
+        isinstance(c, CommandRunWorker) and str(c.step_id) == "other_step"
         for c in commands
     )
 
     # Explicitly route to accepting step → should start
-    tick_ok = TickAddEvent(event=MyTestEvent(value=2), step_name="test_step")
+    tick_ok = TickAddEvent(event=MyTestEvent(value=2), step_id=StepId.root("test_step"))
     _, commands_ok = _process_add_event_tick(tick_ok, base_state, now_seconds=100.0)
     assert any(
-        isinstance(c, CommandRunWorker) and c.step_name == "test_step"
+        isinstance(c, CommandRunWorker) and str(c.step_id) == "test_step"
         for c in commands_ok
     )
 
@@ -493,7 +494,7 @@ def test_step_state_changed_names(base_state: BrokerState) -> None:
 
     # Return a regular Event → output_event_name should be its type, and input_event_name should be str(type(input))
     tick = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=input_ev,
         result=[StepWorkerResult(result=OtherEvent(data="x"))],
@@ -508,7 +509,7 @@ def test_step_state_changed_names(base_state: BrokerState) -> None:
     # Return StopEvent → output_event_name should be None
     add_worker(base_state, input_ev)
     tick2 = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=input_ev,
         result=[StepWorkerResult(result=StopEvent(result="done"))],
@@ -576,7 +577,7 @@ def test_add_when_capacity_available(base_state: BrokerState) -> None:
     event = MyTestEvent(value=42)
     commands = _add_or_enqueue_event(
         EventAttempt(event=event),
-        "test_step",
+        StepId.root("test_step"),
         base_state.workers["test_step"],
         now_seconds=100.0,
     )
@@ -600,7 +601,7 @@ def test_enqueue_when_no_capacity(base_state: BrokerState) -> None:
     event = MyTestEvent(value=42)
     commands = _add_or_enqueue_event(
         EventAttempt(event=event),
-        "test_step",
+        StepId.root("test_step"),
         base_state.workers["test_step"],
         now_seconds=100.0,
     )
@@ -679,7 +680,7 @@ def test_step_worker_failed_retry_preserves_delay(base_state: BrokerState) -> No
     add_worker(base_state, event)
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -723,7 +724,7 @@ def test_step_worker_failed_retry_preserves_first_attempt_at(
     )
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=200.0)],
@@ -753,7 +754,7 @@ def test_step_worker_failed_exponential_jitter_deterministic(
     add_worker(base_state, event)
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -868,7 +869,7 @@ def test_retry_with_zero_delay_dispatches_immediately(base_state: BrokerState) -
     add_worker(base_state, event)
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -948,7 +949,7 @@ def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -959,7 +960,7 @@ def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
     # Old-format journal re-delivers the retry after the delay elapsed
     add_tick = TickAddEvent(
         event=event,
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         attempts=1,
         first_attempt_at=100.0,
         last_failed_at=110.0,
@@ -1012,7 +1013,7 @@ def test_replay_recomputes_jittered_not_before_with_run_id(
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -1066,7 +1067,7 @@ def test_journaled_retry_decision_is_used_without_invoking_policy(
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -1096,7 +1097,7 @@ def test_journaled_stop_decision_fails_workflow_even_if_policy_would_retry(
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -1127,7 +1128,7 @@ def test_replay_with_changed_policy_honors_journaled_decision(
     """
     event = MyTestEvent(value=42)
     fail_tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -1172,7 +1173,7 @@ def test_journaled_first_attempt_at_survives_rebuilt_state(
     # while the failure tick journaled the true dispatch time 100.0.
     add_worker(base_state, event, first_attempt_at=500.0)
     fail_tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -1198,7 +1199,7 @@ def test_journaled_first_attempt_at_used_for_elapsed_on_failure(
     event = MyTestEvent(value=42)
     add_worker(base_state, event, first_attempt_at=500.0)
     fail_tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[
@@ -1290,7 +1291,7 @@ def test_step_result_does_not_emit_idle(base_state: BrokerState) -> None:
     add_worker(base_state, event)
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerResult(result=None)],
@@ -1382,7 +1383,7 @@ def test_no_idle_event_when_work_remains(base_state: BrokerState) -> None:
     )
 
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerResult(result=None)],  # Completes but queue has more
@@ -1416,7 +1417,7 @@ def test_no_idle_event_when_workflow_completes(base_state: BrokerState) -> None:
 
     # Complete the workflow with StopEvent
     tick: TickStepResult = TickStepResult(
-        step_name="test_step",
+        step_id=StepId.root("test_step"),
         worker_id=0,
         event=event,
         result=[StepWorkerResult(result=StopEvent(result="done"))],
@@ -1488,7 +1489,7 @@ def test_rebuild_state_from_ticks_clears_in_progress(base_state: BrokerState) ->
         TickAddEvent(event=event1),
         # Worker 0 completes
         TickStepResult(
-            step_name="test_step",
+            step_id=StepId.root("test_step"),
             worker_id=0,  # New ID assigned after rewind
             event=event1,
             result=[StepWorkerResult(result=OtherEvent(data="done1"))],
@@ -1497,7 +1498,7 @@ def test_rebuild_state_from_ticks_clears_in_progress(base_state: BrokerState) ->
         TickAddEvent(event=event2),
         # Worker 1 completes
         TickStepResult(
-            step_name="test_step",
+            step_id=StepId.root("test_step"),
             worker_id=0,  # Reuses ID 0 since previous worker completed
             event=event2,
             result=[StepWorkerResult(result=StopEvent(result="done2"))],
@@ -1572,14 +1573,14 @@ def _simple_step_tick_sequence() -> list[WorkflowTick]:
     return [
         TickAddEvent(event=event1),
         TickStepResult(
-            step_name="test_step",
+            step_id=StepId.root("test_step"),
             worker_id=0,
             event=event1,
             result=[StepWorkerResult(result=OtherEvent(data="done1"))],
         ),
         TickAddEvent(event=event2),
         TickStepResult(
-            step_name="test_step",
+            step_id=StepId.root("test_step"),
             worker_id=0,
             event=event2,
             result=[StepWorkerResult(result=StopEvent(result="done2"))],
@@ -1677,14 +1678,14 @@ async def test_rebuild_state_from_ticks_stream_clears_in_progress(
     ticks: list[WorkflowTick] = [
         TickAddEvent(event=event1),
         TickStepResult(
-            step_name="test_step",
+            step_id=StepId.root("test_step"),
             worker_id=0,
             event=event1,
             result=[StepWorkerResult(result=OtherEvent(data="done1"))],
         ),
         TickAddEvent(event=event2),
         TickStepResult(
-            step_name="test_step",
+            step_id=StepId.root("test_step"),
             worker_id=0,
             event=event2,
             result=[StepWorkerResult(result=StopEvent(result="done2"))],

--- a/packages/llama-index-workflows/tests/runtime/test_named_task.py
+++ b/packages/llama-index-workflows/tests/runtime/test_named_task.py
@@ -24,6 +24,7 @@ from workflows.runtime.types.named_task import (
     get_key,
     pick_highest_priority,
 )
+from workflows.runtime.types.step_id import StepId
 
 
 async def _never_completes() -> None:
@@ -43,7 +44,7 @@ async def test_worker_task_creates_correct_key() -> None:
     """WorkerTask should create key as 'step_name:worker_id'."""
     task = create_pending_task()
     try:
-        nt = WorkerTask("my_step", 42, task)
+        nt = WorkerTask(StepId.root("my_step"), 42, task)
         assert nt.key == "my_step:42"
         assert nt.task is task
         assert isinstance(nt, WorkerTask)
@@ -81,8 +82,8 @@ async def test_all_tasks_returns_set_of_tasks() -> None:
     pull = create_pending_task()
     try:
         named_tasks = [
-            WorkerTask("step_a", 0, w1),
-            WorkerTask("step_b", 0, w2),
+            WorkerTask(StepId.root("step_a"), 0, w1),
+            WorkerTask(StepId.root("step_b"), 0, w2),
             PullTask(0, pull),
         ]
         result = all_tasks(named_tasks)
@@ -108,7 +109,7 @@ async def test_all_tasks_works_with_asyncio_wait() -> None:
     """all_tasks result should work with asyncio.wait."""
     task = create_pending_task()
     try:
-        named_tasks = [WorkerTask("step", 0, task)]
+        named_tasks = [WorkerTask(StepId.root("step"), 0, task)]
         result = all_tasks(named_tasks)
         done, pending = await asyncio.wait(result, timeout=0.001)
         assert task in pending
@@ -129,8 +130,8 @@ async def test_find_by_key_returns_worker_task() -> None:
     w2 = create_pending_task()
     try:
         named_tasks = [
-            WorkerTask("step_a", 0, w1),
-            WorkerTask("step_b", 1, w2),
+            WorkerTask(StepId.root("step_a"), 0, w1),
+            WorkerTask(StepId.root("step_b"), 1, w2),
         ]
         assert find_by_key(named_tasks, "step_a:0") is w1
         assert find_by_key(named_tasks, "step_b:1") is w2
@@ -161,7 +162,7 @@ async def test_find_by_key_returns_none_for_unknown() -> None:
     """find_by_key should return None for unknown key."""
     task = create_pending_task()
     try:
-        named_tasks = [WorkerTask("step", 0, task)]
+        named_tasks = [WorkerTask(StepId.root("step"), 0, task)]
         assert find_by_key(named_tasks, "unknown:99") is None
     finally:
         task.cancel()
@@ -183,7 +184,7 @@ async def test_get_key_returns_worker_key() -> None:
     """get_key should return the key for a worker task."""
     task = create_pending_task()
     try:
-        named_tasks = [WorkerTask("my_step", 3, task)]
+        named_tasks = [WorkerTask(StepId.root("my_step"), 3, task)]
         assert get_key(named_tasks, task) == "my_step:3"
     finally:
         task.cancel()
@@ -212,7 +213,7 @@ async def test_get_key_raises_for_unknown_task() -> None:
     known = create_pending_task()
     unknown = create_pending_task()
     try:
-        named_tasks = [WorkerTask("step", 0, known)]
+        named_tasks = [WorkerTask(StepId.root("step"), 0, known)]
         with pytest.raises(KeyError):
             get_key(named_tasks, unknown)
     finally:
@@ -231,7 +232,7 @@ async def test_round_trip_worker() -> None:
     """get_key and find_by_key should be inverses for workers."""
     task = create_pending_task()
     try:
-        named_tasks = [WorkerTask("step", 5, task)]
+        named_tasks = [WorkerTask(StepId.root("step"), 5, task)]
         key = get_key(named_tasks, task)
         found = find_by_key(named_tasks, key)
         assert found is task
@@ -269,8 +270,8 @@ async def test_pick_highest_priority_respects_list_order() -> None:
     t3 = create_pending_task()
     try:
         named_tasks = [
-            WorkerTask("step_b", 0, t2),
-            WorkerTask("step_a", 0, t1),
+            WorkerTask(StepId.root("step_b"), 0, t2),
+            WorkerTask(StepId.root("step_a"), 0, t1),
             PullTask(0, t3),
         ]
         done = {t2, t3}
@@ -291,7 +292,7 @@ async def test_pick_highest_priority_workers_before_pull() -> None:
     pull = create_pending_task()
     try:
         named_tasks = [
-            WorkerTask("step", 0, worker),
+            WorkerTask(StepId.root("step"), 0, worker),
             PullTask(0, pull),
         ]
         done = {worker, pull}
@@ -312,7 +313,7 @@ async def test_pick_highest_priority_returns_pull_when_only_pull_done() -> None:
     pull = create_pending_task()
     try:
         named_tasks = [
-            WorkerTask("step", 0, worker),
+            WorkerTask(StepId.root("step"), 0, worker),
             PullTask(0, pull),
         ]
         done = {pull}
@@ -331,7 +332,7 @@ async def test_pick_highest_priority_empty_done() -> None:
     """Should return None when done set is empty."""
     task = create_pending_task()
     try:
-        named_tasks = [WorkerTask("step", 0, task)]
+        named_tasks = [WorkerTask(StepId.root("step"), 0, task)]
         result = pick_highest_priority(named_tasks, set())
         assert result is None
     finally:
@@ -347,7 +348,7 @@ async def test_pick_highest_priority_no_match_raises() -> None:
     task1 = create_pending_task()
     task2 = create_pending_task()
     try:
-        named_tasks = [WorkerTask("step", 0, task1)]
+        named_tasks = [WorkerTask(StepId.root("step"), 0, task1)]
         done = {task2}
         with pytest.raises(ValueError, match="No tasks in done set match"):
             pick_highest_priority(named_tasks, done)
@@ -373,7 +374,7 @@ async def test_integration_with_asyncio_wait() -> None:
     pull = create_pending_task()
     try:
         named_tasks = [
-            WorkerTask("fast_step", 0, worker),
+            WorkerTask(StepId.root("fast_step"), 0, worker),
             PullTask(0, pull),
         ]
 
@@ -401,8 +402,8 @@ async def test_multiple_workers_same_step() -> None:
     w1 = create_pending_task()
     try:
         named_tasks = [
-            WorkerTask("parallel_step", 0, w0),
-            WorkerTask("parallel_step", 1, w1),
+            WorkerTask(StepId.root("parallel_step"), 0, w0),
+            WorkerTask(StepId.root("parallel_step"), 1, w1),
         ]
 
         assert find_by_key(named_tasks, "parallel_step:0") is w0

--- a/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
+++ b/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
@@ -27,19 +27,83 @@ from workflows.runtime.types.results import (
     StepWorkerFailed,
     StepWorkerResult,
 )
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickAddEvent,
     TickCancelRun,
     TickPublishEvent,
     TickStepResult,
     TickTimeout,
+    TickWaiterTimeout,
     TickWakeup,
     WorkflowTick,
+    WorkflowTickAdapter,
 )
 
 
 class MyEvent(Event):
     value: str = "hello"
+
+
+def test_step_id_root_stringifies_as_bare_step_name() -> None:
+    step_id = StepId.root("my_step")
+
+    assert str(step_id) == "my_step"
+
+    adapter = TypeAdapter(StepId)
+    assert adapter.dump_python(step_id, mode="json") == "my_step"
+    assert adapter.validate_python("my_step") == step_id
+
+
+def test_step_id_accepts_forward_namespaced_string_shape() -> None:
+    step_id = StepId.from_str("parent/child/process")
+
+    assert step_id.namespace == ("parent", "child")
+    assert step_id.name == "process"
+    assert str(step_id) == "parent/child/process"
+
+
+def test_root_step_id_tick_serializes_step_id_as_bare_name() -> None:
+    tick = TickStepResult(
+        step_id=StepId.root("process"),
+        worker_id=42,
+        event=MyEvent(value="trigger"),
+        result=[StepWorkerResult(result=StopEvent(result="done"))],
+    )
+
+    serialized = tick.model_dump(mode="json")
+
+    assert serialized["step_id"] == "process"
+    assert "step_name" not in serialized
+
+
+def test_legacy_step_name_tick_payloads_deserialize_to_root_step_ids() -> None:
+    add_event_payload = TickAddEvent(
+        event=StartEvent(), step_id=StepId.root("start")
+    ).model_dump(mode="json")
+    add_event_payload["step_name"] = add_event_payload.pop("step_id")
+    add_event = WorkflowTickAdapter.validate_python(add_event_payload)
+    assert isinstance(add_event, TickAddEvent)
+    assert add_event.step_id == StepId.root("start")
+
+    step_result_payload = TickStepResult(
+        step_id=StepId.root("process"),
+        worker_id=1,
+        event=StartEvent(),
+        result=[StepWorkerResult(result=None)],
+    ).model_dump(mode="json")
+    step_result_payload["step_name"] = step_result_payload.pop("step_id")
+    step_result = WorkflowTickAdapter.validate_python(step_result_payload)
+    assert isinstance(step_result, TickStepResult)
+    assert step_result.step_id == StepId.root("process")
+
+    waiter_payload = TickWaiterTimeout(
+        step_id=StepId.root("waiter"), waiter_id="w-1"
+    ).model_dump(mode="json")
+    waiter_payload["step_name"] = waiter_payload.pop("step_id")
+    waiter = WorkflowTickAdapter.validate_python(waiter_payload)
+    assert isinstance(waiter, TickWaiterTimeout)
+    assert waiter.step_id == StepId.root("waiter")
 
 
 # -- Serialization helper roundtrip tests --
@@ -85,7 +149,7 @@ def test_event_type_roundtrip() -> None:
         pytest.param(
             TickAddEvent(
                 event=StartEvent(),
-                step_name="my_step",
+                step_id=StepId.root("my_step"),
                 attempts=3,
                 first_attempt_at=1234567890.0,
             ),
@@ -109,7 +173,7 @@ def test_event_type_roundtrip() -> None:
         ),
         pytest.param(
             TickStepResult(
-                step_name="process",
+                step_id=StepId.root("process"),
                 worker_id=42,
                 event=MyEvent(value="trigger"),
                 result=[StepWorkerResult(result=StopEvent(result="done"))],
@@ -118,7 +182,7 @@ def test_event_type_roundtrip() -> None:
         ),
         pytest.param(
             TickStepResult(
-                step_name="process",
+                step_id=StepId.root("process"),
                 worker_id=1,
                 event=StartEvent(),
                 result=[StepWorkerResult(result=None)],
@@ -127,7 +191,7 @@ def test_event_type_roundtrip() -> None:
         ),
         pytest.param(
             TickStepResult(
-                step_name="collector",
+                step_id=StepId.root("collector"),
                 worker_id=2,
                 event=StartEvent(),
                 result=[
@@ -140,7 +204,7 @@ def test_event_type_roundtrip() -> None:
         ),
         pytest.param(
             TickStepResult(
-                step_name="collector",
+                step_id=StepId.root("collector"),
                 worker_id=3,
                 event=StartEvent(),
                 result=[DeleteCollectedEvent(event_id="evt-2")],
@@ -149,7 +213,7 @@ def test_event_type_roundtrip() -> None:
         ),
         pytest.param(
             TickStepResult(
-                step_name="cleanup",
+                step_id=StepId.root("cleanup"),
                 worker_id=5,
                 event=StartEvent(),
                 result=[DeleteWaiter(waiter_id="w-2")],
@@ -171,7 +235,7 @@ def test_tick_roundtrip(tick: WorkflowTick) -> None:
 def test_tick_step_result_with_failed_value_error() -> None:
     failed_at = time.time()
     tick = TickStepResult(
-        step_name="broken_step",
+        step_id=StepId.root("broken_step"),
         worker_id=7,
         event=StartEvent(),
         result=[
@@ -196,7 +260,7 @@ def test_tick_step_result_with_failed_unimportable_exception() -> None:
     CustomError = type("CustomError", (Exception,), {})
     failed_at = time.time()
     tick = TickStepResult(
-        step_name="broken_step",
+        step_id=StepId.root("broken_step"),
         worker_id=8,
         event=StartEvent(),
         result=[StepWorkerFailed(exception=CustomError("oops"), failed_at=failed_at)],
@@ -215,7 +279,7 @@ def test_tick_step_result_with_failed_unimportable_exception() -> None:
 
 def test_tick_step_result_with_add_waiter() -> None:
     tick = TickStepResult(
-        step_name="waiter_step",
+        step_id=StepId.root("waiter_step"),
         worker_id=4,
         event=StartEvent(),
         result=[
@@ -258,12 +322,12 @@ def test_workflow_tick_discriminated_union_roundtrip() -> None:
     adapter = TypeAdapter(WorkflowTick)
 
     ticks = [
-        TickAddEvent(event=StartEvent(), step_name="s"),
+        TickAddEvent(event=StartEvent(), step_id=StepId.root("s")),
         TickPublishEvent(event=MyEvent(value="x")),
         TickCancelRun(),
         TickTimeout(timeout=10.0),
         TickStepResult(
-            step_name="s",
+            step_id=StepId.root("s"),
             worker_id=0,
             event=StartEvent(),
             result=[StepWorkerResult(result=None)],

--- a/packages/llama-index-workflows/tests/test_verbose_decorator.py
+++ b/packages/llama-index-workflows/tests/test_verbose_decorator.py
@@ -11,6 +11,7 @@ from workflows import Workflow, step
 from workflows.events import Event, StartEvent, StepState, StepStateChanged, StopEvent
 from workflows.runtime.types.plugin import InternalRunAdapter, WaitResult
 from workflows.runtime.types.results import StepWorkerResult
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickAddEvent,
     TickCancelRun,
@@ -190,7 +191,7 @@ async def test_verbose_forwards_events(
             id="add-event",
         ),
         pytest.param(
-            TickAddEvent(event=StartEvent(), step_name="retrieve"),
+            TickAddEvent(event=StartEvent(), step_id=StepId.root("retrieve")),
             "[tick] add: StartEvent() -> retrieve",
             id="add-event-targeted",
         ),
@@ -205,7 +206,7 @@ async def test_verbose_forwards_events(
             id="timeout",
         ),
         pytest.param(
-            TickWaiterTimeout(step_name="my_step", waiter_id="w-123"),
+            TickWaiterTimeout(step_id=StepId.root("my_step"), waiter_id="w-123"),
             "[tick] waiter timeout: step my_step waiter w-123",
             id="waiter-timeout",
         ),
@@ -239,7 +240,7 @@ async def test_verbose_tick_step_result_logs_stop_event(
     """TickStepResult with a StopEvent logs a [result] line."""
     _, adapter = verbose_adapter
     tick = TickStepResult(
-        step_name="my_step",
+        step_id=StepId.root("my_step"),
         worker_id=0,
         event=StartEvent(),
         result=[StepWorkerResult(result=StopEvent(result="done"))],
@@ -257,7 +258,7 @@ async def test_verbose_tick_step_result_silent_for_non_stop(
     """TickStepResult without a StopEvent produces no on_tick output."""
     _, adapter = verbose_adapter
     tick = TickStepResult(
-        step_name="my_step",
+        step_id=StepId.root("my_step"),
         worker_id=0,
         event=StartEvent(),
         result=[StepWorkerResult(result=StartEvent())],


### PR DESCRIPTION
Workflow runtime ticks, commands, and worker task keys currently carry step identity as bare strings. This makes the control loop's root-only assumptions implicit in every lookup.

This adds an internal `StepId` and threads it through tick, command, named-task, context-send, and control-loop plumbing. Root step ids still stringify to the bare step name, so existing worker task keys remain `step:worker_id` and persisted root worker maps stay keyed by the same names.

Persisted tick compatibility stays narrow: old tick payloads with `step_name` validate into root `StepId`s, while new root tick payloads serialize `step_id` as the same bare step-name value. The execution-graph tick consumer was updated to read the typed field without changing root labels.