### PR TITLE
Regroup the workflows guide sidebar

### DIFF
--- a/docs/src/content/docs/llamaagents/workflows/async_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/async_workflows.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 15
+  order: 4
 title: Writing async workflows
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/client.md
+++ b/docs/src/content/docs/llamaagents/workflows/client.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 13
+  order: 18
 title: Python Client
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 5
+  order: 3
 title: Concurrent execution of workflows
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
+++ b/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
@@ -1,11 +1,11 @@
 ---
 sidebar:
   order: 7
-title: Customizing entry and exit points
+title: Custom start and stop events
 ---
 
-Most of the times, relying on the default entry and exit points we have seen in the [Getting Started](/python/llamaagents/workflows/) section is enough.
-However, workflows support custom events where you normally would expect `StartEvent` and `StopEvent`, let's see how.
+Most of the time, the default `StartEvent` and `StopEvent` we have seen in the [Getting Started](/python/llamaagents/workflows/) section are enough.
+But you can define your own start and stop events where you would normally expect `StartEvent` and `StopEvent`, let's see how.
 
 ## Using a custom `StartEvent`
 

--- a/docs/src/content/docs/llamaagents/workflows/deployment.md
+++ b/docs/src/content/docs/llamaagents/workflows/deployment.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 12
+  order: 17
 title: Run Your Workflow as a Server
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/drawing.md
+++ b/docs/src/content/docs/llamaagents/workflows/drawing.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 8
+  order: 15
 title: Drawing a Workflow
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
+++ b/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 6
+  order: 12
 title: Human in the Loop
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/managing_state.md
+++ b/docs/src/content/docs/llamaagents/workflows/managing_state.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 3
+  order: 6
 title: Managing State
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 15
+  order: 16
 title: Observability
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/retry_steps.md
+++ b/docs/src/content/docs/llamaagents/workflows/retry_steps.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 10
+  order: 11
 title: Error handling
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/streaming.mdx
+++ b/docs/src/content/docs/llamaagents/workflows/streaming.mdx
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 4
+  order: 5
 title: Streaming events
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
+++ b/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 11
+  order: 10
 title: Workflows from unbound functions
 ---
 


### PR DESCRIPTION
The workflow page orders had grown ad hoc. Two pairs collided (`client`/`durable_workflows` both at 13, `async_workflows`/`observability` both at 15), and related topics were scattered across the sidebar. This renumbers them into four conceptual sections. Ordering only, via `sidebar.order`. No folders, so no redirects.

- **Introduction** (1): the model plus one runnable example
- **Core workflow features** (2-12): branches and loops, concurrent execution, async, streaming, managing state, custom start and stop events, resources, unbound functions, error handling, human in the loop
- **Beyond scripting** (13-16): durable workflows, DBOS, drawing, observability
- **Running as a service** (17-18): server, Python client

Order 8 is left open for the child workflows page, which lands in its own PR.

Also renames the "Customizing entry and exit points" page to "Custom start and stop events", since custom `StartEvent`/`StopEvent` subclasses are what it actually teaches. Filename is unchanged.