### PR TITLE
Key workflow state per (run_id, namespace) for child workflows

### DIFF
--- a/.changeset/per-namespace-state-records.md
+++ b/.changeset/per-namespace-state-records.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-server": patch
+---
+
+Store workflow state as one record per (run_id, namespace) instead of a single bundled record per run. Adds an additive migration that introduces a namespace column defaulting to the root namespace, so existing rows are unchanged.

--- a/architecture-docs/server-architecture.md
+++ b/architecture-docs/server-architecture.md
@@ -65,6 +65,12 @@ Two implementations:
 - **`SqliteWorkflowStore`** — SQLite-backed. Survives restarts.
   [`sqlite_workflow_store.py`](../packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py)
 
+### State records are keyed by `(run_id, namespace)`
+
+State persists as one record per `(run_id, namespace)`, not one bundled record per run. The root namespace is `""` (a childless run is exactly one root record, byte-identical to the pre-namespace single row); child workflows get their own records under their namespace key. Whole-run operations stay run-keyed — copy and the in-process facade cache eviction both filter on `run_id` alone, so they span every namespace in one pass.
+
+**No automatic state GC.** State records are never deleted today — there is no `DELETE FROM workflow_state`, no cascade from handler/event deletion, and no TTL. Per-namespace records multiply a childful run's footprint by the number of namespaces but add no new *category* of leak. A retention policy is future work; until then, state accumulates per run.
+
 ## Resumable Event Streams
 
 Events flow from step functions to clients through the store, which acts as both a write-ahead log and a subscription source:

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -144,20 +144,24 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
         state_type: type[Any] | None = None,
         serialized_state: dict[str, Any] | None = None,
         serializer: BaseSerializer | None = None,
+        namespace: tuple[str, ...] = (),
     ) -> StateStore[Any]:
         # Delegate the whole template method so memoization lives in the
         # inner store's single cache (the proxy's own cache stays unused).
         return self._resolve().create_state_store(
-            run_id, state_type, serialized_state, serializer
+            run_id, state_type, serialized_state, serializer, namespace
         )
 
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> StateStoreFacade[Any]:
-        return self._resolve()._build_state_store(run_id, state_type, serializer)
+        return self._resolve()._build_state_store(
+            run_id, namespace, state_type, serializer
+        )
 
     async def query(self, query: HandlerQuery) -> list[PersistentHandler]:
         return await self._resolve().query(query)

--- a/packages/llama-agents-dbos/tests/test_dbos_idle_release.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_idle_release.py
@@ -607,7 +607,7 @@ async def test_do_resume_carries_over_serialized_state(
 
     # Seed the state store with actual state data
     state_store = InMemoryStateStore(MyState(counter=42))
-    store.state_stores["run-1"] = state_store
+    store.state_stores[("run-1", ())] = state_store
 
     await decorator._do_resume("run-1")
 

--- a/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
+++ b/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
@@ -210,6 +210,7 @@ def create_agent_data_state_store(
     monkeypatch: pytest.MonkeyPatch,
     run_id: str,
     state_type: type[Any] | None = None,
+    namespace: tuple[str, ...] = (),
 ) -> AgentDataStateStore[Any]:
     """Create an AgentDataStateStore with httpx patched to use the fake backend."""
     client = AgentDataClient(
@@ -222,6 +223,7 @@ def create_agent_data_state_store(
     store = AgentDataStateStore(
         client=client,
         run_id=run_id,
+        namespace=namespace,
         state_type=state_type,
     )
     return store

--- a/packages/llama-agents-integration-tests/tests/test_state_store_matrix.py
+++ b/packages/llama-agents-integration-tests/tests/test_state_store_matrix.py
@@ -116,12 +116,14 @@ async def _create_postgres_pool(dsn: str) -> asyncpg.Pool:
         await conn.execute("CREATE SCHEMA IF NOT EXISTS dbos")
         await conn.execute("""
             CREATE TABLE IF NOT EXISTS dbos.workflow_state (
-                run_id VARCHAR(255) PRIMARY KEY,
+                run_id VARCHAR(255) NOT NULL,
+                namespace VARCHAR(255) NOT NULL DEFAULT '',
                 state_json TEXT NOT NULL,
                 state_type VARCHAR(255),
                 state_module VARCHAR(255),
                 created_at TIMESTAMPTZ,
-                updated_at TIMESTAMPTZ
+                updated_at TIMESTAMPTZ,
+                PRIMARY KEY (run_id, namespace)
             )
         """)
     return pool

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -116,9 +116,9 @@ class AbstractWorkflowStore(ABC):
         # Weak-valued by default so facades die with their last consumer.
         # Backends needing a different lifecycle (strong refs + explicit
         # eviction) assign a plain dict in their __init__.
-        self._state_store_cache: MutableMapping[str, StateStoreFacade[Any]] = (
-            weakref.WeakValueDictionary()
-        )
+        self._state_store_cache: MutableMapping[
+            tuple[str, tuple[str, ...]], StateStoreFacade[Any]
+        ] = weakref.WeakValueDictionary()
 
     async def start(self) -> None:
         """Initialize backend resources. Default is a no-op."""
@@ -129,18 +129,22 @@ class AbstractWorkflowStore(ABC):
         state_type: type[Any] | None = None,
         serialized_state: dict[str, Any] | None = None,
         serializer: BaseSerializer | None = None,
+        namespace: tuple[str, ...] = (),
     ) -> StateStore[Any]:
-        """Return the per-run state store, creating and caching it on first use.
+        """Return the per-(run, namespace) state store, caching on first use.
 
-        One facade per run per process, so its write lock is a real guarantee.
-        If *serialized_state* is provided, it is staged as a seed on the
-        (possibly already handed-out) facade: validation is eager, the I/O to
-        materialize it stays lazy (first async state access or handoff).
+        Namespace is a key dimension alongside ``run_id``: the default ``()``
+        is the root namespace and reproduces the single-record behavior. One
+        facade per (run, namespace) per process, so its write lock is a real
+        guarantee. If *serialized_state* is provided, it is staged as a seed on
+        the (possibly already handed-out) facade: validation is eager, the I/O
+        to materialize it stays lazy (first async state access or handoff).
         """
-        store = self._state_store_cache.get(run_id)
+        cache_key = (run_id, namespace)
+        store = self._state_store_cache.get(cache_key)
         if store is None:
-            store = self._build_state_store(run_id, state_type, serializer)
-            self._state_store_cache[run_id] = store
+            store = self._build_state_store(run_id, namespace, state_type, serializer)
+            self._state_store_cache[cache_key] = store
         elif state_type is not None and store.state_type is DictState:
             # An earlier type-less caller (e.g. handler continuation) must
             # not shadow the workflow's concrete state type.
@@ -149,14 +153,20 @@ class AbstractWorkflowStore(ABC):
             store.add_seed(serialized_state, serializer or JsonSerializer())
         return store
 
+    def _evict_run_state_stores(self, run_id: str) -> None:
+        """Drop every cached namespace facade for *run_id* (all namespaces)."""
+        for key in [k for k in self._state_store_cache if k[0] == run_id]:
+            self._state_store_cache.pop(key, None)
+
     @abstractmethod
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> StateStoreFacade[Any]:
-        """Construct the backend facade for a run. No caching, no seeding."""
+        """Construct the backend facade for a (run, namespace). No caching."""
 
     @abstractmethod
     async def query(self, query: HandlerQuery) -> list[PersistentHandler]: ...

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -26,9 +26,14 @@ _FIELD_RUN_ID = "run_id"
 
 
 class _AgentDataStateRecord(BaseModel):
-    """Validates the shape persisted in the Agent Data API."""
+    """Validates the shape persisted in the Agent Data API.
+
+    ``namespace`` defaults to ``""`` so pre-namespace items (which carry no
+    namespace field) read back as the root namespace.
+    """
 
     run_id: str
+    namespace: str = ""
     data: str
     state_type: str | None = None
     state_module: str | None = None
@@ -55,10 +60,14 @@ class _AgentDataStateStorage:
         *,
         client: AgentDataClient,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         collection: str = "workflow_state",
     ) -> None:
         self._client = client
         self._run_id = run_id
+        self._namespace = namespace
+        # Persisted key: () -> "" (today's single root item), ("child",) -> "child".
+        self._namespace_key = "/".join(namespace)
         self._collection = collection
         self._item_id: str | None = None
 
@@ -71,16 +80,29 @@ class _AgentDataStateStorage:
         # HTTP-backed: no per-call connections, the storage scopes itself.
         yield self
 
-    async def _load_record(self) -> _AgentDataStateRecord | None:
+    async def _matching_item(self) -> tuple[str, _AgentDataStateRecord] | None:
+        """Find this namespace's item among the run's items.
+
+        Filtering is by ``run_id`` (the Agent Data API has no range op), then
+        the namespace is matched in Python — so pre-namespace items, which
+        lack the field, read back as the root namespace (``""``).
+        """
         items = await self._client.search(
             self._collection,
             {_FIELD_RUN_ID: {"eq": self._run_id}},
-            page_size=1,
         )
-        if not items:
+        for item in items:
+            record = _AgentDataStateRecord.model_validate(item["data"])
+            if record.namespace == self._namespace_key:
+                return item["id"], record
+        return None
+
+    async def _load_record(self) -> _AgentDataStateRecord | None:
+        match = await self._matching_item()
+        if match is None:
             return None
-        self._item_id = items[0]["id"]
-        return _AgentDataStateRecord.model_validate(items[0]["data"])
+        self._item_id, record = match
+        return record
 
     async def load(self) -> StateRecord | None:
         record = await self._load_record()
@@ -91,6 +113,7 @@ class _AgentDataStateStorage:
     async def save(self, record: StateRecord) -> None:
         stored = _AgentDataStateRecord(
             run_id=self._run_id,
+            namespace=self._namespace_key,
             data=record.data,
             state_type=record.state_type,
             state_module=record.state_module,
@@ -98,19 +121,14 @@ class _AgentDataStateStorage:
         payload = stored.model_dump()
         if self._item_id is not None:
             await self._client.update_item(self._item_id, payload)
+            return
+        match = await self._matching_item()
+        if match is not None:
+            self._item_id = match[0]
+            await self._client.update_item(self._item_id, payload)
         else:
-            items = await self._client.search(
-                self._collection,
-                {_FIELD_RUN_ID: {"eq": self._run_id}},
-                page_size=1,
-            )
-            if items:
-                item_id = items[0]["id"]
-                self._item_id = item_id
-                await self._client.update_item(item_id, payload)
-            else:
-                result = await self._client.create(self._collection, payload)
-                self._item_id = result["id"]
+            result = await self._client.create(self._collection, payload)
+            self._item_id = result["id"]
 
     def to_handle(self) -> dict[str, Any]:
         payload = AgentDataSerializedState(
@@ -126,20 +144,32 @@ class _AgentDataStateStorage:
         return AgentDataSerializedState.model_validate(payload)
 
     async def copy_from_handle(self, handle: AgentDataSerializedState) -> None:
-        """Copy the source target's record into this one (no-op if absent).
+        """Copy every namespace item of the source run into this run.
 
-        Goes through ``save`` so ``_item_id`` stays consistent with the
-        copied row.
+        The source has no range op, so its items are enumerated by ``run_id``
+        and each is saved under the same namespace in this run. Saves go
+        through per-namespace storages so each ``_item_id`` stays consistent.
         """
-        source = _AgentDataStateStorage(
-            client=self._client,
-            run_id=handle.run_id,
-            collection=handle.collection,
+        items = await self._client.search(
+            handle.collection,
+            {_FIELD_RUN_ID: {"eq": handle.run_id}},
         )
-        record = await source.load()
-        if record is None:
-            return
-        await self.save(record)
+        for item in items:
+            source = _AgentDataStateRecord.model_validate(item["data"])
+            namespace = tuple(source.namespace.split("/")) if source.namespace else ()
+            dest = _AgentDataStateStorage(
+                client=self._client,
+                run_id=self._run_id,
+                namespace=namespace,
+                collection=self._collection,
+            )
+            await dest.save(
+                StateRecord(
+                    data=source.data,
+                    state_type=source.state_type,
+                    state_module=source.state_module,
+                )
+            )
 
 
 class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
@@ -156,12 +186,18 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         *,
         client: AgentDataClient,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         state_type: type[MODEL_T] | None = None,
         collection: str = "workflow_state",
         serializer: BaseSerializer | None = None,
     ) -> None:
         super().__init__(
-            _AgentDataStateStorage(client=client, run_id=run_id, collection=collection),
+            _AgentDataStateStorage(
+                client=client,
+                run_id=run_id,
+                namespace=namespace,
+                collection=collection,
+            ),
             state_type,
             serializer,
         )

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -169,7 +169,7 @@ class AgentDataStore(AbstractWorkflowStore):
         # Clean up sequence counters and cached state store
         self._event_sequences.pop(run_id, None)
         self._tick_sequences.pop(run_id, None)
-        self._state_store_cache.pop(run_id, None)
+        self._evict_run_state_stores(run_id)
 
     # ------------------------------------------------------------------
     # Sequence helpers
@@ -491,12 +491,14 @@ class AgentDataStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> AgentDataStateStore[Any]:
         return AgentDataStateStore(
             client=self._client,
             run_id=run_id,
+            namespace=namespace,
             state_type=state_type,
             collection=f"{self._collection}_state",
             serializer=serializer,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
@@ -70,7 +70,7 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
         self.ticks: dict[str, list[StoredTick]] = {}
         # Strong refs: facades live until eviction. Public alias kept for
         # tests/plugins that inject stores; the ABC template reads the cache.
-        self.state_stores: dict[str, StateStoreFacade[Any]] = {}
+        self.state_stores: dict[tuple[str, tuple[str, ...]], StateStoreFacade[Any]] = {}
         self._state_store_cache = self.state_stores
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
             weakref.WeakValueDictionary()
@@ -81,6 +81,7 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> InMemoryStateStore[Any]:
@@ -134,7 +135,7 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
             if run_id is not None:
                 self.events.pop(run_id, None)
                 self.ticks.pop(run_id, None)
-                self.state_stores.pop(run_id, None)
+                self._evict_run_state_stores(run_id)
 
     def _get_or_create_condition(self, run_id: str) -> asyncio.Condition:
         cond = self._conditions.get(run_id)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres/migrations/0002_namespace_state.sql
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres/migrations/0002_namespace_state.sql
@@ -1,0 +1,8 @@
+-- migration: 2
+
+-- Per-namespace state records: namespace becomes a key dimension alongside
+-- run_id. Existing single rows are root-namespace rows (namespace = '').
+ALTER TABLE workflow_state ADD COLUMN IF NOT EXISTS namespace VARCHAR(255) NOT NULL DEFAULT '';
+
+ALTER TABLE workflow_state DROP CONSTRAINT IF EXISTS workflow_state_pkey;
+ALTER TABLE workflow_state ADD CONSTRAINT workflow_state_pkey PRIMARY KEY (run_id, namespace);

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -40,11 +40,15 @@ class _PostgresStateStorage:
         self,
         pool: asyncpg.Pool,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         schema: str | None = None,
         connection: asyncpg.Connection | asyncpg.pool.PoolConnectionProxy | None = None,
     ) -> None:
         self._pool = pool
         self._run_id = run_id
+        self._namespace = namespace
+        # Persisted key: () -> "" (today's single root row), ("child",) -> "child".
+        self._namespace_key = "/".join(namespace)
         self._schema = schema
         self._shared_conn = connection
 
@@ -81,15 +85,17 @@ class _PostgresStateStorage:
             return
         async with self._pool.acquire() as conn:
             yield _PostgresStateStorage(
-                self._pool, self._run_id, self._schema, connection=conn
+                self._pool, self._run_id, self._namespace, self._schema, connection=conn
             )
 
     async def load(self) -> StateRecord | None:
         """Load raw state from the database."""
         async with self._acquire() as conn:
             row = await conn.fetchrow(
-                f"SELECT state_json FROM {self._table_ref} WHERE run_id = $1",
+                f"SELECT state_json FROM {self._table_ref} "
+                "WHERE run_id = $1 AND namespace = $2",
                 self._run_id,
+                self._namespace_key,
             )
         if row is None:
             return None
@@ -101,15 +107,16 @@ class _PostgresStateStorage:
         async with self._acquire() as conn:
             await conn.execute(
                 f"""
-                INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
-                VALUES ($1, $2, $3, $4, $5, $6)
-                ON CONFLICT(run_id) DO UPDATE SET
+                INSERT INTO {self._table_ref} (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                ON CONFLICT(run_id, namespace) DO UPDATE SET
                     state_json = EXCLUDED.state_json,
                     state_type = EXCLUDED.state_type,
                     state_module = EXCLUDED.state_module,
                     updated_at = EXCLUDED.updated_at
                 """,
                 self._run_id,
+                self._namespace_key,
                 record.data,
                 record.state_type,
                 record.state_module,
@@ -129,15 +136,20 @@ class _PostgresStateStorage:
         return PostgresSerializedState.model_validate(payload)
 
     async def copy_from_handle(self, handle: PostgresSerializedState) -> None:
-        """Copy state from another run's row using SQL INSERT...SELECT."""
+        """Copy every namespace row from another run using INSERT...SELECT.
+
+        The ``run_id`` filter spans all namespaces, so a single statement
+        copies the source run's root and every child namespace; ``namespace``
+        is carried through unchanged.
+        """
         now = _utc_now()
         async with self._acquire() as conn:
             await conn.execute(
                 f"""
-                INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
-                SELECT $1, state_json, state_type, state_module, $2, $3
+                INSERT INTO {self._table_ref} (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                SELECT $1, namespace, state_json, state_type, state_module, $2, $3
                 FROM {self._table_ref} WHERE run_id = $4
-                ON CONFLICT(run_id) DO UPDATE SET
+                ON CONFLICT(run_id, namespace) DO UPDATE SET
                     state_json = EXCLUDED.state_json,
                     state_type = EXCLUDED.state_type,
                     state_module = EXCLUDED.state_module,
@@ -157,12 +169,15 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         self,
         pool: asyncpg.Pool,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         state_type: type[MODEL_T] | None = None,
         serializer: BaseSerializer | None = None,
         schema: str | None = None,
     ) -> None:
         super().__init__(
-            _PostgresStateStorage(pool, run_id, schema), state_type, serializer
+            _PostgresStateStorage(pool, run_id, namespace, schema),
+            state_type,
+            serializer,
         )
 
     @classmethod

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -298,6 +298,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> PostgresStateStore[Any]:
@@ -308,6 +309,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         return PostgresStateStore(
             pool=self._pool,
             run_id=run_id,
+            namespace=namespace,
             state_type=state_type,
             serializer=serializer,
             schema=self._schema,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/migrations/0005_namespace_state.sql
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/migrations/0005_namespace_state.sql
@@ -1,0 +1,23 @@
+-- migration: 5
+
+-- Per-namespace state records: namespace becomes a key dimension alongside
+-- run_id. SQLite cannot ALTER a primary key, so rebuild the table with the
+-- composite PK and migrate existing rows as root-namespace rows (namespace '').
+CREATE TABLE workflow_state_new (
+    run_id TEXT NOT NULL,
+    namespace TEXT NOT NULL DEFAULT '',
+    state_json TEXT NOT NULL DEFAULT '{}',
+    state_type TEXT NOT NULL DEFAULT 'DictState',
+    state_module TEXT NOT NULL DEFAULT 'workflows.context.state_store',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (run_id, namespace)
+);
+
+INSERT INTO workflow_state_new (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+SELECT run_id, '', state_json, state_type, state_module, created_at, updated_at
+FROM workflow_state;
+
+DROP TABLE workflow_state;
+
+ALTER TABLE workflow_state_new RENAME TO workflow_state;

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -40,10 +40,14 @@ class _SqliteStateStorage:
         self,
         db_path: str,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         connection: sqlite3.Connection | None = None,
     ) -> None:
         self._db_path = db_path
         self._run_id = run_id
+        self._namespace = namespace
+        # Persisted key: () -> "" (today's single root row), ("child",) -> "child".
+        self._namespace_key = "/".join(namespace)
         self._shared_conn = connection
 
     @property
@@ -73,7 +77,9 @@ class _SqliteStateStorage:
             return
         conn = sqlite3.connect(self._db_path, timeout=30.0)
         try:
-            yield _SqliteStateStorage(self._db_path, self._run_id, connection=conn)
+            yield _SqliteStateStorage(
+                self._db_path, self._run_id, self._namespace, connection=conn
+            )
         finally:
             conn.close()
 
@@ -82,8 +88,9 @@ class _SqliteStateStorage:
         with self._connect() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT state_json FROM workflow_state WHERE run_id = ?",
-                (self._run_id,),
+                "SELECT state_json FROM workflow_state "
+                "WHERE run_id = ? AND namespace = ?",
+                (self._run_id, self._namespace_key),
             )
             row = cursor.fetchone()
         if row is None:
@@ -96,9 +103,9 @@ class _SqliteStateStorage:
             now = _utc_now().isoformat()
             conn.execute(
                 """
-                INSERT INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(run_id) DO UPDATE SET
+                INSERT INTO workflow_state (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id, namespace) DO UPDATE SET
                     state_json = excluded.state_json,
                     state_type = excluded.state_type,
                     state_module = excluded.state_module,
@@ -106,6 +113,7 @@ class _SqliteStateStorage:
                 """,
                 (
                     self._run_id,
+                    self._namespace_key,
                     record.data,
                     record.state_type,
                     record.state_module,
@@ -125,13 +133,18 @@ class _SqliteStateStorage:
         return SqliteSerializedState.model_validate(payload)
 
     async def copy_from_handle(self, handle: SqliteSerializedState) -> None:
-        """Copy state from another run's row using SQL INSERT...SELECT."""
+        """Copy every namespace row from another run using INSERT...SELECT.
+
+        The ``run_id`` filter spans all namespaces, so a single statement
+        copies the source run's root and every child namespace; ``namespace``
+        is carried through unchanged.
+        """
         with self._connect() as conn:
             now = _utc_now().isoformat()
             conn.execute(
                 """
-                INSERT OR REPLACE INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
-                SELECT ?, state_json, state_type, state_module, ?, ?
+                INSERT OR REPLACE INTO workflow_state (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                SELECT ?, namespace, state_json, state_type, state_module, ?, ?
                 FROM workflow_state WHERE run_id = ?
                 """,
                 (self._run_id, now, now, handle.run_id),
@@ -146,13 +159,16 @@ class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         self,
         db_path: str,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         state_type: type[MODEL_T] | None = None,
         serializer: BaseSerializer | None = None,
         connection: sqlite3.Connection | None = None,
     ) -> None:
         self._db_path = db_path
         super().__init__(
-            _SqliteStateStorage(db_path, run_id, connection), state_type, serializer
+            _SqliteStateStorage(db_path, run_id, namespace, connection),
+            state_type,
+            serializer,
         )
 
     @classmethod

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -93,12 +93,14 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> SqliteStateStore[Any]:
         return SqliteStateStore(
             db_path=self.db_path,
             run_id=run_id,
+            namespace=namespace,
             state_type=state_type,
             serializer=serializer,
             connection=self._persistent_conn,

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timezone
 from typing import Any
 
@@ -1028,3 +1029,50 @@ async def test_persist_error_does_not_block_in_memory_delivery(
     await store.append_event("run-1", make_envelope(event=StopEvent(data="done")))
     await asyncio.wait_for(task, timeout=2.0)
     assert len(collected) == 3
+
+
+# ---------------------------------------------------------------------------
+# Per-namespace records
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_namespace_round_trip_and_isolation(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root and child namespaces persist as independent items under one run."""
+    root = create_agent_data_state_store(backend, monkeypatch, "run-ns")
+    child = create_agent_data_state_store(
+        backend, monkeypatch, "run-ns", namespace=("child",)
+    )
+
+    await root.set("k", "root-val")
+    await child.set("k", "child-val")
+
+    root2 = create_agent_data_state_store(backend, monkeypatch, "run-ns")
+    child2 = create_agent_data_state_store(
+        backend, monkeypatch, "run-ns", namespace=("child",)
+    )
+    assert await root2.get("k") == "root-val"
+    assert await child2.get("k") == "child-val"
+
+
+@pytest.mark.asyncio
+async def test_pre_namespace_item_reads_as_root(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An item written before namespaces (no namespace field) reads as root."""
+    serializer = JsonSerializer()
+    backend.create(
+        "test-deploy",
+        "workflow_state",
+        {
+            "run_id": "legacy-run",
+            "data": json.dumps({"_data": {"k": serializer.serialize("legacy")}}),
+            "state_type": "DictState",
+            "state_module": "workflows.context.state_store",
+        },
+    )
+
+    root = create_agent_data_state_store(backend, monkeypatch, "legacy-run")
+    assert await root.get("k") == "legacy"

--- a/packages/llama-agents-server/tests/server/test_memory_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_memory_workflow_store.py
@@ -478,7 +478,7 @@ async def test_max_completed_cleans_up_events_ticks_and_state() -> None:
     )
     assert "run-old" in store.events
     assert "run-old" in store.ticks
-    assert "run-old" in store.state_stores
+    assert ("run-old", ()) in store.state_stores
 
     await _insert(
         store,
@@ -490,7 +490,7 @@ async def test_max_completed_cleans_up_events_ticks_and_state() -> None:
 
     assert "run-old" not in store.events
     assert "run-old" not in store.ticks
-    assert "run-old" not in store.state_stores
+    assert ("run-old", ()) not in store.state_stores
     remaining = await store.query(HandlerQuery())
     assert len(remaining) == 1
     assert remaining[0].handler_id == "h-new"

--- a/packages/llama-agents-server/tests/server/test_memory_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_memory_workflow_store.py
@@ -496,6 +496,23 @@ async def test_max_completed_cleans_up_events_ticks_and_state() -> None:
     assert remaining[0].handler_id == "h-new"
 
 
+async def test_evict_run_state_stores_drops_every_namespace() -> None:
+    """Run-scoped eviction removes all of a run's namespace facades at once."""
+    store = MemoryWorkflowStore()
+    store.create_state_store("run-x")
+    store.create_state_store("run-x", namespace=("child",))
+    store.create_state_store("run-other")
+    assert ("run-x", ()) in store.state_stores
+    assert ("run-x", ("child",)) in store.state_stores
+
+    store._evict_run_state_stores("run-x")
+
+    assert ("run-x", ()) not in store.state_stores
+    assert ("run-x", ("child",)) not in store.state_stores
+    # Other runs are untouched.
+    assert ("run-other", ()) in store.state_stores
+
+
 @pytest.mark.asyncio
 async def test_max_completed_eviction_via_update_handler_status() -> None:
     """Eviction triggers when status changes to terminal via update_handler_status."""

--- a/packages/llama-agents-server/tests/server/test_postgres_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_state_store.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import AsyncGenerator
 
 import asyncpg
@@ -35,12 +36,14 @@ async def pool(postgres_dsn: str) -> AsyncGenerator[asyncpg.Pool, None]:
         await conn.execute(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
         await conn.execute(f"""
             CREATE TABLE IF NOT EXISTS {SCHEMA}.workflow_state (
-                run_id VARCHAR(255) PRIMARY KEY,
+                run_id VARCHAR(255) NOT NULL,
+                namespace VARCHAR(255) NOT NULL DEFAULT '',
                 state_json TEXT NOT NULL,
                 state_type VARCHAR(255),
                 state_module VARCHAR(255),
                 created_at TIMESTAMPTZ,
-                updated_at TIMESTAMPTZ
+                updated_at TIMESTAMPTZ,
+                PRIMARY KEY (run_id, namespace)
             )
         """)
         await conn.execute(f"DELETE FROM {SCHEMA}.workflow_state")
@@ -324,16 +327,18 @@ class FakeConnection:
     def __init__(self, rows: dict[str, str]) -> None:
         self._rows = rows
 
-    async def fetchrow(self, query: str, run_id: str) -> dict[str, str] | None:
-        state_json = self._rows.get(run_id)
+    async def fetchrow(
+        self, query: str, run_id: str, namespace: str
+    ) -> dict[str, str] | None:
+        state_json = self._rows.get(f"{run_id}\x00{namespace}")
         if state_json is None:
             return None
         return {"state_json": state_json}
 
     async def execute(self, query: str, *args: object) -> None:
-        # Save upsert: (run_id, state_json, state_type, state_module, now, now)
-        run_id, state_json = str(args[0]), str(args[1])
-        self._rows[run_id] = state_json
+        # Save upsert: (run_id, namespace, state_json, state_type, state_module, now, now)
+        run_id, namespace, state_json = str(args[0]), str(args[1]), str(args[2])
+        self._rows[f"{run_id}\x00{namespace}"] = state_json
 
 
 class FakePoolAcquire:
@@ -376,7 +381,7 @@ async def test_set_state_acquires_exactly_one_pool_connection() -> None:
 
     assert pool.acquire_count == 1
     assert pool.release_count == 1
-    assert "run-conn-count" in pool.rows
+    assert "run-conn-count\x00" in pool.rows
 
 
 async def test_from_dict_empty_raises() -> None:
@@ -389,3 +394,48 @@ async def test_from_dict_no_pool_raises() -> None:
         PostgresStateStore.from_dict(
             {"store_type": "postgres", "run_id": "x"}, JsonSerializer()
         )
+
+
+# -- Per-namespace records --
+
+
+@pytest.mark.docker
+async def test_namespace_round_trip_and_isolation(pool: asyncpg.Pool) -> None:
+    """Root and child namespaces persist as independent rows under one run."""
+    root: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", schema=SCHEMA
+    )
+    child: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", namespace=("child",), schema=SCHEMA
+    )
+
+    await root.set("k", "root-val")
+    await child.set("k", "child-val")
+
+    root2: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", schema=SCHEMA
+    )
+    child2: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", namespace=("child",), schema=SCHEMA
+    )
+    assert await root2.get("k") == "root-val"
+    assert await child2.get("k") == "child-val"
+
+
+@pytest.mark.docker
+async def test_pre_migration_root_row_reads_as_root(pool: asyncpg.Pool) -> None:
+    """A row written without a namespace (additive default '') reads as root."""
+    state_json = json.dumps({"_data": {"k": JsonSerializer().serialize("legacy")}})
+    async with pool.acquire() as conn:
+        await conn.execute(
+            f"INSERT INTO {SCHEMA}.workflow_state "
+            "(run_id, state_json, state_type, state_module, created_at, updated_at) "
+            "VALUES ($1, $2, 'DictState', 'workflows.context.state_store', now(), now())",
+            "legacy-run",
+            state_json,
+        )
+
+    store: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="legacy-run", schema=SCHEMA
+    )
+    assert await store.get("k") == "legacy"

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -491,3 +492,83 @@ async def test_sqlite_workflow_store_single_connection_opens_existing_regular_db
 
     await state_store.set("x", 1)
     assert await state_store.get("x") == 1
+
+
+# -- Per-namespace records --
+
+
+@pytest.mark.asyncio
+async def test_namespace_round_trip_and_isolation(db_path: str) -> None:
+    """Root and child namespaces persist as independent rows under one run."""
+    root: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns"
+    )
+    child: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns", namespace=("child",)
+    )
+
+    await root.set("k", "root-val")
+    await child.set("k", "child-val")
+
+    # Fresh facades read straight from their own row — no cross-namespace bleed.
+    root2: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns"
+    )
+    child2: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns", namespace=("child",)
+    )
+    assert await root2.get("k") == "root-val"
+    assert await child2.get("k") == "child-val"
+
+
+@pytest.mark.asyncio
+async def test_pre_migration_root_row_reads_as_root(tmp_path: Path) -> None:
+    """A row written under the pre-namespace schema reads back as root."""
+    path = str(tmp_path / "legacy.db")
+    serializer = JsonSerializer()
+    legacy_state_json = json.dumps({"_data": {"k": serializer.serialize("legacy")}})
+
+    conn = sqlite3.connect(path)
+    try:
+        # Recreate the schema as it stood at migration 4 (single-column PK,
+        # no namespace) and mark migrations 1-4 applied.
+        conn.executescript(
+            """
+            CREATE TABLE schema_migrations (
+                package TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                applied_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (package, version)
+            );
+            CREATE TABLE workflow_state (
+                run_id TEXT PRIMARY KEY,
+                state_json TEXT NOT NULL DEFAULT '{}',
+                state_type TEXT NOT NULL DEFAULT 'DictState',
+                state_module TEXT NOT NULL DEFAULT 'workflows.context.state_store',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        for version in range(1, 5):
+            conn.execute(
+                "INSERT INTO schema_migrations (package, version) VALUES ('server', ?)",
+                (version,),
+            )
+        conn.execute(
+            "INSERT INTO workflow_state "
+            "(run_id, state_json, state_type, state_module, created_at, updated_at) "
+            "VALUES (?, ?, 'DictState', 'workflows.context.state_store', '', '')",
+            ("legacy-run", legacy_state_json),
+        )
+        conn.commit()
+        # Apply the pending namespace migration (table rebuild).
+        run_migrations(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    store: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=path, run_id="legacy-run"
+    )
+    assert await store.get("k") == "legacy"

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -14,6 +14,7 @@ import pytest
 from llama_agents.server import HandlerQuery, SqliteWorkflowStore
 from llama_agents.server._store.sqlite.migrate import run_migrations
 from llama_agents.server._store.sqlite.sqlite_state_store import (
+    SqliteSerializedState,
     SqliteStateStore,
 )
 from pydantic import BaseModel
@@ -572,3 +573,30 @@ async def test_pre_migration_root_row_reads_as_root(tmp_path: Path) -> None:
         db_path=path, run_id="legacy-run"
     )
     assert await store.get("k") == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_copy_reproduces_every_namespace(db_path: str) -> None:
+    """Copying a run via its handle reproduces root and child namespaces."""
+    src_root: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-src"
+    )
+    src_child: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-src", namespace=("child",)
+    )
+    await src_root.set("k", "root-val")
+    await src_child.set("k", "child-val")
+
+    # Seed the destination root facade from the source handle; ensure_seeded
+    # drives copy_from_handle, which spans every namespace of the source run.
+    serializer = JsonSerializer()
+    dst_root: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-dst"
+    )
+    dst_root.add_seed(SqliteSerializedState(run_id="run-src").model_dump(), serializer)
+    assert await dst_root.get("k") == "root-val"
+
+    dst_child: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-dst", namespace=("child",)
+    )
+    assert await dst_child.get("k") == "child-val"

--- a/packages/llama-agents-server/tests/server/test_workflow_service.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_service.py
@@ -329,8 +329,8 @@ async def test_context_from_handler_id_falls_back_to_legacy_state_snapshot(
             started_at=datetime.now(timezone.utc),
         )
     )
-    state_stores = cast(dict[str, Any], memory_store.state_stores)
-    state_stores["plugin-run"] = ToDictOnlyStateStore()
+    state_stores = cast(dict[Any, Any], memory_store.state_stores)
+    state_stores[("plugin-run", ())] = ToDictOnlyStateStore()
 
     async with server.contextmanager():
         ctx = await server._service._context_from_handler_id(

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -14,6 +14,7 @@ from typing import (
     Any,
     AsyncContextManager,
     AsyncGenerator,
+    Callable,
     Generic,
     Literal,
     Protocol,
@@ -21,7 +22,7 @@ from typing import (
     runtime_checkable,
 )
 
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import BaseModel, ValidationError, model_validator
 from typing_extensions import TypeVar
 
 from workflows.decorators import StepConfig
@@ -37,10 +38,8 @@ MAX_DEPTH = 1000
 # Keys set by pre-built workflows that are known to be unserializable in some cases.
 KNOWN_UNSERIALIZABLE_KEYS: tuple[str, ...] = ("memory",)
 
+# Portable childful snapshots nest per-namespace state data under this key.
 CHILD_STATES_KEY = "children"
-BUNDLE_ROOT_KEY = "root"
-BUNDLE_VERSION = 1
-BUNDLE_VERSION_KEY = "state_bundle_version"
 
 
 class InMemorySerializedState(BaseModel):
@@ -763,16 +762,10 @@ class StateStoreFacade(Generic[MODEL_T]):
                 await self._durable.copy_from_handle(seed.handle)
             else:
                 # Bypass _save_state: its ensure_seeded re-entry would
-                # deadlock on the seed lock we hold.
-                if seed.payload.get(CHILD_STATES_KEY):
-                    await self._write_record(
-                        _record_from_payload_bundle(
-                            seed.payload, durable=self._durable is not None
-                        )
-                    )
-                else:
-                    state = decode_seed_state(seed.payload, seed.serializer)
-                    await self._write_state(state)
+                # deadlock on the seed lock we hold. A namespace facade only
+                # ever seeds its own state; the router distributes children.
+                state = decode_seed_state(seed.payload, seed.serializer)
+                await self._write_state(state)
             # Popped only after success so a failed materialization stays
             # pending; concurrent readers block on the seed lock above
             # until the seed is committed. Identity-checked: sync add_seed
@@ -1073,13 +1066,8 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         if not serialized_state:
             return cls(DictState())  # type: ignore[arg-type]
 
-        if serialized_state.get(CHILD_STATES_KEY):
-            store = cls(DictState())  # type: ignore[arg-type]
-            store._memory_storage._record = _record_from_payload_bundle(
-                serialized_state
-            )
-            return store
-
+        # Childful trees are distributed per namespace by the router; a single
+        # InMemoryStateStore only ever holds one namespace's state.
         state_instance = decode_seed_state(serialized_state, serializer)
         return cls(state_instance)  # type: ignore[arg-type]
 
@@ -1232,327 +1220,135 @@ def _namespace_key(namespace: tuple[str, ...]) -> str:
     return "/".join(namespace)
 
 
-class _StateBundle(BaseModel):
-    """One root state record plus raw child namespace state data."""
-
-    root: StateRecord
-    children: dict[str, Any] = Field(default_factory=dict)
+def _namespace_from_key(key: str) -> tuple[str, ...]:
+    """Inverse of ``_namespace_key``: ``""`` -> ``()``, ``"child"`` -> ``("child",)``."""
+    return tuple(key.split("/")) if key else ()
 
 
-def _json_object_from_data(data: Any) -> tuple[dict[str, Any] | None, bool]:
-    """Return a JSON object plus whether it came from a string payload."""
-    if isinstance(data, dict):
-        return dict(data), False
-    if isinstance(data, str):
-        try:
-            parsed = json.loads(data)
-        except ValueError:
-            return None, True
-        if isinstance(parsed, dict):
-            return dict(parsed), True
-    return None, isinstance(data, str)
-
-
-def _restore_data_shape(data: dict[str, Any], *, was_string: bool) -> Any:
-    return json.dumps(data) if was_string else data
-
-
-def _child_data_from_raw(raw: Any) -> Any:
-    if isinstance(raw, StateRecord):
-        return raw.data
-    if isinstance(raw, dict):
-        if "data" in raw and ("state_type" in raw or "state_module" in raw):
-            return StateRecord.model_validate(raw).data
-        if "state_data" in raw and set(raw) <= {
-            "store_type",
-            "state_type",
-            "state_module",
-            "state_data",
-        }:
-            return parse_in_memory_state(raw).state_data
-    return raw
-
-
-def _children_from_raw(raw: Any) -> dict[str, Any]:
-    if not isinstance(raw, dict):
-        return {}
-    return {namespace: _child_data_from_raw(data) for namespace, data in raw.items()}
-
-
-def _child_data_from_record(record: StateRecord) -> Any:
-    obj, _ = _json_object_from_data(record.data)
-    if obj is not None:
-        return obj
-    return record.data
-
-
-def _with_default_record_metadata(record: StateRecord) -> StateRecord:
-    if record.state_type is not None and record.state_module is not None:
-        return record
-    return record.model_copy(
-        update={
-            "state_type": record.state_type or "DictState",
-            "state_module": record.state_module or "workflows.context.state_store",
-        }
-    )
-
-
-def split_state_bundle(record: StateRecord | None) -> _StateBundle:
-    """Split a stored record into root and child namespace records.
-
-    Root-only records are the normal shape. Childful records either append
-    ``children`` to an object-shaped root payload or, for opaque root payloads,
-    use a small wrapper with ``state_bundle_version`` and ``root``.
-    """
-    if record is None:
-        return _StateBundle(root=StateRecord(data=None))
-
-    obj, was_string = _json_object_from_data(record.data)
-    if obj is None:
-        return _StateBundle(root=record)
-
-    if obj.get(BUNDLE_VERSION_KEY) == BUNDLE_VERSION and BUNDLE_ROOT_KEY in obj:
-        return _StateBundle(
-            root=StateRecord(
-                data=obj[BUNDLE_ROOT_KEY],
-                state_type=record.state_type,
-                state_module=record.state_module,
-            ),
-            children=_children_from_raw(obj.get(CHILD_STATES_KEY)),
-        )
-
-    children_raw = obj.pop(CHILD_STATES_KEY, None)
-    if children_raw is None:
-        return _StateBundle(root=record)
-
-    return _StateBundle(
-        root=StateRecord(
-            data=_restore_data_shape(obj, was_string=was_string),
-            state_type=record.state_type,
-            state_module=record.state_module,
-        ),
-        children=_children_from_raw(children_raw),
-    )
-
-
-def join_state_bundle(bundle: _StateBundle) -> StateRecord:
-    """Join root and child records back into one stored record."""
-    root = _with_default_record_metadata(bundle.root)
-    if not bundle.children:
-        return root
-
-    children = dict(bundle.children)
-    obj, was_string = _json_object_from_data(root.data)
-    if obj is not None:
-        obj[CHILD_STATES_KEY] = children
-        return StateRecord(
-            data=_restore_data_shape(obj, was_string=was_string),
-            state_type=root.state_type,
-            state_module=root.state_module,
-        )
-
-    wrapper = {
-        BUNDLE_VERSION_KEY: BUNDLE_VERSION,
-        BUNDLE_ROOT_KEY: root.data,
-        CHILD_STATES_KEY: children,
-    }
-    return StateRecord(
-        data=wrapper if isinstance(root.data, BaseModel) else json.dumps(wrapper),
-        state_type=root.state_type,
-        state_module=root.state_module,
-    )
-
-
-def _record_from_payload(payload: dict[str, Any]) -> StateRecord:
-    parsed = parse_in_memory_state(payload)
-    return StateRecord(
-        data=parsed.state_data,
-        state_type=parsed.state_type,
-        state_module=parsed.state_module,
-    )
-
-
-def _record_from_payload_bundle(
-    payload: dict[str, Any],
-    *,
-    durable: bool = False,
-) -> StateRecord:
-    root_payload = dict(payload)
-    children_raw = root_payload.pop(CHILD_STATES_KEY, None) or {}
-    root = _record_from_payload(root_payload)
-    bundle = _StateBundle(
-        root=root,
-        children={
-            namespace: _child_data_from_raw(child_payload)
-            for namespace, child_payload in children_raw.items()
-        },
-    )
-    record = join_state_bundle(bundle)
-    if durable and not isinstance(record.data, str):
-        record = record.model_copy(update={"data": json.dumps(record.data)})
-    return record
-
-
-def _payload_from_record(
-    record: StateRecord | None,
-    serializer: BaseSerializer,
-    state_type: type[BaseModel],
+def _in_memory_seed_payload(
+    state_data: Any, state_type: type[BaseModel]
 ) -> dict[str, Any]:
-    if record is None or record.data is None:
-        state = create_cleared_state(state_type)
-    else:
-        state = decode_state(record.data, serializer)
-    return create_in_memory_payload(state, serializer).model_dump()
+    """Wrap raw namespace ``state_data`` as an in-memory seed payload."""
+    return {
+        "store_type": "in_memory",
+        "state_type": state_type.__name__,
+        "state_module": state_type.__module__,
+        "state_data": state_data,
+    }
 
 
-class _NamespaceStateStorage:
-    """Raw storage view over one namespace inside a bundled root record."""
+def namespaced_seed_payloads(
+    serialized_state: dict[str, Any] | None,
+    state_types: dict[tuple[str, ...], type[BaseModel]],
+) -> dict[tuple[str, ...], dict[str, Any]] | None:
+    """Split a portable snapshot into one in-memory seed per namespace.
 
-    def __init__(
-        self,
-        root_storage: _StateStorage,
-        namespace: tuple[str, ...],
-        bundle_lock: asyncio.Lock,
-        *,
-        locked: bool = False,
-    ) -> None:
-        self._root_storage = root_storage
-        self._namespace = namespace
-        self._bundle_lock = bundle_lock
-        self._locked = locked
+    Returns ``namespace -> in_memory payload`` for the root (the snapshot
+    minus ``children``) and each ``children[ns]`` entry, or ``None`` when there
+    is nothing to distribute: an empty payload, or a durable handle (seeded by
+    copy, not by per-namespace payloads).
+    """
+    if not serialized_state:
+        return None
+    if serialized_state.get("store_type", "in_memory") != "in_memory":
+        return None
+    root_payload = {
+        key: value for key, value in serialized_state.items() if key != CHILD_STATES_KEY
+    }
+    seeds: dict[tuple[str, ...], dict[str, Any]] = {(): root_payload}
+    children = serialized_state.get(CHILD_STATES_KEY) or {}
+    for namespace_key, state_data in children.items():
+        namespace = _namespace_from_key(namespace_key)
+        seeds[namespace] = _in_memory_seed_payload(
+            state_data, state_types.get(namespace, DictState)
+        )
+    return seeds
 
-    async def load(self) -> StateRecord | None:
-        bundle = split_state_bundle(await self._root_storage.load())
-        if self._namespace == ():
-            return bundle.root
-        namespace_key = _namespace_key(self._namespace)
-        if namespace_key not in bundle.children:
-            return None
-        return StateRecord(data=bundle.children[namespace_key])
 
-    @asynccontextmanager
-    async def session(self) -> AsyncGenerator[_NamespaceStateStorage, None]:
-        if self._locked:
-            yield self
-            return
-        async with self._bundle_lock:
-            async with self._root_storage.session() as root_storage:
-                yield _NamespaceStateStorage(
-                    root_storage,
-                    self._namespace,
-                    self._bundle_lock,
-                    locked=True,
-                )
-
-    async def save(self, record: StateRecord) -> None:
-        if not self._locked:
-            async with self.session() as storage:
-                await storage.save(record)
-            return
-
-        bundle = split_state_bundle(await self._root_storage.load())
-        if self._namespace == ():
-            bundle.root = record
-        else:
-            bundle.children[_namespace_key(self._namespace)] = _child_data_from_record(
-                record
-            )
-        await self._root_storage.save(join_state_bundle(bundle))
+NamespaceFactory = Callable[[tuple[str, ...]], StateStoreFacade[Any]]
 
 
 class NamespacedStateStores:
-    """Per-namespace StateStore views over one backing store."""
+    """Routes each namespace to its own ``StateStoreFacade``.
+
+    A namespace is just a run with an extra key component: every namespace owns
+    its own backing record, writer lock, and seed lifecycle. There is no shared
+    record and no cross-namespace lock — two namespaces never read-modify-write
+    the same physical record.
+    """
 
     def __init__(
         self,
-        underlying: StateStore[Any],
+        factory: NamespaceFactory,
         serializer: BaseSerializer,
         state_types: dict[tuple[str, ...], type[BaseModel]],
     ) -> None:
-        self.underlying = underlying
+        self._factory = factory
         self.serializer = serializer
         self.state_types = state_types
         self._views: dict[tuple[str, ...], StateStoreFacade[Any]] = {}
-        self._bundle_lock = asyncio.Lock()
 
     @property
     def is_single_namespace(self) -> bool:
         return len(self.state_types) <= 1
 
-    def view(self, namespace: tuple[str, ...]) -> StateStore[Any]:
-        if self.is_single_namespace:
-            return self.underlying
+    def _view_facade(self, namespace: tuple[str, ...]) -> StateStoreFacade[Any]:
         view = self._views.get(namespace)
         if view is None:
-            if not isinstance(self.underlying, StateStoreFacade):
-                raise TypeError(
-                    "Namespaced state requires a StateStoreFacade-backed store"
-                )
-            state_type = self.state_types.get(namespace, DictState)
-            view = StateStoreFacade[Any](
-                _NamespaceStateStorage(
-                    self.underlying._storage,
-                    namespace,
-                    self._bundle_lock,
-                ),
-                state_type,
-                self.serializer,
-            )
+            view = self._factory(namespace)
             self._views[namespace] = view
         return view
 
+    def view(self, namespace: tuple[str, ...]) -> StateStore[Any]:
+        return self._view_facade(namespace)
+
+    def _child_namespaces(self) -> list[tuple[str, ...]]:
+        # Topology is the source of truth for which namespaces exist; union in
+        # any extra materialized views so nothing accessed is silently dropped.
+        namespaces = set(self.state_types) | set(self._views)
+        return sorted(ns for ns in namespaces if ns != ())
+
     def serialize_tree(self, serializer: BaseSerializer) -> dict[str, Any]:
-        if self.is_single_namespace:
-            return self.underlying.to_dict(serializer)
+        """Portable snapshot: the root payload with ``children[ns]`` nested.
 
-        if not isinstance(self.underlying, StateStoreFacade):
-            raise TypeError("Namespaced state requires a StateStoreFacade-backed store")
-
-        load_sync = getattr(self.underlying._storage, "load_sync", None)
-        if not callable(load_sync):
-            return self.underlying.to_dict(serializer)
-
-        bundle = split_state_bundle(cast(StateRecord | None, load_sync()))
-        result = _payload_from_record(
-            bundle.root,
-            serializer,
-            self.state_types.get((), DictState),
-        )
-        children = {
-            namespace: _payload_from_record(
-                StateRecord(data=data),
-                serializer,
-                self.state_types.get(tuple(namespace.split("/")), DictState),
+        Childless runs (a single namespace) produce exactly the flat root
+        snapshot, with no ``children`` key.
+        """
+        result = self.view(()).to_dict(serializer)
+        children: dict[str, Any] = {}
+        for namespace in self._child_namespaces():
+            children[_namespace_key(namespace)] = self.view(namespace).to_dict(
+                serializer
             )["state_data"]
-            for namespace, data in bundle.children.items()
-        }
         if children:
-            result[CHILD_STATES_KEY] = children
+            result = {**result, CHILD_STATES_KEY: children}
         return result
 
+    def add_seed_tree(
+        self, serialized_state: dict[str, Any] | None, serializer: BaseSerializer
+    ) -> None:
+        """Distribute a portable tree snapshot across per-namespace facades.
 
-def namespaced_seed_blob(
-    serialized_state: dict[str, Any] | None, *, child_ful: bool
-) -> dict[str, Any] | None:
-    if not serialized_state:
-        return None
-    if serialized_state.get("store_type") not in (None, "in_memory"):
-        return None
-    if not child_ful:
-        return None
-    return dict(serialized_state)
+        The root payload seeds the root facade; each ``children[ns]`` seeds its
+        own namespace facade via ``add_seed``. There is no single bundle seed.
+        """
+        seeds = namespaced_seed_payloads(serialized_state, self.state_types)
+        if seeds is None:
+            return
+        for namespace, payload in seeds.items():
+            self._view_facade(namespace).add_seed(payload, serializer)
 
 
-def namespaced_seed_payload(
-    serialized_state: dict[str, Any] | None,
-    serializer: BaseSerializer,
-    *,
-    child_ful: bool,
-) -> dict[str, Any] | None:
-    blob = namespaced_seed_blob(serialized_state, child_ful=child_ful)
-    if blob is None:
-        return None
-    return blob
+def in_memory_namespace_factory(
+    state_types: dict[tuple[str, ...], type[BaseModel]],
+) -> NamespaceFactory:
+    """A namespace factory that mints a fresh in-memory facade per namespace."""
+
+    def factory(namespace: tuple[str, ...]) -> StateStoreFacade[Any]:
+        state_type = state_types.get(namespace, DictState)
+        return InMemoryStateStore(create_cleared_state(state_type))
+
+    return factory
 
 
 def namespaced_state_types(
@@ -1574,11 +1370,17 @@ def namespaced_underlying_state_type(root_workflow: "Workflow") -> type[BaseMode
 
 def build_namespaced_state(
     root_workflow: "Workflow",
-    underlying: StateStore[Any],
+    factory: NamespaceFactory,
     serializer: BaseSerializer,
 ) -> NamespacedStateStores:
+    """Build a per-namespace router for *root_workflow*.
+
+    *factory* mints a ``StateStoreFacade`` for a given namespace (durable:
+    ``create_state_store(run_id, namespace, ...)``; in-memory:
+    ``in_memory_namespace_factory``).
+    """
     return NamespacedStateStores(
-        underlying=underlying,
+        factory=factory,
         serializer=serializer,
         state_types=namespaced_state_types(root_workflow),
     )

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -21,7 +21,7 @@ from typing import (
     runtime_checkable,
 )
 
-from pydantic import BaseModel, ValidationError, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from typing_extensions import TypeVar
 
 from workflows.decorators import StepConfig
@@ -36,6 +36,11 @@ MAX_DEPTH = 1000
 
 # Keys set by pre-built workflows that are known to be unserializable in some cases.
 KNOWN_UNSERIALIZABLE_KEYS: tuple[str, ...] = ("memory",)
+
+CHILD_STATES_KEY = "children"
+BUNDLE_ROOT_KEY = "root"
+BUNDLE_VERSION = 1
+BUNDLE_VERSION_KEY = "state_bundle_version"
 
 
 class InMemorySerializedState(BaseModel):
@@ -757,10 +762,17 @@ class StateStoreFacade(Generic[MODEL_T]):
                 assert self._durable is not None
                 await self._durable.copy_from_handle(seed.handle)
             else:
-                state = decode_seed_state(seed.payload, seed.serializer)
                 # Bypass _save_state: its ensure_seeded re-entry would
                 # deadlock on the seed lock we hold.
-                await self._write_state(state)
+                if seed.payload.get(CHILD_STATES_KEY):
+                    await self._write_record(
+                        _record_from_payload_bundle(
+                            seed.payload, durable=self._durable is not None
+                        )
+                    )
+                else:
+                    state = decode_seed_state(seed.payload, seed.serializer)
+                    await self._write_state(state)
             # Popped only after success so a failed materialization stays
             # pending; concurrent readers block on the seed lock above
             # until the seed is committed. Identity-checked: sync add_seed
@@ -802,6 +814,12 @@ class StateStoreFacade(Generic[MODEL_T]):
         await (storage or self._storage).save(
             string_record_from_state(state, self._serializer)
         )
+
+    async def _write_record(
+        self, record: StateRecord, storage: _StateStorage | None = None
+    ) -> None:
+        """Persist a pre-encoded raw state record."""
+        await (storage or self._storage).save(record)
 
     async def _load_state_for_edit(
         self, storage: _StateStorage | None = None
@@ -1019,7 +1037,12 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         record = self._memory_storage.load_sync()
         # Records always hold a live model here (see _write_state); when the
         # storage is empty, snapshot a default without persisting it.
-        state = cast(MODEL_T, record.data) if record is not None else self.state_type()
+        if record is None:
+            state = self.state_type()
+        elif isinstance(record.data, BaseModel):
+            state = cast(MODEL_T, record.data)
+        else:
+            state = cast(MODEL_T, decode_state(record.data, serializer))
         return create_in_memory_payload(state, serializer).model_dump()
 
     async def _write_state(
@@ -1049,6 +1072,13 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         """
         if not serialized_state:
             return cls(DictState())  # type: ignore[arg-type]
+
+        if serialized_state.get(CHILD_STATES_KEY):
+            store = cls(DictState())  # type: ignore[arg-type]
+            store._memory_storage._record = _record_from_payload_bundle(
+                serialized_state
+            )
+            return store
 
         state_instance = decode_seed_state(serialized_state, serializer)
         return cls(state_instance)  # type: ignore[arg-type]
@@ -1196,3 +1226,359 @@ def _find_most_derived_state_type(state_types: set[type[BaseModel]]) -> type[Bas
         )
 
     return most_derived
+
+
+def _namespace_key(namespace: tuple[str, ...]) -> str:
+    return "/".join(namespace)
+
+
+class _StateBundle(BaseModel):
+    """One root state record plus raw child namespace state data."""
+
+    root: StateRecord
+    children: dict[str, Any] = Field(default_factory=dict)
+
+
+def _json_object_from_data(data: Any) -> tuple[dict[str, Any] | None, bool]:
+    """Return a JSON object plus whether it came from a string payload."""
+    if isinstance(data, dict):
+        return dict(data), False
+    if isinstance(data, str):
+        try:
+            parsed = json.loads(data)
+        except ValueError:
+            return None, True
+        if isinstance(parsed, dict):
+            return dict(parsed), True
+    return None, isinstance(data, str)
+
+
+def _restore_data_shape(data: dict[str, Any], *, was_string: bool) -> Any:
+    return json.dumps(data) if was_string else data
+
+
+def _child_data_from_raw(raw: Any) -> Any:
+    if isinstance(raw, StateRecord):
+        return raw.data
+    if isinstance(raw, dict):
+        if "data" in raw and ("state_type" in raw or "state_module" in raw):
+            return StateRecord.model_validate(raw).data
+        if "state_data" in raw and set(raw) <= {
+            "store_type",
+            "state_type",
+            "state_module",
+            "state_data",
+        }:
+            return parse_in_memory_state(raw).state_data
+    return raw
+
+
+def _children_from_raw(raw: Any) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        return {}
+    return {namespace: _child_data_from_raw(data) for namespace, data in raw.items()}
+
+
+def _child_data_from_record(record: StateRecord) -> Any:
+    obj, _ = _json_object_from_data(record.data)
+    if obj is not None:
+        return obj
+    return record.data
+
+
+def _with_default_record_metadata(record: StateRecord) -> StateRecord:
+    if record.state_type is not None and record.state_module is not None:
+        return record
+    return record.model_copy(
+        update={
+            "state_type": record.state_type or "DictState",
+            "state_module": record.state_module or "workflows.context.state_store",
+        }
+    )
+
+
+def split_state_bundle(record: StateRecord | None) -> _StateBundle:
+    """Split a stored record into root and child namespace records.
+
+    Root-only records are the normal shape. Childful records either append
+    ``children`` to an object-shaped root payload or, for opaque root payloads,
+    use a small wrapper with ``state_bundle_version`` and ``root``.
+    """
+    if record is None:
+        return _StateBundle(root=StateRecord(data=None))
+
+    obj, was_string = _json_object_from_data(record.data)
+    if obj is None:
+        return _StateBundle(root=record)
+
+    if obj.get(BUNDLE_VERSION_KEY) == BUNDLE_VERSION and BUNDLE_ROOT_KEY in obj:
+        return _StateBundle(
+            root=StateRecord(
+                data=obj[BUNDLE_ROOT_KEY],
+                state_type=record.state_type,
+                state_module=record.state_module,
+            ),
+            children=_children_from_raw(obj.get(CHILD_STATES_KEY)),
+        )
+
+    children_raw = obj.pop(CHILD_STATES_KEY, None)
+    if children_raw is None:
+        return _StateBundle(root=record)
+
+    return _StateBundle(
+        root=StateRecord(
+            data=_restore_data_shape(obj, was_string=was_string),
+            state_type=record.state_type,
+            state_module=record.state_module,
+        ),
+        children=_children_from_raw(children_raw),
+    )
+
+
+def join_state_bundle(bundle: _StateBundle) -> StateRecord:
+    """Join root and child records back into one stored record."""
+    root = _with_default_record_metadata(bundle.root)
+    if not bundle.children:
+        return root
+
+    children = dict(bundle.children)
+    obj, was_string = _json_object_from_data(root.data)
+    if obj is not None:
+        obj[CHILD_STATES_KEY] = children
+        return StateRecord(
+            data=_restore_data_shape(obj, was_string=was_string),
+            state_type=root.state_type,
+            state_module=root.state_module,
+        )
+
+    wrapper = {
+        BUNDLE_VERSION_KEY: BUNDLE_VERSION,
+        BUNDLE_ROOT_KEY: root.data,
+        CHILD_STATES_KEY: children,
+    }
+    return StateRecord(
+        data=wrapper if isinstance(root.data, BaseModel) else json.dumps(wrapper),
+        state_type=root.state_type,
+        state_module=root.state_module,
+    )
+
+
+def _record_from_payload(payload: dict[str, Any]) -> StateRecord:
+    parsed = parse_in_memory_state(payload)
+    return StateRecord(
+        data=parsed.state_data,
+        state_type=parsed.state_type,
+        state_module=parsed.state_module,
+    )
+
+
+def _record_from_payload_bundle(
+    payload: dict[str, Any],
+    *,
+    durable: bool = False,
+) -> StateRecord:
+    root_payload = dict(payload)
+    children_raw = root_payload.pop(CHILD_STATES_KEY, None) or {}
+    root = _record_from_payload(root_payload)
+    bundle = _StateBundle(
+        root=root,
+        children={
+            namespace: _child_data_from_raw(child_payload)
+            for namespace, child_payload in children_raw.items()
+        },
+    )
+    record = join_state_bundle(bundle)
+    if durable and not isinstance(record.data, str):
+        record = record.model_copy(update={"data": json.dumps(record.data)})
+    return record
+
+
+def _payload_from_record(
+    record: StateRecord | None,
+    serializer: BaseSerializer,
+    state_type: type[BaseModel],
+) -> dict[str, Any]:
+    if record is None or record.data is None:
+        state = create_cleared_state(state_type)
+    else:
+        state = decode_state(record.data, serializer)
+    return create_in_memory_payload(state, serializer).model_dump()
+
+
+class _NamespaceStateStorage:
+    """Raw storage view over one namespace inside a bundled root record."""
+
+    def __init__(
+        self,
+        root_storage: _StateStorage,
+        namespace: tuple[str, ...],
+        bundle_lock: asyncio.Lock,
+        *,
+        locked: bool = False,
+    ) -> None:
+        self._root_storage = root_storage
+        self._namespace = namespace
+        self._bundle_lock = bundle_lock
+        self._locked = locked
+
+    async def load(self) -> StateRecord | None:
+        bundle = split_state_bundle(await self._root_storage.load())
+        if self._namespace == ():
+            return bundle.root
+        namespace_key = _namespace_key(self._namespace)
+        if namespace_key not in bundle.children:
+            return None
+        return StateRecord(data=bundle.children[namespace_key])
+
+    @asynccontextmanager
+    async def session(self) -> AsyncGenerator[_NamespaceStateStorage, None]:
+        if self._locked:
+            yield self
+            return
+        async with self._bundle_lock:
+            async with self._root_storage.session() as root_storage:
+                yield _NamespaceStateStorage(
+                    root_storage,
+                    self._namespace,
+                    self._bundle_lock,
+                    locked=True,
+                )
+
+    async def save(self, record: StateRecord) -> None:
+        if not self._locked:
+            async with self.session() as storage:
+                await storage.save(record)
+            return
+
+        bundle = split_state_bundle(await self._root_storage.load())
+        if self._namespace == ():
+            bundle.root = record
+        else:
+            bundle.children[_namespace_key(self._namespace)] = _child_data_from_record(
+                record
+            )
+        await self._root_storage.save(join_state_bundle(bundle))
+
+
+class NamespacedStateStores:
+    """Per-namespace StateStore views over one backing store."""
+
+    def __init__(
+        self,
+        underlying: StateStore[Any],
+        serializer: BaseSerializer,
+        state_types: dict[tuple[str, ...], type[BaseModel]],
+    ) -> None:
+        self.underlying = underlying
+        self.serializer = serializer
+        self.state_types = state_types
+        self._views: dict[tuple[str, ...], StateStoreFacade[Any]] = {}
+        self._bundle_lock = asyncio.Lock()
+
+    @property
+    def is_single_namespace(self) -> bool:
+        return len(self.state_types) <= 1
+
+    def view(self, namespace: tuple[str, ...]) -> StateStore[Any]:
+        if self.is_single_namespace:
+            return self.underlying
+        view = self._views.get(namespace)
+        if view is None:
+            if not isinstance(self.underlying, StateStoreFacade):
+                raise TypeError(
+                    "Namespaced state requires a StateStoreFacade-backed store"
+                )
+            state_type = self.state_types.get(namespace, DictState)
+            view = StateStoreFacade[Any](
+                _NamespaceStateStorage(
+                    self.underlying._storage,
+                    namespace,
+                    self._bundle_lock,
+                ),
+                state_type,
+                self.serializer,
+            )
+            self._views[namespace] = view
+        return view
+
+    def serialize_tree(self, serializer: BaseSerializer) -> dict[str, Any]:
+        if self.is_single_namespace:
+            return self.underlying.to_dict(serializer)
+
+        if not isinstance(self.underlying, StateStoreFacade):
+            raise TypeError("Namespaced state requires a StateStoreFacade-backed store")
+
+        load_sync = getattr(self.underlying._storage, "load_sync", None)
+        if not callable(load_sync):
+            return self.underlying.to_dict(serializer)
+
+        bundle = split_state_bundle(cast(StateRecord | None, load_sync()))
+        result = _payload_from_record(
+            bundle.root,
+            serializer,
+            self.state_types.get((), DictState),
+        )
+        children = {
+            namespace: _payload_from_record(
+                StateRecord(data=data),
+                serializer,
+                self.state_types.get(tuple(namespace.split("/")), DictState),
+            )["state_data"]
+            for namespace, data in bundle.children.items()
+        }
+        if children:
+            result[CHILD_STATES_KEY] = children
+        return result
+
+
+def namespaced_seed_blob(
+    serialized_state: dict[str, Any] | None, *, child_ful: bool
+) -> dict[str, Any] | None:
+    if not serialized_state:
+        return None
+    if serialized_state.get("store_type") not in (None, "in_memory"):
+        return None
+    if not child_ful:
+        return None
+    return dict(serialized_state)
+
+
+def namespaced_seed_payload(
+    serialized_state: dict[str, Any] | None,
+    serializer: BaseSerializer,
+    *,
+    child_ful: bool,
+) -> dict[str, Any] | None:
+    blob = namespaced_seed_blob(serialized_state, child_ful=child_ful)
+    if blob is None:
+        return None
+    return blob
+
+
+def namespaced_state_types(
+    root_workflow: "Workflow",
+) -> dict[tuple[str, ...], type[BaseModel]]:
+    return {
+        namespace: infer_state_type(instance)
+        for namespace, instance in root_workflow._namespace_instances().items()
+    }
+
+
+def is_child_ful(root_workflow: "Workflow") -> bool:
+    return len(root_workflow._namespace_instances()) > 1
+
+
+def namespaced_underlying_state_type(root_workflow: "Workflow") -> type[BaseModel]:
+    return infer_state_type(root_workflow)
+
+
+def build_namespaced_state(
+    root_workflow: "Workflow",
+    underlying: StateStore[Any],
+    serializer: BaseSerializer,
+) -> NamespacedStateStores:
+    return NamespacedStateStores(
+        underlying=underlying,
+        serializer=serializer,
+        state_types=namespaced_state_types(root_workflow),
+    )

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import Protocol, TypeVar, cast
 
 from workflows._event_matching import is_subclass, step_accepts_type, type_matches
 from workflows._stream_levels import (
@@ -26,6 +27,25 @@ from workflows.resource import ResourceDescriptor, ResourceManager, _ResourceCon
 
 # Graph nodes: step names (str) for steps, event classes (type) for events.
 GraphNode = str | type
+WORKFLOW_T = TypeVar("WORKFLOW_T", bound="_WorkflowForValidation")
+
+
+class _WorkflowClassForValidation(Protocol):
+    __name__: str
+
+    @classmethod
+    def _get_child_workflow_slots(cls) -> dict[str, type]: ...
+
+
+class _WorkflowForValidation(Protocol):
+    @classmethod
+    def _get_child_workflow_slots(cls) -> dict[str, type]: ...
+
+    @property
+    def _start_event_class(self) -> type[StartEvent]: ...
+
+    @property
+    def _child_workflows(self) -> dict[str, WORKFLOW_T]: ...
 
 
 @dataclass
@@ -743,6 +763,55 @@ def _validate_multi_slot_levels(
         )
     if errors:
         raise WorkflowValidationError("\n".join(errors))
+
+
+def _validate_child_workflow_declarations(
+    workflow: _WorkflowForValidation,
+) -> None:
+    """Validate child workflow declarations that need the workflow tree.
+
+    Per-workflow graph validation runs from step configs. These checks sit one
+    level up: they validate the declared child type graph and event routing
+    boundary between a parent instance and its direct children.
+    """
+    root = cast("type[_WorkflowClassForValidation]", type(workflow))
+    _validate_child_type_graph(root)
+    _validate_child_start_events(workflow)
+
+
+def _validate_child_type_graph(root: type[_WorkflowClassForValidation]) -> None:
+    """Reject cycles in the declared child-workflow type graph."""
+
+    def walk(
+        node: type[_WorkflowClassForValidation],
+        path: tuple[type[_WorkflowClassForValidation], ...],
+    ) -> None:
+        for child_type in node._get_child_workflow_slots().values():
+            child_cls = cast("type[_WorkflowClassForValidation]", child_type)
+            if child_cls in path:
+                chain = " -> ".join(c.__name__ for c in (*path, child_cls))
+                raise WorkflowValidationError(
+                    f"Child workflow type cycle detected: {chain}. A child "
+                    "workflow cannot transitively declare itself as a child."
+                )
+            walk(child_cls, (*path, child_cls))
+
+    walk(root, (root,))
+
+
+def _validate_child_start_events(workflow: _WorkflowForValidation) -> None:
+    """Each direct child's ``StartEvent`` type must be unique."""
+    seen: dict[type[StartEvent], str] = {}
+    for field_name, child in workflow._child_workflows.items():
+        start_cls = child._start_event_class
+        if start_cls in seen:
+            raise WorkflowValidationError(
+                f"Child workflows '{seen[start_cls]}' and '{field_name}' on "
+                f"'{type(workflow).__name__}' both accept StartEvent type "
+                f"'{start_cls.__name__}'; each child's StartEvent type must "
+                "be unique so the parent can route to exactly one child."
+            )
+        seen[start_cls] = field_name
 
 
 def _validate_workflow(

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
+    cast,
     get_args,
 )
 
 from llama_index_instrumentation import get_dispatcher
 from pydantic import ValidationError
+from typing_extensions import dataclass_transform
 
 if TYPE_CHECKING:  # pragma: no cover
     from .context import Context
@@ -23,20 +27,123 @@ from .errors import (
     WorkflowRuntimeError,
     WorkflowValidationError,
 )
-from .events import Event, StartEvent
+from .events import Event, StartEvent, StopEvent
 from .handler import WorkflowHandler
 from .resource import ResourceManager
+from .runtime.types.step_id import StepId
 from .types import RunResultT
 from .utils import get_steps_from_class, get_steps_from_instance
 
 dispatcher = get_dispatcher(__name__)
 logger = logging.getLogger(__name__)
 
+# Default run timeout. Referenced by the constructor and type-checker field.
+DEFAULT_TIMEOUT = 45.0
 
+
+def _resolve_child_slots(cls: type) -> dict[str, type]:
+    """Resolve workflow-typed annotations from ``cls`` and its bases."""
+    workflow_cls = globals().get("Workflow")
+    if workflow_cls is None:
+        return {}
+    slots: dict[str, type] = {}
+    for klass in reversed(cls.__mro__):
+        annotations = klass.__dict__.get("__annotations__") or getattr(
+            klass, "__annotations__", None
+        )
+        if not annotations:
+            continue
+        module = sys.modules.get(klass.__module__)
+        globalns = getattr(module, "__dict__", {})
+        localns = dict(vars(klass))
+        for field_name, annotation in annotations.items():
+            resolved: Any = annotation
+            if isinstance(annotation, str):
+                try:
+                    resolved = eval(annotation, globalns, localns)  # noqa: S307
+                except Exception:
+                    continue
+            if isinstance(resolved, type) and issubclass(resolved, workflow_cls):
+                slots[field_name] = resolved
+    return slots
+
+
+def _synthesized_workflow_init(self: Workflow, *args: Any, **kwargs: Any) -> None:
+    """Constructor synthesized for classes that only declare child slots."""
+    slots = type(self)._get_child_workflow_slots()
+    children: dict[str, Any] = {}
+    for slot_name in slots:
+        if slot_name in kwargs:
+            children[slot_name] = kwargs.pop(slot_name)
+    Workflow.__init__(self, *args, **kwargs)
+    for slot_name, child in children.items():
+        self._attach_child(slot_name, child)
+
+
+def _validate_includable_child(child: Workflow, slot_name: str) -> None:
+    """A workflow is includable as a child only if it declares custom
+    ``StartEvent`` and ``StopEvent`` subclasses — the typed IO is the routing
+    contract that maps each child's events to exactly one child.
+    """
+    cls_name = type(child).__name__
+    if child._start_event_class is StartEvent:
+        raise WorkflowValidationError(
+            f"Child workflow '{cls_name}' (slot '{slot_name}') must declare a "
+            "custom StartEvent subclass; a bare StartEvent cannot be routed to a "
+            "child unambiguously."
+        )
+    if child._stop_event_class is StopEvent:
+        raise WorkflowValidationError(
+            f"Child workflow '{cls_name}' (slot '{slot_name}') must declare a "
+            "custom StopEvent subclass; a bare StopEvent cannot be routed back "
+            "to the parent unambiguously."
+        )
+
+
+def _config_field(*, alias: str, default: Any = None) -> Any:
+    """dataclass_transform field specifier for Workflow config params."""
+    return default
+
+
+@dataclass_transform(kw_only_default=True, field_specifiers=(_config_field,))
 class WorkflowMeta(type):
+    # Defined only at runtime, hidden from type checkers. As a metaclass
+    # __call__ it is the single entry point for every instantiation and sits
+    # above the whole __init__/super() chain: type.__call__ drives __new__ and
+    # the complete chain as one unit, so when it returns — every derived
+    # __init__ done and all children assigned — _finalize_construction runs at
+    # the true outermost point of construction. Registration then sees the full
+    # child tree regardless of init style, subclassing depth, or launch timing.
+    #
+    # It is hidden behind ``if not TYPE_CHECKING`` because a typed metaclass
+    # __call__ can't satisfy both type checkers at once: basedpyright needs a
+    # generic ``cls: type[T] -> T`` self-type to preserve the constructed type,
+    # but that exact annotation makes ty reject the ``super().__call__`` as not
+    # bound to the metaclass. Hiding it lets both fall back to the correct
+    # dataclass_transform constructor typing (``Parent(...)`` -> ``Parent``).
+    if not TYPE_CHECKING:
+
+        def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+            obj = super().__call__(*args, **kwargs)
+            obj._finalize_construction()
+            return obj
+
     def __init__(cls, name: str, bases: tuple[type, ...], dct: dict[str, Any]) -> None:
         super().__init__(name, bases, dct)
         cls._step_functions: dict[str, StepFunction] = {}
+
+        # A user-defined __init__ always wins.
+        workflow_cls = globals().get("Workflow")
+        if workflow_cls is None or "__init__" in dct:
+            return
+        if not _resolve_child_slots(cls):
+            return
+        inherited_init = getattr(cls, "__init__", None)
+        if (
+            inherited_init is workflow_cls.__init__
+            or inherited_init is _synthesized_workflow_init
+        ):
+            setattr(cls, "__init__", _synthesized_workflow_init)
 
 
 class Workflow(metaclass=WorkflowMeta):
@@ -87,16 +194,32 @@ class Workflow(metaclass=WorkflowMeta):
         - [RetryPolicy][workflows.retry_policy.RetryPolicy]
     """
 
-    # Populated by the metaclass; declared here for type checkers.
-    _step_functions: dict[str, StepFunction]
-    _step_functions_version: int = 0
+    # Class-level state (metaclass / per-class), NOT constructor fields.
+    _step_functions: ClassVar[dict[str, StepFunction]]
+    _step_functions_version: ClassVar[int] = 0
+    _child_workflow_slots_cache: ClassVar[dict[str, type] | None] = None
 
-    _runtime: Runtime
-    _workflow_name: str | None
+    # Phantom dataclass_transform fields for typed subclass constructors.
+    _timeout_arg: float | None = _config_field(alias="timeout", default=DEFAULT_TIMEOUT)
+    _disable_validation_arg: bool = _config_field(
+        alias="disable_validation", default=False
+    )
+    _verbose_arg: bool = _config_field(alias="verbose", default=False)
+    _resource_manager_arg: ResourceManager | None = _config_field(
+        alias="resource_manager", default=None
+    )
+    _num_concurrent_runs_arg: int | None = _config_field(
+        alias="num_concurrent_runs", default=None
+    )
+    _runtime_arg: Runtime | None = _config_field(alias="runtime", default=None)
+    _workflow_name_arg: str | None = _config_field(alias="workflow_name", default=None)
+    _skip_graph_checks_arg: set[WorkflowGraphCheck] | None = _config_field(
+        alias="skip_graph_checks", default=None
+    )
 
     def __init__(
         self,
-        timeout: float | None = 45.0,
+        timeout: float | None = DEFAULT_TIMEOUT,
         disable_validation: bool = False,
         verbose: bool = False,
         resource_manager: ResourceManager | None = None,
@@ -144,7 +267,7 @@ class Workflow(metaclass=WorkflowMeta):
         self._disable_validation = disable_validation
         self._num_concurrent_runs = num_concurrent_runs
         # Store explicit name (None means use computed name)
-        self._workflow_name = workflow_name
+        self._workflow_name: str | None = workflow_name
 
         step_configs = self._step_configs()
         cls_name = self.__class__.__name__
@@ -154,6 +277,8 @@ class Workflow(metaclass=WorkflowMeta):
         # Populated by _validate(); empty until a successful validation runs.
         self._catch_error_handlers: dict[str, CatchErrorHandler] = {}
         self._handler_for_step: dict[str, str] = {}
+        # Attached child-workflow instances, keyed by declared field name.
+        self._child_workflows: dict[str, Workflow] = {}
         self._events = _collect_events(step_configs)
         # Resource management
         self._resource_manager = resource_manager or ResourceManager()
@@ -175,9 +300,26 @@ class Workflow(metaclass=WorkflowMeta):
         self._skip_graph_checks: set[WorkflowGraphCheck] = checks
 
         # Runtime registration: explicit > context-scoped > basic_runtime
-        self._runtime = runtime if runtime is not None else get_current_runtime()
+        self._runtime: Runtime = (
+            runtime if runtime is not None else get_current_runtime()
+        )
         if self._verbose:
             self._runtime = VerboseDecorator(self._runtime)
+        # Tracking is deferred until subclass construction has finished.
+
+    def _finalize_construction(self) -> None:
+        """Attach declared children and track the workflow once."""
+        if not hasattr(self, "_runtime"):
+            # _runtime is the last attribute set by Workflow.__init__, so its
+            # absence means a subclass __init__ skipped super().__init__().
+            # __call__ runs this for every instance, so without the guard the
+            # next lines raise an opaque AttributeError on a private attribute.
+            raise WorkflowValidationError(
+                f"{type(self).__name__}.__init__ did not call super().__init__(). "
+                "Workflow subclasses with a custom __init__ must call "
+                "super().__init__(...) so the base workflow is initialized."
+            )
+        self._ensure_children_attached()
         # Register with runtime for tracking (no-op for BasicRuntime)
         self._runtime.track_workflow(self)
 
@@ -203,17 +345,73 @@ class Workflow(metaclass=WorkflowMeta):
         """The runtime this workflow is registered with."""
         return self._runtime
 
-    def _switch_runtime(self, new_runtime: Runtime) -> None:
-        if new_runtime is self._runtime:
+    def _switch_runtime(self, new_runtime: Runtime, *, register: bool = True) -> None:
+        """Reassign this workflow's runtime, propagating into children."""
+        if new_runtime is not self._runtime:
+            if self._runtime_locked:
+                raise RuntimeError(
+                    "Cannot reassign runtime after workflow has been launched"
+                )
+            self._runtime.untrack_workflow(self)
+            self._runtime = new_runtime
+            if register:
+                new_runtime.track_workflow(self)
+        # Descendants may have been attached after this node last switched.
+        for child in self._child_workflows.values():
+            was_locked = child._runtime_locked
+            child._runtime_locked = False
+            try:
+                child._switch_runtime(new_runtime, register=False)
+            finally:
+                child._runtime_locked = was_locked
+
+    @classmethod
+    def _get_child_workflow_slots(cls) -> dict[str, type]:
+        """Return ``{field_name: child_workflow_type}`` declared on this class.
+
+        Resolved from class annotations whose type is a ``Workflow`` subclass.
+        Cached per-class on first access.
+        """
+        cached = cls.__dict__.get("_child_workflow_slots_cache")
+        if cached is None:
+            cached = _resolve_child_slots(cls)
+            cls._child_workflow_slots_cache = cached
+        return cached
+
+    @property
+    def child_workflows(self) -> dict[str, Workflow]:
+        """Attached child-workflow instances, keyed by declared field name."""
+        return dict(self._child_workflows)
+
+    def _attach_child(self, name: str, child: Workflow) -> None:
+        """Wire a child workflow instance into this parent."""
+        if self._child_workflows.get(name) is child:
             return
-        if self._runtime_locked:
-            raise RuntimeError(
-                "Cannot reassign runtime after workflow has been launched"
+        if not isinstance(child, Workflow):
+            raise WorkflowValidationError(
+                f"Child workflow slot '{name}' on '{type(self).__name__}' must be "
+                f"a Workflow instance, got {type(child).__name__}."
             )
-        old = self._runtime
-        old.untrack_workflow(self)
-        self._runtime = new_runtime
-        new_runtime.track_workflow(self)
+        expected = type(self)._get_child_workflow_slots().get(name)
+        if expected is not None and not isinstance(child, expected):
+            raise WorkflowValidationError(
+                f"Child workflow slot '{name}' on '{type(self).__name__}' expects "
+                f"{expected.__name__}, got {type(child).__name__}."
+            )
+        _validate_includable_child(child, name)
+        child._switch_runtime(self._runtime)
+        child._runtime_locked = True
+        setattr(self, name, child)
+        self._child_workflows[name] = child
+
+    def _ensure_children_attached(self) -> None:
+        """Attach any declared child instances not yet wired in."""
+        for name in type(self)._get_child_workflow_slots():
+            if name in self._child_workflows:
+                continue
+            child = getattr(self, name, None)
+            if isinstance(child, Workflow):
+                self._attach_child(name, child)
 
     @property
     def workflow_name(self) -> str:
@@ -276,6 +474,18 @@ class Workflow(metaclass=WorkflowMeta):
         return {**get_steps_from_class(cls), **cls._step_functions}
 
     @classmethod
+    def _get_namespaced_steps_from_class(cls) -> dict[StepId, StepFunction]:
+        """Return class-declared steps keyed by namespaced ``StepId``."""
+        result: dict[StepId, StepFunction] = {
+            StepId((), name): func for name, func in cls._get_steps_from_class().items()
+        }
+        for field_name, child_type in cls._get_child_workflow_slots().items():
+            child_cls = cast("type[Workflow]", child_type)
+            for child_id, func in child_cls._get_namespaced_steps_from_class().items():
+                result[StepId((field_name, *child_id.namespace), child_id.name)] = func
+        return result
+
+    @classmethod
     def add_step(cls, func: StepFunction) -> None:
         """
         Adds a free function as step for this workflow instance.
@@ -297,6 +507,26 @@ class Workflow(metaclass=WorkflowMeta):
     def _get_steps(self) -> dict[str, StepFunction]:
         """Returns all the steps, whether defined as methods or free functions."""
         return {**get_steps_from_instance(self), **self.__class__._step_functions}
+
+    def _get_namespaced_steps(self) -> dict[StepId, StepFunction]:
+        """Return this workflow's steps keyed by namespaced ``StepId``."""
+        self._ensure_children_attached()
+        result: dict[StepId, StepFunction] = {
+            StepId((), name): func for name, func in self._get_steps().items()
+        }
+        for field_name, child in self._child_workflows.items():
+            for child_id, func in child._get_namespaced_steps().items():
+                result[StepId((field_name, *child_id.namespace), child_id.name)] = func
+        return result
+
+    def _namespace_instances(self) -> dict[tuple[str, ...], Workflow]:
+        """Map each namespace path to the workflow instance that owns it."""
+        self._ensure_children_attached()
+        result: dict[tuple[str, ...], Workflow] = {(): self}
+        for field_name, child in self._child_workflows.items():
+            for ns, inst in child._namespace_instances().items():
+                result[(field_name, *ns)] = inst
+        return result
 
     def _get_start_event_instance(
         self, start_event: StartEvent | None, **kwargs: Any
@@ -379,6 +609,8 @@ class Workflow(metaclass=WorkflowMeta):
         """
         from workflows.context import Context
 
+        self._ensure_children_attached()
+
         if not self._runtime_locked:
             # don't allow switching runtime after a workflow has been launched
             self._runtime_locked = True
@@ -446,6 +678,7 @@ class Workflow(metaclass=WorkflowMeta):
         validate_resources: bool = False,
         force: bool = False,
     ) -> bool:
+        self._ensure_children_attached()
         if self._disable_validation and not force:
             return False
         stale = self._validated_version != self.__class__._step_functions_version
@@ -454,6 +687,7 @@ class Workflow(metaclass=WorkflowMeta):
 
         # Inline import: ``representation`` transitively imports ``Workflow``.
         from .representation.validate import (
+            _validate_child_workflow_declarations,
             _validate_resource_configs,
             _validate_resources,
             _validate_workflow,
@@ -484,6 +718,14 @@ class Workflow(metaclass=WorkflowMeta):
                     "Resource validation failed:\n"
                     + "\n".join(f"  - {e}" for e in errors)
                 )
+
+        _validate_child_workflow_declarations(self)
+        for child in self._child_workflows.values():
+            child._validate(
+                validate_resource_configs=validate_resource_configs,
+                validate_resources=validate_resources,
+                force=force,
+            )
 
         self._validation_result = result.uses_hitl
         self._validated_version = self.__class__._step_functions_version

--- a/packages/llama-index-workflows/tests/test_child_workflow_validation.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_validation.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import pytest
+from workflows import Workflow, step
+from workflows.errors import WorkflowValidationError
+from workflows.events import StartEvent, StopEvent
+
+
+class ChildStart(StartEvent):
+    pass
+
+
+class ChildStop(StopEvent):
+    pass
+
+
+class OtherChildStop(StopEvent):
+    pass
+
+
+class FirstChild(Workflow):
+    @step
+    async def first(self, ev: ChildStart) -> ChildStop:
+        return ChildStop()
+
+
+class SecondChild(Workflow):
+    @step
+    async def second(self, ev: ChildStart) -> OtherChildStop:
+        return OtherChildStop()
+
+
+class ParentWithDuplicateChildStarts(Workflow):
+    first: FirstChild
+    second: SecondChild
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent()
+
+
+def test_duplicate_direct_child_start_event_validation_error() -> None:
+    wf = ParentWithDuplicateChildStarts(first=FirstChild(), second=SecondChild())
+
+    with pytest.raises(
+        WorkflowValidationError,
+        match=(
+            "Child workflows 'first' and 'second'.*"
+            "both accept StartEvent type 'ChildStart'"
+        ),
+    ):
+        wf.validate()
+
+
+class CycleAStart(StartEvent):
+    pass
+
+
+class CycleAStop(StopEvent):
+    pass
+
+
+class CycleBStart(StartEvent):
+    pass
+
+
+class CycleBStop(StopEvent):
+    pass
+
+
+class CycleA(Workflow):
+    @step
+    async def a_step(self, ev: CycleAStart) -> CycleAStop:
+        return CycleAStop()
+
+
+class CycleB(Workflow):
+    a: CycleA
+
+    @step
+    async def b_step(self, ev: CycleBStart) -> CycleBStop:
+        return CycleBStop()
+
+
+def test_child_workflow_type_cycle_validation_error() -> None:
+    CycleA.__annotations__["b"] = CycleB
+    CycleA._child_workflow_slots_cache = None
+    try:
+        with pytest.raises(
+            WorkflowValidationError,
+            match=("Child workflow type cycle detected: CycleA -> CycleB -> CycleA"),
+        ):
+            CycleA().validate()
+    finally:
+        CycleA.__annotations__.pop("b", None)
+        CycleA._child_workflow_slots_cache = None

--- a/packages/llama-index-workflows/tests/test_namespaced_state_builder.py
+++ b/packages/llama-index-workflows/tests/test_namespaced_state_builder.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Unit tests for namespaced-state stores and seed conversion."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+from workflows import Context, Workflow
+from workflows.context.serializers import JsonSerializer
+from workflows.context.state_store import (
+    BUNDLE_ROOT_KEY,
+    BUNDLE_VERSION,
+    BUNDLE_VERSION_KEY,
+    CHILD_STATES_KEY,
+    DictState,
+    InMemoryStateStore,
+    StateRecord,
+    build_namespaced_state,
+    join_state_bundle,
+    namespaced_seed_blob,
+    namespaced_seed_payload,
+    namespaced_state_types,
+    namespaced_underlying_state_type,
+    split_state_bundle,
+)
+from workflows.decorators import step
+from workflows.events import StartEvent, StopEvent
+
+
+class RootState(BaseModel):
+    root_value: str = ""
+
+
+class ChildStart(StartEvent):
+    payload: str = ""
+
+
+class ChildStop(StopEvent):
+    out: str = ""
+
+
+class Child(Workflow):
+    @step
+    async def run_child(self, ctx: Context, ev: ChildStart) -> ChildStop:
+        await ctx.store.set("child_value", ev.payload)
+        return ChildStop(out=ev.payload.upper())
+
+
+class Parent(Workflow):
+    child: Child
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> ChildStart:
+        return ChildStart(payload="hi")
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result=ev.out)
+
+
+class TypedParent(Workflow):
+    child: Child
+
+    @step
+    async def start(self, ctx: Context[RootState], ev: StartEvent) -> StopEvent:
+        await ctx.store.set("root_value", "typed")
+        return StopEvent(result="done")
+
+
+class Childless(Workflow):
+    @step
+    async def go(self, ctx: Context[RootState], ev: StartEvent) -> StopEvent:
+        await ctx.store.set("root_value", "x")
+        return StopEvent(result="done")
+
+
+def test_state_types_and_underlying_type_for_childless() -> None:
+    wf = Childless()
+    assert set(namespaced_state_types(wf)) == {()}
+    assert namespaced_underlying_state_type(wf) is RootState
+
+
+def test_state_types_and_underlying_type_for_child_ful() -> None:
+    wf = Parent(child=Child())
+    types = namespaced_state_types(wf)
+    assert set(types) == {(), ("child",)}
+    assert namespaced_underlying_state_type(wf) is DictState
+
+
+def test_single_namespace_view_resolves_to_underlying_flat() -> None:
+    wf = Childless()
+    underlying = InMemoryStateStore(RootState(root_value="x"))
+    namespaced = build_namespaced_state(wf, underlying, JsonSerializer())
+
+    assert namespaced.is_single_namespace
+    assert namespaced.view(()) is underlying
+    serializer = JsonSerializer()
+    assert namespaced.serialize_tree(serializer) == underlying.to_dict(serializer)
+    assert CHILD_STATES_KEY not in namespaced.serialize_tree(serializer)
+
+
+@pytest.mark.asyncio
+async def test_multi_namespace_serialize_tree_is_per_slot_nested() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    underlying = InMemoryStateStore(DictState())
+    namespaced = build_namespaced_state(wf, underlying, serializer)
+
+    assert not namespaced.is_single_namespace
+    await namespaced.view(()).set("root_value", "R")
+    await namespaced.view(("child",)).set("child_value", "C")
+
+    tree = namespaced.serialize_tree(serializer)
+    assert tree["state_data"]["_data"]["root_value"] == serializer.serialize("R")
+    child_states = tree[CHILD_STATES_KEY]
+    assert set(child_states) == {"child"}
+    assert child_states["child"]["_data"]["child_value"] == (serializer.serialize("C"))
+    assert "data" not in child_states["child"]
+    assert "state_type" not in child_states["child"]
+    assert "state_module" not in child_states["child"]
+
+
+@pytest.mark.asyncio
+async def test_seed_round_trip_rebuilds_slots() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    underlying = InMemoryStateStore(DictState())
+    namespaced = build_namespaced_state(wf, underlying, serializer)
+    await namespaced.view(()).set("root_value", "R")
+    await namespaced.view(("child",)).set("child_value", "C")
+
+    tree = namespaced.serialize_tree(serializer)
+
+    seed = namespaced_seed_payload(tree, serializer, child_ful=True)
+    assert seed is not None
+    assert seed == tree
+
+    rebuilt = build_namespaced_state(
+        wf, InMemoryStateStore.from_dict(seed, serializer), serializer
+    )
+    assert await rebuilt.view(()).get("root_value") == "R"
+    assert await rebuilt.view(("child",)).get("child_value") == "C"
+
+
+@pytest.mark.asyncio
+async def test_typed_root_round_trip_keeps_root_metadata_with_children() -> None:
+    wf = TypedParent(child=Child())
+    serializer = JsonSerializer()
+    underlying = InMemoryStateStore(RootState(root_value="initial"))
+    namespaced = build_namespaced_state(wf, underlying, serializer)
+
+    await namespaced.view(()).set("root_value", "R")
+    await namespaced.view(("child",)).set("child_value", "C")
+
+    tree = namespaced.serialize_tree(serializer)
+    assert tree["state_type"] == "RootState"
+    assert tree["state_module"] == __name__
+    assert CHILD_STATES_KEY in tree
+
+    rebuilt = build_namespaced_state(
+        wf, InMemoryStateStore.from_dict(tree, serializer), serializer
+    )
+    root_state = await rebuilt.view(()).get_state()
+    assert isinstance(root_state, RootState)
+    assert root_state.root_value == "R"
+    assert await rebuilt.view(("child",)).get("child_value") == "C"
+
+
+@pytest.mark.asyncio
+async def test_child_view_uses_standard_facade_operations() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = build_namespaced_state(wf, InMemoryStateStore(DictState()), serializer)
+    child_store = namespaced.view(("child",))
+
+    await child_store.set_state(DictState(_data={"a": 1}))
+    async with child_store.edit_state() as state:
+        state._data["b"] = 2
+    assert await child_store.get("a") == 1
+    assert await child_store.get("b") == 2
+
+    await child_store.clear()
+    assert await child_store.get("a", None) is None
+    assert await child_store.get("b", None) is None
+
+
+def test_seed_helpers_noop_for_childless_and_references() -> None:
+    serializer = JsonSerializer()
+    flat = InMemoryStateStore(RootState(root_value="x")).to_dict(serializer)
+    assert namespaced_seed_blob(flat, child_ful=False) is None
+    assert namespaced_seed_payload(flat, serializer, child_ful=False) is None
+    assert (
+        namespaced_seed_blob({"store_type": "postgres", "run_id": "r"}, child_ful=True)
+        is None
+    )
+    assert namespaced_seed_blob(None, child_ful=True) is None
+
+
+@pytest.mark.asyncio
+async def test_flat_childless_checkpoint_carries_root_state_into_child_ful_run() -> (
+    None
+):
+    serializer = JsonSerializer()
+    flat = InMemoryStateStore(DictState(_data={"counter": 5})).to_dict(serializer)
+    assert CHILD_STATES_KEY not in flat
+
+    blob = namespaced_seed_blob(flat, child_ful=True)
+    assert blob is not None
+    assert blob == flat
+
+    wf = Parent(child=Child())
+    rebuilt = build_namespaced_state(
+        wf, InMemoryStateStore.from_dict(blob, serializer), serializer
+    )
+    assert await rebuilt.view(()).get("counter") == 5
+    assert await rebuilt.view(("child",)).get("child_value", None) is None
+
+
+@pytest.mark.asyncio
+async def test_childless_dict_state_to_dict_stays_flat() -> None:
+    class W(Workflow):
+        @step
+        async def go(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            await ctx.store.set("k", "v")
+            return StopEvent(result="ok")
+
+    wf = W()
+    ctx = Context(wf)
+    await wf.run(ctx=ctx)
+
+    state = ctx.to_dict()["state"]
+    serializer = JsonSerializer()
+    assert state == {
+        "store_type": "in_memory",
+        "state_type": "DictState",
+        "state_module": "workflows.context.state_store",
+        "state_data": {"_data": {"k": serializer.serialize("v")}},
+    }
+    assert CHILD_STATES_KEY not in state
+
+
+@pytest.mark.asyncio
+async def test_childless_typed_state_to_dict_stays_flat() -> None:
+    wf = Childless()
+    ctx = Context(wf)
+    await wf.run(ctx=ctx)
+
+    state = ctx.to_dict()["state"]
+    assert state["store_type"] == "in_memory"
+    assert state["state_type"] == "RootState"
+    assert CHILD_STATES_KEY not in state
+    assert Context.from_dict(wf, ctx.to_dict()) is not None
+
+
+def test_seed_payload_matches_blob_dump() -> None:
+    serializer = JsonSerializer()
+    tree = {
+        "store_type": "in_memory",
+        "state_type": "DictState",
+        "state_module": "workflows.context.state_store",
+        "state_data": {"_data": {"root_value": serializer.serialize("R")}},
+        CHILD_STATES_KEY: {"child": {"_data": {}}},
+    }
+    blob = namespaced_seed_blob(tree, child_ful=True)
+    assert blob == tree
+    payload = namespaced_seed_payload(tree, serializer, child_ful=True)
+    assert payload == tree
+
+
+def test_bundle_split_join_appends_children_to_object_root() -> None:
+    root = StateRecord(
+        data={"_data": {"root_value": '"R"'}},
+        state_type="DictState",
+        state_module="workflows.context.state_store",
+    )
+    child = {"_data": {"child_value": '"C"'}}
+
+    bundle = split_state_bundle(root).model_copy(update={"children": {"child": child}})
+    joined = join_state_bundle(bundle)
+
+    assert joined.state_type == "DictState"
+    assert joined.data["_data"]["root_value"] == '"R"'
+    assert joined.data[CHILD_STATES_KEY]["child"] == child
+    split = split_state_bundle(joined)
+    assert split.root.data == {"_data": {"root_value": '"R"'}}
+    assert split.children["child"] == {"_data": {"child_value": '"C"'}}
+
+
+def test_bundle_split_join_wraps_opaque_root() -> None:
+    root = StateRecord(data="not-json", state_type="Opaque", state_module="app")
+    child = {"_data": {"child_value": '"C"'}}
+
+    bundle = split_state_bundle(root).model_copy(update={"children": {"child": child}})
+    joined = join_state_bundle(bundle)
+
+    assert isinstance(joined.data, str)
+    split = split_state_bundle(joined)
+    assert split.root.data == "not-json"
+    assert split.root.state_type == "Opaque"
+    assert split.children["child"] == {"_data": {"child_value": '"C"'}}
+
+    parsed = JsonSerializer().deserialize(joined.data)
+    assert parsed[BUNDLE_VERSION_KEY] == BUNDLE_VERSION
+    assert parsed[BUNDLE_ROOT_KEY] == "not-json"
+    assert parsed[CHILD_STATES_KEY]["child"] == child
+
+
+def test_bundle_split_accepts_previous_child_record_shape() -> None:
+    root = StateRecord(
+        data={
+            "_data": {"root_value": '"R"'},
+            CHILD_STATES_KEY: {
+                "child": {
+                    "data": {"_data": {"child_value": '"C"'}},
+                    "state_type": "DictState",
+                    "state_module": "workflows.context.state_store",
+                }
+            },
+        },
+        state_type="DictState",
+        state_module="workflows.context.state_store",
+    )
+
+    split = split_state_bundle(root)
+
+    assert split.root.data == {"_data": {"root_value": '"R"'}}
+    assert split.children["child"] == {"_data": {"child_value": '"C"'}}
+
+
+def test_bundle_split_keeps_compact_child_payload_with_state_data_key() -> None:
+    child_data = {"state_data": "user value", "other": "field"}
+    root = StateRecord(
+        data={
+            "_data": {"root_value": '"R"'},
+            CHILD_STATES_KEY: {"child": child_data},
+        },
+        state_type="DictState",
+        state_module="workflows.context.state_store",
+    )
+
+    split = split_state_bundle(root)
+
+    assert split.children["child"] == child_data
+
+
+@pytest.mark.asyncio
+async def test_child_first_write_stores_compact_json_child_and_root_metadata() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = build_namespaced_state(wf, InMemoryStateStore(DictState()), serializer)
+
+    await namespaced.view(("child",)).set("child_value", "C")
+
+    underlying = namespaced.underlying
+    assert isinstance(underlying, InMemoryStateStore)
+    record = underlying._memory_storage.load_sync()
+    assert record is not None
+    assert record.state_type == "DictState"
+    assert record.state_module == "workflows.context.state_store"
+    bundle = split_state_bundle(record)
+    assert bundle.children["child"]["_data"]["child_value"] == (
+        serializer.serialize("C")
+    )
+    assert "data" not in bundle.children["child"]

--- a/packages/llama-index-workflows/tests/test_namespaced_state_builder.py
+++ b/packages/llama-index-workflows/tests/test_namespaced_state_builder.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
-"""Unit tests for namespaced-state stores and seed conversion."""
+"""Unit tests for the per-namespace state router and seed distribution."""
 
 from __future__ import annotations
 
@@ -9,20 +9,15 @@ from pydantic import BaseModel
 from workflows import Context, Workflow
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import (
-    BUNDLE_ROOT_KEY,
-    BUNDLE_VERSION,
-    BUNDLE_VERSION_KEY,
     CHILD_STATES_KEY,
     DictState,
     InMemoryStateStore,
-    StateRecord,
+    NamespacedStateStores,
     build_namespaced_state,
-    join_state_bundle,
-    namespaced_seed_blob,
-    namespaced_seed_payload,
+    in_memory_namespace_factory,
+    namespaced_seed_payloads,
     namespaced_state_types,
     namespaced_underlying_state_type,
-    split_state_bundle,
 )
 from workflows.decorators import step
 from workflows.events import StartEvent, StopEvent
@@ -75,6 +70,12 @@ class Childless(Workflow):
         return StopEvent(result="done")
 
 
+def _namespaced(wf: Workflow, serializer: JsonSerializer) -> NamespacedStateStores:
+    """Build an in-memory per-namespace router for *wf*."""
+    types = namespaced_state_types(wf)
+    return build_namespaced_state(wf, in_memory_namespace_factory(types), serializer)
+
+
 def test_state_types_and_underlying_type_for_childless() -> None:
     wf = Childless()
     assert set(namespaced_state_types(wf)) == {()}
@@ -88,15 +89,15 @@ def test_state_types_and_underlying_type_for_child_ful() -> None:
     assert namespaced_underlying_state_type(wf) is DictState
 
 
-def test_single_namespace_view_resolves_to_underlying_flat() -> None:
+def test_single_namespace_router_is_flat() -> None:
     wf = Childless()
-    underlying = InMemoryStateStore(RootState(root_value="x"))
-    namespaced = build_namespaced_state(wf, underlying, JsonSerializer())
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
 
     assert namespaced.is_single_namespace
-    assert namespaced.view(()) is underlying
-    serializer = JsonSerializer()
-    assert namespaced.serialize_tree(serializer) == underlying.to_dict(serializer)
+    # view() is memoized per namespace.
+    assert namespaced.view(()) is namespaced.view(())
+    assert isinstance(namespaced.view(()), InMemoryStateStore)
     assert CHILD_STATES_KEY not in namespaced.serialize_tree(serializer)
 
 
@@ -104,8 +105,7 @@ def test_single_namespace_view_resolves_to_underlying_flat() -> None:
 async def test_multi_namespace_serialize_tree_is_per_slot_nested() -> None:
     wf = Parent(child=Child())
     serializer = JsonSerializer()
-    underlying = InMemoryStateStore(DictState())
-    namespaced = build_namespaced_state(wf, underlying, serializer)
+    namespaced = _namespaced(wf, serializer)
 
     assert not namespaced.is_single_namespace
     await namespaced.view(()).set("root_value", "R")
@@ -115,30 +115,39 @@ async def test_multi_namespace_serialize_tree_is_per_slot_nested() -> None:
     assert tree["state_data"]["_data"]["root_value"] == serializer.serialize("R")
     child_states = tree[CHILD_STATES_KEY]
     assert set(child_states) == {"child"}
-    assert child_states["child"]["_data"]["child_value"] == (serializer.serialize("C"))
+    assert child_states["child"]["_data"]["child_value"] == serializer.serialize("C")
+    # children carry only raw state_data, not a full record/payload.
     assert "data" not in child_states["child"]
     assert "state_type" not in child_states["child"]
     assert "state_module" not in child_states["child"]
 
 
 @pytest.mark.asyncio
+async def test_namespaces_are_isolated() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
+
+    await namespaced.view(()).set("shared_key", "root")
+    await namespaced.view(("child",)).set("shared_key", "child")
+
+    # Same path, different records: no cross-namespace bleed.
+    assert await namespaced.view(()).get("shared_key") == "root"
+    assert await namespaced.view(("child",)).get("shared_key") == "child"
+
+
+@pytest.mark.asyncio
 async def test_seed_round_trip_rebuilds_slots() -> None:
     wf = Parent(child=Child())
     serializer = JsonSerializer()
-    underlying = InMemoryStateStore(DictState())
-    namespaced = build_namespaced_state(wf, underlying, serializer)
+    namespaced = _namespaced(wf, serializer)
     await namespaced.view(()).set("root_value", "R")
     await namespaced.view(("child",)).set("child_value", "C")
 
     tree = namespaced.serialize_tree(serializer)
 
-    seed = namespaced_seed_payload(tree, serializer, child_ful=True)
-    assert seed is not None
-    assert seed == tree
-
-    rebuilt = build_namespaced_state(
-        wf, InMemoryStateStore.from_dict(seed, serializer), serializer
-    )
+    rebuilt = _namespaced(wf, serializer)
+    rebuilt.add_seed_tree(tree, serializer)
     assert await rebuilt.view(()).get("root_value") == "R"
     assert await rebuilt.view(("child",)).get("child_value") == "C"
 
@@ -147,8 +156,7 @@ async def test_seed_round_trip_rebuilds_slots() -> None:
 async def test_typed_root_round_trip_keeps_root_metadata_with_children() -> None:
     wf = TypedParent(child=Child())
     serializer = JsonSerializer()
-    underlying = InMemoryStateStore(RootState(root_value="initial"))
-    namespaced = build_namespaced_state(wf, underlying, serializer)
+    namespaced = _namespaced(wf, serializer)
 
     await namespaced.view(()).set("root_value", "R")
     await namespaced.view(("child",)).set("child_value", "C")
@@ -158,9 +166,8 @@ async def test_typed_root_round_trip_keeps_root_metadata_with_children() -> None
     assert tree["state_module"] == __name__
     assert CHILD_STATES_KEY in tree
 
-    rebuilt = build_namespaced_state(
-        wf, InMemoryStateStore.from_dict(tree, serializer), serializer
-    )
+    rebuilt = _namespaced(wf, serializer)
+    rebuilt.add_seed_tree(tree, serializer)
     root_state = await rebuilt.view(()).get_state()
     assert isinstance(root_state, RootState)
     assert root_state.root_value == "R"
@@ -171,7 +178,7 @@ async def test_typed_root_round_trip_keeps_root_metadata_with_children() -> None
 async def test_child_view_uses_standard_facade_operations() -> None:
     wf = Parent(child=Child())
     serializer = JsonSerializer()
-    namespaced = build_namespaced_state(wf, InMemoryStateStore(DictState()), serializer)
+    namespaced = _namespaced(wf, serializer)
     child_store = namespaced.view(("child",))
 
     await child_store.set_state(DictState(_data={"a": 1}))
@@ -185,16 +192,47 @@ async def test_child_view_uses_standard_facade_operations() -> None:
     assert await child_store.get("b", None) is None
 
 
-def test_seed_helpers_noop_for_childless_and_references() -> None:
-    serializer = JsonSerializer()
-    flat = InMemoryStateStore(RootState(root_value="x")).to_dict(serializer)
-    assert namespaced_seed_blob(flat, child_ful=False) is None
-    assert namespaced_seed_payload(flat, serializer, child_ful=False) is None
+def test_seed_payloads_none_for_empty_and_durable() -> None:
+    types = namespaced_state_types(Parent(child=Child()))
+    assert namespaced_seed_payloads(None, types) is None
+    assert namespaced_seed_payloads({}, types) is None
     assert (
-        namespaced_seed_blob({"store_type": "postgres", "run_id": "r"}, child_ful=True)
+        namespaced_seed_payloads({"store_type": "postgres", "run_id": "r"}, types)
         is None
     )
-    assert namespaced_seed_blob(None, child_ful=True) is None
+
+
+def test_seed_payloads_flat_childless_is_root_only() -> None:
+    serializer = JsonSerializer()
+    flat = InMemoryStateStore(DictState(_data={"counter": 5})).to_dict(serializer)
+    assert CHILD_STATES_KEY not in flat
+
+    seeds = namespaced_seed_payloads(flat, namespaced_state_types(Childless()))
+    assert seeds is not None
+    assert set(seeds) == {()}
+    assert seeds[()] == flat
+
+
+def test_seed_payloads_splits_children_per_namespace() -> None:
+    serializer = JsonSerializer()
+    tree = {
+        "store_type": "in_memory",
+        "state_type": "DictState",
+        "state_module": "workflows.context.state_store",
+        "state_data": {"_data": {"root_value": serializer.serialize("R")}},
+        CHILD_STATES_KEY: {
+            "child": {"_data": {"child_value": serializer.serialize("C")}}
+        },
+    }
+    types = namespaced_state_types(Parent(child=Child()))
+    seeds = namespaced_seed_payloads(tree, types)
+    assert seeds is not None
+    assert set(seeds) == {(), ("child",)}
+    assert CHILD_STATES_KEY not in seeds[()]
+    assert seeds[()]["state_data"]["_data"]["root_value"] == serializer.serialize("R")
+    child_seed = seeds[("child",)]
+    assert child_seed["store_type"] == "in_memory"
+    assert child_seed["state_data"]["_data"]["child_value"] == serializer.serialize("C")
 
 
 @pytest.mark.asyncio
@@ -205,14 +243,9 @@ async def test_flat_childless_checkpoint_carries_root_state_into_child_ful_run()
     flat = InMemoryStateStore(DictState(_data={"counter": 5})).to_dict(serializer)
     assert CHILD_STATES_KEY not in flat
 
-    blob = namespaced_seed_blob(flat, child_ful=True)
-    assert blob is not None
-    assert blob == flat
-
     wf = Parent(child=Child())
-    rebuilt = build_namespaced_state(
-        wf, InMemoryStateStore.from_dict(blob, serializer), serializer
-    )
+    rebuilt = _namespaced(wf, serializer)
+    rebuilt.add_seed_tree(flat, serializer)
     assert await rebuilt.view(()).get("counter") == 5
     assert await rebuilt.view(("child",)).get("child_value", None) is None
 
@@ -251,115 +284,3 @@ async def test_childless_typed_state_to_dict_stays_flat() -> None:
     assert state["state_type"] == "RootState"
     assert CHILD_STATES_KEY not in state
     assert Context.from_dict(wf, ctx.to_dict()) is not None
-
-
-def test_seed_payload_matches_blob_dump() -> None:
-    serializer = JsonSerializer()
-    tree = {
-        "store_type": "in_memory",
-        "state_type": "DictState",
-        "state_module": "workflows.context.state_store",
-        "state_data": {"_data": {"root_value": serializer.serialize("R")}},
-        CHILD_STATES_KEY: {"child": {"_data": {}}},
-    }
-    blob = namespaced_seed_blob(tree, child_ful=True)
-    assert blob == tree
-    payload = namespaced_seed_payload(tree, serializer, child_ful=True)
-    assert payload == tree
-
-
-def test_bundle_split_join_appends_children_to_object_root() -> None:
-    root = StateRecord(
-        data={"_data": {"root_value": '"R"'}},
-        state_type="DictState",
-        state_module="workflows.context.state_store",
-    )
-    child = {"_data": {"child_value": '"C"'}}
-
-    bundle = split_state_bundle(root).model_copy(update={"children": {"child": child}})
-    joined = join_state_bundle(bundle)
-
-    assert joined.state_type == "DictState"
-    assert joined.data["_data"]["root_value"] == '"R"'
-    assert joined.data[CHILD_STATES_KEY]["child"] == child
-    split = split_state_bundle(joined)
-    assert split.root.data == {"_data": {"root_value": '"R"'}}
-    assert split.children["child"] == {"_data": {"child_value": '"C"'}}
-
-
-def test_bundle_split_join_wraps_opaque_root() -> None:
-    root = StateRecord(data="not-json", state_type="Opaque", state_module="app")
-    child = {"_data": {"child_value": '"C"'}}
-
-    bundle = split_state_bundle(root).model_copy(update={"children": {"child": child}})
-    joined = join_state_bundle(bundle)
-
-    assert isinstance(joined.data, str)
-    split = split_state_bundle(joined)
-    assert split.root.data == "not-json"
-    assert split.root.state_type == "Opaque"
-    assert split.children["child"] == {"_data": {"child_value": '"C"'}}
-
-    parsed = JsonSerializer().deserialize(joined.data)
-    assert parsed[BUNDLE_VERSION_KEY] == BUNDLE_VERSION
-    assert parsed[BUNDLE_ROOT_KEY] == "not-json"
-    assert parsed[CHILD_STATES_KEY]["child"] == child
-
-
-def test_bundle_split_accepts_previous_child_record_shape() -> None:
-    root = StateRecord(
-        data={
-            "_data": {"root_value": '"R"'},
-            CHILD_STATES_KEY: {
-                "child": {
-                    "data": {"_data": {"child_value": '"C"'}},
-                    "state_type": "DictState",
-                    "state_module": "workflows.context.state_store",
-                }
-            },
-        },
-        state_type="DictState",
-        state_module="workflows.context.state_store",
-    )
-
-    split = split_state_bundle(root)
-
-    assert split.root.data == {"_data": {"root_value": '"R"'}}
-    assert split.children["child"] == {"_data": {"child_value": '"C"'}}
-
-
-def test_bundle_split_keeps_compact_child_payload_with_state_data_key() -> None:
-    child_data = {"state_data": "user value", "other": "field"}
-    root = StateRecord(
-        data={
-            "_data": {"root_value": '"R"'},
-            CHILD_STATES_KEY: {"child": child_data},
-        },
-        state_type="DictState",
-        state_module="workflows.context.state_store",
-    )
-
-    split = split_state_bundle(root)
-
-    assert split.children["child"] == child_data
-
-
-@pytest.mark.asyncio
-async def test_child_first_write_stores_compact_json_child_and_root_metadata() -> None:
-    wf = Parent(child=Child())
-    serializer = JsonSerializer()
-    namespaced = build_namespaced_state(wf, InMemoryStateStore(DictState()), serializer)
-
-    await namespaced.view(("child",)).set("child_value", "C")
-
-    underlying = namespaced.underlying
-    assert isinstance(underlying, InMemoryStateStore)
-    record = underlying._memory_storage.load_sync()
-    assert record is not None
-    assert record.state_type == "DictState"
-    assert record.state_module == "workflows.context.state_store"
-    bundle = split_state_bundle(record)
-    assert bundle.children["child"]["_data"]["child_value"] == (
-        serializer.serialize("C")
-    )
-    assert "data" not in bundle.children["child"]


### PR DESCRIPTION
Two things on `main` block hosting workflow-typed child attributes cleanly. Workflow construction tracks an instance with the runtime before subclass `__init__` finishes, so attaching child workflows races registration. And state persistence exposes a single root store per run, so child state has nowhere to live without threading namespace logic through every storage adapter.

This branch adds the groundwork for child workflows. It is foundation only — the namespaced layer is not wired into `Context`/`Runtime` yet.

## Child-workflow construction and validation

- Workflow construction finalizes after subclass `__init__`, then tracks with the runtime once child attributes are attached.
- Declared child slots are resolved from workflow-typed annotations, validated, propagated to the runtime, and exposed through namespaced step IDs.

## Per-namespace state records

State is keyed by `(run_id, namespace)` — each namespace routes `get`/`set`/`edit_state` through a normal `StateStoreFacade` over its own backing record. There is no shared record and no cross-namespace lock; two namespaces never read-modify-write the same row. (An earlier iteration of this branch packed root + children into one record behind an in-process `asyncio.Lock`; that bundle and its lock are gone.)

`namespace` threads through `create_state_store`/`_build_state_store` with `()` as the default root, and the per-run facade cache is re-keyed to `(run_id, namespace)`. The root namespace `""` is byte-identical to today's single row, so childless runs and existing serialized state are unchanged.

The durable backends gain a `namespace` column instead of splicing children into the root blob:

```sql
-- before: one row per run
SELECT state_json FROM workflow_state WHERE run_id = $1;

-- after: one row per (run_id, namespace); root namespace = ''
SELECT state_json FROM workflow_state WHERE run_id = $1 AND namespace = $2;
```

Migrations are additive: a `namespace` column defaulting to `''` and a repointed `(run_id, namespace)` primary key (Postgres alters in place; SQLite rebuilds the table since it can't alter a PK). A row written under the pre-migration schema reads back as the root namespace. `copy_from_handle` copies every namespace of the source run in one `run_id`-scoped statement.

State records are still never garbage-collected — per-namespace multiplies a childful run's row count but adds no new category of leak. Documented in `architecture-docs/server-architecture.md`.