### PR TITLE
Document child workflows and regroup the workflow guide

### DIFF
--- a/docs/src/content/docs/llamaagents/workflows/async_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/async_workflows.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 15
+  order: 4
 title: Writing async workflows
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/child_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/child_workflows.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 4
+  order: 5.5
 title: Child workflows
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/child_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/child_workflows.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 5.5
+  order: 8
 title: Child workflows
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/child_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/child_workflows.md
@@ -1,0 +1,108 @@
+---
+sidebar:
+  order: 4
+title: Child workflows
+---
+
+As a workflow grows, you often find a chunk of it that stands on its own. A document pipeline has an extraction phase, a research agent has a single-question loop, a report builder has a section it runs once per heading. You could paste those steps into the parent, but then you maintain two copies and they drift. A child workflow lets you keep that piece as its own workflow and drop it into a bigger one as a single unit.
+
+The child runs as part of the parent, but it keeps its own steps, its own state, and its own event routing. You can also run it on its own, unchanged. Nothing about being a child changes how the workflow behaves when you run it directly.
+
+## Declaring a child
+
+A parent declares a child as a typed field on the class. The field name is up to you, and the type is the child workflow class:
+
+```python
+from workflows import Workflow, step
+from workflows.events import StartEvent, StopEvent
+
+
+class SummarizeStart(StartEvent):
+    text: str = ""
+
+
+class SummarizeStop(StopEvent):
+    summary: str = ""
+
+
+class Summarize(Workflow):
+    @step
+    async def run(self, ev: SummarizeStart) -> SummarizeStop:
+        return SummarizeStop(summary=ev.text[:100])
+
+
+class Report(Workflow):
+    summarize: Summarize
+
+    @step
+    async def start(self, ev: StartEvent) -> SummarizeStart:
+        return SummarizeStart(text="a long document...")
+
+    @step
+    async def finish(self, ev: SummarizeStop) -> StopEvent:
+        return StopEvent(result=ev.summary)
+```
+
+You pass the child in when you construct the parent:
+
+```python
+report = Report(summarize=Summarize())
+result = await report.run()
+```
+
+The `summarize: Summarize` annotation generates a constructor that asks for the child, so `Report(summarize=Summarize())` type-checks the same as the base config arguments like `timeout`. If you would rather build the child yourself, write your own `__init__` and assign `self.summarize = Summarize()` after calling `super().__init__()`. Either way the child is wired in by the time construction finishes.
+
+## The start and stop boundary
+
+A child used inside a parent must define its own `StartEvent` subclass and `StopEvent` subclass. That is what makes it addressable. The parent starts the child by emitting the child's `StartEvent`, and the child hands control back by emitting its `StopEvent`, which the parent receives as an ordinary event.
+
+In the example above, `start` returns a `SummarizeStart`, which runs the child. The child finishes with a `SummarizeStop`, and the parent's `finish` step picks it up like any other event. The child's stop does not end the run. Only the root workflow's `StopEvent` does that, so the parent stays in control of when the whole thing is done.
+
+A child that uses the bare `StartEvent` or `StopEvent` is rejected when you construct the parent, because there would be no distinct event type to route to it.
+
+## Nesting
+
+A child can have children of its own. The boundary rule is the same at every level: each workflow defines its own start and stop events, the parent emits the start, and the stop comes back as a routable event one level up.
+
+```python
+top = Top(mid=Mid(grand=Grand()))
+```
+
+## Isolation
+
+Each workflow in the tree runs in its own namespace, so a child and its parent stay out of each other's way in two places.
+
+State is separate. A child's `ctx.store` is its own. Keys the parent writes are not visible inside the child, and keys the child writes do not leak back into the parent. The handler's store, after the run, holds only the root workflow's state.
+
+Event routing stays within a namespace. If the same event type is used in both the parent and a child, the parent's copy routes to the parent's steps and the child's copy routes to the child's steps. They never cross.
+
+```python
+class SharedMid(Event):
+    tag: str = ""
+
+# The parent emits SharedMid(tag="parent") and the child emits
+# SharedMid(tag="child"). Each one is only seen by steps in the workflow
+# that produced it.
+```
+
+This is what lets you compose two workflows that were written separately without auditing them for event-name collisions.
+
+## Streaming child events
+
+By default, a parent's `stream_events()` shows only the parent's own streamed events. Events written from inside a child are hidden, so a consumer that already streams a parent keeps seeing the same thing after you add a child to it.
+
+To see the child's events too, pass `include_children=True`. The child's events come through tagged with the namespace path of the child that produced them, which you can read with `get_event_origin_namespace`:
+
+```python
+from workflows.events import get_event_origin_namespace
+
+handler = report.run()
+async for ev in handler.stream_events(include_children=True):
+    namespace = get_event_origin_namespace(ev)  # () for the parent, ("summarize",) for the child
+    print(namespace, ev)
+await handler
+```
+
+## Configuration
+
+A `timeout` set on a child is honored as a deadline for that child's own execution. Other run-level settings like `verbose` only apply to the workflow you actually run, so setting them on a nested child does nothing. Attaching a child that carries one of those dead settings emits a warning that names it, so it does not silently get ignored.

--- a/docs/src/content/docs/llamaagents/workflows/client.md
+++ b/docs/src/content/docs/llamaagents/workflows/client.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 16
+  order: 18
 title: Python Client
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/client.md
+++ b/docs/src/content/docs/llamaagents/workflows/client.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 13
+  order: 16
 title: Python Client
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 5
+  order: 3
 title: Concurrent execution of workflows
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
+++ b/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
@@ -1,11 +1,11 @@
 ---
 sidebar:
   order: 9
-title: Customizing entry and exit points
+title: Custom start and stop events
 ---
 
-Most of the times, relying on the default entry and exit points we have seen in the [Getting Started](/python/llamaagents/workflows/) section is enough.
-However, workflows support custom events where you normally would expect `StartEvent` and `StopEvent`, let's see how.
+Most of the time, the default `StartEvent` and `StopEvent` we have seen in the [Getting Started](/python/llamaagents/workflows/) section are enough.
+But you can define your own start and stop events where you would normally expect `StartEvent` and `StopEvent`, let's see how.
 
 ## Using a custom `StartEvent`
 

--- a/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
+++ b/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 9
+  order: 7
 title: Custom start and stop events
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
+++ b/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 7
+  order: 9
 title: Customizing entry and exit points
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/deployment.md
+++ b/docs/src/content/docs/llamaagents/workflows/deployment.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 15
+  order: 17
 title: Run Your Workflow as a Server
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/deployment.md
+++ b/docs/src/content/docs/llamaagents/workflows/deployment.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 12
+  order: 15
 title: Run Your Workflow as a Server
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/drawing.md
+++ b/docs/src/content/docs/llamaagents/workflows/drawing.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 8
+  order: 18
 title: Drawing a Workflow
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/drawing.md
+++ b/docs/src/content/docs/llamaagents/workflows/drawing.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 18
+  order: 15
 title: Drawing a Workflow
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
+++ b/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 6
+  order: 12
 title: Human in the Loop
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/managing_state.md
+++ b/docs/src/content/docs/llamaagents/workflows/managing_state.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 3
+  order: 6
 title: Managing State
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 15
+  order: 17
 title: Observability
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 17
+  order: 16
 title: Observability
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/resources.md
+++ b/docs/src/content/docs/llamaagents/workflows/resources.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 9
+  order: 7
 title: Resource Objects
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/resources.md
+++ b/docs/src/content/docs/llamaagents/workflows/resources.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 7
+  order: 9
 title: Resource Objects
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/retry_steps.md
+++ b/docs/src/content/docs/llamaagents/workflows/retry_steps.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 10
+  order: 11
 title: Error handling
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/streaming.mdx
+++ b/docs/src/content/docs/llamaagents/workflows/streaming.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 4
+  order: 5
 title: Streaming events
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
+++ b/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 11
+  order: 10
 title: Workflows from unbound functions
 ---
 


### PR DESCRIPTION
Two things in the workflows guide.

## Child workflows page

The guide covers looping, branching, concurrency, and state, but nothing on composing one workflow inside another. The child workflows feature adds that, so there's a new `workflows/child_workflows.md` covering:

- declaring a child as a typed class field (`summarize: Summarize`) and the synthesized constructor that asks for it
- the start/stop boundary: a child needs its own `StartEvent`/`StopEvent` subclasses, the parent triggers it by emitting the child's start, and the child's stop comes back as a routable parent event without ending the run
- nesting children, and namespace isolation of both state and event routing (shared event types stay within their namespace)
- streaming, where child events are hidden by default and `stream_events(include_children=True)` surfaces them tagged via `get_event_origin_namespace`
- which run-level config a nested child honors (`timeout`) versus ignores (`verbose`)

This documents the feature on the child workflows branch; it should land with or after that.

## Sidebar regroup

The page orders had grown ad hoc, with two pairs colliding (`client`/`durable_workflows` at 13, `async_workflows`/`observability` at 15) and topics scattered. Regrouped into four conceptual sections, ordered by `sidebar.order` only (no folders, so no redirects):

- **Introduction** (1): the model plus one runnable example
- **Core workflow features** (2-12): branches and loops, concurrent execution, async, streaming, managing state, custom start and stop events, child workflows, resources, unbound functions, error handling, human in the loop
- **Beyond scripting** (13-16): durable workflows, DBOS, drawing, observability
- **Running as a service** (17-18): server, Python client

Also renames the "Customizing entry and exit points" page to "Custom start and stop events", since that's the actual terminology it teaches. Filename is unchanged.