### PR TITLE
Add isolated in-process child workflow runs

### DIFF
--- a/.changeset/child-workflows.md
+++ b/.changeset/child-workflows.md
@@ -1,0 +1,12 @@
+---
+"llama-index-workflows": minor
+"llama-agents-agentcore": patch
+"llama-agents-server": patch
+"llama-agents-dbos": patch
+---
+
+Add in-process child workflow composition with typed child declarations, namespaced execution, per-child state, catch-error recovery, timeouts, and opt-in child event streaming.
+
+Annotated Workflow attributes are only auto-attached when they use the typed child workflow contract, so existing manual composition with bare StartEvent/StopEvent workflows remains compatible.
+
+Update server, DBOS, and AgentCore runtime adapter compatibility for namespaced step IDs and state-store access.

--- a/.changeset/per-namespace-state-records.md
+++ b/.changeset/per-namespace-state-records.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-server": patch
+---
+
+Store workflow state as one record per (run_id, namespace) instead of a single bundled record per run. Adds an additive migration that introduces a namespace column defaulting to the root namespace, so existing rows are unchanged.

--- a/architecture-docs/server-architecture.md
+++ b/architecture-docs/server-architecture.md
@@ -65,6 +65,12 @@ Two implementations:
 - **`SqliteWorkflowStore`** — SQLite-backed. Survives restarts.
   [`sqlite_workflow_store.py`](../packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py)
 
+### State records are keyed by `(run_id, namespace)`
+
+State persists as one record per `(run_id, namespace)`, not one bundled record per run. The root namespace is `""` (a childless run is exactly one root record, byte-identical to the pre-namespace single row); child workflows get their own records under their namespace key. Whole-run operations stay run-keyed — copy and the in-process facade cache eviction both filter on `run_id` alone, so they span every namespace in one pass.
+
+**No automatic state GC.** State records are never deleted today — there is no `DELETE FROM workflow_state`, no cascade from handler/event deletion, and no TTL. Per-namespace records multiply a childful run's footprint by the number of namespaces but add no new *category* of leak. A retention policy is future work; until then, state accumulates per run.
+
 ## Resumable Event Streams
 
 Events flow from step functions to clients through the store, which acts as both a write-ahead log and a subscription source:

--- a/packages/llama-agents-agentcore/pyproject.toml
+++ b/packages/llama-agents-agentcore/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
   "boto3>=1.42.75",
   "llama-agents-core>=0.5.0",
   "llama-agents-appserver>=0.5.0",
-  "llama-agents-server>=0.2.0",
+  "llama-agents-server>=0.6.1",
+  "llama-index-workflows>=2.22.0,<3.0.0",
   "click>=8.3.1"
 ]
 
@@ -34,3 +35,4 @@ module-name = "llama_agents.agentcore"
 [tool.uv.sources]
 llama-agents-core = {workspace = true}
 llama-agents-appserver = {workspace = true}
+llama-index-workflows = {workspace = true}

--- a/packages/llama-agents-agentcore/src/llama_agents/agentcore/_runtime_decorator.py
+++ b/packages/llama-agents-agentcore/src/llama_agents/agentcore/_runtime_decorator.py
@@ -18,6 +18,7 @@ from workflows.runtime.types.step_function import (
     as_step_worker_functions,
     create_workflow_run_function,
 )
+from workflows.runtime.types.step_id import StepId
 
 _P = ParamSpec("_P")
 _R = TypeVar("_R")
@@ -81,7 +82,7 @@ class AgentCoreRuntimeDecorator(ServerRuntimeDecorator):
         name = workflow.workflow_name
         if name not in self._tracked:
             self._tracked[name] = workflow
-        wrapped_steps: dict[str, StepWorkerFunction] = {
+        wrapped_steps: dict[StepId, StepWorkerFunction] = {
             step_name: as_agentcore_async_task(self.app, f"{name}.{step_name}", step)
             for step_name, step in as_step_worker_functions(workflow).items()
         }

--- a/packages/llama-agents-dbos/pyproject.toml
+++ b/packages/llama-agents-dbos/pyproject.toml
@@ -24,8 +24,8 @@ license = "MIT"
 requires-python = ">=3.10"
 dependencies = [
   "dbos>=2.18.0",
-  "llama-agents-server[asyncpg]>=0.5.1",
-  "llama-index-workflows>=2.21.0,<3.0.0"
+  "llama-agents-server[asyncpg]>=0.6.1",
+  "llama-index-workflows>=2.22.0,<3.0.0"
 ]
 
 [tool.basedpyright]

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -85,6 +85,7 @@ from workflows.runtime.types.step_function import (
     as_step_worker_functions,
     create_workflow_run_function,
 )
+from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import WorkflowTick
 from workflows.workflow import Workflow
 
@@ -144,20 +145,24 @@ class DBOSWorkflowStore(AbstractWorkflowStore):
         state_type: type[Any] | None = None,
         serialized_state: dict[str, Any] | None = None,
         serializer: BaseSerializer | None = None,
+        namespace: tuple[str, ...] = (),
     ) -> StateStore[Any]:
         # Delegate the whole template method so memoization lives in the
         # inner store's single cache (the proxy's own cache stays unused).
         return self._resolve().create_state_store(
-            run_id, state_type, serialized_state, serializer
+            run_id, state_type, serialized_state, serializer, namespace
         )
 
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> StateStoreFacade[Any]:
-        return self._resolve()._build_state_store(run_id, state_type, serializer)
+        return self._resolve()._build_state_store(
+            run_id, namespace, state_type, serializer
+        )
 
     async def query(self, query: HandlerQuery) -> list[PersistentHandler]:
         return await self._resolve().query(query)
@@ -281,6 +286,8 @@ class DBOSRuntime(Runtime):
     State is persisted to the database using SQL state stores,
     enabling state recovery across process restarts.
     """
+
+    _supports_child_workflows = False
 
     def __init__(self, **kwargs: Unpack[DBOSRuntimeConfig]) -> None:
         """Initialize the DBOS runtime.
@@ -416,7 +423,7 @@ class DBOSRuntime(Runtime):
             return await workflow_run_fn(init_state, start_event, tags)
 
         # Wrap steps with stable names
-        wrapped_steps: dict[str, StepWorkerFunction] = {
+        wrapped_steps: dict[StepId, StepWorkerFunction] = {
             step_name: DBOS.step(name=f"{name}.{step_name}")(step)
             for step_name, step in as_step_worker_functions(workflow).items()
         }
@@ -1152,7 +1159,9 @@ class InternalDBOSAdapter(InternalRunAdapter):
                 )
         return self._state_store
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return self._get_or_create_state_store()
 
     def is_replaying(self) -> bool:

--- a/packages/llama-agents-dbos/tests/test_dbos_idle_release.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_idle_release.py
@@ -80,7 +80,9 @@ class StubInternalAdapter(InternalRunAdapter):
     async def close(self) -> None:
         self.closed = True
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return None
 
 
@@ -107,7 +109,9 @@ class StubExternalAdapter(ExternalRunAdapter):
     async def get_result(self) -> StopEvent:
         return self._result
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return None
 
 
@@ -820,7 +824,7 @@ async def test_do_resume_carries_over_serialized_state(
 
     # Seed the state store with actual state data
     state_store = InMemoryStateStore(MyState(counter=42))
-    store.state_stores["run-1"] = state_store
+    store.state_stores[("run-1", ())] = state_store
 
     claim = await _claim_resume(lifecycle)
     await decorator._do_resume("run-1", resume_claim=claim)

--- a/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
+++ b/packages/llama-agents-integration-tests/src/llama_agents_integration_tests/fake_agent_data.py
@@ -210,6 +210,7 @@ def create_agent_data_state_store(
     monkeypatch: pytest.MonkeyPatch,
     run_id: str,
     state_type: type[Any] | None = None,
+    namespace: tuple[str, ...] = (),
 ) -> AgentDataStateStore[Any]:
     """Create an AgentDataStateStore with httpx patched to use the fake backend."""
     client = AgentDataClient(
@@ -222,6 +223,7 @@ def create_agent_data_state_store(
     store = AgentDataStateStore(
         client=client,
         run_id=run_id,
+        namespace=namespace,
         state_type=state_type,
     )
     return store

--- a/packages/llama-agents-integration-tests/tests/test_state_store_matrix.py
+++ b/packages/llama-agents-integration-tests/tests/test_state_store_matrix.py
@@ -116,12 +116,14 @@ async def _create_postgres_pool(dsn: str) -> asyncpg.Pool:
         await conn.execute("CREATE SCHEMA IF NOT EXISTS dbos")
         await conn.execute("""
             CREATE TABLE IF NOT EXISTS dbos.workflow_state (
-                run_id VARCHAR(255) PRIMARY KEY,
+                run_id VARCHAR(255) NOT NULL,
+                namespace VARCHAR(255) NOT NULL DEFAULT '',
                 state_json TEXT NOT NULL,
                 state_type VARCHAR(255),
                 state_module VARCHAR(255),
                 created_at TIMESTAMPTZ,
-                updated_at TIMESTAMPTZ
+                updated_at TIMESTAMPTZ,
+                PRIMARY KEY (run_id, namespace)
             )
         """)
     return pool

--- a/packages/llama-agents-server/pyproject.toml
+++ b/packages/llama-agents-server/pyproject.toml
@@ -24,7 +24,7 @@ description = "HTTP server for deploying and serving LlamaIndex workflows as web
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-  "llama-index-workflows>=2.21.0,<3.0.0",
+  "llama-index-workflows>=2.22.0,<3.0.0",
   "llama-agents-client>=0.2.0",
   "starlette>=0.39.0",
   "uvicorn>=0.32.0",

--- a/packages/llama-agents-server/src/llama_agents/server/_runtime/server_runtime.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_runtime/server_runtime.py
@@ -77,7 +77,7 @@ class _ServerInternalRunAdapter(BaseInternalRunAdapterDecorator):
         self._write_lock: asyncio.Lock | None = None
 
     @override
-    def get_state_store(self) -> StateStore[Any]:
+    def get_state_store(self, namespace: tuple[str, ...] = ()) -> StateStore[Any]:
         if self._state_store is not None:
             return self._state_store
         initial = self._runtime._initial_state.pop(self.run_id, None)
@@ -160,6 +160,8 @@ class ServerRuntimeDecorator(BaseRuntimeDecorator):
     workflow store, for integration with the WorkflowService for querying
     workflow run state.
     """
+
+    _supports_child_workflows = False
 
     def __init__(
         self,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/abstract_workflow_store.py
@@ -116,9 +116,9 @@ class AbstractWorkflowStore(ABC):
         # Weak-valued by default so facades die with their last consumer.
         # Backends needing a different lifecycle (strong refs + explicit
         # eviction) assign a plain dict in their __init__.
-        self._state_store_cache: MutableMapping[str, StateStoreFacade[Any]] = (
-            weakref.WeakValueDictionary()
-        )
+        self._state_store_cache: MutableMapping[
+            tuple[str, tuple[str, ...]], StateStoreFacade[Any]
+        ] = weakref.WeakValueDictionary()
 
     async def start(self) -> None:
         """Initialize backend resources. Default is a no-op."""
@@ -129,18 +129,22 @@ class AbstractWorkflowStore(ABC):
         state_type: type[Any] | None = None,
         serialized_state: dict[str, Any] | None = None,
         serializer: BaseSerializer | None = None,
+        namespace: tuple[str, ...] = (),
     ) -> StateStore[Any]:
-        """Return the per-run state store, creating and caching it on first use.
+        """Return the per-(run, namespace) state store, caching on first use.
 
-        One facade per run per process, so its write lock is a real guarantee.
-        If *serialized_state* is provided, it is staged as a seed on the
-        (possibly already handed-out) facade: validation is eager, the I/O to
-        materialize it stays lazy (first async state access or handoff).
+        Namespace is a key dimension alongside ``run_id``: the default ``()``
+        is the root namespace and reproduces the single-record behavior. One
+        facade per (run, namespace) per process, so its write lock is a real
+        guarantee. If *serialized_state* is provided, it is staged as a seed on
+        the (possibly already handed-out) facade: validation is eager, the I/O
+        to materialize it stays lazy (first async state access or handoff).
         """
-        store = self._state_store_cache.get(run_id)
+        cache_key = (run_id, namespace)
+        store = self._state_store_cache.get(cache_key)
         if store is None:
-            store = self._build_state_store(run_id, state_type, serializer)
-            self._state_store_cache[run_id] = store
+            store = self._build_state_store(run_id, namespace, state_type, serializer)
+            self._state_store_cache[cache_key] = store
         elif state_type is not None and store.state_type is DictState:
             # An earlier type-less caller (e.g. handler continuation) must
             # not shadow the workflow's concrete state type.
@@ -149,14 +153,20 @@ class AbstractWorkflowStore(ABC):
             store.add_seed(serialized_state, serializer or JsonSerializer())
         return store
 
+    def _evict_run_state_stores(self, run_id: str) -> None:
+        """Drop every cached namespace facade for *run_id* (all namespaces)."""
+        for key in [k for k in self._state_store_cache if k[0] == run_id]:
+            self._state_store_cache.pop(key, None)
+
     @abstractmethod
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> StateStoreFacade[Any]:
-        """Construct the backend facade for a run. No caching, no seeding."""
+        """Construct the backend facade for a (run, namespace). No caching."""
 
     @abstractmethod
     async def query(self, query: HandlerQuery) -> list[PersistentHandler]: ...

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_state_store.py
@@ -26,9 +26,14 @@ _FIELD_RUN_ID = "run_id"
 
 
 class _AgentDataStateRecord(BaseModel):
-    """Validates the shape persisted in the Agent Data API."""
+    """Validates the shape persisted in the Agent Data API.
+
+    ``namespace`` defaults to ``""`` so pre-namespace items (which carry no
+    namespace field) read back as the root namespace.
+    """
 
     run_id: str
+    namespace: str = ""
     data: str
     state_type: str | None = None
     state_module: str | None = None
@@ -55,10 +60,14 @@ class _AgentDataStateStorage:
         *,
         client: AgentDataClient,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         collection: str = "workflow_state",
     ) -> None:
         self._client = client
         self._run_id = run_id
+        self._namespace = namespace
+        # Persisted key: () -> "" (today's single root item), ("child",) -> "child".
+        self._namespace_key = "/".join(namespace)
         self._collection = collection
         self._item_id: str | None = None
 
@@ -71,16 +80,29 @@ class _AgentDataStateStorage:
         # HTTP-backed: no per-call connections, the storage scopes itself.
         yield self
 
-    async def _load_record(self) -> _AgentDataStateRecord | None:
+    async def _matching_item(self) -> tuple[str, _AgentDataStateRecord] | None:
+        """Find this namespace's item among the run's items.
+
+        Filtering is by ``run_id`` (the Agent Data API has no range op), then
+        the namespace is matched in Python — so pre-namespace items, which
+        lack the field, read back as the root namespace (``""``).
+        """
         items = await self._client.search(
             self._collection,
             {_FIELD_RUN_ID: {"eq": self._run_id}},
-            page_size=1,
         )
-        if not items:
+        for item in items:
+            record = _AgentDataStateRecord.model_validate(item["data"])
+            if record.namespace == self._namespace_key:
+                return item["id"], record
+        return None
+
+    async def _load_record(self) -> _AgentDataStateRecord | None:
+        match = await self._matching_item()
+        if match is None:
             return None
-        self._item_id = items[0]["id"]
-        return _AgentDataStateRecord.model_validate(items[0]["data"])
+        self._item_id, record = match
+        return record
 
     async def load(self) -> StateRecord | None:
         record = await self._load_record()
@@ -91,6 +113,7 @@ class _AgentDataStateStorage:
     async def save(self, record: StateRecord) -> None:
         stored = _AgentDataStateRecord(
             run_id=self._run_id,
+            namespace=self._namespace_key,
             data=record.data,
             state_type=record.state_type,
             state_module=record.state_module,
@@ -98,19 +121,14 @@ class _AgentDataStateStorage:
         payload = stored.model_dump()
         if self._item_id is not None:
             await self._client.update_item(self._item_id, payload)
+            return
+        match = await self._matching_item()
+        if match is not None:
+            self._item_id = match[0]
+            await self._client.update_item(self._item_id, payload)
         else:
-            items = await self._client.search(
-                self._collection,
-                {_FIELD_RUN_ID: {"eq": self._run_id}},
-                page_size=1,
-            )
-            if items:
-                item_id = items[0]["id"]
-                self._item_id = item_id
-                await self._client.update_item(item_id, payload)
-            else:
-                result = await self._client.create(self._collection, payload)
-                self._item_id = result["id"]
+            result = await self._client.create(self._collection, payload)
+            self._item_id = result["id"]
 
     def to_handle(self) -> dict[str, Any]:
         payload = AgentDataSerializedState(
@@ -126,20 +144,32 @@ class _AgentDataStateStorage:
         return AgentDataSerializedState.model_validate(payload)
 
     async def copy_from_handle(self, handle: AgentDataSerializedState) -> None:
-        """Copy the source target's record into this one (no-op if absent).
+        """Copy every namespace item of the source run into this run.
 
-        Goes through ``save`` so ``_item_id`` stays consistent with the
-        copied row.
+        The source has no range op, so its items are enumerated by ``run_id``
+        and each is saved under the same namespace in this run. Saves go
+        through per-namespace storages so each ``_item_id`` stays consistent.
         """
-        source = _AgentDataStateStorage(
-            client=self._client,
-            run_id=handle.run_id,
-            collection=handle.collection,
+        items = await self._client.search(
+            handle.collection,
+            {_FIELD_RUN_ID: {"eq": handle.run_id}},
         )
-        record = await source.load()
-        if record is None:
-            return
-        await self.save(record)
+        for item in items:
+            source = _AgentDataStateRecord.model_validate(item["data"])
+            namespace = tuple(source.namespace.split("/")) if source.namespace else ()
+            dest = _AgentDataStateStorage(
+                client=self._client,
+                run_id=self._run_id,
+                namespace=namespace,
+                collection=self._collection,
+            )
+            await dest.save(
+                StateRecord(
+                    data=source.data,
+                    state_type=source.state_type,
+                    state_module=source.state_module,
+                )
+            )
 
 
 class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
@@ -156,12 +186,18 @@ class AgentDataStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         *,
         client: AgentDataClient,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         state_type: type[MODEL_T] | None = None,
         collection: str = "workflow_state",
         serializer: BaseSerializer | None = None,
     ) -> None:
         super().__init__(
-            _AgentDataStateStorage(client=client, run_id=run_id, collection=collection),
+            _AgentDataStateStorage(
+                client=client,
+                run_id=run_id,
+                namespace=namespace,
+                collection=collection,
+            ),
             state_type,
             serializer,
         )

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_store.py
@@ -169,7 +169,7 @@ class AgentDataStore(AbstractWorkflowStore):
         # Clean up sequence counters and cached state store
         self._event_sequences.pop(run_id, None)
         self._tick_sequences.pop(run_id, None)
-        self._state_store_cache.pop(run_id, None)
+        self._evict_run_state_stores(run_id)
 
     # ------------------------------------------------------------------
     # Sequence helpers
@@ -491,12 +491,14 @@ class AgentDataStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> AgentDataStateStore[Any]:
         return AgentDataStateStore(
             client=self._client,
             run_id=run_id,
+            namespace=namespace,
             state_type=state_type,
             collection=f"{self._collection}_state",
             serializer=serializer,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/memory_workflow_store.py
@@ -70,7 +70,7 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
         self.ticks: dict[str, list[StoredTick]] = {}
         # Strong refs: facades live until eviction. Public alias kept for
         # tests/plugins that inject stores; the ABC template reads the cache.
-        self.state_stores: dict[str, StateStoreFacade[Any]] = {}
+        self.state_stores: dict[tuple[str, tuple[str, ...]], StateStoreFacade[Any]] = {}
         self._state_store_cache = self.state_stores
         self._conditions: weakref.WeakValueDictionary[str, asyncio.Condition] = (
             weakref.WeakValueDictionary()
@@ -81,6 +81,7 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> InMemoryStateStore[Any]:
@@ -134,7 +135,7 @@ class MemoryWorkflowStore(AbstractWorkflowStore):
             if run_id is not None:
                 self.events.pop(run_id, None)
                 self.ticks.pop(run_id, None)
-                self.state_stores.pop(run_id, None)
+                self._evict_run_state_stores(run_id)
 
     def _get_or_create_condition(self, run_id: str) -> asyncio.Condition:
         cond = self._conditions.get(run_id)

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres/migrations/0002_namespace_state.sql
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres/migrations/0002_namespace_state.sql
@@ -1,0 +1,8 @@
+-- migration: 2
+
+-- Per-namespace state records: namespace becomes a key dimension alongside
+-- run_id. Existing single rows are root-namespace rows (namespace = '').
+ALTER TABLE workflow_state ADD COLUMN IF NOT EXISTS namespace VARCHAR(255) NOT NULL DEFAULT '';
+
+ALTER TABLE workflow_state DROP CONSTRAINT IF EXISTS workflow_state_pkey;
+ALTER TABLE workflow_state ADD CONSTRAINT workflow_state_pkey PRIMARY KEY (run_id, namespace);

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_state_store.py
@@ -40,11 +40,15 @@ class _PostgresStateStorage:
         self,
         pool: asyncpg.Pool,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         schema: str | None = None,
         connection: asyncpg.Connection | asyncpg.pool.PoolConnectionProxy | None = None,
     ) -> None:
         self._pool = pool
         self._run_id = run_id
+        self._namespace = namespace
+        # Persisted key: () -> "" (today's single root row), ("child",) -> "child".
+        self._namespace_key = "/".join(namespace)
         self._schema = schema
         self._shared_conn = connection
 
@@ -81,15 +85,17 @@ class _PostgresStateStorage:
             return
         async with self._pool.acquire() as conn:
             yield _PostgresStateStorage(
-                self._pool, self._run_id, self._schema, connection=conn
+                self._pool, self._run_id, self._namespace, self._schema, connection=conn
             )
 
     async def load(self) -> StateRecord | None:
         """Load raw state from the database."""
         async with self._acquire() as conn:
             row = await conn.fetchrow(
-                f"SELECT state_json FROM {self._table_ref} WHERE run_id = $1",
+                f"SELECT state_json FROM {self._table_ref} "
+                "WHERE run_id = $1 AND namespace = $2",
                 self._run_id,
+                self._namespace_key,
             )
         if row is None:
             return None
@@ -101,15 +107,16 @@ class _PostgresStateStorage:
         async with self._acquire() as conn:
             await conn.execute(
                 f"""
-                INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
-                VALUES ($1, $2, $3, $4, $5, $6)
-                ON CONFLICT(run_id) DO UPDATE SET
+                INSERT INTO {self._table_ref} (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                ON CONFLICT(run_id, namespace) DO UPDATE SET
                     state_json = EXCLUDED.state_json,
                     state_type = EXCLUDED.state_type,
                     state_module = EXCLUDED.state_module,
                     updated_at = EXCLUDED.updated_at
                 """,
                 self._run_id,
+                self._namespace_key,
                 record.data,
                 record.state_type,
                 record.state_module,
@@ -129,15 +136,20 @@ class _PostgresStateStorage:
         return PostgresSerializedState.model_validate(payload)
 
     async def copy_from_handle(self, handle: PostgresSerializedState) -> None:
-        """Copy state from another run's row using SQL INSERT...SELECT."""
+        """Copy every namespace row from another run using INSERT...SELECT.
+
+        The ``run_id`` filter spans all namespaces, so a single statement
+        copies the source run's root and every child namespace; ``namespace``
+        is carried through unchanged.
+        """
         now = _utc_now()
         async with self._acquire() as conn:
             await conn.execute(
                 f"""
-                INSERT INTO {self._table_ref} (run_id, state_json, state_type, state_module, created_at, updated_at)
-                SELECT $1, state_json, state_type, state_module, $2, $3
+                INSERT INTO {self._table_ref} (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                SELECT $1, namespace, state_json, state_type, state_module, $2, $3
                 FROM {self._table_ref} WHERE run_id = $4
-                ON CONFLICT(run_id) DO UPDATE SET
+                ON CONFLICT(run_id, namespace) DO UPDATE SET
                     state_json = EXCLUDED.state_json,
                     state_type = EXCLUDED.state_type,
                     state_module = EXCLUDED.state_module,
@@ -157,12 +169,15 @@ class PostgresStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         self,
         pool: asyncpg.Pool,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         state_type: type[MODEL_T] | None = None,
         serializer: BaseSerializer | None = None,
         schema: str | None = None,
     ) -> None:
         super().__init__(
-            _PostgresStateStorage(pool, run_id, schema), state_type, serializer
+            _PostgresStateStorage(pool, run_id, namespace, schema),
+            state_type,
+            serializer,
         )
 
     @classmethod

--- a/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/postgres_workflow_store.py
@@ -298,6 +298,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> PostgresStateStore[Any]:
@@ -308,6 +309,7 @@ class PostgresWorkflowStore(AbstractWorkflowStore):
         return PostgresStateStore(
             pool=self._pool,
             run_id=run_id,
+            namespace=namespace,
             state_type=state_type,
             serializer=serializer,
             schema=self._schema,

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/migrations/0005_namespace_state.sql
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/migrations/0005_namespace_state.sql
@@ -1,0 +1,23 @@
+-- migration: 5
+
+-- Per-namespace state records: namespace becomes a key dimension alongside
+-- run_id. SQLite cannot ALTER a primary key, so rebuild the table with the
+-- composite PK and migrate existing rows as root-namespace rows (namespace '').
+CREATE TABLE workflow_state_new (
+    run_id TEXT NOT NULL,
+    namespace TEXT NOT NULL DEFAULT '',
+    state_json TEXT NOT NULL DEFAULT '{}',
+    state_type TEXT NOT NULL DEFAULT 'DictState',
+    state_module TEXT NOT NULL DEFAULT 'workflows.context.state_store',
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    PRIMARY KEY (run_id, namespace)
+);
+
+INSERT INTO workflow_state_new (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+SELECT run_id, '', state_json, state_type, state_module, created_at, updated_at
+FROM workflow_state;
+
+DROP TABLE workflow_state;
+
+ALTER TABLE workflow_state_new RENAME TO workflow_state;

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_state_store.py
@@ -40,10 +40,14 @@ class _SqliteStateStorage:
         self,
         db_path: str,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         connection: sqlite3.Connection | None = None,
     ) -> None:
         self._db_path = db_path
         self._run_id = run_id
+        self._namespace = namespace
+        # Persisted key: () -> "" (today's single root row), ("child",) -> "child".
+        self._namespace_key = "/".join(namespace)
         self._shared_conn = connection
 
     @property
@@ -73,7 +77,9 @@ class _SqliteStateStorage:
             return
         conn = sqlite3.connect(self._db_path, timeout=30.0)
         try:
-            yield _SqliteStateStorage(self._db_path, self._run_id, connection=conn)
+            yield _SqliteStateStorage(
+                self._db_path, self._run_id, self._namespace, connection=conn
+            )
         finally:
             conn.close()
 
@@ -82,8 +88,9 @@ class _SqliteStateStorage:
         with self._connect() as conn:
             cursor = conn.cursor()
             cursor.execute(
-                "SELECT state_json FROM workflow_state WHERE run_id = ?",
-                (self._run_id,),
+                "SELECT state_json FROM workflow_state "
+                "WHERE run_id = ? AND namespace = ?",
+                (self._run_id, self._namespace_key),
             )
             row = cursor.fetchone()
         if row is None:
@@ -96,9 +103,9 @@ class _SqliteStateStorage:
             now = _utc_now().isoformat()
             conn.execute(
                 """
-                INSERT INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?)
-                ON CONFLICT(run_id) DO UPDATE SET
+                INSERT INTO workflow_state (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(run_id, namespace) DO UPDATE SET
                     state_json = excluded.state_json,
                     state_type = excluded.state_type,
                     state_module = excluded.state_module,
@@ -106,6 +113,7 @@ class _SqliteStateStorage:
                 """,
                 (
                     self._run_id,
+                    self._namespace_key,
                     record.data,
                     record.state_type,
                     record.state_module,
@@ -125,13 +133,18 @@ class _SqliteStateStorage:
         return SqliteSerializedState.model_validate(payload)
 
     async def copy_from_handle(self, handle: SqliteSerializedState) -> None:
-        """Copy state from another run's row using SQL INSERT...SELECT."""
+        """Copy every namespace row from another run using INSERT...SELECT.
+
+        The ``run_id`` filter spans all namespaces, so a single statement
+        copies the source run's root and every child namespace; ``namespace``
+        is carried through unchanged.
+        """
         with self._connect() as conn:
             now = _utc_now().isoformat()
             conn.execute(
                 """
-                INSERT OR REPLACE INTO workflow_state (run_id, state_json, state_type, state_module, created_at, updated_at)
-                SELECT ?, state_json, state_type, state_module, ?, ?
+                INSERT OR REPLACE INTO workflow_state (run_id, namespace, state_json, state_type, state_module, created_at, updated_at)
+                SELECT ?, namespace, state_json, state_type, state_module, ?, ?
                 FROM workflow_state WHERE run_id = ?
                 """,
                 (self._run_id, now, now, handle.run_id),
@@ -146,13 +159,16 @@ class SqliteStateStore(StateStoreFacade[MODEL_T], Generic[MODEL_T]):
         self,
         db_path: str,
         run_id: str,
+        namespace: tuple[str, ...] = (),
         state_type: type[MODEL_T] | None = None,
         serializer: BaseSerializer | None = None,
         connection: sqlite3.Connection | None = None,
     ) -> None:
         self._db_path = db_path
         super().__init__(
-            _SqliteStateStorage(db_path, run_id, connection), state_type, serializer
+            _SqliteStateStorage(db_path, run_id, namespace, connection),
+            state_type,
+            serializer,
         )
 
     @classmethod

--- a/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/sqlite/sqlite_workflow_store.py
@@ -93,12 +93,14 @@ class SqliteWorkflowStore(AbstractWorkflowStore):
     def _build_state_store(
         self,
         run_id: str,
+        namespace: tuple[str, ...],
         state_type: type[Any] | None,
         serializer: BaseSerializer | None,
     ) -> SqliteStateStore[Any]:
         return SqliteStateStore(
             db_path=self.db_path,
             run_id=run_id,
+            namespace=namespace,
             state_type=state_type,
             serializer=serializer,
             connection=self._persistent_conn,

--- a/packages/llama-agents-server/tests/server/test_agent_data_store.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_store.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from datetime import datetime, timezone
 from typing import Any
 
@@ -1028,3 +1029,50 @@ async def test_persist_error_does_not_block_in_memory_delivery(
     await store.append_event("run-1", make_envelope(event=StopEvent(data="done")))
     await asyncio.wait_for(task, timeout=2.0)
     assert len(collected) == 3
+
+
+# ---------------------------------------------------------------------------
+# Per-namespace records
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_namespace_round_trip_and_isolation(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root and child namespaces persist as independent items under one run."""
+    root = create_agent_data_state_store(backend, monkeypatch, "run-ns")
+    child = create_agent_data_state_store(
+        backend, monkeypatch, "run-ns", namespace=("child",)
+    )
+
+    await root.set("k", "root-val")
+    await child.set("k", "child-val")
+
+    root2 = create_agent_data_state_store(backend, monkeypatch, "run-ns")
+    child2 = create_agent_data_state_store(
+        backend, monkeypatch, "run-ns", namespace=("child",)
+    )
+    assert await root2.get("k") == "root-val"
+    assert await child2.get("k") == "child-val"
+
+
+@pytest.mark.asyncio
+async def test_pre_namespace_item_reads_as_root(
+    backend: FakeAgentDataBackend, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An item written before namespaces (no namespace field) reads as root."""
+    serializer = JsonSerializer()
+    backend.create(
+        "test-deploy",
+        "workflow_state",
+        {
+            "run_id": "legacy-run",
+            "data": json.dumps({"_data": {"k": serializer.serialize("legacy")}}),
+            "state_type": "DictState",
+            "state_module": "workflows.context.state_store",
+        },
+    )
+
+    root = create_agent_data_state_store(backend, monkeypatch, "legacy-run")
+    assert await root.get("k") == "legacy"

--- a/packages/llama-agents-server/tests/server/test_event_interceptor.py
+++ b/packages/llama-agents-server/tests/server/test_event_interceptor.py
@@ -51,7 +51,9 @@ class _RecordingInternalAdapter(InternalRunAdapter):
     async def close(self) -> None:
         self.closed = True
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return None
 
 

--- a/packages/llama-agents-server/tests/server/test_memory_workflow_store.py
+++ b/packages/llama-agents-server/tests/server/test_memory_workflow_store.py
@@ -478,7 +478,7 @@ async def test_max_completed_cleans_up_events_ticks_and_state() -> None:
     )
     assert "run-old" in store.events
     assert "run-old" in store.ticks
-    assert "run-old" in store.state_stores
+    assert ("run-old", ()) in store.state_stores
 
     await _insert(
         store,
@@ -490,10 +490,27 @@ async def test_max_completed_cleans_up_events_ticks_and_state() -> None:
 
     assert "run-old" not in store.events
     assert "run-old" not in store.ticks
-    assert "run-old" not in store.state_stores
+    assert ("run-old", ()) not in store.state_stores
     remaining = await store.query(HandlerQuery())
     assert len(remaining) == 1
     assert remaining[0].handler_id == "h-new"
+
+
+async def test_evict_run_state_stores_drops_every_namespace() -> None:
+    """Run-scoped eviction removes all of a run's namespace facades at once."""
+    store = MemoryWorkflowStore()
+    store.create_state_store("run-x")
+    store.create_state_store("run-x", namespace=("child",))
+    store.create_state_store("run-other")
+    assert ("run-x", ()) in store.state_stores
+    assert ("run-x", ("child",)) in store.state_stores
+
+    store._evict_run_state_stores("run-x")
+
+    assert ("run-x", ()) not in store.state_stores
+    assert ("run-x", ("child",)) not in store.state_stores
+    # Other runs are untouched.
+    assert ("run-other", ()) in store.state_stores
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-server/tests/server/test_postgres_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_postgres_state_store.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import AsyncGenerator
 
 import asyncpg
@@ -35,12 +36,14 @@ async def pool(postgres_dsn: str) -> AsyncGenerator[asyncpg.Pool, None]:
         await conn.execute(f"CREATE SCHEMA IF NOT EXISTS {SCHEMA}")
         await conn.execute(f"""
             CREATE TABLE IF NOT EXISTS {SCHEMA}.workflow_state (
-                run_id VARCHAR(255) PRIMARY KEY,
+                run_id VARCHAR(255) NOT NULL,
+                namespace VARCHAR(255) NOT NULL DEFAULT '',
                 state_json TEXT NOT NULL,
                 state_type VARCHAR(255),
                 state_module VARCHAR(255),
                 created_at TIMESTAMPTZ,
-                updated_at TIMESTAMPTZ
+                updated_at TIMESTAMPTZ,
+                PRIMARY KEY (run_id, namespace)
             )
         """)
         await conn.execute(f"DELETE FROM {SCHEMA}.workflow_state")
@@ -324,16 +327,18 @@ class FakeConnection:
     def __init__(self, rows: dict[str, str]) -> None:
         self._rows = rows
 
-    async def fetchrow(self, query: str, run_id: str) -> dict[str, str] | None:
-        state_json = self._rows.get(run_id)
+    async def fetchrow(
+        self, query: str, run_id: str, namespace: str
+    ) -> dict[str, str] | None:
+        state_json = self._rows.get(f"{run_id}\x00{namespace}")
         if state_json is None:
             return None
         return {"state_json": state_json}
 
     async def execute(self, query: str, *args: object) -> None:
-        # Save upsert: (run_id, state_json, state_type, state_module, now, now)
-        run_id, state_json = str(args[0]), str(args[1])
-        self._rows[run_id] = state_json
+        # Save upsert: (run_id, namespace, state_json, state_type, state_module, now, now)
+        run_id, namespace, state_json = str(args[0]), str(args[1]), str(args[2])
+        self._rows[f"{run_id}\x00{namespace}"] = state_json
 
 
 class FakePoolAcquire:
@@ -376,7 +381,7 @@ async def test_set_state_acquires_exactly_one_pool_connection() -> None:
 
     assert pool.acquire_count == 1
     assert pool.release_count == 1
-    assert "run-conn-count" in pool.rows
+    assert "run-conn-count\x00" in pool.rows
 
 
 async def test_from_dict_empty_raises() -> None:
@@ -389,3 +394,48 @@ async def test_from_dict_no_pool_raises() -> None:
         PostgresStateStore.from_dict(
             {"store_type": "postgres", "run_id": "x"}, JsonSerializer()
         )
+
+
+# -- Per-namespace records --
+
+
+@pytest.mark.docker
+async def test_namespace_round_trip_and_isolation(pool: asyncpg.Pool) -> None:
+    """Root and child namespaces persist as independent rows under one run."""
+    root: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", schema=SCHEMA
+    )
+    child: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", namespace=("child",), schema=SCHEMA
+    )
+
+    await root.set("k", "root-val")
+    await child.set("k", "child-val")
+
+    root2: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", schema=SCHEMA
+    )
+    child2: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="run-ns", namespace=("child",), schema=SCHEMA
+    )
+    assert await root2.get("k") == "root-val"
+    assert await child2.get("k") == "child-val"
+
+
+@pytest.mark.docker
+async def test_pre_migration_root_row_reads_as_root(pool: asyncpg.Pool) -> None:
+    """A row written without a namespace (additive default '') reads as root."""
+    state_json = json.dumps({"_data": {"k": JsonSerializer().serialize("legacy")}})
+    async with pool.acquire() as conn:
+        await conn.execute(
+            f"INSERT INTO {SCHEMA}.workflow_state "
+            "(run_id, state_json, state_type, state_module, created_at, updated_at) "
+            "VALUES ($1, $2, 'DictState', 'workflows.context.state_store', now(), now())",
+            "legacy-run",
+            state_json,
+        )
+
+    store: PostgresStateStore[DictState] = PostgresStateStore(
+        pool=pool, run_id="legacy-run", schema=SCHEMA
+    )
+    assert await store.get("k") == "legacy"

--- a/packages/llama-agents-server/tests/server/test_runtime_decorators.py
+++ b/packages/llama-agents-server/tests/server/test_runtime_decorators.py
@@ -53,7 +53,9 @@ class StubInternalAdapter(InternalRunAdapter):
     async def close(self) -> None:
         self.closed = True
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return None
 
 
@@ -77,7 +79,9 @@ class StubExternalAdapter(ExternalRunAdapter):
     async def get_result(self) -> StopEvent:
         return StopEvent(result="done")
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return None
 
 

--- a/packages/llama-agents-server/tests/server/test_server_runtime.py
+++ b/packages/llama-agents-server/tests/server/test_server_runtime.py
@@ -67,7 +67,9 @@ class StubInternalAdapter(InternalRunAdapter):
     async def close(self) -> None:
         self.closed = True
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return None
 
 
@@ -91,7 +93,9 @@ class StubExternalAdapter(ExternalRunAdapter):
     async def get_result(self) -> StopEvent:
         return StopEvent(result="done")
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         return None
 
 

--- a/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
+++ b/packages/llama-agents-server/tests/server/test_sqlite_state_store.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -13,6 +14,7 @@ import pytest
 from llama_agents.server import HandlerQuery, SqliteWorkflowStore
 from llama_agents.server._store.sqlite.migrate import run_migrations
 from llama_agents.server._store.sqlite.sqlite_state_store import (
+    SqliteSerializedState,
     SqliteStateStore,
 )
 from pydantic import BaseModel
@@ -491,3 +493,110 @@ async def test_sqlite_workflow_store_single_connection_opens_existing_regular_db
 
     await state_store.set("x", 1)
     assert await state_store.get("x") == 1
+
+
+# -- Per-namespace records --
+
+
+@pytest.mark.asyncio
+async def test_namespace_round_trip_and_isolation(db_path: str) -> None:
+    """Root and child namespaces persist as independent rows under one run."""
+    root: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns"
+    )
+    child: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns", namespace=("child",)
+    )
+
+    await root.set("k", "root-val")
+    await child.set("k", "child-val")
+
+    # Fresh facades read straight from their own row — no cross-namespace bleed.
+    root2: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns"
+    )
+    child2: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-ns", namespace=("child",)
+    )
+    assert await root2.get("k") == "root-val"
+    assert await child2.get("k") == "child-val"
+
+
+@pytest.mark.asyncio
+async def test_pre_migration_root_row_reads_as_root(tmp_path: Path) -> None:
+    """A row written under the pre-namespace schema reads back as root."""
+    path = str(tmp_path / "legacy.db")
+    serializer = JsonSerializer()
+    legacy_state_json = json.dumps({"_data": {"k": serializer.serialize("legacy")}})
+
+    conn = sqlite3.connect(path)
+    try:
+        # Recreate the schema as it stood at migration 4 (single-column PK,
+        # no namespace) and mark migrations 1-4 applied.
+        conn.executescript(
+            """
+            CREATE TABLE schema_migrations (
+                package TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                applied_at TEXT NOT NULL DEFAULT (datetime('now')),
+                PRIMARY KEY (package, version)
+            );
+            CREATE TABLE workflow_state (
+                run_id TEXT PRIMARY KEY,
+                state_json TEXT NOT NULL DEFAULT '{}',
+                state_type TEXT NOT NULL DEFAULT 'DictState',
+                state_module TEXT NOT NULL DEFAULT 'workflows.context.state_store',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            );
+            """
+        )
+        for version in range(1, 5):
+            conn.execute(
+                "INSERT INTO schema_migrations (package, version) VALUES ('server', ?)",
+                (version,),
+            )
+        conn.execute(
+            "INSERT INTO workflow_state "
+            "(run_id, state_json, state_type, state_module, created_at, updated_at) "
+            "VALUES (?, ?, 'DictState', 'workflows.context.state_store', '', '')",
+            ("legacy-run", legacy_state_json),
+        )
+        conn.commit()
+        # Apply the pending namespace migration (table rebuild).
+        run_migrations(conn)
+        conn.commit()
+    finally:
+        conn.close()
+
+    store: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=path, run_id="legacy-run"
+    )
+    assert await store.get("k") == "legacy"
+
+
+@pytest.mark.asyncio
+async def test_copy_reproduces_every_namespace(db_path: str) -> None:
+    """Copying a run via its handle reproduces root and child namespaces."""
+    src_root: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-src"
+    )
+    src_child: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-src", namespace=("child",)
+    )
+    await src_root.set("k", "root-val")
+    await src_child.set("k", "child-val")
+
+    # Seed the destination root facade from the source handle; ensure_seeded
+    # drives copy_from_handle, which spans every namespace of the source run.
+    serializer = JsonSerializer()
+    dst_root: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-dst"
+    )
+    dst_root.add_seed(SqliteSerializedState(run_id="run-src").model_dump(), serializer)
+    assert await dst_root.get("k") == "root-val"
+
+    dst_child: SqliteStateStore[DictState] = SqliteStateStore(
+        db_path=db_path, run_id="run-dst", namespace=("child",)
+    )
+    assert await dst_child.get("k") == "child-val"

--- a/packages/llama-agents-server/tests/server/test_workflow_service.py
+++ b/packages/llama-agents-server/tests/server/test_workflow_service.py
@@ -329,8 +329,8 @@ async def test_context_from_handler_id_falls_back_to_legacy_state_snapshot(
             started_at=datetime.now(timezone.utc),
         )
     )
-    state_stores = cast(dict[str, Any], memory_store.state_stores)
-    state_stores["plugin-run"] = ToDictOnlyStateStore()
+    state_stores = cast(dict[Any, Any], memory_store.state_stores)
+    state_stores[("plugin-run", ())] = ToDictOnlyStateStore()
 
     async with server.contextmanager():
         ctx = await server._service._context_from_handler_id(

--- a/packages/llama-index-workflows/pyproject.toml
+++ b/packages/llama-index-workflows/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 # Optionals are now just an alias to additionally install
 # a less pinned version of the client/server packages.
 [project.optional-dependencies]
-server = ["llama-agents-server>=0.1.0,<1.0.0"]
+server = ["llama-agents-server>=0.6.1,<1.0.0"]
 client = ["llama-agents-client>=0.1.0,<1.0.0"]
 
 [tool.basedpyright]

--- a/packages/llama-index-workflows/src/workflows/context/context.py
+++ b/packages/llama-index-workflows/src/workflows/context/context.py
@@ -227,6 +227,7 @@ class Context(Generic[MODEL_T]):
     def _create_internal(
         cls,
         workflow: Workflow,
+        state_store: StateStore[Any] | None = None,
     ) -> Context[MODEL_T]:
         """Create a Context directly in internal face state.
 
@@ -239,6 +240,7 @@ class Context(Generic[MODEL_T]):
             InternalContext(
                 internal_adapter=internal_adapter,
                 workflow=workflow,
+                state_store=state_store,
             ),
         )
         return new_ctx

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -97,6 +97,9 @@ class SerializedEventAttempt(BaseModel):
     not_before: float | None = None
     # Collection stream scope path (innermost stream id last).
     scope_path: list[str] = Field(default_factory=list)
+    # Runtime invocation namespace. Static StepId keys still identify the step
+    # config; this separates sibling child calls through the same slot.
+    invocation_namespace: list[str] = Field(default_factory=list)
     # Explicit collect invocation payload, serialized only for queued/in-progress
     # list[E] collect executions.
     collection_release_payload: SerializedCollectionReleasePayload | None = None
@@ -132,6 +135,8 @@ class SerializedWaiter(BaseModel):
     # Originating work record: collection stream scope of the suspended work
     # item (innermost stream id last).
     scope_path: list[str] = Field(default_factory=list)
+    # Runtime invocation namespace for the suspended work item.
+    invocation_namespace: list[str] = Field(default_factory=list)
     # For a suspended collect invocation, the release batch to re-invoke with.
     collection_release_payload: SerializedCollectionReleasePayload | None = None
     # Stable identity for the suspended work item, if available.
@@ -161,8 +166,16 @@ class SerializedStepWorkerState(BaseModel):
     # Collected events for ctx.collect_events(), keyed by buffer_id -> [event, ...]
     # Events are serialized strings
     collected_events: dict[str, list[str]] = Field(default_factory=dict)
+    # Non-root invocation collect buffers, keyed by invocation namespace.
+    collected_events_by_invocation: dict[str, dict[str, list[str]]] = Field(
+        default_factory=dict
+    )
     # Pending static multi-parameter fan-in events.
     static_collect_events: list[str] = Field(default_factory=list)
+    # Pending static multi-parameter fan-in events for non-root invocations.
+    static_collect_events_by_invocation: dict[str, list[str]] = Field(
+        default_factory=dict
+    )
     # Active waiters created by ctx.wait_for_event()
     collected_waiters: list[SerializedWaiter] = Field(default_factory=list)
 
@@ -172,6 +185,7 @@ class SerializedCollectionStreamInstance(BaseModel):
 
     stream_id: str
     source_step: str
+    source_invocation_namespace: list[str] = Field(default_factory=list)
     scope_path: list[str] = Field(default_factory=list)
     open_work_items: int = 0
     accepting_binding_ids: list[str] = Field(default_factory=list)
@@ -215,6 +229,13 @@ class SerializedContext(BaseModel):
     collection_release_states: dict[str, SerializedCollectionReleaseState] = Field(
         default_factory=dict
     )
+    # Per-child namespace timeout activation times, keyed by "child/grandchild".
+    # Additive to v2: older payloads default to no active namespace deadlines.
+    namespace_started: dict[str, float] = Field(default_factory=dict)
+    # Active child invocation namespaces, keyed like namespace_started. These
+    # remain live until the child invocation stops or is terminated, even if the
+    # child is currently idle while waiting for an external targeted event.
+    active_invocation_namespaces: list[str] = Field(default_factory=list)
 
     @staticmethod
     def from_v0(v0: SerializedContextV0) -> "SerializedContext":

--- a/packages/llama-index-workflows/src/workflows/context/external_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/external_context.py
@@ -3,16 +3,22 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine, Generic
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Coroutine, Generic, cast
 
 from typing_extensions import TypeVar
 
 from workflows.context.context_types import MODEL_T
 from workflows.context.serializers import JsonSerializer
-from workflows.context.state_store import StateStore
+from workflows.context.state_store import (
+    NamespacedStateStores,
+    StateStore,
+    StateStoreFacade,
+    build_namespaced_state,
+)
 from workflows.errors import WorkflowRuntimeError
 from workflows.events import StopEvent
 from workflows.runtime.types.internal_state import BrokerState
+from workflows.runtime.types.invocation import slot_namespace
 from workflows.runtime.types.plugin import (
     ExternalRunAdapter,
     SnapshottableAdapter,
@@ -108,22 +114,48 @@ class ExternalContext(Generic[MODEL_T, RunResultT]):
 
     @property
     def store(self) -> StateStore[MODEL_T]:
-        """Access workflow state store."""
-        state_store = self._external_adapter.get_state_store()
+        """Access workflow state store (the root namespace)."""
+        state_store = self._external_adapter.get_state_store(())
         if state_store is None:
             raise RuntimeError("State store not available from adapter")
-        return state_store  # type: ignore[return-value]
+        return cast("StateStore[MODEL_T]", state_store)
+
+    def _namespaced_state(self, serializer: BaseSerializer) -> NamespacedStateStores:
+        """A per-namespace router over the adapter's stores, for tree ops.
+
+        The adapter mints (and caches) each namespace's store; this lens just
+        walks the workflow's namespaces to serialize the whole tree.
+        """
+        return build_namespaced_state(
+            self._workflow,
+            lambda ns: cast(
+                "StateStoreFacade[Any]", self._external_adapter.get_state_store(ns)
+            ),
+            serializer,
+        )
 
     def send_event(self, message: Event, step: str | None = None) -> None:
-        """Send an event into the workflow."""
+        """Send an event into the workflow.
+
+        ``step`` is an absolute path from the root: a bare name targets a root
+        step, ``"child/answer"`` targets a step inside a child namespace.
+        """
+        step_id = None
+        origin_namespace: tuple[str, ...] = ()
         if step is not None:
-            self._workflow._validate_valid_step_message(step, message)
+            parsed = StepId.from_str(step)
+            static_namespace = slot_namespace(parsed.namespace)
+            static_step = "/".join((*static_namespace, parsed.name))
+            step_id = self._workflow._resolve_target_step(static_step, message)
+            if parsed.namespace != static_namespace:
+                origin_namespace = parsed.namespace
 
         self._execute_task(
             self._external_adapter.send_event(
                 TickAddEvent(
                     event=message,
-                    step_id=StepId.root(step) if step is not None else None,
+                    step_id=step_id,
+                    origin_namespace=origin_namespace,
                 )
             )
         )
@@ -132,7 +164,9 @@ class ExternalContext(Generic[MODEL_T, RunResultT]):
         """Get list of currently running step names."""
         state = self._state
         return [
-            step for step in state.workers.keys() if state.workers[step].in_progress
+            str(step)
+            for step in state.workers.keys()
+            if state.workers[step].in_progress
         ]
 
     def _require_v2_runtime_compatibility(self) -> V2RuntimeCompatibilityShim:
@@ -160,14 +194,18 @@ class ExternalContext(Generic[MODEL_T, RunResultT]):
         """Serialize context state for persistence."""
         active_serializer = serializer or self._serializer
 
-        # Fetch state store from adapter and serialize
-        state_data = {}
-        state_store = self._external_adapter.get_state_store()
-        if state_store is not None:
-            state_data = state_store.to_dict(active_serializer)
-
         # Get the broker state
         broker_state = self._state
+
+        # Fetch state store from adapter and serialize the live namespace tree.
+        # Completed child invocation stores may still be materialized in-memory;
+        # only live invocation namespaces belong in a resumable snapshot.
+        state_data = {}
+        if self._external_adapter.get_state_store(()) is not None:
+            state_data = self._namespaced_state(active_serializer).serialize_tree(
+                active_serializer,
+                child_namespaces=broker_state.live_invocation_namespaces(),
+            )
 
         context = broker_state.to_serialized(active_serializer)
         context.state = state_data

--- a/packages/llama-index-workflows/src/workflows/context/internal_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/internal_context.py
@@ -13,7 +13,9 @@ from typing import TYPE_CHECKING, Any, Coroutine, Generic, TypeVar, cast
 from workflows.context.context_types import MODEL_T
 from workflows.context.state_store import StateStore
 from workflows.errors import WorkflowRuntimeError
+from workflows.events import _set_event_origin_namespace
 from workflows.retry_policy import RetryInfo
+from workflows.runtime.types.invocation import slot_namespace
 from workflows.runtime.types.results import (
     AddCollectedEvent,
     AddWaiter,
@@ -23,7 +25,6 @@ from workflows.runtime.types.results import (
     StepWorkerStateContextVar,
     WaitingForEvent,
 )
-from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import TickAddEvent
 
 if TYPE_CHECKING:
@@ -51,9 +52,14 @@ class InternalContext(Generic[MODEL_T]):
         self,
         internal_adapter: InternalRunAdapter,
         workflow: Workflow,
+        state_store: StateStore[Any] | None = None,
     ) -> None:
         self._internal_adapter = internal_adapter
         self._workflow = workflow
+        # The per-namespace state view threaded in by the control loop for a
+        # step. ``None`` outside a step (e.g. the run-level context); ``store``
+        # then resolves the root view on demand from the underlying store.
+        self._state_store = state_store
         self._workers = []
 
     def _execute_task(self, coro: Coroutine[Any, Any, Any]) -> asyncio.Task[Any]:
@@ -141,11 +147,18 @@ class InternalContext(Generic[MODEL_T]):
 
     @property
     def store(self) -> StateStore[MODEL_T]:
-        """Access workflow state store."""
-        state_store = self._internal_adapter.get_state_store()
-        if state_store is None:
+        """Access workflow state store.
+
+        Inside a step the per-namespace view is threaded in at construction. For
+        a context built outside a step (no threaded view), resolve the root
+        namespace's store on demand from the adapter.
+        """
+        if self._state_store is not None:
+            return cast("StateStore[MODEL_T]", self._state_store)
+        store = self._internal_adapter.get_state_store(())
+        if store is None:
             raise RuntimeError("State store not available from adapter")
-        return state_store  # type: ignore[return-value]
+        return cast("StateStore[MODEL_T]", store)
 
     def collect_events(
         self,
@@ -187,21 +200,35 @@ class InternalContext(Generic[MODEL_T]):
 
     def send_event(self, message: Event, step: str | None = None) -> None:
         """Send an event to trigger another step."""
-        if step is not None:
-            self._workflow._validate_valid_step_message(step, message)
-
         recovery_counts: dict[str, int] = {}
+        namespace: tuple[str, ...] = ()
         try:
             step_ctx = StepWorkerStateContextVar.get()
             recovery_counts = dict(step_ctx.retry.recovery_counts)
+            # Inherit the emitting step's namespace so the event routes within
+            # the same child (or, for a targeted send, to the named step in this
+            # namespace rather than a root step).
+            namespace = step_ctx.namespace
         except LookupError:
             pass
+
+        # Resolve and validate the target relative to the emitting namespace: a
+        # bare name targets a sibling step in this namespace, a "child/answer"
+        # path descends into a child of it.
+        step_id = (
+            self._workflow._resolve_target_step(
+                step, message, slot_namespace(namespace)
+            )
+            if step is not None
+            else None
+        )
 
         self._execute_task(
             self._internal_adapter.send_event(
                 TickAddEvent(
                     event=message,
-                    step_id=StepId.root(step) if step is not None else None,
+                    step_id=step_id,
+                    origin_namespace=namespace,
                     recovery_counts=recovery_counts,
                 )
             )
@@ -262,6 +289,16 @@ class InternalContext(Generic[MODEL_T]):
     def write_event_to_stream(self, ev: Event | None) -> None:
         """Write an event to the published event stream."""
         if ev is not None:
+            # Tag the event with the emitting step's namespace so child streams
+            # can be filtered out by default (and surfaced via
+            # ``stream_events(include_children=True)``). Same contextvar source
+            # ``send_event`` reads; root steps leave the default ``()``.
+            try:
+                namespace = StepWorkerStateContextVar.get().namespace
+            except LookupError:
+                namespace = ()
+            if namespace:
+                _set_event_origin_namespace(ev, namespace)
             self._execute_task(self._internal_adapter.write_to_event_stream(ev))
 
     def retry_info(self) -> RetryInfo:

--- a/packages/llama-index-workflows/src/workflows/context/pre_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/pre_context.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from workflows.context.context_types import MODEL_T, SerializedContext
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
+    CHILD_STATES_KEY,
     InMemoryStateStore,
     StateStore,
     infer_state_type,
@@ -104,8 +105,25 @@ class PreContext(Generic[MODEL_T]):
         unchanged, avoiding unnecessary work.
         """
         if self._store is not None:
-            return self._store.to_dict(self._serializer)
-        return self._init_snapshot.state
+            payload = self._store.to_dict(self._serializer)
+            # The staging store only holds root state. Preserve child invocation
+            # state only for a live resume; completed continuations intentionally
+            # start child invocations fresh.
+            child_states = (
+                self._init_snapshot.state.get(CHILD_STATES_KEY)
+                if self._init_snapshot.is_running
+                else None
+            )
+            if child_states is not None:
+                payload[CHILD_STATES_KEY] = child_states
+            return payload
+        if self._init_snapshot.is_running:
+            return self._init_snapshot.state
+        return {
+            key: value
+            for key, value in self._init_snapshot.state.items()
+            if key != CHILD_STATES_KEY
+        }
 
     @property
     def is_running(self) -> bool:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -15,6 +15,7 @@ from typing import (
     Any,
     AsyncContextManager,
     AsyncGenerator,
+    Callable,
     Generic,
     Literal,
     Protocol,
@@ -27,6 +28,7 @@ from typing_extensions import TypeVar
 
 from workflows.decorators import StepConfig
 from workflows.events import DictLikeModel
+from workflows.runtime.types.invocation import slot_namespace
 
 from .serializers import BaseSerializer, JsonSerializer
 
@@ -37,6 +39,9 @@ MAX_DEPTH = 1000
 
 # Keys set by pre-built workflows that are known to be unserializable in some cases.
 KNOWN_UNSERIALIZABLE_KEYS: tuple[str, ...] = ("memory",)
+
+# Portable childful snapshots nest per-namespace state data under this key.
+CHILD_STATES_KEY = "children"
 
 
 class InMemorySerializedState(BaseModel):
@@ -792,9 +797,10 @@ class StateStoreFacade(Generic[MODEL_T]):
                 assert self._durable is not None
                 await self._durable.copy_from_handle(seed.handle)
             else:
-                state = decode_seed_state(seed.payload, seed.serializer)
                 # Bypass _save_state: its ensure_seeded re-entry would
-                # deadlock on the seed lock we hold.
+                # deadlock on the seed lock we hold. A namespace facade only
+                # ever seeds its own state; the router distributes children.
+                state = decode_seed_state(seed.payload, seed.serializer)
                 await self._write_state(state)
             # Popped only after success so a failed materialization stays
             # pending; concurrent readers block on the seed lock above
@@ -837,6 +843,12 @@ class StateStoreFacade(Generic[MODEL_T]):
         await (storage or self._storage).save(
             string_record_from_state(state, self._serializer)
         )
+
+    async def _write_record(
+        self, record: StateRecord, storage: _StateStorage | None = None
+    ) -> None:
+        """Persist a pre-encoded raw state record."""
+        await (storage or self._storage).save(record)
 
     async def _load_state_for_edit(
         self, storage: _StateStorage | None = None
@@ -971,6 +983,9 @@ class _InMemoryStateStorage:
     def load_sync(self) -> StateRecord | None:
         return self._record.model_copy() if self._record is not None else None
 
+    def save_sync(self, record: StateRecord) -> None:
+        self._record = record.model_copy()
+
 
 class InMemoryStateStore(StateStoreFacade[MODEL_T]):
     """
@@ -1026,6 +1041,24 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
             JsonSerializer(),
         )
 
+    def add_seed(self, payload: dict[str, Any], serializer: BaseSerializer) -> None:
+        """Apply a seed eagerly — in-memory storage has no I/O to defer.
+
+        Lazy seeding (the base implementation) exists to keep durable backends
+        from materializing on construction. In-process state has nothing to
+        defer, and sync readers (``to_dict``) would otherwise miss a seed that
+        no async access ever triggered. Decode and commit it now.
+        """
+        if not payload:
+            raise ValueError("Cannot seed state store from an empty payload")
+        if is_durable_serialized_state(payload):
+            raise ValueError(
+                "Cannot seed this state store from a durable handle with "
+                f"store_type '{payload.get('store_type')}'"
+            )
+        state = decode_seed_state(payload, serializer)
+        self._memory_storage.save_sync(_live_record(state))
+
     async def _load_state_for_edit(
         self, storage: _StateStorage | None = None
     ) -> MODEL_T:
@@ -1054,7 +1087,12 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         record = self._memory_storage.load_sync()
         # Records always hold a live model here (see _write_state); when the
         # storage is empty, snapshot a default without persisting it.
-        state = cast(MODEL_T, record.data) if record is not None else self.state_type()
+        if record is None:
+            state = self.state_type()
+        elif isinstance(record.data, BaseModel):
+            state = cast(MODEL_T, record.data)
+        else:
+            state = cast(MODEL_T, decode_state(record.data, serializer))
         return create_in_memory_payload(state, serializer).model_dump()
 
     async def _write_state(
@@ -1085,6 +1123,8 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         if not serialized_state:
             return cls(DictState())  # type: ignore[arg-type]
 
+        # Childful trees are distributed per namespace by the router; a single
+        # InMemoryStateStore only ever holds one namespace's state.
         state_instance = decode_seed_state(serialized_state, serializer)
         return cls(state_instance)  # type: ignore[arg-type]
 
@@ -1231,3 +1271,184 @@ def _find_most_derived_state_type(state_types: set[type[BaseModel]]) -> type[Bas
         )
 
     return most_derived
+
+
+def _namespace_key(namespace: tuple[str, ...]) -> str:
+    return "/".join(namespace)
+
+
+def _namespace_from_key(key: str) -> tuple[str, ...]:
+    """Inverse of ``_namespace_key``: ``""`` -> ``()``, ``"child"`` -> ``("child",)``."""
+    return tuple(key.split("/")) if key else ()
+
+
+def _in_memory_seed_payload(
+    state_data: Any, state_type: type[BaseModel]
+) -> dict[str, Any]:
+    """Wrap raw namespace ``state_data`` as an in-memory seed payload."""
+    return {
+        "store_type": "in_memory",
+        "state_type": state_type.__name__,
+        "state_module": state_type.__module__,
+        "state_data": state_data,
+    }
+
+
+def namespaced_seed_payloads(
+    serialized_state: dict[str, Any] | None,
+    state_types: dict[tuple[str, ...], type[BaseModel]],
+) -> dict[tuple[str, ...], dict[str, Any]] | None:
+    """Split a portable snapshot into one in-memory seed per namespace.
+
+    Returns ``namespace -> in_memory payload`` for the root (the snapshot
+    minus ``children``) and each ``children[ns]`` entry, or ``None`` when there
+    is nothing to distribute: an empty payload, or a durable handle (seeded by
+    copy, not by per-namespace payloads).
+    """
+    if not serialized_state:
+        return None
+    if serialized_state.get("store_type", "in_memory") != "in_memory":
+        return None
+    root_payload = {
+        key: value for key, value in serialized_state.items() if key != CHILD_STATES_KEY
+    }
+    seeds: dict[tuple[str, ...], dict[str, Any]] = {(): root_payload}
+    children = serialized_state.get(CHILD_STATES_KEY) or {}
+    for namespace_key, state_data in children.items():
+        namespace = _namespace_from_key(namespace_key)
+        seeds[namespace] = _in_memory_seed_payload(
+            state_data, state_types.get(slot_namespace(namespace), DictState)
+        )
+    return seeds
+
+
+NamespaceFactory = Callable[[tuple[str, ...]], StateStoreFacade[Any]]
+
+
+class NamespacedStateStores:
+    """Routes each namespace to its own ``StateStoreFacade``.
+
+    A namespace is just a run with an extra key component: every namespace owns
+    its own backing record, writer lock, and seed lifecycle. There is no shared
+    record and no cross-namespace lock — two namespaces never read-modify-write
+    the same physical record.
+    """
+
+    def __init__(
+        self,
+        factory: NamespaceFactory,
+        serializer: BaseSerializer,
+        state_types: dict[tuple[str, ...], type[BaseModel]],
+    ) -> None:
+        self._factory = factory
+        self.serializer = serializer
+        self.state_types = state_types
+        self._views: dict[tuple[str, ...], StateStoreFacade[Any]] = {}
+
+    @property
+    def is_single_namespace(self) -> bool:
+        return len(self.state_types) <= 1
+
+    def _view_facade(self, namespace: tuple[str, ...]) -> StateStoreFacade[Any]:
+        view = self._views.get(namespace)
+        if view is None:
+            view = self._factory(namespace)
+            self._views[namespace] = view
+        return view
+
+    def view(self, namespace: tuple[str, ...]) -> StateStore[Any]:
+        return self._view_facade(namespace)
+
+    def _child_namespaces(self) -> list[tuple[str, ...]]:
+        # Topology is the source of truth for which namespaces exist; union in
+        # any extra materialized views so nothing accessed is silently dropped.
+        namespaces = set(self.state_types) | set(self._views)
+        return sorted(ns for ns in namespaces if ns != ())
+
+    def serialize_tree(
+        self,
+        serializer: BaseSerializer,
+        child_namespaces: set[tuple[str, ...]] | None = None,
+    ) -> dict[str, Any]:
+        """Portable snapshot: the root payload with ``children[ns]`` nested.
+
+        Childless runs (a single namespace) produce exactly the flat root
+        snapshot, with no ``children`` key.
+
+        Durable roots hand back a reconnect handle, not inline state: the
+        handle already spans every namespace row for the run (``copy_from_handle``
+        copies all rows under the ``run_id``), so resume reconnects the whole
+        tree from it. There is nothing to nest, and the durable child facades
+        have no sync ``state_data`` to gather — return the handle as-is.
+        """
+        result = self.view(()).to_dict(serializer)
+        if is_durable_serialized_state(result):
+            return result
+        children: dict[str, Any] = {}
+        namespaces = (
+            sorted(child_namespaces)
+            if child_namespaces is not None
+            else self._child_namespaces()
+        )
+        for namespace in namespaces:
+            if namespace == ():
+                continue
+            children[_namespace_key(namespace)] = self.view(namespace).to_dict(
+                serializer
+            )["state_data"]
+        if children:
+            result = {**result, CHILD_STATES_KEY: children}
+        return result
+
+    def add_seed_tree(
+        self, serialized_state: dict[str, Any] | None, serializer: BaseSerializer
+    ) -> None:
+        """Distribute a portable tree snapshot across per-namespace facades.
+
+        The root payload seeds the root facade; each ``children[ns]`` seeds its
+        own namespace facade via ``add_seed``. There is no single bundle seed.
+        """
+        seeds = namespaced_seed_payloads(serialized_state, self.state_types)
+        if seeds is None:
+            return
+        for namespace, payload in seeds.items():
+            self._view_facade(namespace).add_seed(payload, serializer)
+
+
+def in_memory_namespace_factory(
+    state_types: dict[tuple[str, ...], type[BaseModel]],
+) -> NamespaceFactory:
+    """A namespace factory that mints a fresh in-memory facade per namespace."""
+
+    def factory(namespace: tuple[str, ...]) -> StateStoreFacade[Any]:
+        state_type = state_types.get(slot_namespace(namespace), DictState)
+        return InMemoryStateStore(create_cleared_state(state_type))
+
+    return factory
+
+
+def namespaced_state_types(
+    root_workflow: "Workflow",
+) -> dict[tuple[str, ...], type[BaseModel]]:
+    return {
+        namespace: infer_state_type(instance)
+        for namespace, instance in root_workflow._namespace_instances().items()
+    }
+
+
+def build_namespaced_state(
+    root_workflow: "Workflow",
+    factory: NamespaceFactory,
+    serializer: BaseSerializer,
+) -> NamespacedStateStores:
+    """Build a per-namespace router for *root_workflow*.
+
+    *factory* mints a ``StateStoreFacade`` for a given namespace (durable:
+    ``create_state_store(run_id, namespace, ...)``; in-memory:
+    ``in_memory_namespace_factory``).
+    """
+    return NamespacedStateStores(
+        factory=factory,
+        serializer=serializer,
+        state_types=namespaced_state_types(root_workflow),
+    )

--- a/packages/llama-index-workflows/src/workflows/events.py
+++ b/packages/llama-index-workflows/src/workflows/events.py
@@ -150,8 +150,31 @@ class Event(DictLikeModel):
         - [HumanResponseEvent][workflows.events.HumanResponseEvent]
     """
 
+    # Namespace of the child execution that published this event to the stream.
+    # Empty tuple (the default) means root — i.e. an ordinary parent event. The
+    # runtime tags streaming copies at the publish chokepoints; it is never
+    # serialized, so the wire/checkpoint schema is unchanged.
+    _origin_namespace: tuple[str, ...] = PrivateAttr(default=())
+
     def __init__(self, **params: Any):
         super().__init__(**params)
+
+
+def get_event_origin_namespace(event: Event) -> tuple[str, ...]:
+    """Namespace path of the child execution that published ``event`` to the
+    stream, or ``()`` for a root (parent) event.
+
+    Populated only on the streaming copy of an event; not serialized. See
+    [`stream_events(include_children=True)`][workflows.handler.WorkflowHandler.stream_events].
+    """
+    return event._origin_namespace
+
+
+def _set_event_origin_namespace(event: Event, namespace: tuple[str, ...]) -> None:
+    """Tag a published event with the namespace of the child execution it came
+    from. Package-internal: the runtime stamps this at the stream-publish
+    chokepoints. Read it back with the public ``get_event_origin_namespace``."""
+    event._origin_namespace = namespace
 
 
 _json_serializer = JsonSerializer()

--- a/packages/llama-index-workflows/src/workflows/handler.py
+++ b/packages/llama-index-workflows/src/workflows/handler.py
@@ -15,7 +15,13 @@ from workflows.runtime.types.plugin import (
 )
 
 from .errors import WorkflowCancelledByUser, WorkflowRuntimeError
-from .events import Event, InternalDispatchEvent, StopEvent, WorkflowCancelledEvent
+from .events import (
+    Event,
+    InternalDispatchEvent,
+    StopEvent,
+    WorkflowCancelledEvent,
+    get_event_origin_namespace,
+)
 from .types import RunResultT
 
 if TYPE_CHECKING:
@@ -102,7 +108,7 @@ class WorkflowHandler(Awaitable[RunResultT]):
         return self._result_task.done()
 
     async def stream_events(
-        self, expose_internal: bool = False
+        self, expose_internal: bool = False, include_children: bool = False
     ) -> AsyncGenerator[Event, None]:
         """
         Stream events from the workflow execution as they occur.
@@ -117,6 +123,11 @@ class WorkflowHandler(Awaitable[RunResultT]):
 
         Args:
             expose_internal (bool): Whether to expose internal events.
+            include_children (bool): Whether to surface events published from
+                within child-workflow executions. Off by default so existing
+                parent consumers are unaffected; when on, child events are
+                yielded tagged with their origin namespace (read via
+                [`get_event_origin_namespace`][workflows.events.get_event_origin_namespace]).
 
         Returns:
             AsyncGenerator[Event, None]: An async generator that yields Event objects
@@ -155,9 +166,15 @@ class WorkflowHandler(Awaitable[RunResultT]):
         async for ev in self.ctx.stream_events():
             if isinstance(ev, InternalDispatchEvent) and not expose_internal:
                 continue
+            is_child = bool(get_event_origin_namespace(ev))
+            if is_child and not include_children:
+                continue
             yield ev
 
-            if isinstance(ev, StopEvent):
+            # Only the root StopEvent terminates the run (child StopEvents are
+            # boundary events that are never published); break solely on it so a
+            # child writing a StopEvent to the stream can't truncate the parent.
+            if isinstance(ev, StopEvent) and not is_child:
                 self._all_events_consumed = True
                 break
 

--- a/packages/llama-index-workflows/src/workflows/plugins/basic.py
+++ b/packages/llama-index-workflows/src/workflows/plugins/basic.py
@@ -18,10 +18,12 @@ from llama_index_instrumentation import get_dispatcher
 
 from workflows.context.serializers import BaseSerializer, JsonSerializer
 from workflows.context.state_store import (
-    InMemoryStateStore,
+    NamespacedStateStores,
     StateStore,
-    infer_state_type,
+    build_namespaced_state,
+    in_memory_namespace_factory,
     is_durable_serialized_state,
+    namespaced_state_types,
 )
 from workflows.errors import WorkflowRuntimeError
 from workflows.events import Event, StartEvent, StopEvent
@@ -60,12 +62,14 @@ class AsyncioAdapterQueues:
         self,
         run_id: str,
         init_state: BrokerState,
-        state_store: StateStore[Any] | None = None,
+        namespaced: NamespacedStateStores | None = None,
     ):
         self.run_id = run_id
         self.init_state = init_state
         self.ticks: list[WorkflowTick] = []
-        self.state_store = state_store
+        # Per-namespace in-memory stores for the run; each namespace owns an
+        # isolated record. ``None`` until run_workflow() builds it.
+        self.namespaced = namespaced
 
     # created lazily via cached_property for Python 3.14+ compatibility (they require a running event loop)
     @functools.cached_property
@@ -137,8 +141,12 @@ class InternalAsyncioAdapter(InternalRunAdapter, SnapshottableAdapter):
     def replay(self) -> list[WorkflowTick]:
         return self._queues.ticks
 
-    def get_state_store(self) -> StateStore[Any] | None:
-        return self._queues.state_store
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
+        if self._queues.namespaced is None:
+            return None
+        return self._queues.namespaced.view(namespace)
 
 
 class ExternalAsyncioAdapter(
@@ -178,8 +186,12 @@ class ExternalAsyncioAdapter(
     def replay(self) -> list[WorkflowTick]:
         return self._queues.ticks
 
-    def get_state_store(self) -> StateStore[Any] | None:
-        return self._queues.state_store
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
+        if self._queues.namespaced is None:
+            return None
+        return self._queues.namespaced.view(namespace)
 
     async def get_result(self) -> StopEvent:
         return await self._queues.complete
@@ -279,8 +291,15 @@ class BasicRuntime(Runtime):
 
         registered = self.get_or_register(workflow)
 
-        # Create state store from serialized state or infer type from workflow
+        # Build per-namespace in-memory stores, seeding the whole tree from a
+        # portable snapshot when resuming. Each namespace owns an isolated record.
         active_serializer = serializer or JsonSerializer()
+        state_types = namespaced_state_types(registered.workflow)
+        namespaced = build_namespaced_state(
+            registered.workflow,
+            in_memory_namespace_factory(state_types),
+            active_serializer,
+        )
         if serialized_state:
             if is_durable_serialized_state(serialized_state):
                 store_type = serialized_state.get("store_type")
@@ -288,16 +307,10 @@ class BasicRuntime(Runtime):
                     f"BasicRuntime cannot restore durable state store '{store_type}'. "
                     "Use the matching durable runtime or pass an in-memory context snapshot."
                 )
-            state_store = InMemoryStateStore.from_dict(
-                serialized_state, active_serializer
-            )
-        else:
-            # Infer state type from workflow step configs
-            state_type = infer_state_type(registered.workflow)
-            state_store = InMemoryStateStore(state_type())
+            namespaced.add_seed_tree(serialized_state, active_serializer)
         # might want to lock this better. Unlikely race condition if you spam with the same run_id.
         queues = self._get_or_create_queues(run_id, init_state)
-        queues.state_store = state_store
+        queues.namespaced = namespaced
 
         # Capture propagation context (otel trace, instrument tags, etc.)
         # BEFORE creating the task — contextvars won't be inherited.

--- a/packages/llama-index-workflows/src/workflows/representation/validate.py
+++ b/packages/llama-index-workflows/src/workflows/representation/validate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from typing import Protocol, TypeVar, cast
 
 from workflows._event_matching import is_subclass, step_accepts_type, type_matches
 from workflows._stream_levels import (
@@ -26,6 +27,25 @@ from workflows.resource import ResourceDescriptor, ResourceManager, _ResourceCon
 
 # Graph nodes: step names (str) for steps, event classes (type) for events.
 GraphNode = str | type
+WORKFLOW_T = TypeVar("WORKFLOW_T", bound="_WorkflowForValidation")
+
+
+class _WorkflowClassForValidation(Protocol):
+    __name__: str
+
+    @classmethod
+    def _get_child_workflow_slots(cls) -> dict[str, type]: ...
+
+
+class _WorkflowForValidation(Protocol):
+    @classmethod
+    def _get_child_workflow_slots(cls) -> dict[str, type]: ...
+
+    @property
+    def _start_event_class(self) -> type[StartEvent]: ...
+
+    @property
+    def _child_workflows(self) -> dict[str, WORKFLOW_T]: ...
 
 
 @dataclass
@@ -58,6 +78,7 @@ def build_step_graph(
     steps: dict[str, StepConfig],
     start_event_class: type,
     catch_error_steps: list[str] | None = None,
+    child_boundaries: list[tuple[type, type]] | None = None,
 ) -> StepGraph:
     """Build a StepGraph from step configs and a start event class.
 
@@ -65,6 +86,13 @@ def build_step_graph(
     events (StartEvent + HumanResponseEvent subclasses + any catch_error handler
     step names) and reverse reachability from output events (StopEvent +
     InputRequiredEvent).
+
+    ``child_boundaries`` is a list of ``(child_start_event, child_stop_event)``
+    pairs, one per attached child workflow. Each becomes a synthetic boundary
+    node that consumes the child's StartEvent (emitted by a parent step) and
+    produces the child's StopEvent (re-injected to a parent step), so the parent
+    graph stays connected across the child boundary without instantiating the
+    child's steps here.
     """
     outgoing: dict[GraphNode, list[GraphNode]] = {}
     event_types: set[type] = {start_event_class} if steps else set()
@@ -96,6 +124,14 @@ def build_step_graph(
                 allow_subclasses=allow_subclasses,
             ):
                 outgoing.setdefault(ev_type, []).append(name)
+
+    for i, (child_start, child_stop) in enumerate(child_boundaries or []):
+        boundary = f"<child-boundary-{i}>"
+        step_names.add(boundary)
+        event_types.add(child_start)
+        event_types.add(child_stop)
+        outgoing.setdefault(child_start, []).append(boundary)
+        outgoing.setdefault(boundary, []).append(child_stop)
 
     # Forward DFS from StartEvent + HumanResponseEvent subclasses +
     # catch_error handler step names (their sub-graphs are reachable via
@@ -164,6 +200,7 @@ def validate_graph(
     start_event_class: type,
     skip_checks: set[WorkflowGraphCheck] | None = None,
     catch_error_steps: list[str] | None = None,
+    child_boundaries: list[tuple[type, type]] | None = None,
 ) -> list[GraphValidationError]:
     """Validate the graph structure of a workflow, accumulating all errors.
 
@@ -186,7 +223,9 @@ def validate_graph(
     skip_checks = skip_checks or set()
     errors: list[GraphValidationError] = []
 
-    graph = build_step_graph(steps, start_event_class, catch_error_steps)
+    graph = build_step_graph(
+        steps, start_event_class, catch_error_steps, child_boundaries
+    )
 
     # Check 1: Reachability
     if "reachability" not in skip_checks:
@@ -451,28 +490,37 @@ def _collect_catch_error_handlers(
 def _validate_event_connectivity(
     steps: dict[str, StepConfig],
     start_event_class: type[StartEvent],
+    child_start_event_classes: set[type] | None = None,
+    child_stop_event_classes: set[type] | None = None,
 ) -> bool:
     """Validate event production/consumption across the step graph.
 
     Checks that:
-    - No user step accepts ``StopEvent``.
+    - No user step accepts ``StopEvent`` (except an attached child's StopEvent,
+      which a parent step consumes as a boundary event).
     - Every consumed event is either produced or crosses the workflow
       boundary (``InputRequiredEvent``/``HumanResponseEvent``/``StopEvent``/
       ``StepFailedEvent``).
     - Every produced event is consumed, except for
-      ``InputRequiredEvent``/``HumanResponseEvent``/``StopEvent`` subclasses.
+      ``InputRequiredEvent``/``HumanResponseEvent``/``StopEvent`` subclasses and
+      a triggered child's StartEvent (consumed across the child boundary).
 
     Returns ``True`` if the workflow uses human-in-the-loop
     (``InputRequiredEvent`` produced or ``HumanResponseEvent`` consumed).
     Raises ``WorkflowValidationError`` on any violation.
     """
+    child_start_event_classes = child_start_event_classes or set()
+    child_stop_event_classes = child_stop_event_classes or set()
     produced_events: set[type] = {start_event_class}
     consumed_events: set[type] = set()
     steps_accepting_stop_event: list[str] = []
 
     for name, cfg in steps.items():
         for event_type in cfg.accepted_events:
-            if is_subclass(event_type, StopEvent):
+            if (
+                is_subclass(event_type, StopEvent)
+                and event_type not in child_stop_event_classes
+            ):
                 steps_accepting_stop_event.append(name)
                 break
         for event_type in cfg.accepted_events:
@@ -520,7 +568,7 @@ def _validate_event_connectivity(
     boundary_out = (InputRequiredEvent, HumanResponseEvent, StopEvent)
     unused_events = set()
     for x in produced_events:
-        if is_subclass(x, boundary_out):
+        if is_subclass(x, boundary_out) or x in child_start_event_classes:
             continue
         consumed = any(
             step_accepts_type(
@@ -745,10 +793,60 @@ def _validate_multi_slot_levels(
         raise WorkflowValidationError("\n".join(errors))
 
 
+def _validate_child_workflow_declarations(
+    workflow: _WorkflowForValidation,
+) -> None:
+    """Validate child workflow declarations that need the workflow tree.
+
+    Per-workflow graph validation runs from step configs. These checks sit one
+    level up: they validate the declared child type graph and event routing
+    boundary between a parent instance and its direct children.
+    """
+    root = cast("type[_WorkflowClassForValidation]", type(workflow))
+    _validate_child_type_graph(root)
+    _validate_child_start_events(workflow)
+
+
+def _validate_child_type_graph(root: type[_WorkflowClassForValidation]) -> None:
+    """Reject cycles in the declared child-workflow type graph."""
+
+    def walk(
+        node: type[_WorkflowClassForValidation],
+        path: tuple[type[_WorkflowClassForValidation], ...],
+    ) -> None:
+        for child_type in node._get_child_workflow_slots().values():
+            child_cls = cast("type[_WorkflowClassForValidation]", child_type)
+            if child_cls in path:
+                chain = " -> ".join(c.__name__ for c in (*path, child_cls))
+                raise WorkflowValidationError(
+                    f"Child workflow type cycle detected: {chain}. A child "
+                    "workflow cannot transitively declare itself as a child."
+                )
+            walk(child_cls, (*path, child_cls))
+
+    walk(root, (root,))
+
+
+def _validate_child_start_events(workflow: _WorkflowForValidation) -> None:
+    """Each direct child's ``StartEvent`` type must be unique."""
+    seen: dict[type[StartEvent], str] = {}
+    for field_name, child in workflow._child_workflows.items():
+        start_cls = child._start_event_class
+        if start_cls in seen:
+            raise WorkflowValidationError(
+                f"Child workflows '{seen[start_cls]}' and '{field_name}' on "
+                f"'{type(workflow).__name__}' both accept StartEvent type "
+                f"'{start_cls.__name__}'; each child's StartEvent type must "
+                "be unique so the parent can route to exactly one child."
+            )
+        seen[start_cls] = field_name
+
+
 def _validate_workflow(
     steps: dict[str, StepConfig],
     workflow_cls_name: str,
     skip_graph_checks: set[WorkflowGraphCheck],
+    child_boundaries: list[tuple[type, type]] | None = None,
 ) -> _WorkflowValidationResult:
     """Run every structural check on a workflow's step set.
 
@@ -767,13 +865,22 @@ def _validate_workflow(
             "free-function steps via @step(workflow=...)?"
         )
 
+    child_boundaries = child_boundaries or []
+    child_start_event_classes = {start for start, _ in child_boundaries}
+    child_stop_event_classes = {stop for _, stop in child_boundaries}
+
     start_event_class = _ensure_start_event_class(steps, workflow_cls_name)
     stop_event_class = _ensure_stop_event_class(steps, workflow_cls_name)
 
     _validate_collection_bindings(steps)
     _validate_multi_slot_levels(steps, start_event_class)
 
-    uses_hitl = _validate_event_connectivity(steps, start_event_class)
+    uses_hitl = _validate_event_connectivity(
+        steps,
+        start_event_class,
+        child_start_event_classes,
+        child_stop_event_classes,
+    )
 
     catch_error_handlers, handler_for_step = _collect_catch_error_handlers(steps)
 
@@ -782,6 +889,7 @@ def _validate_workflow(
         start_event_class=start_event_class,
         skip_checks=skip_graph_checks,
         catch_error_steps=list(catch_error_handlers.keys()),
+        child_boundaries=child_boundaries,
     )
     if graph_errors:
         detail = "\n".join(

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -8,7 +8,7 @@ import inspect
 import logging
 import time
 from collections.abc import AsyncIterable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any
 
@@ -45,12 +45,14 @@ from workflows.runtime.control_loop.streams import (
     _close_collection_stream,
     _count_accepting_steps,
     _detect_stuck_streams,
+    _event_routes_to,
     _fire_collection_release,
     _mint_stream_id,
     _release_on_item,
     _release_state_for,
 )
 from workflows.runtime.types.commands import (
+    CommandCancelNamespace,
     CommandCompleteRun,
     CommandFailWorkflow,
     CommandHalt,
@@ -58,17 +60,24 @@ from workflows.runtime.types.commands import (
     CommandQueueEvent,
     CommandRunWorker,
     CommandScheduleIdleCheck,
+    CommandScheduleNamespaceTimeout,
     CommandScheduleWaiterTimeout,
     CommandScheduleWakeup,
     WorkflowCommand,
     indicates_exit,
 )
 from workflows.runtime.types.internal_state import (
+    BrokerConfig,
     BrokerState,
     CollectionStreamInstance,
     EventAttempt,
     InProgressState,
     InternalStepWorkerState,
+)
+from workflows.runtime.types.invocation import (
+    mint_child_invocation_namespace,
+    namespace_startswith,
+    slot_namespace,
 )
 from workflows.runtime.types.results import (
     AddCollectedEvent,
@@ -87,6 +96,7 @@ from workflows.runtime.types.ticks import (
     TickCancelRun,
     TickIdleCheck,
     TickIdleRelease,
+    TickNamespaceTimeout,
     TickPublishEvent,
     TickStepResult,
     TickTimeout,
@@ -96,10 +106,6 @@ from workflows.runtime.types.ticks import (
 )
 
 logger = logging.getLogger("workflows.runtime.control_loop")
-
-
-def _root_step_key(step_id: StepId) -> str:
-    return str(step_id)
 
 
 def rebuild_state_from_ticks(
@@ -129,6 +135,7 @@ def rebuild_state_from_ticks(
 
     # Replay ticks to rebuild state
     for tick in ticks:
+        tick = prepare_tick_for_reduce(tick, state)
         state, _ = _reduce_tick(
             tick, state, time.time(), run_id=run_id
         )  # somewhat broken kludge on the timestamps, need to move these to ticks
@@ -174,6 +181,7 @@ async def replay_ticks_stream(
     state, _ = rewind_in_progress(state, time.time())
     exit_command: ExitCommand | None = None
     async for tick in ticks:
+        tick = prepare_tick_for_reduce(tick, state)
         state, commands = _reduce_tick(tick, state, time.time(), run_id=run_id)
         for command in commands:
             if isinstance(
@@ -218,6 +226,8 @@ def _reduce_tick(
         state, commands = _process_timeout_tick(tick, init)
     elif isinstance(tick, TickWaiterTimeout):
         state, commands = _process_waiter_timeout_tick(tick, init, now_seconds)
+    elif isinstance(tick, TickNamespaceTimeout):
+        state, commands = _process_namespace_timeout_tick(tick, init, now_seconds)
     elif isinstance(tick, TickIdleCheck):
         # Return early — idle check ticks don't schedule further idle checks
         if _check_idle_state(init):
@@ -249,6 +259,46 @@ def _reduce_tick(
         commands.append(CommandScheduleIdleCheck())
 
     return state, commands
+
+
+def _namespace_key(namespace: tuple[str, ...]) -> str:
+    return "/".join(namespace)
+
+
+def prepare_tick_for_reduce(tick: WorkflowTick, state: BrokerState) -> WorkflowTick:
+    if (
+        not isinstance(tick, TickAddEvent)
+        or tick.step_id is not None
+        or not isinstance(tick.event, StartEvent)
+    ):
+        return tick
+
+    child_invocation_namespaces = dict(tick.child_invocation_namespaces)
+    changed = False
+    origin_slot_namespace = slot_namespace(tick.origin_namespace)
+    for step_id, step_config in state.config.steps.items():
+        if not (
+            len(step_id.namespace) == len(origin_slot_namespace) + 1
+            and step_id.namespace[: len(origin_slot_namespace)] == origin_slot_namespace
+            and step_accepts_event(
+                tick.event,
+                step_config.accepted_events,
+                allow_subclasses=step_config.accept_event_subclasses,
+            )
+        ):
+            continue
+        key = _namespace_key(step_id.namespace)
+        if key not in child_invocation_namespaces:
+            child_invocation_namespaces[key] = mint_child_invocation_namespace(
+                tick.origin_namespace, step_id.namespace[-1]
+            )
+            changed = True
+
+    if not changed:
+        return tick
+    return tick.model_copy(
+        update={"child_invocation_namespaces": child_invocation_namespaces}
+    )
 
 
 def _is_eligible(attempt: EventAttempt) -> bool:
@@ -312,9 +362,15 @@ def _drain_eligible_queue(
     eligible attempts is preserved.
     """
     commands: list[WorkflowCommand] = []
-    while len(state.in_progress) < state.config.num_workers:
+    while True:
         index = next(
-            (i for i, a in enumerate(state.queue) if _is_eligible(a)),
+            (
+                i
+                for i, a in enumerate(state.queue)
+                if _is_eligible(a)
+                and len(_worker_in_progress(state, a.invocation_namespace))
+                < state.config.num_workers
+            ),
             None,
         )
         if index is None:
@@ -337,8 +393,7 @@ def rewind_in_progress(
     """
     state = state.deepcopy()
     commands: list[WorkflowCommand] = []
-    for step_name, step_state in sorted(state.workers.items(), key=lambda x: x[0]):
-        step_id = StepId.root(step_name)
+    for step_id, step_state in sorted(state.workers.items(), key=lambda x: str(x[0])):
         for in_progress in step_state.in_progress:
             step_state.queue.insert(
                 0,
@@ -351,6 +406,7 @@ def rewind_in_progress(
                     last_failed_at=in_progress.last_failed_at,
                     recovery_counts=dict(in_progress.recovery_counts),
                     scope_path=in_progress.scope_path,
+                    invocation_namespace=in_progress.invocation_namespace,
                     collection_release_payload=in_progress.shared_state.collection_release_payload,
                     work_item_id=in_progress.work_item_id,
                 ),
@@ -385,6 +441,87 @@ def _check_idle_state(state: BrokerState) -> bool:
     return True
 
 
+def _worker_collected_events(
+    worker_state: InternalStepWorkerState, invocation_namespace: tuple[str, ...]
+) -> dict[str, list[Event]]:
+    if invocation_namespace == ():
+        return worker_state.collected_events
+    return worker_state.collected_events_by_invocation.setdefault(
+        invocation_namespace, {}
+    )
+
+
+def _worker_static_collect_events(
+    worker_state: InternalStepWorkerState, invocation_namespace: tuple[str, ...]
+) -> list[Event]:
+    if invocation_namespace == ():
+        return worker_state.static_collect_events
+    return worker_state.static_collect_events_by_invocation.setdefault(
+        invocation_namespace, []
+    )
+
+
+def _set_worker_static_collect_events(
+    worker_state: InternalStepWorkerState,
+    invocation_namespace: tuple[str, ...],
+    events: list[Event],
+) -> None:
+    if invocation_namespace == ():
+        worker_state.static_collect_events = events
+    else:
+        worker_state.static_collect_events_by_invocation[invocation_namespace] = events
+
+
+def _worker_waiters(
+    worker_state: InternalStepWorkerState, invocation_namespace: tuple[str, ...]
+) -> list[StepWorkerWaiter]:
+    return [
+        waiter
+        for waiter in worker_state.collected_waiters
+        if waiter.invocation_namespace == invocation_namespace
+    ]
+
+
+def _worker_in_progress(
+    worker_state: InternalStepWorkerState, invocation_namespace: tuple[str, ...]
+) -> list[InProgressState]:
+    return [
+        worker
+        for worker in worker_state.in_progress
+        if worker.invocation_namespace == invocation_namespace
+    ]
+
+
+def _child_invocation_for_route(
+    tick: TickAddEvent,
+    origin_namespace: tuple[str, ...],
+    target_namespace: tuple[str, ...],
+    event: Event,
+) -> tuple[str, ...]:
+    origin_slot_namespace = slot_namespace(origin_namespace)
+    if (
+        isinstance(event, StartEvent)
+        and len(target_namespace) == len(origin_slot_namespace) + 1
+        and target_namespace[: len(origin_slot_namespace)] == origin_slot_namespace
+    ):
+        mapped = tick.child_invocation_namespaces.get(_namespace_key(target_namespace))
+        if mapped is not None:
+            return mapped
+        return mint_child_invocation_namespace(origin_namespace, target_namespace[-1])
+    return origin_namespace
+
+
+def _target_invocation_for_static_step(
+    step_id: StepId,
+    origin_namespace: tuple[str, ...],
+) -> tuple[str, ...] | None:
+    if step_id.namespace == slot_namespace(origin_namespace):
+        return origin_namespace
+    if step_id.namespace == ():
+        return origin_namespace
+    return None
+
+
 def _collect_buffer_diverged(live: list[Event], snapshot: list[Event]) -> bool:
     """True when a live ctx.collect_events() buffer no longer matches a snapshot."""
     return len(live) != len(snapshot) or any(a is not b for a, b in zip(live, snapshot))
@@ -403,6 +540,7 @@ def _queue_catch_error_event(
         step_id=step_id,
         recovery_counts=recovery_counts,
         scope_path=this_execution.scope_path,
+        origin_namespace=this_execution.invocation_namespace,
     )
 
 
@@ -445,10 +583,18 @@ class _FanOutScope:
 
 
 def _find_in_progress(
-    worker_state: InternalStepWorkerState, worker_id: int
+    worker_state: InternalStepWorkerState,
+    worker_id: int,
+    invocation_namespace: tuple[str, ...],
 ) -> InProgressState:
     execution = next(
-        (w for w in worker_state.in_progress if w.worker_id == worker_id), None
+        (
+            w
+            for w in worker_state.in_progress
+            if w.worker_id == worker_id
+            and w.invocation_namespace == invocation_namespace
+        ),
+        None,
     )
     if execution is None:
         # this should not happen unless there's a logic bug in the control loop
@@ -472,7 +618,9 @@ def _rerun_for_stale_collect_buffer(
     stale_firing = any(
         isinstance(r, DeleteCollectedEvent)
         and _collect_buffer_diverged(
-            worker_state.collected_events.get(r.event_id, []),
+            _worker_collected_events(
+                worker_state, this_execution.invocation_namespace
+            ).get(r.event_id, []),
             this_execution.shared_state.collected_events.get(r.event_id, []),
         )
         for r in tick.result
@@ -481,7 +629,12 @@ def _rerun_for_stale_collect_buffer(
         return None
     this_execution.shared_state = replace(
         this_execution.shared_state,
-        collected_events={x: list(y) for x, y in worker_state.collected_events.items()},
+        collected_events={
+            x: list(y)
+            for x, y in _worker_collected_events(
+                worker_state, this_execution.invocation_namespace
+            ).items()
+        },
     )
     return [
         CommandRunWorker(
@@ -489,6 +642,7 @@ def _rerun_for_stale_collect_buffer(
             event=this_execution.event,
             bound_events=this_execution.bound_events,
             id=this_execution.worker_id,
+            invocation_namespace=this_execution.invocation_namespace,
         )
     ]
 
@@ -517,6 +671,85 @@ def _fan_out_scope(
     )
 
 
+def terminate_namespace(state: BrokerState, namespace: tuple[str, ...]) -> None:
+    """Tear down a namespace and every descendant, in place.
+
+    The single teardown mechanic behind all three paths (root stop, child-stop
+    boundary, child timeout): clear every worker buffer for the namespace, drop
+    the collection streams opened inside it, and forget its timeout activations.
+    The match is a *prefix* match, so terminating a child takes its grandchildren
+    with it. Root is ``namespace == ()`` — the prefix matches everything, exactly
+    the whole-run clear the root StopEvent needs.
+
+    Cancellation of the namespace's live worker *tasks* is a separate concern the
+    caller schedules via :class:`CommandCancelNamespace` (the reducer owns
+    journaled buffers; only the runner owns the asyncio tasks). Whether the run
+    then completes or the boundary event is re-injected also lives in the caller,
+    not here.
+    """
+    if namespace == ():
+        for worker in state.workers.values():
+            worker.queue.clear()
+            worker.in_progress.clear()
+            worker.collected_events.clear()
+            worker.collected_events_by_invocation.clear()
+            worker.static_collect_events.clear()
+            worker.static_collect_events_by_invocation.clear()
+            worker.collected_waiters.clear()
+    else:
+        for worker in state.workers.values():
+            worker.queue = [
+                attempt
+                for attempt in worker.queue
+                if not namespace_startswith(attempt.invocation_namespace, namespace)
+            ]
+            worker.in_progress = [
+                running
+                for running in worker.in_progress
+                if not namespace_startswith(running.invocation_namespace, namespace)
+            ]
+            worker.collected_waiters = [
+                waiter
+                for waiter in worker.collected_waiters
+                if not namespace_startswith(waiter.invocation_namespace, namespace)
+            ]
+            for dead_namespace in [
+                ns
+                for ns in worker.collected_events_by_invocation
+                if namespace_startswith(ns, namespace)
+            ]:
+                worker.collected_events_by_invocation.pop(dead_namespace, None)
+            for dead_namespace in [
+                ns
+                for ns in worker.static_collect_events_by_invocation
+                if namespace_startswith(ns, namespace)
+            ]:
+                worker.static_collect_events_by_invocation.pop(dead_namespace, None)
+    dead_streams = {
+        sid
+        for sid, stream in state.streams.items()
+        if namespace_startswith(stream.source_invocation_namespace, namespace)
+    }
+    for sid in dead_streams:
+        state.streams.pop(sid, None)
+    for key in [
+        key
+        for key, release in state.collection_release_states.items()
+        if release.stream_id in dead_streams
+    ]:
+        state.collection_release_states.pop(key, None)
+    for started_ns in [
+        ns for ns in state.namespace_started if namespace_startswith(ns, namespace)
+    ]:
+        state.namespace_started.pop(started_ns, None)
+    for active_ns in [
+        ns
+        for ns in state.active_invocation_namespaces
+        if namespace_startswith(ns, namespace)
+    ]:
+        state.active_invocation_namespaces.discard(active_ns)
+
+
 def _apply_step_result(
     result: StepFunctionResult,
     *,
@@ -531,33 +764,59 @@ def _apply_step_result(
 ) -> None:
     """Apply a single result item from a step execution to the state."""
     step_id = tick.step_id
-    step_name = _root_step_key(step_id)
+    # String projection of the step identity. For a root step this is the bare
+    # name (matching collection binding source/target names); for a child step
+    # it is the namespaced "path/name".
+    step_name = str(step_id)
     if isinstance(result, StepWorkerResult):
         acc.output_event_name = str(type(result.result))
-        if isinstance(result.result, StopEvent):
-            # huzzah! The workflow has completed
+        if isinstance(result.result, StopEvent) and step_id.is_root:
+            # huzzah! The (root) workflow has completed
             acc.commands.append(
                 CommandPublishEvent(event=result.result)
             )  # stop event always published to the stream
             state.is_running = False
-            # Clear collected_events and collected_waiters since workflow is complete
-            for worker in state.workers.values():
-                worker.queue.clear()
-                worker.in_progress.clear()
-                worker.collected_events.clear()
-                worker.static_collect_events.clear()
-                worker.collected_waiters.clear()
-            # Drop open collection state; no release can fire after the run ends.
-            _clear_collection_state(state)
+            # Tear down the whole run (root prefix matches every namespace); the
+            # runner cancels the live tasks on CommandCompleteRun.
+            terminate_namespace(state, ())
             acc.commands.append(CommandCompleteRun(result=result.result))
+        elif isinstance(result.result, StopEvent):
+            # A child's StopEvent is a *boundary* event, not a run terminal: the
+            # child run is over, so terminate its namespace (and any grandchild
+            # under it) and re-inject the event into the parent namespace as an
+            # ordinary routable event. Tearing down cancels sibling branches
+            # still in flight, so a child that stops while a sibling runs cannot
+            # surface a second StopEvent. The run keeps running; only the root
+            # StopEvent above completes it. The event is NOT published to the
+            # root stream by default because root consumers treat StopEvent as
+            # completion; stream_events(include_children=True) opts into child
+            # events separately.
+            parent_invocation_namespace = this_execution.invocation_namespace[:-1]
+            terminate_namespace(state, this_execution.invocation_namespace)
+            acc.commands.append(
+                CommandCancelNamespace(namespace=this_execution.invocation_namespace)
+            )
+            acc.commands.append(
+                CommandQueueEvent(
+                    event=result.result,
+                    origin_namespace=parent_invocation_namespace,
+                    recovery_counts=dict(this_execution.recovery_counts),
+                )
+            )
         elif isinstance(result.result, Event):
             # queue any subsequent events
             # human input required are automatically published to the stream
             if isinstance(result.result, InputRequiredEvent):
-                acc.commands.append(CommandPublishEvent(event=result.result))
+                acc.commands.append(
+                    CommandPublishEvent(
+                        event=result.result,
+                        origin_namespace=this_execution.invocation_namespace,
+                    )
+                )
             acc.commands.append(
                 CommandQueueEvent(
                     event=result.result,
+                    origin_namespace=this_execution.invocation_namespace,
                     recovery_counts=dict(this_execution.recovery_counts),
                     scope_path=scope.emit_stack,
                 )
@@ -581,9 +840,9 @@ def _apply_step_result(
         )
     elif isinstance(result, AddCollectedEvent):
         # The current state of collected events.
-        collected_events = state.workers[step_name].collected_events.setdefault(
-            result.event_id, []
-        )
+        collected_events = _worker_collected_events(
+            state.workers[step_id], this_execution.invocation_namespace
+        ).setdefault(result.event_id, [])
         # the events snapshot that was sent with the step function execution that yielded this result
         snapshot_events = this_execution.shared_state.collected_events.get(
             result.event_id, []
@@ -596,7 +855,9 @@ def _apply_step_result(
                 this_execution.shared_state,
                 collected_events={
                     x: list(y)
-                    for x, y in state.workers[step_name].collected_events.items()
+                    for x, y in _worker_collected_events(
+                        state.workers[step_id], this_execution.invocation_namespace
+                    ).items()
                 },
             )
             this_execution.shared_state = updated_state
@@ -606,6 +867,7 @@ def _apply_step_result(
                     event=result.event,
                     bound_events=this_execution.bound_events,
                     id=this_execution.worker_id,
+                    invocation_namespace=this_execution.invocation_namespace,
                 )
             )
         else:
@@ -613,7 +875,9 @@ def _apply_step_result(
     elif isinstance(result, DeleteCollectedEvent):
         if did_complete_step:  # allow retries to grab the events
             # indicates that a run has successfully collected its events, and they can be deleted from the collected events state
-            state.workers[step_name].collected_events.pop(result.event_id, None)
+            _worker_collected_events(
+                state.workers[step_id], this_execution.invocation_namespace
+            ).pop(result.event_id, None)
     elif isinstance(result, AddWaiter):
         # indicates that a run has added a waiter to the collected waiters state
         existing = next(
@@ -621,6 +885,7 @@ def _apply_step_result(
                 (i)
                 for i, x in enumerate(worker_state.collected_waiters)
                 if x.waiter_id == result.waiter_id
+                and x.invocation_namespace == this_execution.invocation_namespace
             ),
             None,
         )
@@ -635,6 +900,7 @@ def _apply_step_result(
             # Store the suspended work item's record so resume re-delivers
             # it whole: same stream scope, same collect batch.
             scope_path=this_execution.scope_path,
+            invocation_namespace=this_execution.invocation_namespace,
             collection_release_payload=this_execution.shared_state.collection_release_payload,
             work_item_id=this_execution.work_item_id,
         )
@@ -643,21 +909,34 @@ def _apply_step_result(
         else:
             worker_state.collected_waiters.append(new_waiter)
             if result.waiter_event:
-                acc.commands.append(CommandPublishEvent(event=result.waiter_event))
+                acc.commands.append(
+                    CommandPublishEvent(
+                        event=result.waiter_event,
+                        origin_namespace=this_execution.invocation_namespace,
+                    )
+                )
             if result.timeout is not None:
                 acc.commands.append(
                     CommandScheduleWaiterTimeout(
                         step_id=step_id,
                         waiter_id=result.waiter_id,
                         timeout=result.timeout,
+                        invocation_namespace=this_execution.invocation_namespace,
                     )
                 )
     elif isinstance(result, DeleteWaiter):
         if did_complete_step:  # allow retries to grab the waiter events
             # indicates that a run has obtained the waiting event, and it can be deleted from the collected waiters state
             to_remove = result.waiter_id
-            waiters = state.workers[step_name].collected_waiters
-            item = next(filter(lambda w: w.waiter_id == to_remove, waiters), None)
+            waiters = state.workers[step_id].collected_waiters
+            item = next(
+                filter(
+                    lambda w: w.waiter_id == to_remove
+                    and w.invocation_namespace == this_execution.invocation_namespace,
+                    waiters,
+                ),
+                None,
+            )
             if item is not None:
                 waiters.remove(item)
     else:
@@ -677,7 +956,7 @@ def _schedule_retry_or_route_failure(
     """Handle a failed execution: schedule a retry if permitted, route to a
     catch_error handler if one applies, otherwise fail the workflow."""
     step_id = tick.step_id
-    step_name = _root_step_key(step_id)
+    step_name = str(step_id)
     # Prefer the journaled dispatch time: rebuilds re-stamp
     # this_execution.first_attempt_at with the rebuild clock, which
     # would silently restart elapsed-based retry budgets on resume.
@@ -723,6 +1002,7 @@ def _schedule_retry_or_route_failure(
                 recovery_counts=dict(this_execution.recovery_counts),
                 not_before=not_before,
                 scope_path=this_execution.scope_path,
+                invocation_namespace=this_execution.invocation_namespace,
                 collection_release_payload=this_execution.shared_state.collection_release_payload,
                 work_item_id=this_execution.work_item_id,
             ),
@@ -736,24 +1016,30 @@ def _schedule_retry_or_route_failure(
     total_attempts = this_execution.attempts + 1
     elapsed = result.failed_at - first_attempt_at
 
-    handler_name = state.config.handler_for_step.get(step_name)
+    # Route a failed step to the catch-error handler in its own
+    # namespace, if any. Tables are StepId-keyed, so a child's
+    # handler recovers only the child's steps; the recovery budget is
+    # keyed by the handler's str(StepId) to avoid colliding with a
+    # same-named root handler.
+    handler_step_id = state.config.handler_for_step.get(step_id)
     handler = (
-        state.config.catch_error_handlers.get(handler_name)
-        if handler_name is not None
+        state.config.catch_error_handlers.get(handler_step_id)
+        if handler_step_id is not None
         else None
     )
+    recovery_key = str(handler_step_id) if handler_step_id is not None else None
     current_count = (
-        this_execution.recovery_counts.get(handler.step_name, 0)
-        if handler is not None
+        this_execution.recovery_counts.get(recovery_key, 0)
+        if recovery_key is not None
         else 0
     )
     new_count = current_count + 1
     should_route = handler is not None and new_count <= handler.max_recoveries
-    if should_route and handler is not None:
+    if should_route and handler_step_id is not None and recovery_key is not None:
         # Route to the catch-error handler. Keep workflow running so
         # the handler can produce either a StopEvent or a new failure.
         step_failed_event = StepFailedEvent(
-            step_name=step_name,
+            step_name=str(step_id),
             input_event=tick.event,
             exception=exception,
             attempts=total_attempts,
@@ -769,10 +1055,10 @@ def _schedule_retry_or_route_failure(
             _queue_catch_error_event(
                 this_execution,
                 event=step_failed_event,
-                step_id=StepId.root(handler.step_name),
+                step_id=handler_step_id,
                 recovery_counts={
                     **this_execution.recovery_counts,
-                    handler.step_name: new_count,
+                    recovery_key: new_count,
                 },
             )
         )
@@ -783,7 +1069,7 @@ def _schedule_retry_or_route_failure(
         acc.commands.append(
             CommandPublishEvent(
                 event=WorkflowFailedEvent(
-                    step_name=step_name,
+                    step_name=str(step_id),
                     exception=exception,
                     attempts=total_attempts,
                     elapsed_seconds=elapsed,
@@ -798,6 +1084,7 @@ def _resolve_work_item_in_stream(
     state: BrokerState,
     scope: _FanOutScope,
     acc: _StepResultAcc,
+    invocation_namespace: tuple[str, ...],
     now_seconds: float,
 ) -> list[WorkflowCommand]:
     """Resolve this execution's work item in its enclosing collection stream.
@@ -806,7 +1093,6 @@ def _resolve_work_item_in_stream(
     is driven only by source exhaustion plus ``open_work_items == 0``.
     Classification happens once, before any counter mutation.
     """
-    step_name = _root_step_key(tick.step_id)
     commands: list[WorkflowCommand] = []
     emitted_non_stop = [
         x.result
@@ -828,13 +1114,17 @@ def _resolve_work_item_in_stream(
         disposition is WorkDisposition.FANNED_OUT
         and scope.fan_out_stream_id is not None
     ):
-        bindings = state.config.bindings_for_source(step_name)
+        bindings = state.config.bindings_for_source(tick.step_id)
         accepting_binding_ids = tuple(binding.id for binding in bindings)
-        seed = sum(_count_accepting_steps(state, type(m)) for m in emitted_non_stop)
+        seed = sum(
+            _count_accepting_steps(state, m, invocation_namespace)
+            for m in emitted_non_stop
+        )
         state.streams[scope.fan_out_stream_id] = CollectionStreamInstance(
             stream_id=scope.fan_out_stream_id,
-            source_step=step_name,
+            source_step=tick.step_id,
             scope_path=scope.trigger_stack,
+            source_invocation_namespace=invocation_namespace,
             accepting_binding_ids=accepting_binding_ids,
             open_work_items=seed,
         )
@@ -854,7 +1144,8 @@ def _resolve_work_item_in_stream(
         # work item per accepting step per emitted event. A step that returns
         # None adds zero successors and simply leaves the set.
         successors = sum(
-            _count_accepting_steps(state, type(ev)) for ev in emitted_non_stop
+            _count_accepting_steps(state, ev, invocation_namespace)
+            for ev in emitted_non_stop
         )
         commands.extend(
             _adjust_open_work_items(state, enclosing, successors - 1, now_seconds)
@@ -883,9 +1174,14 @@ def _process_step_result_tick(
     """
     state = init.deepcopy()
     step_id = tick.step_id
-    step_name = _root_step_key(step_id)
-    worker_state = state.workers[step_name]
-    this_execution = _find_in_progress(worker_state, tick.worker_id)
+    worker_state = state.workers[step_id]
+    # String projection of the step identity. For a root step this is the bare
+    # name (matching collection binding source/target names); for a child step
+    # it is the namespaced "path/name".
+    step_name = str(step_id)
+    this_execution = _find_in_progress(
+        worker_state, tick.worker_id, tick.invocation_namespace
+    )
 
     rerun = _rerun_for_stale_collect_buffer(tick, worker_state, this_execution)
     if rerun is not None:
@@ -912,7 +1208,9 @@ def _process_step_result_tick(
         )
 
     acc.commands.extend(
-        _resolve_work_item_in_stream(tick, state, scope, acc, now_seconds)
+        _resolve_work_item_in_stream(
+            tick, state, scope, acc, this_execution.invocation_namespace, now_seconds
+        )
     )
 
     is_completed = any(indicates_exit(c) for c in acc.commands)
@@ -926,7 +1224,8 @@ def _process_step_result_tick(
                     input_event_name=str(type(tick.event)),
                     output_event_name=acc.output_event_name,
                     worker_id=str(tick.worker_id),
-                )
+                ),
+                origin_namespace=this_execution.invocation_namespace,
             ),
         )
         if this_execution in worker_state.in_progress:
@@ -941,15 +1240,19 @@ def _process_step_result_tick(
 def _static_collect_events(
     event: Event,
     worker_state: InternalStepWorkerState,
+    invocation_namespace: tuple[str, ...],
 ) -> dict[str, Event] | None:
     """Buffer a statically routed fan-in event until every declared slot is filled."""
     collect_params = worker_state.config.collect_params
     if collect_params is None:
         return None
 
-    worker_state.static_collect_events.append(event)
+    static_collect_events = _worker_static_collect_events(
+        worker_state, invocation_namespace
+    )
+    static_collect_events.append(event)
     selected_indices = _select_static_collect_batch(
-        events=worker_state.static_collect_events,
+        events=static_collect_events,
         collect_params=collect_params,
         allow_subclasses=worker_state.config.accept_event_subclasses,
     )
@@ -957,15 +1260,19 @@ def _static_collect_events(
         return None
 
     binding = {
-        param_name: worker_state.static_collect_events[event_index]
+        param_name: static_collect_events[event_index]
         for (param_name, _), event_index in zip(collect_params, selected_indices)
     }
     selected = set(selected_indices)
-    worker_state.static_collect_events = [
-        pending
-        for index, pending in enumerate(worker_state.static_collect_events)
-        if index not in selected
-    ]
+    _set_worker_static_collect_events(
+        worker_state,
+        invocation_namespace,
+        [
+            pending
+            for index, pending in enumerate(static_collect_events)
+            if index not in selected
+        ],
+    )
     return binding
 
 
@@ -1010,23 +1317,25 @@ def _add_or_enqueue_event(
     Note! This mutates the state, assuming that its already been deepcopied in an outer scope.
     """
     commands: list[WorkflowCommand] = []
-    step_name = _root_step_key(step_id)
     # Determine if there is available capacity based on in_progress workers.
     # Delayed attempts (not_before set) are never dispatched here; they wait
     # in the queue without consuming a worker slot until a wakeup flips them.
-    has_space = len(state.in_progress) < state.config.num_workers and _is_eligible(
+    invocation_in_progress = _worker_in_progress(state, event.invocation_namespace)
+    has_space = len(invocation_in_progress) < state.config.num_workers and _is_eligible(
         event
     )
     if has_space:
         # Assign the smallest available worker id
-        used = set(x.worker_id for x in state.in_progress)
+        used = set(x.worker_id for x in invocation_in_progress)
         id_candidates = [i for i in range(state.config.num_workers) if i not in used]
         id = id_candidates[0]
         state_copy = state._deepcopy()
         shared_state: StepWorkerState = StepWorkerState(
-            step_name=step_name,
-            collected_events=state_copy.collected_events,
-            collected_waiters=state_copy.collected_waiters,
+            step_name=step_id.name,
+            collected_events=_worker_collected_events(
+                state_copy, event.invocation_namespace
+            ),
+            collected_waiters=_worker_waiters(state_copy, event.invocation_namespace),
             collection_release_payload=event.collection_release_payload._copy()
             if event.collection_release_payload is not None
             else None,
@@ -1046,6 +1355,7 @@ def _add_or_enqueue_event(
                 recovery_counts=dict(event.recovery_counts),
                 scope_path=event.scope_path,
                 work_item_id=event.work_item_id,
+                invocation_namespace=event.invocation_namespace,
             )
         )
         commands.append(
@@ -1053,6 +1363,7 @@ def _add_or_enqueue_event(
                 step_id=step_id,
                 event=event.event,
                 id=id,
+                invocation_namespace=event.invocation_namespace,
                 bound_events=event.bound_events,
             )
         )
@@ -1060,10 +1371,11 @@ def _add_or_enqueue_event(
             CommandPublishEvent(
                 StepStateChanged(
                     step_state=StepState.RUNNING,
-                    name=step_name,
+                    name=str(step_id),
                     input_event_name=type(event.event).__name__,
                     worker_id=str(id),
-                )
+                ),
+                origin_namespace=event.invocation_namespace,
             )
         )
     else:
@@ -1071,10 +1383,11 @@ def _add_or_enqueue_event(
             CommandPublishEvent(
                 StepStateChanged(
                     step_state=StepState.PREPARING,
-                    name=step_name,
+                    name=str(step_id),
                     input_event_name=type(event.event).__name__,
                     worker_id="<enqueued>",
-                )
+                ),
+                origin_namespace=event.invocation_namespace,
             )
         )
         state.queue.append(event)
@@ -1091,6 +1404,8 @@ class _RouteResult:
     # The run was failed (a targeted send to a collect step); the caller must
     # return immediately rather than emit further commands.
     failed: bool = False
+    # Namespaces this event routed work into; used to arm per-child timeouts.
+    touched_namespaces: set[tuple[str, ...]] = field(default_factory=set)
 
 
 def _redeliver_collection_payload(
@@ -1124,10 +1439,11 @@ def _redeliver_collection_payload(
             last_failed_at=tick.last_failed_at,
             recovery_counts=dict(tick.recovery_counts),
             scope_path=tuple(tick.scope_path),
+            invocation_namespace=tick.origin_namespace,
             collection_release_payload=payload,
             work_item_id=tick.work_item_id,
         ),
-        StepId.root(binding.target_step),
+        binding.target_step,
         state.workers[binding.target_step],
         now_seconds,
     )
@@ -1135,19 +1451,30 @@ def _redeliver_collection_payload(
 
 def _resolve_waiters(
     tick: TickAddEvent, state: BrokerState, now_seconds: float
-) -> tuple[list[WorkflowCommand], set[str]]:
+) -> tuple[list[WorkflowCommand], set[StepId], set[tuple[str, ...]]]:
     """Resolve any waiters the event satisfies, resuming their work items.
 
-    Returns the emitted commands plus the set of steps woken via waiter
-    resolution, so the routing pass can skip them and avoid double-processing
-    the same delivery as a normally-accepted event.
+    Returns the emitted commands, the set of steps woken via waiter resolution
+    (so the routing pass can skip them and avoid double-processing the same
+    delivery as a normally-accepted event), and the namespaces work routed into
+    (so the caller can arm per-child timeouts).
     """
     commands: list[WorkflowCommand] = []
-    waiter_resolved_steps: set[str] = set()
-    for step_name, step_config in state.config.steps.items():
-        step_id = StepId.root(step_name)
-        wait_conditions = state.workers[step_name].collected_waiters
+    waiter_resolved_steps: set[StepId] = set()
+    touched_namespaces: set[tuple[str, ...]] = set()
+    for step_id, step_config in state.config.steps.items():
+        # Scope waiter resolution to the event's namespace (exact step when the
+        # tick is targeted), so a child's waiter is only woken by events in its
+        # own namespace.
+        if tick.step_id is not None:
+            if tick.step_id != step_id:
+                continue
+        elif not _event_routes_to(tick.origin_namespace, step_id.namespace, tick.event):
+            continue
+        wait_conditions = state.workers[step_id].collected_waiters
         for wait_condition in wait_conditions:
+            if wait_condition.invocation_namespace != tick.origin_namespace:
+                continue
             is_match = event_matches(
                 tick.event,
                 wait_condition.waiting_for_event,
@@ -1158,7 +1485,8 @@ def _resolve_waiters(
                 for k, v in wait_condition.requirements.items()
             )
             if is_match:
-                waiter_resolved_steps.add(step_name)
+                waiter_resolved_steps.add(step_id)
+                touched_namespaces.add(tick.origin_namespace)
                 wait_condition.resolved_event = tick.event
                 # Resume re-delivers the suspended work item whole from the
                 # waiter record: original trigger, stream scope, collect batch.
@@ -1168,21 +1496,22 @@ def _resolve_waiters(
                             event=wait_condition.event,
                             bound_events=wait_condition.bound_events,
                             scope_path=wait_condition.scope_path,
+                            invocation_namespace=wait_condition.invocation_namespace,
                             collection_release_payload=wait_condition.collection_release_payload,
                             work_item_id=wait_condition.work_item_id,
                         ),
                         step_id,
-                        state.workers[step_name],
+                        state.workers[step_id],
                         now_seconds,
                     )
                 )
-    return commands, waiter_resolved_steps
+    return commands, waiter_resolved_steps, touched_namespaces
 
 
 def _route_member_to_collect_step(
     tick: TickAddEvent,
     state: BrokerState,
-    step_name: str,
+    step_id: StepId,
     worker_state: InternalStepWorkerState,
     now_seconds: float,
 ) -> tuple[list[WorkflowCommand], bool]:
@@ -1203,7 +1532,7 @@ def _route_member_to_collect_step(
             # data, so fail the run loudly instead.
             error = WorkflowRuntimeError(
                 f"{type(tick.event).__name__} was sent to collect "
-                f"step {step_name!r} via send_event(step=...), but "
+                f"step {step_id.name!r} via send_event(step=...), but "
                 "a collect step cannot receive targeted events: it "
                 "only collects events emitted inside a fan-out "
                 "stream."
@@ -1211,12 +1540,10 @@ def _route_member_to_collect_step(
             state.is_running = False
             commands.append(
                 CommandPublishEvent(
-                    event=WorkflowFailedEvent(step_name=step_name, exception=error)
+                    event=WorkflowFailedEvent(step_name=str(step_id), exception=error)
                 )
             )
-            commands.append(
-                CommandFailWorkflow(step_id=StepId.root(step_name), exception=error)
-            )
+            commands.append(CommandFailWorkflow(step_id=step_id, exception=error))
             return commands, True
         # An untargeted send may be legitimate traffic for other
         # steps that merely overlaps an open stream — warn.
@@ -1225,11 +1552,11 @@ def _route_member_to_collect_step(
             "outside any collection stream (e.g. via "
             "ctx.send_event) so it cannot join a batch.",
             type(tick.event).__name__,
-            step_name,
+            step_id.name,
         )
         return commands, False
     stream_id = tick.scope_path[-1]
-    binding = state.config.binding_for_target(stream_id, step_name, state.streams)
+    binding = state.config.binding_for_target(stream_id, step_id, state.streams)
     if binding is None:
         # Dropped member: its nearest stream has no binding to this
         # collect step. Balance the stream accounting for the dead
@@ -1239,7 +1566,7 @@ def _route_member_to_collect_step(
             "stream %r has no collection binding targeting that "
             "step, so it can never join a batch.",
             type(tick.event).__name__,
-            step_name,
+            step_id.name,
             stream_id,
         )
         commands.extend(_adjust_open_work_items(state, stream_id, -1, now_seconds))
@@ -1256,6 +1583,7 @@ def _route_member_to_collect_step(
                     worker_state,
                     release,
                     tuple(tick.scope_path[:-1]),
+                    tick.origin_namespace,
                     now_seconds,
                 )
             )
@@ -1266,7 +1594,7 @@ def _route_member_to_collect_step(
 def _route_to_accepting_steps(
     tick: TickAddEvent,
     state: BrokerState,
-    waiter_resolved_steps: set[str],
+    waiter_resolved_steps: set[StepId],
     now_seconds: float,
 ) -> _RouteResult:
     """Route the event to every step that accepts (and is targeted by) it.
@@ -1275,16 +1603,20 @@ def _route_to_accepting_steps(
     accounting is balanced for the delivery the waiter swallowed.
     """
     result = _RouteResult(commands=[])
-    for step_name, step_config in state.config.steps.items():
-        step_id = StepId.root(step_name)
+    for step_id, step_config in state.config.steps.items():
         is_accepted = step_accepts_event(
             tick.event,
             step_config.accepted_events,
             allow_subclasses=step_config.accept_event_subclasses,
         )
-        is_targeted = tick.step_id is None or _root_step_key(tick.step_id) == step_name
-        if step_name in waiter_resolved_steps:
-            if is_accepted and is_targeted and tick.scope_path:
+        if tick.step_id is not None:
+            routes = tick.step_id == step_id
+        else:
+            routes = _event_routes_to(
+                tick.origin_namespace, step_id.namespace, tick.event
+            )
+        if step_id in waiter_resolved_steps:
+            if is_accepted and routes and tick.scope_path:
                 # The waiter swallowed a delivery this step would otherwise
                 # have received. The delivery was birth-counted as a work item
                 # in its stream, so consume it here — otherwise the stream can
@@ -1296,25 +1628,58 @@ def _route_to_accepting_steps(
                     _adjust_open_work_items(state, tick.scope_path[-1], -1, now_seconds)
                 )
             continue
-        if not (is_accepted and is_targeted):
+        if not (is_accepted and routes):
             continue
         result.handled = True
-        worker_state = state.workers[step_name]
+        invocation_namespace = (
+            _target_invocation_for_static_step(step_id, tick.origin_namespace)
+            if tick.step_id is not None
+            else _child_invocation_for_route(
+                tick, tick.origin_namespace, step_id.namespace, tick.event
+            )
+        )
+        if invocation_namespace is None:
+            error = WorkflowRuntimeError(
+                f"Targeted send to child step {str(step_id)!r} is ambiguous or "
+                "has no live child invocation. Use the concrete child invocation "
+                "namespace from the event stream, e.g. 'child#id/step'."
+            )
+            state.is_running = False
+            result.commands.append(
+                CommandPublishEvent(
+                    event=WorkflowFailedEvent(step_name=str(step_id), exception=error)
+                )
+            )
+            result.commands.append(
+                CommandFailWorkflow(step_id=step_id, exception=error)
+            )
+            result.failed = True
+            return result
+        if (
+            tick.step_id is None
+            and isinstance(tick.event, StartEvent)
+            and invocation_namespace != tick.origin_namespace
+        ):
+            state.active_invocation_namespaces.add(invocation_namespace)
+        result.touched_namespaces.add(invocation_namespace)
+        worker_state = state.workers[step_id]
         if worker_state.config.collection_param is not None:
             member_commands, failed = _route_member_to_collect_step(
-                tick, state, step_name, worker_state, now_seconds
+                tick, state, step_id, worker_state, now_seconds
             )
             result.commands.extend(member_commands)
             if failed:
                 result.failed = True
                 return result
             continue
-        _consume_superseded_delayed_attempt(tick, worker_state)
+        if tick.step_id is not None:
+            _consume_superseded_delayed_attempt(tick, worker_state)
         bound_events = tick.bound_events
         if bound_events is None and worker_state.config.collect_params:
             bound_events = _static_collect_events(
                 event=tick.event,
                 worker_state=worker_state,
+                invocation_namespace=invocation_namespace,
             )
             if bound_events is None:
                 if tick.scope_path:
@@ -1336,9 +1701,10 @@ def _route_to_accepting_steps(
                     recovery_counts=dict(tick.recovery_counts),
                     scope_path=tuple(tick.scope_path),
                     work_item_id=tick.work_item_id,
+                    invocation_namespace=invocation_namespace,
                 ),
                 step_id,
-                state.workers[step_name],
+                state.workers[step_id],
                 now_seconds,
             )
         )
@@ -1359,9 +1725,13 @@ def _unhandled_event_commands(
             UnhandledEvent(
                 event_type=event_cls.__name__,
                 qualified_name=f"{event_cls.__module__}.{event_cls.__name__}",
-                step_name=str(tick.step_id) if tick.step_id else None,
+                step_name=str(tick.step_id) if tick.step_id is not None else None,
                 idle=_check_idle_state(state),
-            )
+            ),
+            # An unhandled event from inside a child is a child-stream
+            # diagnostic, so tag it by origin and keep it out of the
+            # default (root) stream like every other child event.
+            origin_namespace=tick.origin_namespace,
         )
     ]
 
@@ -1395,12 +1765,31 @@ def _process_add_event_tick(
     if payload_commands is not None:
         return state, payload_commands
 
-    commands, waiter_resolved_steps = _resolve_waiters(tick, state, now_seconds)
+    commands, waiter_resolved_steps, touched_namespaces = _resolve_waiters(
+        tick, state, now_seconds
+    )
 
     routed = _route_to_accepting_steps(tick, state, waiter_resolved_steps, now_seconds)
     commands.extend(routed.commands)
     if routed.failed:
         return state, commands
+    touched_namespaces |= routed.touched_namespaces
+
+    # Arm a per-namespace timeout the first time an event routes into a child
+    # namespace that declares one. Re-arms after a prior activation completed
+    # (its start was cleared); only the root deadline is the global timeout.
+    for namespace in sorted(touched_namespaces):
+        if namespace == ():
+            continue
+        timeout = state.config.namespace_timeouts.get(slot_namespace(namespace))
+        if timeout is None or namespace in state.namespace_started:
+            continue
+        state.namespace_started[namespace] = now_seconds
+        commands.append(
+            CommandScheduleNamespaceTimeout(
+                namespace=namespace, timeout=timeout, started_at=now_seconds
+            )
+        )
 
     handled = bool(waiter_resolved_steps) or routed.handled
     if not handled:
@@ -1431,6 +1820,7 @@ def _consume_superseded_delayed_attempt(
             if a.not_before is not None
             and a.attempts == tick.attempts
             and type(a.event) is type(tick.event)
+            and a.invocation_namespace == tick.origin_namespace
         ),
         None,
     )
@@ -1463,8 +1853,8 @@ def _process_timeout_tick(
     state.is_running = False
     _clear_collection_state(state)
     active_steps = [
-        step_name
-        for step_name, worker_state in init.workers.items()
+        str(step_id)
+        for step_id, worker_state in init.workers.items()
         if len(worker_state.in_progress) > 0
     ]
     steps_info = (
@@ -1499,8 +1889,7 @@ def _process_wakeup_tick(
     """
     state = init.deepcopy()
     commands: list[WorkflowCommand] = []
-    for step_name, worker_state in sorted(state.workers.items(), key=lambda x: x[0]):
-        step_id = StepId.root(step_name)
+    for step_id, worker_state in sorted(state.workers.items(), key=lambda x: str(x[0])):
         for attempt in worker_state.queue:
             if attempt.not_before is not None and attempt.not_before <= tick.due:
                 attempt.not_before = None
@@ -1513,13 +1902,16 @@ def _process_waiter_timeout_tick(
 ) -> tuple[BrokerState, list[WorkflowCommand]]:
     state = init.deepcopy()
     commands: list[WorkflowCommand] = []
-    step_id = tick.step_id
-    step_name = _root_step_key(step_id)
-    if step_name not in state.workers:
+    if tick.step_id not in state.workers:
         return state, commands
-    worker_state = state.workers[step_name]
+    worker_state = state.workers[tick.step_id]
     waiter = next(
-        (w for w in worker_state.collected_waiters if w.waiter_id == tick.waiter_id),
+        (
+            w
+            for w in worker_state.collected_waiters
+            if w.waiter_id == tick.waiter_id
+            and w.invocation_namespace == tick.invocation_namespace
+        ),
         None,
     )
     # Only act if the waiter is still pending (not yet resolved by an event)
@@ -1532,12 +1924,150 @@ def _process_waiter_timeout_tick(
             event=waiter.event,
             bound_events=waiter.bound_events,
             scope_path=waiter.scope_path,
+            invocation_namespace=waiter.invocation_namespace,
             collection_release_payload=waiter.collection_release_payload,
             work_item_id=waiter.work_item_id,
         ),
-        step_id,
+        tick.step_id,
         worker_state,
         now_seconds,
     )
     commands.extend(subcommands)
     return state, commands
+
+
+def _namespace_catch_error_handler(
+    config: BrokerConfig, namespace: tuple[str, ...]
+) -> StepId | None:
+    """The handler StepId that can catch a failure within ``namespace``, if any.
+
+    Prefers a wildcard handler (``for_steps is None``) since a child timeout is
+    not attributable to one specific step; falls back to any handler declared in
+    the namespace.
+    """
+    candidates = [
+        handler_id
+        for handler_id in config.catch_error_handlers
+        if handler_id.namespace == namespace
+    ]
+    if not candidates:
+        return None
+    for handler_id in candidates:
+        if config.catch_error_handlers[handler_id].for_steps is None:
+            return handler_id
+    return candidates[0]
+
+
+def _process_namespace_timeout_tick(
+    tick: TickNamespaceTimeout, init: BrokerState, now_seconds: float
+) -> tuple[BrokerState, list[WorkflowCommand]]:
+    """Expire a single child namespace on its own deadline.
+
+    A no-op if the namespace already completed or was re-armed (its recorded
+    start no longer matches this tick). Otherwise terminate the namespace's
+    workers and route a :class:`WorkflowTimeoutError` through the namespaced
+    catch-error path so the child's ``@catch_error`` can recover it. If no
+    handler catches it, the uncaught child timeout fails the whole run — but it
+    never ``CommandHalt``s, since only the root timeout halts the run.
+    """
+    state = init.deepcopy()
+    namespace = tick.namespace
+    static_namespace = slot_namespace(namespace)
+    # Stale tick: the child completed or a re-trigger re-armed with a new start.
+    if state.namespace_started.get(namespace) != tick.started_at:
+        return state, []
+
+    # Representative in-flight event and recovery lineage for the StepFailedEvent
+    # payload, and the namespace's active steps for the timeout event. The
+    # recovery counts carry across re-arms so the catch-error budget below is
+    # honored exactly like the step-failure path.
+    input_event: Event | None = None
+    recovery_counts: dict[str, int] = {}
+    active_steps: list[str] = []
+    for step_id, worker in init.workers.items():
+        if step_id.namespace != static_namespace:
+            continue
+        in_progress = [
+            item
+            for item in worker.in_progress
+            if item.invocation_namespace == namespace
+        ]
+        queue = [
+            item for item in worker.queue if item.invocation_namespace == namespace
+        ]
+        waiters = [
+            item
+            for item in worker.collected_waiters
+            if item.invocation_namespace == namespace
+        ]
+        if in_progress or queue:
+            active_steps.append(str(step_id))
+        if input_event is None:
+            if in_progress:
+                input_event = in_progress[0].event
+                recovery_counts = dict(in_progress[0].recovery_counts)
+            elif queue:
+                input_event = queue[0].event
+                recovery_counts = dict(queue[0].recovery_counts)
+            elif waiters:
+                input_event = waiters[0].event
+
+    # Terminate the namespace (and any grandchild) through the one teardown, and
+    # cancel its live worker tasks so an orphaned child coroutine cannot crash
+    # the loop by reporting into a slot that no longer exists.
+    terminate_namespace(state, namespace)
+
+    timeout_error = WorkflowTimeoutError(
+        f"Child workflow '{'/'.join(namespace)}' timed out after "
+        f"{tick.timeout} seconds."
+    )
+
+    handler_step_id = _namespace_catch_error_handler(state.config, static_namespace)
+    handler = (
+        state.config.catch_error_handlers.get(handler_step_id)
+        if handler_step_id is not None
+        else None
+    )
+    if handler is not None and handler_step_id is not None:
+        # Honor the handler's recovery budget: a child whose @catch_error
+        # re-arms the timeout is bounded by max_recoveries, not looping forever.
+        recovery_key = str(handler_step_id)
+        new_count = recovery_counts.get(recovery_key, 0) + 1
+        if new_count <= handler.max_recoveries:
+            step_failed_event = StepFailedEvent(
+                step_name="/".join(namespace),
+                input_event=input_event if input_event is not None else Event(),
+                exception=timeout_error,
+                attempts=1,
+                elapsed_seconds=tick.timeout,
+                failed_at=datetime.fromtimestamp(now_seconds, tz=timezone.utc),
+            )
+            return state, [
+                CommandCancelNamespace(namespace=namespace),
+                CommandQueueEvent(
+                    event=step_failed_event,
+                    step_id=handler_step_id,
+                    origin_namespace=namespace,
+                    recovery_counts={**recovery_counts, recovery_key: new_count},
+                ),
+            ]
+        # Recovery budget exhausted: fall through and fail the run.
+
+    # Uncaught (or budget-exhausted) child timeout: fail the whole run. Publish
+    # on the root stream so default clients see the failure.
+    state.is_running = False
+    failing_step_id = next(
+        (sid for sid in state.workers if sid.namespace == static_namespace),
+        StepId(static_namespace, static_namespace[-1] if static_namespace else ""),
+    )
+    return state, [
+        CommandCancelNamespace(namespace=namespace),
+        CommandPublishEvent(
+            event=WorkflowTimedOutEvent(
+                timeout=tick.timeout,
+                active_steps=active_steps,
+            ),
+            origin_namespace=(),
+        ),
+        CommandFailWorkflow(step_id=failing_step_id, exception=timeout_error),
+    ]

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
@@ -8,14 +8,19 @@ import heapq
 import logging
 from typing import TYPE_CHECKING
 
+from workflows.context.state_store import (
+    StateStore,
+)
 from workflows.errors import (
     WorkflowRuntimeError,
 )
 from workflows.events import (
     Event,
     StopEvent,
+    _set_event_origin_namespace,
 )
 from workflows.runtime.types.commands import (
+    CommandCancelNamespace,
     CommandCompleteRun,
     CommandFailWorkflow,
     CommandHalt,
@@ -23,6 +28,7 @@ from workflows.runtime.types.commands import (
     CommandQueueEvent,
     CommandRunWorker,
     CommandScheduleIdleCheck,
+    CommandScheduleNamespaceTimeout,
     CommandScheduleWaiterTimeout,
     CommandScheduleWakeup,
     WorkflowCommand,
@@ -31,6 +37,7 @@ from workflows.runtime.types.internal_state import (
     BrokerState,
     InProgressState,
 )
+from workflows.runtime.types.invocation import namespace_startswith, slot_namespace
 from workflows.runtime.types.named_task import (
     PendingPull,
     PendingStart,
@@ -54,6 +61,7 @@ from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickAddEvent,
     TickIdleCheck,
+    TickNamespaceTimeout,
     TickStepResult,
     TickTimeout,
     TickWaiterTimeout,
@@ -69,7 +77,7 @@ if TYPE_CHECKING:
 from workflows.runtime.control_loop.reduce import (
     _decide_retry_delay,
     _reduce_tick,
-    _root_step_key,
+    prepare_tick_for_reduce,
     rewind_in_progress,
 )
 
@@ -113,13 +121,21 @@ class _ControlLoopRunner:
         workflow: Workflow,
         adapter: InternalRunAdapter,
         context: Context,
-        step_workers: dict[str, StepWorkerFunction],
+        step_workers: dict[StepId, StepWorkerFunction],
         init_state: BrokerState,
+        instances: dict[tuple[str, ...], Workflow] | None = None,
     ):
         self.workflow = workflow
         self.adapter = adapter
         self.context = context
         self.step_workers = step_workers
+        # Per-run map from a step's namespace to the workflow instance that owns
+        # it. Dispatch binds the bare step name against this instance, so the
+        # registered worker table can stay unbound (GC-friendly). Defaults to
+        # root -> the run's workflow when no children are wired.
+        self.instances: dict[tuple[str, ...], Workflow] = (
+            instances if instances is not None else {(): workflow}
+        )
         self.state = init_state
         self.worker_tasks: set[asyncio.Task[TickStepResult]] = set()
         # Transient tick buffer - drained synchronously at start of each loop iteration
@@ -134,18 +150,46 @@ class _ControlLoopRunner:
         self._wakeup_sequence = 0
         # Pull task sequence counter for deterministic journaling
         self._pull_sequence = 0
-        # Map from worker task to (step_id, worker_id) key
-        self._task_keys: dict[asyncio.Task[TickStepResult], tuple[StepId, int]] = {}
+        # Map from worker task to (step_id, invocation_namespace, worker_id) key
+        self._task_keys: dict[
+            asyncio.Task[TickStepResult], tuple[StepId, tuple[str, ...], int]
+        ] = {}
         # Whether a TickIdleCheck is currently in tick_buffer
         self._idle_check_pending = False
         # Pending worker coroutines not yet started (started by adapter in wait_for_next_task)
         self._pending_workers: list[PendingStart] = []
+
+    def _resolve_state_view(self, namespace: tuple[str, ...]) -> StateStore | None:
+        """Resolve a step's own per-namespace state view from the adapter.
+
+        Each namespace owns an isolated record; the adapter mints (and caches)
+        the per-namespace store, so this stays a thin lookup. ``None`` when the
+        adapter vends no store.
+        """
+        return self.adapter.get_state_store(namespace)
 
     def schedule_tick(self, tick: WorkflowTick, at_time: float) -> None:
         """Schedule a tick to be processed at a specific time."""
         seq = self._wakeup_sequence
         self._wakeup_sequence += 1
         heapq.heappush(self.scheduled_wakeups, (at_time, seq, tick))
+
+    def schedule_active_namespace_timeouts(self) -> None:
+        """Re-arm child namespace deadlines restored from serialized state."""
+        for namespace, started_at in sorted(self.state.namespace_started.items()):
+            timeout = self.state.config.namespace_timeouts.get(
+                slot_namespace(namespace)
+            )
+            if timeout is None:
+                continue
+            self.schedule_tick(
+                TickNamespaceTimeout(
+                    namespace=namespace,
+                    timeout=timeout,
+                    started_at=started_at,
+                ),
+                at_time=started_at + timeout,
+            )
 
     def next_wakeup_timeout(self, now: float) -> float | None:
         """Calculate timeout until next scheduled wakeup.
@@ -176,13 +220,13 @@ class _ControlLoopRunner:
 
         async def _run_worker() -> TickStepResult:
             worker: InProgressState | None = None
-            step_name = _root_step_key(command.step_id)
             try:
                 worker = next(
                     (
                         w
-                        for w in self.state.workers[step_name].in_progress
+                        for w in self.state.workers[command.step_id].in_progress
                         if w.worker_id == command.id
+                        and w.invocation_namespace == command.invocation_namespace
                     ),
                     None,
                 )
@@ -191,14 +235,23 @@ class _ControlLoopRunner:
                         f"Worker {command.id} not found in in_progress. This should not happen."
                     )
                 snapshot = worker.shared_state
-                step_fn: StepWorkerFunction = self.step_workers[step_name]
+                step_fn: StepWorkerFunction = self.step_workers[command.step_id]
+                # Bind the bare step name against the instance that owns this
+                # namespace (root -> parent, child slot -> child instance).
+                static_namespace = slot_namespace(command.invocation_namespace)
+                instance = self.instances[static_namespace]
+                # Resolve the step's state view now (the backend store/pool is
+                # ready once this coroutine runs) and thread it into the step.
+                state_store = self._resolve_state_view(command.invocation_namespace)
 
                 result = await step_fn(
                     state=snapshot,
-                    step_name=step_name,
+                    step_name=command.step_id.name,
                     event=command.event,
-                    workflow=self.workflow,
+                    workflow=instance,
                     bound_events=command.bound_events,
+                    namespace=command.invocation_namespace,
+                    state_store=state_store,
                     retry=RetryAttempt(
                         retry_number=worker.attempts,
                         first_attempt_at=worker.first_attempt_at,
@@ -211,6 +264,7 @@ class _ControlLoopRunner:
                 return TickStepResult(
                     step_id=command.step_id,
                     worker_id=command.id,
+                    invocation_namespace=command.invocation_namespace,
                     event=command.event,
                     result=self._stamp_retry_decisions(command.step_id, worker, result),
                 )
@@ -227,6 +281,7 @@ class _ControlLoopRunner:
                 return TickStepResult(
                     step_id=command.step_id,
                     worker_id=command.id,
+                    invocation_namespace=command.invocation_namespace,
                     event=command.event,
                     result=self._stamp_retry_decisions(
                         command.step_id, worker, [failed]
@@ -234,7 +289,12 @@ class _ControlLoopRunner:
                 )
 
         self._pending_workers.append(
-            PendingWorker(command.step_id, command.id, _run_worker())
+            PendingWorker(
+                command.step_id,
+                command.id,
+                _run_worker(),
+                invocation_namespace=command.invocation_namespace,
+            )
         )
 
     def _stamp_retry_decisions(
@@ -253,8 +313,7 @@ class _ControlLoopRunner:
         """
         if worker is None:
             return results
-        step_name = _root_step_key(step_id)
-        policy = self.state.workers[step_name].config.retry_policy
+        policy = self.state.workers[step_id].config.retry_policy
         out: list[StepFunctionResult] = []
         for result in results:
             if isinstance(result, StepWorkerFailed) and result.retry_decision is None:
@@ -264,7 +323,7 @@ class _ControlLoopRunner:
                     failures=worker.attempts + 1,
                     exception=result.exception,
                     run_id=self.adapter.run_id,
-                    step_name=step_name,
+                    step_name=str(step_id),
                 )
                 result = result.model_copy(
                     update={
@@ -282,6 +341,7 @@ class _ControlLoopRunner:
                 TickAddEvent(
                     event=command.event,
                     step_id=command.step_id,
+                    origin_namespace=command.origin_namespace,
                     recovery_counts=dict(command.recovery_counts),
                     scope_path=command.scope_path,
                 )
@@ -298,11 +358,16 @@ class _ControlLoopRunner:
             await self.cleanup_tasks()
             return command.result
         elif isinstance(command, CommandPublishEvent):
+            if command.origin_namespace:
+                _set_event_origin_namespace(command.event, command.origin_namespace)
             await self.adapter.write_to_event_stream(command.event)
             return None
         elif isinstance(command, CommandFailWorkflow):
             await self.cleanup_tasks()
             raise command.exception
+        elif isinstance(command, CommandCancelNamespace):
+            await self._cancel_namespace_tasks(command.namespace)
+            return None
         elif isinstance(command, CommandScheduleIdleCheck):
             if not self._idle_check_pending:
                 self.tick_buffer.append(TickIdleCheck())
@@ -311,15 +376,68 @@ class _ControlLoopRunner:
         elif isinstance(command, CommandScheduleWaiterTimeout):
             now = await self.adapter.get_now()
             self.schedule_tick(
-                TickWaiterTimeout(step_id=command.step_id, waiter_id=command.waiter_id),
+                TickWaiterTimeout(
+                    step_id=command.step_id,
+                    waiter_id=command.waiter_id,
+                    invocation_namespace=command.invocation_namespace,
+                ),
                 at_time=now + command.timeout,
             )
             return None
         elif isinstance(command, CommandScheduleWakeup):
             self.schedule_tick(TickWakeup(due=command.at_time), at_time=command.at_time)
             return None
+        elif isinstance(command, CommandScheduleNamespaceTimeout):
+            self.schedule_tick(
+                TickNamespaceTimeout(
+                    namespace=command.namespace,
+                    timeout=command.timeout,
+                    started_at=command.started_at,
+                ),
+                at_time=command.started_at + command.timeout,
+            )
+            return None
         else:
             raise ValueError(f"Unknown command type: {type(command)}")
+
+    async def _cancel_namespace_tasks(self, namespace: tuple[str, ...]) -> None:
+        """Cancel worker tasks for a namespace and its descendants.
+
+        The reducer has already cleared the namespace's journaled buffers; this
+        cancels the live coroutines that back them (prefix-matched, so a
+        terminated child takes its grandchildren too) so an orphaned task cannot
+        complete and report into a now-empty worker slot. Pending workers not yet
+        started are dropped and their coroutines closed.
+        """
+        # Drop not-yet-started pending workers for this namespace.
+        kept: list[PendingStart] = []
+        for pending in self._pending_workers:
+            if isinstance(pending, PendingWorker) and namespace_startswith(
+                pending.invocation_namespace, namespace
+            ):
+                pending.coro.close()
+            else:
+                kept.append(pending)
+        self._pending_workers = kept
+
+        # Cancel running worker tasks for this namespace.
+        to_cancel = [
+            task
+            for task, key in self._task_keys.items()
+            if namespace_startswith(key[1], namespace)
+        ]
+        for task in to_cancel:
+            task.cancel()
+            self.worker_tasks.discard(task)
+            self._task_keys.pop(task, None)
+        if to_cancel:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*to_cancel, return_exceptions=True),
+                    timeout=0.5,
+                )
+            except Exception:
+                pass
 
     async def cleanup_tasks(self) -> None:
         """Cancel and cleanup all running worker tasks and pending coroutines."""
@@ -382,6 +500,8 @@ class _ControlLoopRunner:
                 at_time=timeout_time,
             )
 
+        self.schedule_active_namespace_timeouts()
+
         # Resume any in-progress work
         self.state, commands = rewind_in_progress(self.state, start)
         for command in commands:
@@ -439,7 +559,12 @@ class _ControlLoopRunner:
 
                 # Build running list from existing tasks
                 running: list[WorkerTask | PullTask] = [
-                    WorkerTask(key[0], key[1], task)
+                    WorkerTask(
+                        key[0],
+                        key[2],
+                        task,
+                        invocation_namespace=key[1],
+                    )
                     for task in self.worker_tasks
                     for key in [self._task_keys.get(task)]
                     if key is not None
@@ -464,7 +589,11 @@ class _ControlLoopRunner:
                         pull_task = nt.task
                     elif isinstance(nt, WorkerTask):
                         self.worker_tasks.add(nt.task)
-                        self._task_keys[nt.task] = (nt.step_id, nt.worker_id)
+                        self._task_keys[nt.task] = (
+                            nt.step_id,
+                            nt.invocation_namespace,
+                            nt.worker_id,
+                        )
 
                 completed_task = result.completed
 
@@ -502,12 +631,16 @@ class _ControlLoopRunner:
                             "Worker task failed unexpectedly", exc_info=True
                         )
                     else:
-                        # Check if this worker returned a StopEvent - if so,
-                        # cancel other workers immediately to prevent them from
-                        # writing to the event stream after workflow completion
+                        # Check if this worker returned a *root* StopEvent - if
+                        # so, cancel other workers immediately to prevent them
+                        # from writing to the event stream after workflow
+                        # completion. A child's StopEvent is only a boundary
+                        # event, so it must not cancel the parent's workers.
                         for res in tick_result.result:
-                            if isinstance(res, StepWorkerResult) and isinstance(
-                                res.result, StopEvent
+                            if (
+                                isinstance(res, StepWorkerResult)
+                                and isinstance(res.result, StopEvent)
+                                and tick_result.step_id.is_root
                             ):
                                 await self.cleanup_tasks()
                                 break
@@ -527,6 +660,7 @@ class _ControlLoopRunner:
         """Process a single tick and return StopEvent if workflow completes."""
         try:
             start = await self.adapter.get_now()
+            tick = prepare_tick_for_reduce(tick, self.state)
             self.state, commands = _reduce_tick(
                 tick, self.state, start, run_id=self.adapter.run_id
             )
@@ -568,6 +702,11 @@ async def control_loop(
     run = consume_current_run()
     state = init_state or BrokerState.from_workflow(run.workflow)
     runner = _ControlLoopRunner(
-        run.workflow, run.run_adapter, run.context, run.steps, state
+        run.workflow,
+        run.run_adapter,
+        run.context,
+        run.steps,
+        state,
+        instances=run.workflow._namespace_instances(),
     )
     return await runner.run(start_event=start_event)

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
@@ -8,7 +8,7 @@ import logging
 from enum import Enum
 
 from workflows._event_matching import (
-    step_accepts_type,
+    step_accepts_event,
 )
 from workflows.collect import Collect, Take
 from workflows.errors import (
@@ -16,6 +16,7 @@ from workflows.errors import (
 )
 from workflows.events import (
     Event,
+    StartEvent,
 )
 from workflows.runtime.types.commands import (
     WorkflowCommand,
@@ -28,6 +29,7 @@ from workflows.runtime.types.internal_state import (
     EventAttempt,
     InternalStepWorkerState,
 )
+from workflows.runtime.types.invocation import slot_namespace
 from workflows.runtime.types.results import (
     AddCollectedEvent,
     AddWaiter,
@@ -35,7 +37,6 @@ from workflows.runtime.types.results import (
     StepWorkerFailed,
     StepWorkerResult,
 )
-from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickStepResult,
 )
@@ -70,7 +71,7 @@ def _detect_stuck_streams(
     )
     if orphaned is not None:
         binding = state.config.collection_bindings.get(orphaned.binding_id)
-        step_name = binding.target_step if binding is not None else "<unknown>"
+        step_name = str(binding.target_step) if binding is not None else "<unknown>"
         return step_name, WorkflowRuntimeError(
             f"Workflow is idle with a pending collect release for step "
             f"{step_name!r} (binding {orphaned.binding_id!r}) whose stream "
@@ -91,11 +92,11 @@ def _detect_stuck_streams(
         return None
     first_leaked = next(iter(state.streams.values()))
     details = "; ".join(
-        f"stream {stream.stream_id!r} opened by step {stream.source_step!r} "
+        f"stream {stream.stream_id!r} opened by step {str(stream.source_step)!r} "
         f"with {stream.open_work_items} open work item(s)"
         for stream in state.streams.values()
     )
-    return first_leaked.source_step, WorkflowRuntimeError(
+    return str(first_leaked.source_step), WorkflowRuntimeError(
         "Workflow is idle but collection streams are still open, so the run "
         f"can never complete: {details}. No queued, running, or resumable "
         "scoped work remains that can close the stream. This indicates "
@@ -119,24 +120,58 @@ def _clear_collection_state(state: BrokerState) -> None:
     state.collection_release_states.clear()
 
 
-def _count_accepting_steps(state: BrokerState, event_type: type) -> int:
-    """Number of steps that accept ``event_type`` — the work-item fan-out factor.
+def _event_routes_to(
+    origin_namespace: tuple[str, ...],
+    target_namespace: tuple[str, ...],
+    event: Event,
+) -> bool:
+    """Whether a type-routed event from ``origin_namespace`` reaches a step in
+    ``target_namespace``.
 
-    An event routed at a stream level becomes one work item per accepting step
-    (1:1 *and* collect steps count). This is the per-emission birth count for the
-    open_work_items set: a single emitted event accepted by N steps is N work
-    items. Must mirror the routing predicate in ``_process_add_event_tick``
-    exactly (including subclass-aware acceptance) — a birth count that differs
-    from the delivery count drifts the stream counter.
+    An event stays within the namespace that emitted it, except that a
+    ``StartEvent`` may cross *down* into a direct child namespace (that is how a
+    parent triggers a child). A child's ``StopEvent`` crossing back *up* is
+    handled by re-injecting it with the parent namespace as its origin, so it is
+    just an ordinary same-namespace route here.
+
+    This is the single routing predicate shared by delivery
+    (``_route_to_accepting_steps``) and birth-counting
+    (``_count_accepting_steps``); the two must never diverge.
+    """
+    origin_slot_namespace = slot_namespace(origin_namespace)
+    if target_namespace == origin_slot_namespace:
+        return True
+    if (
+        isinstance(event, StartEvent)
+        and len(target_namespace) == len(origin_slot_namespace) + 1
+        and target_namespace[: len(origin_slot_namespace)] == origin_slot_namespace
+    ):
+        return True
+    return False
+
+
+def _count_accepting_steps(
+    state: BrokerState, event: Event, origin_namespace: tuple[str, ...]
+) -> int:
+    """Number of steps an emitted ``event`` routes to — the work-item fan-out
+    factor for the stream that produced it.
+
+    This is the per-emission birth count for the open_work_items set: a single
+    emitted event delivered to N steps is N work items. It *is* the delivery
+    predicate (``step_accepts_event`` ∧ ``_event_routes_to``), counted — so the
+    birth count can never drift from the delivery count. A flat (namespace-blind)
+    count is exactly what wedged a root stream when a child step accepted the
+    same event type.
     """
     return sum(
         1
-        for cfg in state.config.steps.values()
-        if step_accepts_type(
-            event_type,
+        for step_id, cfg in state.config.steps.items()
+        if step_accepts_event(
+            event,
             cfg.accepted_events,
             allow_subclasses=cfg.accept_event_subclasses,
         )
+        and _event_routes_to(origin_namespace, step_id.namespace, event)
     )
 
 
@@ -200,6 +235,7 @@ def _close_collection_stream(
                 worker_state,
                 release,
                 tuple(stream.scope_path),
+                stream.source_invocation_namespace,
                 now_seconds,
             )
         )
@@ -332,6 +368,7 @@ def _fire_collection_release(
     worker_state: InternalStepWorkerState,
     events: list[Event],
     output_stack: tuple[str, ...],
+    invocation_namespace: tuple[str, ...],
     now_seconds: float,
 ) -> list[WorkflowCommand]:
     # Inline import breaks the reduce<->streams cycle: _add_or_enqueue_event is
@@ -349,10 +386,11 @@ def _fire_collection_release(
         EventAttempt(
             event=payload.as_event(),
             scope_path=output_stack,
+            invocation_namespace=invocation_namespace,
             collection_release_payload=payload,
             work_item_id=payload.work_item_id(),
         ),
-        StepId.root(binding.target_step),
+        binding.target_step,
         worker_state,
         now_seconds,
     )

--- a/packages/llama-index-workflows/src/workflows/runtime/runtime_decorators.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/runtime_decorators.py
@@ -135,8 +135,10 @@ class BaseInternalRunAdapterDecorator(InternalRunAdapter):
     async def close(self) -> None:
         await self._decorated.close()
 
-    def get_state_store(self) -> StateStore[Any] | None:
-        return self._decorated.get_state_store()
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
+        return self._decorated.get_state_store(namespace)
 
     async def finalize_step(self) -> None:
         await self._decorated.finalize_step()
@@ -188,5 +190,7 @@ class BaseExternalRunAdapterDecorator(ExternalRunAdapter):
     async def cancel(self) -> None:
         await self._decorated.cancel()
 
-    def get_state_store(self) -> StateStore[Any] | None:
-        return self._decorated.get_state_store()
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
+        return self._decorated.get_state_store(namespace)

--- a/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
@@ -27,6 +27,7 @@ class CommandRunWorker:
     step_id: StepId
     event: Event
     id: int
+    invocation_namespace: tuple[str, ...] = ()
     bound_events: dict[str, Event] | None = None
 
 
@@ -34,6 +35,9 @@ class CommandRunWorker:
 class CommandQueueEvent:
     event: Event
     step_id: StepId | None = None
+    # Namespace of the step (or boundary) that emitted this event; threaded into
+    # the resulting TickAddEvent so type-routing stays scoped to the namespace.
+    origin_namespace: tuple[str, ...] = ()
     recovery_counts: dict[str, int] = field(default_factory=dict)
     scope_path: tuple[str, ...] = field(default_factory=tuple)
 
@@ -57,6 +61,10 @@ class CommandFailWorkflow:
 @dataclass(frozen=True)
 class CommandPublishEvent:
     event: Event
+    # Namespace of the child execution that produced this event. Stamped onto
+    # the event at publish time so the stream can be filtered to root-only by
+    # default; ``()`` (the default) is the root/parent stream.
+    origin_namespace: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -64,6 +72,7 @@ class CommandScheduleWaiterTimeout:
     step_id: StepId
     waiter_id: str
     timeout: float
+    invocation_namespace: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -76,6 +85,35 @@ class CommandScheduleWakeup:
     """
 
     at_time: float
+
+
+@dataclass(frozen=True)
+class CommandScheduleNamespaceTimeout:
+    """Schedule a per-child-namespace timeout via TickNamespaceTimeout.
+
+    Emitted when the first event routes into a child namespace that declares a
+    ``timeout``. ``started_at`` is the routing time; the tick fires at
+    ``started_at + timeout`` and is pinned to this activation.
+    """
+
+    namespace: tuple[str, ...]
+    timeout: float
+    started_at: float
+
+
+@dataclass(frozen=True)
+class CommandCancelNamespace:
+    """Cancel the live worker tasks of a namespace and all its descendants.
+
+    Teardown of a child namespace (its StopEvent boundary, or its timeout)
+    clears the reducer's journaled buffers, but only the runner owns the asyncio
+    tasks. This command carries the cancellation across the reduce/runner
+    boundary: the runner cancels every worker task whose step's namespace is
+    prefix-matched by ``namespace``, so an orphaned child coroutine cannot report
+    a result into a worker slot that no longer exists.
+    """
+
+    namespace: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -98,9 +136,11 @@ WorkflowCommand = (
     | CommandCompleteRun
     | CommandFailWorkflow
     | CommandPublishEvent
+    | CommandCancelNamespace
     | CommandScheduleIdleCheck
     | CommandScheduleWaiterTimeout
     | CommandScheduleWakeup
+    | CommandScheduleNamespaceTimeout
 )
 
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dataclasses
 import importlib
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar
 
 from workflows._event_matching import step_accepts_type
 from workflows._stream_levels import event_types, stream_level_types_by_producer
@@ -38,6 +38,25 @@ if TYPE_CHECKING:
     from workflows.context.serializers import BaseSerializer
 
 
+T = TypeVar("T")
+
+
+def _normalize_step_id(value: Any) -> StepId:
+    return value if isinstance(value, StepId) else StepId.from_str(value)
+
+
+def _normalize_step_id_keys(mapping: Mapping[Any, T]) -> dict[StepId, T]:
+    return {_normalize_step_id(step_id): value for step_id, value in mapping.items()}
+
+
+def _namespace_key(namespace: tuple[str, ...]) -> str:
+    return "/".join(namespace)
+
+
+def _namespace_from_key(key: str) -> tuple[str, ...]:
+    return tuple(key.split("/")) if key else ()
+
+
 @dataclass(frozen=True)
 class CollectionBinding:
     """
@@ -49,8 +68,8 @@ class CollectionBinding:
     """
 
     id: str
-    source_step: str
-    target_step: str
+    source_step: StepId
+    target_step: StepId
     item_types: tuple[type[Event], ...]
     policy: Collect
 
@@ -66,8 +85,9 @@ class CollectionStreamInstance:
     """
 
     stream_id: str
-    source_step: str
+    source_step: StepId
     scope_path: tuple[str, ...]
+    source_invocation_namespace: tuple[str, ...] = ()
     open_work_items: int = 0
     accepting_binding_ids: tuple[str, ...] = ()
 
@@ -112,13 +132,34 @@ class BrokerState:
 
     is_running: bool
     config: BrokerConfig
-    workers: dict[str, InternalStepWorkerState]
+    workers: dict[StepId, InternalStepWorkerState]
     stream_seq: int = 0
     work_item_seq: int = 0
     streams: dict[str, CollectionStreamInstance] = field(default_factory=dict)
     collection_release_states: dict[str, CollectionReleaseState] = field(
         default_factory=dict
     )
+    # Per-child-namespace activation times: the moment the first event routed
+    # into a namespace that declares a ``timeout``. Used to arm and to staleness-
+    # check :class:`TickNamespaceTimeout`. Cleared when the namespace completes
+    # (StopEvent boundary) or is expired, so a re-triggered child re-arms.
+    # Serialized so resume preserves the original child timeout clock.
+    namespace_started: dict[tuple[str, ...], float] = field(default_factory=dict)
+    active_invocation_namespaces: set[tuple[str, ...]] = field(default_factory=set)
+
+    def __post_init__(self) -> None:
+        self._normalize_worker_keys()
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        if "namespace_started" not in state:
+            self.namespace_started = {}
+        if "active_invocation_namespaces" not in state:
+            self.active_invocation_namespaces = set()
+        self._normalize_worker_keys()
+
+    def _normalize_worker_keys(self) -> None:
+        self.workers = _normalize_step_id_keys(self.workers)
 
     def deepcopy(self) -> BrokerState:
         """
@@ -128,8 +169,8 @@ class BrokerState:
             is_running=self.is_running,
             config=self.config,  # immutable
             workers={
-                name: worker_state._deepcopy()
-                for name, worker_state in self.workers.items()
+                step_id: worker_state._deepcopy()
+                for step_id, worker_state in self.workers.items()
             },
             stream_seq=self.stream_seq,
             work_item_seq=self.work_item_seq,
@@ -138,37 +179,93 @@ class BrokerState:
                 key: state._copy()
                 for key, state in self.collection_release_states.items()
             },
+            namespace_started=dict(self.namespace_started),
+            active_invocation_namespaces=set(self.active_invocation_namespaces),
         )
+
+    def live_invocation_namespaces(self) -> set[tuple[str, ...]]:
+        """Runtime invocation namespaces that still have live broker state."""
+        namespaces: set[tuple[str, ...]] = set(self.active_invocation_namespaces)
+        namespaces.update(self.namespace_started)
+        for stream in self.streams.values():
+            if stream.source_invocation_namespace:
+                namespaces.add(stream.source_invocation_namespace)
+        for worker in self.workers.values():
+            namespaces.update(
+                attempt.invocation_namespace
+                for attempt in worker.queue
+                if attempt.invocation_namespace
+            )
+            namespaces.update(
+                running.invocation_namespace
+                for running in worker.in_progress
+                if running.invocation_namespace
+            )
+            namespaces.update(
+                waiter.invocation_namespace
+                for waiter in worker.collected_waiters
+                if waiter.invocation_namespace
+            )
+            namespaces.update(worker.collected_events_by_invocation)
+            namespaces.update(worker.static_collect_events_by_invocation)
+        return namespaces
 
     @staticmethod
     def from_workflow(workflow: Workflow) -> BrokerState:
+        namespaced_steps = workflow._get_namespaced_steps()
+        # Catch-error tables are per-instance (bare-name keyed) on each workflow;
+        # namespace them by the owning instance's path so a child's handlers
+        # recover its own steps. Root steps (namespace ()) project back to bare
+        # names, preserving the pre-namespace wire format.
+        catch_error_handlers: dict[StepId, CatchErrorHandler] = {}
+        handler_for_step: dict[StepId, StepId] = {}
+        # Per-child-namespace timeouts from each child instance. A child only
+        # arms its own deadline when it was given an explicit, non-None timeout;
+        # an unset child defers to its parent (see ``_child_namespace_timeout``).
+        # The root timeout (namespace ()) stays the single global deadline
+        # scheduled in the control loop's ``run()``.
+        namespace_timeouts: dict[tuple[str, ...], float] = {}
+        for namespace, instance in workflow._namespace_instances().items():
+            for name, handler in instance._catch_error_handlers.items():
+                catch_error_handlers[StepId(namespace, name)] = handler
+            for step_name, handler_name in instance._handler_for_step.items():
+                handler_for_step[StepId(namespace, step_name)] = StepId(
+                    namespace, handler_name
+                )
+            if namespace != ():
+                child_timeout = instance._child_namespace_timeout()
+                if child_timeout is not None:
+                    namespace_timeouts[namespace] = child_timeout
         return BrokerState(
             is_running=False,
             config=BrokerConfig(
                 steps={
-                    name: InternalStepConfig(
+                    step_id: InternalStepConfig(
                         accepted_events=step_func._step_config.accepted_events,
                         retry_policy=step_func._step_config.retry_policy,
                         num_workers=step_func._step_config.num_workers,
                         accept_event_subclasses=step_func._step_config.accept_event_subclasses,
                     )
-                    for name, step_func in workflow._get_steps().items()
+                    for step_id, step_func in namespaced_steps.items()
                 },
                 timeout=workflow._timeout,
-                catch_error_handlers=dict(workflow._catch_error_handlers),
-                handler_for_step=dict(workflow._handler_for_step),
+                catch_error_handlers=catch_error_handlers,
+                handler_for_step=handler_for_step,
+                namespace_timeouts=namespace_timeouts,
                 collection_bindings=_compute_collection_bindings(workflow),
             ),
             workers={
-                name: InternalStepWorkerState(
+                step_id: InternalStepWorkerState(
                     queue=[],
                     config=step_func._step_config,
                     in_progress=[],
                     collected_events={},
+                    collected_events_by_invocation={},
                     static_collect_events=[],
+                    static_collect_events_by_invocation={},
                     collected_waiters=[],
                 )
-                for name, step_func in workflow._get_steps().items()
+                for step_id, step_func in namespaced_steps.items()
             },
         )
 
@@ -177,7 +274,9 @@ class BrokerState:
         Rehydrates non-serializable state by re-running commands
         """
         commands: list[WorkflowTick] = []
-        for step_name, worker_state in sorted(self.workers.items(), key=lambda x: x[0]):
+        for step_id, worker_state in sorted(
+            self.workers.items(), key=lambda x: str(x[0])
+        ):
             for waiter in sorted(
                 worker_state.collected_waiters, key=lambda x: x.waiter_id
             ):
@@ -188,9 +287,10 @@ class BrokerState:
                     commands.append(
                         TickAddEvent(
                             event=waiter.event,
-                            step_id=StepId.root(step_name),
+                            step_id=step_id,
                             bound_events=waiter.bound_events,
                             scope_path=waiter.scope_path,
+                            origin_namespace=waiter.invocation_namespace,
                             collection_release_payload=waiter.collection_release_payload,
                             work_item_id=waiter.work_item_id,
                         )
@@ -201,7 +301,7 @@ class BrokerState:
         """Serialize the broker state to a SerializedContext."""
 
         workers_dict = {}
-        for step_name, worker_state in self.workers.items():
+        for step_id, worker_state in self.workers.items():
             # Serialize queue with retry and stream scope info
             queue = [
                 SerializedEventAttempt(
@@ -219,6 +319,7 @@ class BrokerState:
                     recovery_counts=dict(attempt.recovery_counts),
                     not_before=attempt.not_before,
                     scope_path=list(attempt.scope_path),
+                    invocation_namespace=list(attempt.invocation_namespace),
                     collection_release_payload=_serialize_release_payload(
                         attempt.collection_release_payload, serializer
                     ),
@@ -242,6 +343,7 @@ class BrokerState:
                     last_failed_at=ip.last_failed_at,
                     recovery_counts=dict(ip.recovery_counts),
                     scope_path=list(ip.scope_path),
+                    invocation_namespace=list(ip.invocation_namespace),
                     collection_release_payload=_serialize_release_payload(
                         ip.shared_state.collection_release_payload, serializer
                     ),
@@ -254,6 +356,13 @@ class BrokerState:
             collected_events = {
                 buffer_id: [serializer.serialize(ev) for ev in events]
                 for buffer_id, events in worker_state.collected_events.items()
+            }
+            collected_events_by_invocation = {
+                _namespace_key(namespace): {
+                    buffer_id: [serializer.serialize(ev) for ev in events]
+                    for buffer_id, events in buffers.items()
+                }
+                for namespace, buffers in worker_state.collected_events_by_invocation.items()
             }
 
             # Serialize waiters
@@ -274,6 +383,7 @@ class BrokerState:
                     if waiter.resolved_event
                     else None,
                     scope_path=list(waiter.scope_path),
+                    invocation_namespace=list(waiter.invocation_namespace),
                     collection_release_payload=_serialize_release_payload(
                         waiter.collection_release_payload, serializer
                     ),
@@ -282,14 +392,24 @@ class BrokerState:
                 for waiter in worker_state.collected_waiters
             ]
 
-            workers_dict[step_name] = SerializedStepWorkerState(
+            # The wire format keys workers by the string projection of the
+            # StepId (root steps -> bare name, identical to the pre-StepId
+            # format; child steps -> "namespace/name").
+            workers_dict[str(step_id)] = SerializedStepWorkerState(
                 queue=queue,
                 in_progress=in_progress,
                 collected_events=collected_events,
+                collected_events_by_invocation=collected_events_by_invocation,
                 static_collect_events=[
                     serializer.serialize(ev)
                     for ev in worker_state.static_collect_events
                 ],
+                static_collect_events_by_invocation={
+                    _namespace_key(namespace): [
+                        serializer.serialize(ev) for ev in events
+                    ]
+                    for namespace, events in worker_state.static_collect_events_by_invocation.items()
+                },
                 collected_waiters=waiters,
             )
 
@@ -303,7 +423,12 @@ class BrokerState:
             streams={
                 sid: SerializedCollectionStreamInstance(
                     stream_id=stream.stream_id,
-                    source_step=stream.source_step,
+                    # Wire format keeps the bare string projection (root -> name,
+                    # child -> "ns/name"), byte-identical to the pre-StepId format.
+                    source_step=str(stream.source_step),
+                    source_invocation_namespace=list(
+                        stream.source_invocation_namespace
+                    ),
                     scope_path=list(stream.scope_path),
                     open_work_items=stream.open_work_items,
                     accepting_binding_ids=list(stream.accepting_binding_ids),
@@ -319,6 +444,14 @@ class BrokerState:
                 )
                 for key, release in self.collection_release_states.items()
             },
+            namespace_started={
+                _namespace_key(namespace): started_at
+                for namespace, started_at in self.namespace_started.items()
+            },
+            active_invocation_namespaces=[
+                _namespace_key(namespace)
+                for namespace in sorted(self.active_invocation_namespaces)
+            ],
         )
 
     @staticmethod
@@ -341,7 +474,8 @@ class BrokerState:
         base_state.streams = {
             sid: CollectionStreamInstance(
                 stream_id=stream.stream_id,
-                source_step=stream.source_step,
+                source_step=StepId.from_str(stream.source_step),
+                source_invocation_namespace=tuple(stream.source_invocation_namespace),
                 scope_path=tuple(stream.scope_path),
                 open_work_items=stream.open_work_items,
                 accepting_binding_ids=tuple(stream.accepting_binding_ids),
@@ -357,14 +491,23 @@ class BrokerState:
             )
             for key, release in serialized.collection_release_states.items()
         }
+        base_state.namespace_started = {
+            _namespace_from_key(namespace): started_at
+            for namespace, started_at in serialized.namespace_started.items()
+        }
+        base_state.active_invocation_namespaces = {
+            _namespace_from_key(namespace)
+            for namespace in serialized.active_invocation_namespaces
+        }
 
         # Restore worker state (queues, collected events, waiters)
         # We do this regardless of is_running state so workflows can resume from where they left off
-        for step_name, worker_data in serialized.workers.items():
-            if step_name not in base_state.workers:
+        for step_key, worker_data in serialized.workers.items():
+            step_id = StepId.from_str(step_key)
+            if step_id not in base_state.workers:
                 continue
 
-            worker = base_state.workers[step_name]
+            worker = base_state.workers[step_id]
 
             # Restore queue with retry and stream scope info.
             # in_progress events are moved to the queue on deserialization;
@@ -379,9 +522,22 @@ class BrokerState:
                 buffer_id: [serializer.deserialize(ev) for ev in events]
                 for buffer_id, events in worker_data.collected_events.items()
             }
+            worker.collected_events_by_invocation = {
+                _namespace_from_key(namespace): {
+                    buffer_id: [serializer.deserialize(ev) for ev in events]
+                    for buffer_id, events in buffers.items()
+                }
+                for namespace, buffers in worker_data.collected_events_by_invocation.items()
+            }
             worker.static_collect_events = [
                 serializer.deserialize(ev) for ev in worker_data.static_collect_events
             ]
+            worker.static_collect_events_by_invocation = {
+                _namespace_from_key(namespace): [
+                    serializer.deserialize(ev) for ev in events
+                ]
+                for namespace, events in worker_data.static_collect_events_by_invocation.items()
+            }
 
             # Restore waiters
             worker.collected_waiters = []
@@ -415,6 +571,7 @@ class BrokerState:
                         if waiter_data.resolved_event
                         else None,
                         scope_path=tuple(waiter_data.scope_path),
+                        invocation_namespace=tuple(waiter_data.invocation_namespace),
                         collection_release_payload=waiter_payload,
                         work_item_id=waiter_data.work_item_id,
                     )
@@ -452,6 +609,7 @@ def _deserialize_event_attempt(
         recovery_counts=dict(attempt.recovery_counts),
         not_before=attempt.not_before,
         scope_path=tuple(attempt.scope_path),
+        invocation_namespace=tuple(attempt.invocation_namespace),
         collection_release_payload=payload,
         work_item_id=attempt.work_item_id,
     )
@@ -470,12 +628,18 @@ def _import_event_type(qualified_name: str) -> type[Event]:
 
 
 def _binding_id(
-    source_step: str,
-    target_step: str,
+    source_step: StepId,
+    target_step: StepId,
     item_types: tuple[type[Event], ...],
     policy: Collect,
 ) -> str:
-    """Build a stable id for one static source-to-collect-step binding."""
+    """Build a stable id for one static source-to-collect-step binding.
+
+    The id embeds the *string projection* of each StepId, so a root binding
+    (namespace ``()`` -> bare name) keeps the exact pre-StepId id string. This
+    id is serialized by value into stream state, so a changed root id would
+    break snapshot resume.
+    """
     type_names = ",".join(f"{t.__module__}.{t.__qualname__}" for t in item_types)
     card = policy.cardinality
     card_repr = f"Take({card.n})" if isinstance(card, Take) else type(card).__name__
@@ -490,38 +654,50 @@ def _compute_collection_bindings(workflow: Workflow) -> dict[str, CollectionBind
     type appears at the same stream level reachable from the source (see
     :mod:`workflows._stream_levels` for the level traversal, shared with static
     validation).
+
+    Bindings are computed **per-namespace**: each namespace's steps are fed to
+    the stream-level walk on their own, so a binding only ever forms within one
+    namespace. Feeding the flattened whole tree would re-open cross-namespace
+    binding, since the stream-level walk has no StartEvent boundary of its own
+    (that boundary lives in routing, not here). Source/target are keyed by the
+    namespaced StepId.
     """
-    steps = {name: fn._step_config for name, fn in workflow._get_steps().items()}
-    collects: dict[str, tuple[Any, ...]] = {
-        name: cfg.collection_param[1]
-        for name, cfg in steps.items()
-        if cfg.collection_param is not None
-    }
+    by_namespace: dict[tuple[str, ...], dict[str, StepConfig]] = {}
+    for step_id, fn in workflow._get_namespaced_steps().items():
+        by_namespace.setdefault(step_id.namespace, {})[step_id.name] = fn._step_config
 
     bindings: dict[str, CollectionBinding] = {}
-    for source_step, level_types in stream_level_types_by_producer(steps).items():
-        for target_step, collect_types in collects.items():
-            item_types = tuple(event_types(collect_types))
-            if not any(
-                step_accepts_type(
-                    produced,
-                    item_types,
-                    allow_subclasses=steps[target_step].accept_event_subclasses,
+    for namespace, steps in by_namespace.items():
+        collects: dict[str, tuple[Any, ...]] = {
+            name: cfg.collection_param[1]
+            for name, cfg in steps.items()
+            if cfg.collection_param is not None
+        }
+        for source_name, level_types in stream_level_types_by_producer(steps).items():
+            for target_name, collect_types in collects.items():
+                item_types = tuple(event_types(collect_types))
+                if not any(
+                    step_accepts_type(
+                        produced,
+                        item_types,
+                        allow_subclasses=steps[target_name].accept_event_subclasses,
+                    )
+                    for produced in level_types
+                ):
+                    continue
+                policy = steps[target_name].collection_policy
+                if policy is None:
+                    continue
+                source_step = StepId(namespace, source_name)
+                target_step = StepId(namespace, target_name)
+                binding = CollectionBinding(
+                    id=_binding_id(source_step, target_step, item_types, policy),
+                    source_step=source_step,
+                    target_step=target_step,
+                    item_types=item_types,
+                    policy=policy,
                 )
-                for produced in level_types
-            ):
-                continue
-            policy = steps[target_step].collection_policy
-            if policy is None:
-                continue
-            binding = CollectionBinding(
-                id=_binding_id(source_step, target_step, item_types, policy),
-                source_step=source_step,
-                target_step=target_step,
-                item_types=item_types,
-                policy=policy,
-            )
-            bindings[binding.id] = binding
+                bindings[binding.id] = binding
     return bindings
 
 
@@ -535,18 +711,50 @@ class BrokerConfig:
     Attributes:
         steps: Configuration for each step indexed by step name
         timeout: Maximum seconds before the workflow times out, or None for no timeout
-        catch_error_handlers: handler step name -> CatchErrorHandler descriptor
-        handler_for_step: step name -> handler step name that owns it
+        catch_error_handlers: handler StepId -> CatchErrorHandler descriptor
+        handler_for_step: covered step's StepId -> the handler StepId that owns it
         collection_bindings: Static list[E] stream bindings keyed by binding id
     """
 
-    steps: dict[str, InternalStepConfig]
+    steps: dict[StepId, InternalStepConfig]
     timeout: float | None
-    catch_error_handlers: dict[str, CatchErrorHandler] = field(default_factory=dict)
-    handler_for_step: dict[str, str] = field(default_factory=dict)
+    # Catch-error routing is keyed by StepId so a handler declared on a child
+    # recovers only that child's steps and keeps a recovery budget distinct from
+    # a same-named root handler. Merged from every namespace instance in
+    # ``from_workflow``; ``handler_for_step`` maps a covered step's StepId to its
+    # handler's StepId, ``catch_error_handlers`` maps a handler StepId to its
+    # descriptor.
+    catch_error_handlers: dict[StepId, CatchErrorHandler] = field(default_factory=dict)
+    handler_for_step: dict[StepId, StepId] = field(default_factory=dict)
+    # Per-child-namespace timeout (seconds), from each child's ``_timeout``.
+    # Root (``()``) is absent: its deadline is the global ``timeout`` above.
+    namespace_timeouts: dict[tuple[str, ...], float] = field(default_factory=dict)
     collection_bindings: dict[str, CollectionBinding] = field(default_factory=dict)
 
-    def bindings_for_source(self, source_step: str) -> tuple[CollectionBinding, ...]:
+    def __post_init__(self) -> None:
+        self._normalize_step_id_maps()
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._normalize_step_id_maps()
+
+    def _normalize_step_id_maps(self) -> None:
+        object.__setattr__(self, "steps", _normalize_step_id_keys(self.steps))
+        object.__setattr__(
+            self,
+            "catch_error_handlers",
+            _normalize_step_id_keys(self.catch_error_handlers),
+        )
+        object.__setattr__(
+            self,
+            "handler_for_step",
+            {
+                _normalize_step_id(step_id): _normalize_step_id(handler_id)
+                for step_id, handler_id in self.handler_for_step.items()
+            },
+        )
+
+    def bindings_for_source(self, source_step: StepId) -> tuple[CollectionBinding, ...]:
         return tuple(
             binding
             for binding in self.collection_bindings.values()
@@ -556,7 +764,7 @@ class BrokerConfig:
     def binding_for_target(
         self,
         stream_id: str,
-        target_step: str,
+        target_step: StepId,
         streams: dict[str, CollectionStreamInstance],
     ) -> CollectionBinding | None:
         stream = streams.get(stream_id)
@@ -617,6 +825,7 @@ class EventAttempt:
     scope_path: tuple[str, ...] = field(default_factory=tuple)
     collection_release_payload: CollectionReleasePayload | None = None
     work_item_id: str | None = None
+    invocation_namespace: tuple[str, ...] = ()
 
 
 @dataclass()
@@ -640,7 +849,13 @@ class InternalStepWorkerState:
     in_progress: list[InProgressState]
     collected_events: dict[str, list[Event]]
     collected_waiters: list[StepWorkerWaiter]
+    collected_events_by_invocation: dict[tuple[str, ...], dict[str, list[Event]]] = (
+        field(default_factory=dict)
+    )
     static_collect_events: list[Event] = field(default_factory=list)
+    static_collect_events_by_invocation: dict[tuple[str, ...], list[Event]] = field(
+        default_factory=dict
+    )
 
     def _deepcopy(self) -> InternalStepWorkerState:
         return InternalStepWorkerState(
@@ -648,7 +863,15 @@ class InternalStepWorkerState:
             config=self.config,
             in_progress=[x._deepcopy() for x in self.in_progress],
             collected_events={k: list(v) for k, v in self.collected_events.items()},
+            collected_events_by_invocation={
+                namespace: {k: list(v) for k, v in buffers.items()}
+                for namespace, buffers in self.collected_events_by_invocation.items()
+            },
             static_collect_events=list(self.static_collect_events),
+            static_collect_events_by_invocation={
+                namespace: list(events)
+                for namespace, events in self.static_collect_events_by_invocation.items()
+            },
             collected_waiters=[dataclasses.replace(x) for x in self.collected_waiters],
         )
 
@@ -686,6 +909,7 @@ class InProgressState:
     bound_events: dict[str, Event] | None = None
     scope_path: tuple[str, ...] = field(default_factory=tuple)
     work_item_id: str | None = None
+    invocation_namespace: tuple[str, ...] = ()
 
     def _deepcopy(self) -> InProgressState:
         return InProgressState(
@@ -700,6 +924,7 @@ class InProgressState:
             recovery_counts=dict(self.recovery_counts),
             scope_path=self.scope_path,
             work_item_id=self.work_item_id,
+            invocation_namespace=self.invocation_namespace,
         )
 
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/invocation.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/invocation.py
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+from workflows.utils import _nanoid
+
+INVOCATION_SEPARATOR = "#"
+
+
+def mint_child_invocation_namespace(
+    parent_invocation_namespace: tuple[str, ...], child_slot: str
+) -> tuple[str, ...]:
+    return (
+        *parent_invocation_namespace,
+        f"{child_slot}{INVOCATION_SEPARATOR}{_nanoid()}",
+    )
+
+
+def slot_segment(segment: str) -> str:
+    return segment.split(INVOCATION_SEPARATOR, 1)[0]
+
+
+def slot_namespace(
+    invocation_namespace: tuple[str, ...],
+) -> tuple[str, ...]:
+    return tuple(slot_segment(segment) for segment in invocation_namespace)
+
+
+def namespace_startswith(namespace: tuple[str, ...], prefix: tuple[str, ...]) -> bool:
+    return namespace[: len(prefix)] == prefix

--- a/packages/llama-index-workflows/src/workflows/runtime/types/named_task.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/named_task.py
@@ -23,10 +23,14 @@ class WorkerTask:
     step_id: StepId
     worker_id: int
     task: Task[Any]
+    invocation_namespace: tuple[str, ...] = ()
 
     @property
     def key(self) -> str:
-        return f"{self.step_id}:{self.worker_id}"
+        if self.invocation_namespace == ():
+            return f"{self.step_id}:{self.worker_id}"
+        invocation = "/".join(self.invocation_namespace)
+        return f"{self.step_id}:{invocation}:{self.worker_id}"
 
 
 @dataclass
@@ -94,14 +98,23 @@ class PendingWorker:
     step_id: StepId
     worker_id: int
     coro: Coroutine[Any, Any, Any]
+    invocation_namespace: tuple[str, ...] = ()
 
     @property
     def key(self) -> str:
-        return f"{self.step_id}:{self.worker_id}"
+        if self.invocation_namespace == ():
+            return f"{self.step_id}:{self.worker_id}"
+        invocation = "/".join(self.invocation_namespace)
+        return f"{self.step_id}:{invocation}:{self.worker_id}"
 
     def start(self, task: Task[Any]) -> WorkerTask:
         """Convert to a started WorkerTask."""
-        return WorkerTask(self.step_id, self.worker_id, task)
+        return WorkerTask(
+            self.step_id,
+            self.worker_id,
+            task,
+            invocation_namespace=self.invocation_namespace,
+        )
 
 
 @dataclass

--- a/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/plugin.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
     from workflows.context.serializers import BaseSerializer
     from workflows.runtime.types.internal_state import BrokerState
     from workflows.runtime.types.step_function import StepWorkerFunction
+    from workflows.runtime.types.step_id import StepId
     from workflows.workflow import Workflow
 from workflows.runtime.types.ticks import TickCancelRun, WorkflowTick
 
@@ -75,7 +76,7 @@ class WaitForNextTaskResult:
 class RegisteredWorkflow:
     workflow: Workflow
     workflow_run_fn: WorkflowRunFunction
-    steps: dict[str, StepWorkerFunction]
+    steps: dict[StepId, StepWorkerFunction]
 
 
 class InternalRunAdapter(ABC):
@@ -181,11 +182,14 @@ class InternalRunAdapter(ABC):
         """
         pass
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         """
-        Get the state store for this workflow run.
+        Get the per-namespace state store for this workflow run.
 
-        Returns the state store from the runtime, or None if not initialized.
+        ``namespace`` selects the namespace's own record (``()`` is the root);
+        each namespace owns an isolated store. Returns None if not initialized.
         Default implementation returns None.
         """
         return None
@@ -334,12 +338,14 @@ class ExternalRunAdapter(ABC):
         """
         await self.send_event(TickCancelRun())
 
-    def get_state_store(self) -> StateStore[Any] | None:
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> StateStore[Any] | None:
         """
-        Get the state store for this workflow run.
+        Get the per-namespace state store for this workflow run.
 
-        Returns the state store if this adapter owns it, or None if state
-        is managed externally. Default implementation returns None.
+        ``namespace`` selects the namespace's own record (``()`` is the root).
+        Returns None if this adapter doesn't own state. Default returns None.
         """
         return None
 
@@ -353,7 +359,7 @@ class RunContext:
     workflow: Workflow
     run_adapter: InternalRunAdapter
     context: Context
-    steps: dict[str, StepWorkerFunction]
+    steps: dict[StepId, StepWorkerFunction]
 
 
 @dataclass

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -73,6 +73,10 @@ class StepWorkerContext:
     # add commands here to mutate the internal worker state after step execution
     returns: Returns
     retry: RetryAttempt = dataclasses.field(default_factory=RetryAttempt)
+    # The namespace of the step that is currently executing. Root steps run at
+    # ``()``; a child-workflow step runs under its declared field path. Read by
+    # ``InternalContext.send_event`` so events a child emits stay namespaced.
+    namespace: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -205,6 +209,8 @@ class StepWorkerWaiter(Generic[EventType]):
     # Originating work record: stream scope of the suspended work item, restored
     # whole on resume so the resumed attempt still closes its stream.
     scope_path: tuple[str, ...] = ()
+    # Runtime invocation namespace of the suspended work item.
+    invocation_namespace: tuple[str, ...] = ()
     # For a suspended collect invocation, the release batch to re-invoke with.
     collection_release_payload: CollectionReleasePayload | None = None
     # Stable identity for the suspended work item. Used to rebuild implicit

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -21,6 +21,7 @@ from llama_index_instrumentation.dispatcher import (
 from llama_index_instrumentation.events.span import SpanDropEvent
 from llama_index_instrumentation.span import active_span_id
 from workflows._event_summary import summarize_event
+from workflows.context.state_store import StateStore
 from workflows.decorators import P, StepConfig
 from workflows.errors import WorkflowCancelledByUser, WorkflowRuntimeError
 from workflows.events import (
@@ -48,6 +49,7 @@ from workflows.runtime.types.results import (
     StepWorkerStateContextVar,
     WaitingForEvent,
 )
+from workflows.runtime.types.step_id import StepId
 from workflows.workflow import Workflow
 
 if TYPE_CHECKING:
@@ -111,6 +113,8 @@ class StepWorkerFunction(Protocol):
         workflow: Workflow,
         bound_events: dict[str, Event] | None = None,
         retry: RetryAttempt = RetryAttempt(),
+        namespace: tuple[str, ...] = (),
+        state_store: StateStore[Any] | None = None,
     ) -> Awaitable[list[StepFunctionResult]]: ...
 
 
@@ -145,11 +149,11 @@ async def partial(
     return functools.partial(func, **kwargs)
 
 
-def as_step_worker_functions(workflow: Workflow) -> dict[str, StepWorkerFunction]:
-    step_funcs = workflow._get_steps()
-    step_workers: dict[str, StepWorkerFunction] = {
-        name: as_step_worker_function(getattr(func, "__func__", func))
-        for name, func in step_funcs.items()
+def as_step_worker_functions(workflow: Workflow) -> dict[StepId, StepWorkerFunction]:
+    step_funcs = workflow._get_namespaced_steps()
+    step_workers: dict[StepId, StepWorkerFunction] = {
+        step_id: as_step_worker_function(getattr(func, "__func__", func))
+        for step_id, func in step_funcs.items()
     }
     return step_workers
 
@@ -176,19 +180,25 @@ def as_step_worker_function(
         workflow: Workflow,
         bound_events: dict[str, Event] | None = None,
         retry: RetryAttempt = RetryAttempt(),
+        namespace: tuple[str, ...] = (),
+        state_store: StateStore[Any] | None = None,
     ) -> list[StepFunctionResult]:
         from workflows.context.context import Context
 
-        internal_context = Context._create_internal(workflow=workflow)
+        internal_context = Context._create_internal(
+            workflow=workflow, state_store=state_store
+        )
         returns = Returns(return_values=[])
 
-        step_ctx = StepWorkerContext(
-            event=event,
-            state=state,
-            returns=returns,
-            retry=retry,
+        token = StepWorkerStateContextVar.set(
+            StepWorkerContext(
+                event=event,
+                state=state,
+                returns=returns,
+                retry=retry,
+                namespace=namespace,
+            )
         )
-        token = StepWorkerStateContextVar.set(step_ctx)
         ctx_token = InternalContextVar.set(weakref.ref(internal_context))
 
         try:

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_id.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_id.py
@@ -22,6 +22,10 @@ class StepId:
         if any(not part for part in self.namespace):
             raise ValueError("StepId namespace parts cannot be empty")
 
+    @property
+    def is_root(self) -> bool:
+        return not self.namespace
+
     @classmethod
     def root(cls, name: str) -> StepId:
         return cls(namespace=(), name=name)

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -17,13 +17,24 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, TypeAdapter
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    TypeAdapter,
+)
 from workflows.events import SerializableEvent, SerializableOptionalException
 from workflows.runtime.types.results import (
     SerializableCollectionReleasePayload,
     StepFunctionResult,
 )
 from workflows.runtime.types.step_id import StepId
+
+# Pre-StepId journals serialized this field as ``step_name``; accept both so
+# persisted ticks still deserialize. New ticks serialize under ``step_id``.
+_STEP_ID_ALIAS = AliasChoices("step_id", "step_name")
 
 
 class TickStepResult(BaseModel):
@@ -33,8 +44,9 @@ class TickStepResult(BaseModel):
         frozen=True, arbitrary_types_allowed=True, populate_by_name=True
     )
     type: Literal["step_result"] = "step_result"
-    step_id: StepId = Field(validation_alias="step_name")
+    step_id: StepId = Field(validation_alias=_STEP_ID_ALIAS)
     worker_id: int
+    invocation_namespace: tuple[str, ...] = ()
     event: SerializableEvent
     result: list[Annotated[StepFunctionResult, Discriminator("type")]]
 
@@ -47,14 +59,25 @@ class TickAddEvent(BaseModel):
     )
     type: Literal["add_event"] = "add_event"
     event: SerializableEvent
-    step_id: StepId | None = Field(default=None, validation_alias="step_name")
+    step_id: StepId | None = Field(default=None, validation_alias=_STEP_ID_ALIAS)
     bound_events: dict[str, SerializableEvent] | None = None
+    # Namespace of the step (or boundary) that emitted this event. Type-routing
+    # is scoped to this namespace so events emitted inside a child stay in the
+    # child; ``()`` (the default) is the root namespace, preserving the
+    # pre-child wire format for old journals.
+    origin_namespace: tuple[str, ...] = ()
     attempts: int | None = None
     first_attempt_at: float | None = None
     last_exception: SerializableOptionalException = None
     last_failed_at: float | None = None
     recovery_counts: dict[str, int] = Field(default_factory=dict)
     scope_path: tuple[str, ...] = Field(default_factory=tuple)
+    # Static child target namespace -> minted runtime invocation namespace for
+    # StartEvent routes. Filled before the tick is reduced so replay uses the
+    # same opaque child invocation ids as the live run.
+    child_invocation_namespaces: dict[str, tuple[str, ...]] = Field(
+        default_factory=dict
+    )
     # Collect-invocation work record. A payload-carrying tick is routed
     # directly to the binding's target step, before waiter matching and the
     # member-arrival path.
@@ -98,8 +121,27 @@ class TickWaiterTimeout(BaseModel):
 
     model_config = ConfigDict(frozen=True, populate_by_name=True)
     type: Literal["waiter_timeout"] = "waiter_timeout"
-    step_id: StepId = Field(validation_alias="step_name")
+    step_id: StepId = Field(validation_alias=_STEP_ID_ALIAS)
     waiter_id: str
+    invocation_namespace: tuple[str, ...] = ()
+
+
+class TickNamespaceTimeout(BaseModel):
+    """When processed, times out a single child namespace (not the whole run).
+
+    Scheduled when the first event routes into a child namespace that declares a
+    ``timeout``. On fire it expires *that child* through the namespaced failure
+    path (so the child's ``@catch_error`` can recover it); only the root timeout
+    (:class:`TickTimeout`) halts the whole run. ``started_at`` pins the activation
+    this tick was scheduled for: if the namespace has since completed or been
+    re-armed, the tick is a stale no-op.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    type: Literal["namespace_timeout"] = "namespace_timeout"
+    namespace: tuple[str, ...]
+    timeout: float
+    started_at: float
 
 
 class TickIdleCheck(BaseModel):
@@ -139,6 +181,7 @@ WorkflowTick = Annotated[
     | TickPublishEvent
     | TickTimeout
     | TickWaiterTimeout
+    | TickNamespaceTimeout
     | TickIdleCheck
     | TickIdleRelease
     | TickWakeup,

--- a/packages/llama-index-workflows/src/workflows/testing/runner.py
+++ b/packages/llama-index-workflows/src/workflows/testing/runner.py
@@ -43,6 +43,7 @@ class WorkflowTestRunner:
         ctx: Optional["Context"] = None,
         expose_internal: bool = True,
         exclude_events: list[EventType] | None = None,
+        include_children: bool = False,
     ) -> WorkflowTestResult:
         """
         Run a workflow end-to-end and collect the events that are streamed during its execution.
@@ -51,6 +52,7 @@ class WorkflowTestRunner:
             start_event (StartEvent): The input event for the workflow
             expose_internal (bool): Whether or not to expose internal events. Defaults to True if not set.
             exclude_events. (list[EventType]): A list of event types to exclude from the collected events. Defaults to None if not set.
+            include_children (bool): Whether to surface events published from within child-workflow executions. Defaults to False.
 
         Returns:
             WorkflowTestResult
@@ -67,7 +69,9 @@ class WorkflowTestRunner:
         """
         handler = self._workflow.run(start_event=start_event, ctx=ctx)
         collected_events: list[Event] = []
-        async for event in handler.stream_events(expose_internal=expose_internal):
+        async for event in handler.stream_events(
+            expose_internal=expose_internal, include_children=include_children
+        ):
             if exclude_events and type(event) in exclude_events:
                 continue
             collected_events.append(event)

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -5,14 +5,20 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
+import warnings
+from inspect import Parameter, Signature
 from typing import (
     TYPE_CHECKING,
     Any,
+    ClassVar,
+    cast,
     get_args,
 )
 
 from llama_index_instrumentation import get_dispatcher
 from pydantic import ValidationError
+from typing_extensions import dataclass_transform
 
 if TYPE_CHECKING:  # pragma: no cover
     from .context import Context
@@ -23,20 +29,238 @@ from .errors import (
     WorkflowRuntimeError,
     WorkflowValidationError,
 )
-from .events import Event, StartEvent
+from .events import Event, StartEvent, StopEvent
 from .handler import WorkflowHandler
 from .resource import ResourceManager
+from .runtime.types.step_id import StepId
 from .types import RunResultT
 from .utils import get_steps_from_class, get_steps_from_instance
 
 dispatcher = get_dispatcher(__name__)
 logger = logging.getLogger(__name__)
 
+# Default run timeout. Referenced by the constructor and type-checker field.
+DEFAULT_TIMEOUT = 45.0
 
+
+class _UnsetTimeout:
+    """Sentinel for an unspecified ``timeout``.
+
+    Lets the constructor tell "user passed nothing" apart from "user passed a
+    value" without knowing yet whether this instance is a root or a child. A
+    root resolves an unset timeout to ``DEFAULT_TIMEOUT``; a child defers to its
+    parent and gets no deadline of its own.
+    """
+
+    def __repr__(self) -> str:
+        return "<unset>"
+
+
+_UNSET_TIMEOUT = _UnsetTimeout()
+
+
+def _resolve_child_slots(cls: type) -> dict[str, type]:
+    """Resolve workflow-typed annotations from ``cls`` and its bases."""
+    workflow_cls = globals().get("Workflow")
+    if workflow_cls is None:
+        return {}
+    slots: dict[str, type] = {}
+    for klass in reversed(cls.__mro__):
+        annotations = klass.__dict__.get("__annotations__") or getattr(
+            klass, "__annotations__", None
+        )
+        if not annotations:
+            continue
+        module = sys.modules.get(klass.__module__)
+        globalns = getattr(module, "__dict__", {})
+        localns = dict(vars(klass))
+        for field_name, annotation in annotations.items():
+            resolved: Any = annotation
+            if isinstance(annotation, str):
+                try:
+                    resolved = eval(annotation, globalns, localns)  # noqa: S307
+                except Exception:
+                    continue
+            if isinstance(resolved, type) and issubclass(resolved, workflow_cls):
+                slots[field_name] = resolved
+    return slots
+
+
+def _synthesized_workflow_init(self: Workflow, *args: Any, **kwargs: Any) -> None:
+    """Constructor synthesized for classes that only declare child slots."""
+    slots = type(self)._get_child_workflow_slots()
+    children: dict[str, Any] = {}
+    for slot_name in slots:
+        if slot_name in kwargs:
+            children[slot_name] = kwargs.pop(slot_name)
+    Workflow.__init__(self, *args, **kwargs)
+    for slot_name, child in children.items():
+        self._attach_child(slot_name, child)
+
+
+def _validate_includable_child(child: Workflow, slot_name: str) -> None:
+    """A workflow is includable as a child only if it declares custom
+    ``StartEvent`` and ``StopEvent`` subclasses — the typed IO is the routing
+    contract that maps each child's events to exactly one child.
+    """
+    cls_name = type(child).__name__
+    if child._start_event_class is StartEvent:
+        raise WorkflowValidationError(
+            f"Child workflow '{cls_name}' (slot '{slot_name}') must declare a "
+            "custom StartEvent subclass; a bare StartEvent cannot be routed to a "
+            "child unambiguously."
+        )
+    if child._stop_event_class is StopEvent:
+        raise WorkflowValidationError(
+            f"Child workflow '{cls_name}' (slot '{slot_name}') must declare a "
+            "custom StopEvent subclass; a bare StopEvent cannot be routed back "
+            "to the parent unambiguously."
+        )
+
+
+def _warn_ignored_child_config(child: Workflow, slot_name: str) -> None:
+    ignored: list[str] = []
+    if child._verbose:
+        ignored.append("verbose=True")
+    if child._num_concurrent_runs is not None:
+        ignored.append(f"num_concurrent_runs={child._num_concurrent_runs!r}")
+    if child._workflow_name is not None:
+        ignored.append(f"workflow_name={child._workflow_name!r}")
+    if not ignored:
+        return
+    warnings.warn(
+        f"Child workflow slot '{slot_name}' on '{type(child).__name__}' has "
+        f"run-level config ignored when nested: {', '.join(ignored)}.",
+        UserWarning,
+        stacklevel=3,
+    )
+
+
+def _runtime_supports_child_workflows(runtime: Runtime) -> bool:
+    return bool(getattr(runtime, "_supports_child_workflows", True))
+
+
+def _has_custom_workflow_init(cls: type) -> bool:
+    return bool(getattr(cls, "_custom_workflow_init", False))
+
+
+def _config_field(*, alias: str, default: Any = None) -> Any:
+    """dataclass_transform field specifier for Workflow config params."""
+    return default
+
+
+@dataclass_transform(kw_only_default=True, field_specifiers=(_config_field,))
 class WorkflowMeta(type):
+    # Defined only at runtime, hidden from type checkers. As a metaclass
+    # __call__ it is the single entry point for every instantiation and sits
+    # above the whole __init__/super() chain: type.__call__ drives __new__ and
+    # the complete chain as one unit, so when it returns — every derived
+    # __init__ done and all children assigned — _finalize_construction runs at
+    # the true outermost point of construction. Registration then sees the full
+    # child tree regardless of init style, subclassing depth, or launch timing.
+    #
+    # It is hidden behind ``if not TYPE_CHECKING`` because a typed metaclass
+    # __call__ can't satisfy both type checkers at once: basedpyright needs a
+    # generic ``cls: type[T] -> T`` self-type to preserve the constructed type,
+    # but that exact annotation makes ty reject the ``super().__call__`` as not
+    # bound to the metaclass. Hiding it lets both fall back to the correct
+    # dataclass_transform constructor typing (``Parent(...)`` -> ``Parent``).
+    if not TYPE_CHECKING:
+
+        def __call__(cls, *args: Any, **kwargs: Any) -> Any:
+            obj = super().__call__(*args, **kwargs)
+            obj._finalize_construction()
+            return obj
+
     def __init__(cls, name: str, bases: tuple[type, ...], dct: dict[str, Any]) -> None:
         super().__init__(name, bases, dct)
         cls._step_functions: dict[str, StepFunction] = {}
+        cls._custom_workflow_init = False
+
+        # A user-defined __init__ always wins.
+        workflow_cls = globals().get("Workflow")
+        if workflow_cls is None:
+            return
+        if "__init__" in dct:
+            cls._custom_workflow_init = cls is not workflow_cls
+            return
+        if any(getattr(base, "_custom_workflow_init", False) for base in bases):
+            cls._custom_workflow_init = True
+            return
+        if not _resolve_child_slots(cls):
+            return
+        inherited_init = getattr(cls, "__init__", None)
+        if (
+            inherited_init is workflow_cls.__init__
+            or inherited_init is _synthesized_workflow_init
+        ):
+            setattr(cls, "__init__", _synthesized_workflow_init)
+            cls.__signature__ = _child_slot_signature(cls)
+
+
+def _child_slot_signature(cls: type) -> Signature:
+    params = [
+        Parameter(
+            name,
+            kind=Parameter.KEYWORD_ONLY,
+            default=Parameter.empty,
+            annotation=slot_type,
+        )
+        for name, slot_type in _resolve_child_slots(cls).items()
+    ]
+    params.extend(
+        [
+            Parameter(
+                "timeout",
+                kind=Parameter.KEYWORD_ONLY,
+                default=_UNSET_TIMEOUT,
+                annotation=float | None | _UnsetTimeout,
+            ),
+            Parameter(
+                "disable_validation",
+                kind=Parameter.KEYWORD_ONLY,
+                default=False,
+                annotation=bool,
+            ),
+            Parameter(
+                "verbose",
+                kind=Parameter.KEYWORD_ONLY,
+                default=False,
+                annotation=bool,
+            ),
+            Parameter(
+                "resource_manager",
+                kind=Parameter.KEYWORD_ONLY,
+                default=None,
+                annotation=ResourceManager | None,
+            ),
+            Parameter(
+                "num_concurrent_runs",
+                kind=Parameter.KEYWORD_ONLY,
+                default=None,
+                annotation=int | None,
+            ),
+            Parameter(
+                "runtime",
+                kind=Parameter.KEYWORD_ONLY,
+                default=None,
+                annotation=Any,
+            ),
+            Parameter(
+                "workflow_name",
+                kind=Parameter.KEYWORD_ONLY,
+                default=None,
+                annotation=str | None,
+            ),
+            Parameter(
+                "skip_graph_checks",
+                kind=Parameter.KEYWORD_ONLY,
+                default=None,
+                annotation=set[WorkflowGraphCheck] | None,
+            ),
+        ]
+    )
+    return Signature(params)
 
 
 class Workflow(metaclass=WorkflowMeta):
@@ -87,16 +311,32 @@ class Workflow(metaclass=WorkflowMeta):
         - [RetryPolicy][workflows.retry_policy.RetryPolicy]
     """
 
-    # Populated by the metaclass; declared here for type checkers.
-    _step_functions: dict[str, StepFunction]
-    _step_functions_version: int = 0
+    # Class-level state (metaclass / per-class), NOT constructor fields.
+    _step_functions: ClassVar[dict[str, StepFunction]]
+    _step_functions_version: ClassVar[int] = 0
+    _child_workflow_slots_cache: ClassVar[dict[str, type] | None] = None
 
-    _runtime: Runtime
-    _workflow_name: str | None
+    # Phantom dataclass_transform fields for typed subclass constructors.
+    _timeout_arg: float | None = _config_field(alias="timeout", default=_UNSET_TIMEOUT)
+    _disable_validation_arg: bool = _config_field(
+        alias="disable_validation", default=False
+    )
+    _verbose_arg: bool = _config_field(alias="verbose", default=False)
+    _resource_manager_arg: ResourceManager | None = _config_field(
+        alias="resource_manager", default=None
+    )
+    _num_concurrent_runs_arg: int | None = _config_field(
+        alias="num_concurrent_runs", default=None
+    )
+    _runtime_arg: Runtime | None = _config_field(alias="runtime", default=None)
+    _workflow_name_arg: str | None = _config_field(alias="workflow_name", default=None)
+    _skip_graph_checks_arg: set[WorkflowGraphCheck] | None = _config_field(
+        alias="skip_graph_checks", default=None
+    )
 
     def __init__(
         self,
-        timeout: float | None = 45.0,
+        timeout: float | None | _UnsetTimeout = _UNSET_TIMEOUT,
         disable_validation: bool = False,
         verbose: bool = False,
         resource_manager: ResourceManager | None = None,
@@ -110,7 +350,10 @@ class Workflow(metaclass=WorkflowMeta):
 
         Args:
             timeout (float | None): Max seconds to wait for completion. `None`
-                disables the timeout.
+                disables the timeout. When unset, a root workflow defaults to
+                45s; a child workflow defaults to no timeout of its own and is
+                bounded by its parent. An explicit value (including `None`) is
+                always honored.
             disable_validation (bool): Skip pre-run validation of the event graph
                 (not recommended).
             verbose (bool): If True, print step activity.
@@ -138,13 +381,21 @@ class Workflow(metaclass=WorkflowMeta):
             _ensure_stop_event_class,
         )
 
-        # Configuration
-        self._timeout = timeout
+        # Configuration. Resolve an unset timeout to the root default so the
+        # runner and `_timeout` readers see a concrete value; `_timeout_set`
+        # records whether the user supplied one, which lets a child suppress its
+        # own deadline (see `_child_namespace_timeout`).
+        if isinstance(timeout, _UnsetTimeout):
+            self._timeout_set = False
+            self._timeout: float | None = DEFAULT_TIMEOUT
+        else:
+            self._timeout_set = True
+            self._timeout = timeout
         self._verbose = verbose
         self._disable_validation = disable_validation
         self._num_concurrent_runs = num_concurrent_runs
         # Store explicit name (None means use computed name)
-        self._workflow_name = workflow_name
+        self._workflow_name: str | None = workflow_name
 
         step_configs = self._step_configs()
         cls_name = self.__class__.__name__
@@ -154,6 +405,8 @@ class Workflow(metaclass=WorkflowMeta):
         # Populated by _validate(); empty until a successful validation runs.
         self._catch_error_handlers: dict[str, CatchErrorHandler] = {}
         self._handler_for_step: dict[str, str] = {}
+        # Attached child-workflow instances, keyed by declared field name.
+        self._child_workflows: dict[str, Workflow] = {}
         self._events = _collect_events(step_configs)
         # Resource management
         self._resource_manager = resource_manager or ResourceManager()
@@ -175,45 +428,206 @@ class Workflow(metaclass=WorkflowMeta):
         self._skip_graph_checks: set[WorkflowGraphCheck] = checks
 
         # Runtime registration: explicit > context-scoped > basic_runtime
-        self._runtime = runtime if runtime is not None else get_current_runtime()
+        self._runtime: Runtime = (
+            runtime if runtime is not None else get_current_runtime()
+        )
         if self._verbose:
             self._runtime = VerboseDecorator(self._runtime)
+        # Tracking is deferred until subclass construction has finished.
+
+    def _finalize_construction(self) -> None:
+        """Attach declared children and track the workflow once."""
+        if not hasattr(self, "_runtime"):
+            # _runtime is the last attribute set by Workflow.__init__, so its
+            # absence means a subclass __init__ skipped super().__init__().
+            # __call__ runs this for every instance, so without the guard the
+            # next lines raise an opaque AttributeError on a private attribute.
+            raise WorkflowValidationError(
+                f"{type(self).__name__}.__init__ did not call super().__init__(). "
+                "Workflow subclasses with a custom __init__ must call "
+                "super().__init__(...) so the base workflow is initialized."
+            )
+        self._ensure_children_attached()
         # Register with runtime for tracking (no-op for BasicRuntime)
         self._runtime.track_workflow(self)
 
     def _validate_valid_step_message(self, step: str, message: Event) -> None:
-        """Validate that a step name exists in the workflow."""
-        if step not in self._get_steps():
-            raise WorkflowRuntimeError(f"Step {step} does not exist")
+        """Validate that a step name exists in the workflow and accepts ``message``."""
+        self._resolve_target_step(step, message)
 
-        step_func = self._get_steps()[step]
+    def _resolve_target_step(
+        self, step: str, message: Event, base_namespace: tuple[str, ...] = ()
+    ) -> StepId:
+        """Resolve a ``send_event(step=...)`` target to a validated ``StepId``.
+
+        ``step`` is resolved relative to ``base_namespace`` — root (``()``) for
+        external sends, the emitting step's namespace for internal sends — so a
+        bare name lands in that namespace and a ``"child/answer"`` path descends
+        from it. The single resolver shared by ``Context.send_event`` and
+        ``ExternalContext.send_event``: it validates against the full namespaced
+        step set (not the root-only one) and that the target accepts the message,
+        naming the valid steps when it rejects.
+        """
+        parsed = StepId.from_str(step)
+        target = StepId(base_namespace + parsed.namespace, parsed.name)
+        namespaced = self._get_namespaced_steps()
+        step_func = namespaced.get(target)
+        if step_func is None:
+            valid = ", ".join(sorted(str(s) for s in namespaced))
+            raise WorkflowRuntimeError(
+                f"Step {step} does not exist. Valid steps: {valid}"
+            )
         step_config = step_func._step_config
-        is_accepted = step_accepts_event(
+        if not step_accepts_event(
             message,
             step_config.accepted_events,
             allow_subclasses=step_config.accept_event_subclasses,
-        )
-        if not is_accepted:
+        ):
             raise WorkflowRuntimeError(
                 f"Step {step} does not accept event of type {type(message)}"
             )
+        return target
 
     @property
     def runtime(self) -> Runtime:
         """The runtime this workflow is registered with."""
         return self._runtime
 
-    def _switch_runtime(self, new_runtime: Runtime) -> None:
-        if new_runtime is self._runtime:
-            return
-        if self._runtime_locked:
-            raise RuntimeError(
-                "Cannot reassign runtime after workflow has been launched"
+    def _switch_runtime(self, new_runtime: Runtime, *, register: bool = True) -> None:
+        """Reassign this workflow's runtime, propagating into children."""
+        if self._child_workflows and not _runtime_supports_child_workflows(new_runtime):
+            raise WorkflowValidationError(
+                f"Runtime {type(new_runtime).__name__} does not support child "
+                "workflows. Child workflows require a runtime with namespaced "
+                "child state support."
             )
-        old = self._runtime
-        old.untrack_workflow(self)
-        self._runtime = new_runtime
-        new_runtime.track_workflow(self)
+        if new_runtime is not self._runtime:
+            if self._runtime_locked:
+                raise RuntimeError(
+                    "Cannot reassign runtime after workflow has been launched"
+                )
+            self._runtime.untrack_workflow(self)
+            self._runtime = new_runtime
+            if register:
+                new_runtime.track_workflow(self)
+        # Descendants may have been attached after this node last switched.
+        for child in self._child_workflows.values():
+            was_locked = child._runtime_locked
+            child._runtime_locked = False
+            try:
+                child._switch_runtime(new_runtime, register=False)
+            finally:
+                child._runtime_locked = was_locked
+
+    @classmethod
+    def _get_child_workflow_slots(cls) -> dict[str, type]:
+        """Return ``{field_name: child_workflow_type}`` declared on this class.
+
+        Resolved from class annotations whose type is a ``Workflow`` subclass.
+        Cached per-class on first access.
+        """
+        cached = cls.__dict__.get("_child_workflow_slots_cache")
+        if cached is None:
+            cached = _resolve_child_slots(cls)
+            cls._child_workflow_slots_cache = cached
+        return cached
+
+    @property
+    def child_workflows(self) -> dict[str, Workflow]:
+        """Attached child-workflow instances, keyed by declared field name."""
+        return dict(self._child_workflows)
+
+    def _attach_child(self, name: str, child: Workflow) -> None:
+        """Wire a child workflow instance into this parent."""
+        if self._child_workflows.get(name) is child:
+            return
+        if not isinstance(child, Workflow):
+            raise WorkflowValidationError(
+                f"Child workflow slot '{name}' on '{type(self).__name__}' must be "
+                f"a Workflow instance, got {type(child).__name__}."
+            )
+        expected = type(self)._get_child_workflow_slots().get(name)
+        if expected is not None and not isinstance(child, expected):
+            raise WorkflowValidationError(
+                f"Child workflow slot '{name}' on '{type(self).__name__}' expects "
+                f"{expected.__name__}, got {type(child).__name__}."
+            )
+        _validate_includable_child(child, name)
+        if not _runtime_supports_child_workflows(self._runtime):
+            raise WorkflowValidationError(
+                f"Runtime {type(self._runtime).__name__} does not support child "
+                f"workflow slot '{name}' on '{type(self).__name__}'. Child "
+                "workflows require a runtime with namespaced child state support."
+            )
+        _warn_ignored_child_config(child, name)
+        register_child = getattr(self._runtime, "_register_child_workflows", True)
+        if child._runtime is self._runtime:
+            if not register_child:
+                child._runtime.untrack_workflow(child)
+        else:
+            child._runtime.untrack_workflow(child)
+            child._switch_runtime(self._runtime, register=register_child)
+        child._runtime_locked = True
+        setattr(self, name, child)
+        self._child_workflows[name] = child
+
+    def _ensure_children_attached(self) -> None:
+        """Attach any declared child instances not yet wired in."""
+        for name, expected in type(self)._get_child_workflow_slots().items():
+            if name in self._child_workflows:
+                continue
+            if name not in self.__dict__ and isinstance(
+                getattr(type(self), name, None), Workflow
+            ):
+                raise WorkflowValidationError(
+                    f"Child workflow slot '{name}' on '{type(self).__name__}' uses "
+                    "a shared class-body Workflow instance. Pass a fresh child "
+                    "instance to the constructor instead."
+                )
+            child = getattr(self, name, None)
+            if child is None:
+                if _has_custom_workflow_init(type(self)) and not (
+                    self._missing_child_is_used(name, expected)
+                ):
+                    continue
+                # Inline import: representation validation imports Workflow.
+                from .representation.validate import _validate_child_type_graph
+
+                _validate_child_type_graph(cast(Any, type(self)))
+                raise WorkflowValidationError(
+                    f"Missing child workflow for slot '{name}' on "
+                    f"'{type(self).__name__}'. Pass a {expected.__name__} "
+                    "instance to the constructor."
+                )
+            if isinstance(child, Workflow):
+                if _has_custom_workflow_init(type(self)) and (
+                    child._start_event_class is StartEvent
+                    or child._stop_event_class is StopEvent
+                ):
+                    continue
+                self._attach_child(name, child)
+
+    def _missing_child_is_used(self, name: str, expected: type) -> bool:
+        """Whether a missing declared child forms a parent graph boundary."""
+        # Inline import: representation validation imports Workflow.
+        from .representation.validate import (
+            _ensure_start_event_class,
+            _ensure_stop_event_class,
+        )
+
+        expected_workflow = cast("type[Workflow]", expected)
+        child_step_configs = {
+            step_name: step_func._step_config
+            for step_name, step_func in expected_workflow._get_steps_from_class().items()
+        }
+        child_start = _ensure_start_event_class(child_step_configs, expected.__name__)
+        child_stop = _ensure_stop_event_class(child_step_configs, expected.__name__)
+        if child_start is StartEvent or child_stop is StopEvent:
+            return False
+        for cfg in self._step_configs().values():
+            if child_start in cfg.return_types or child_stop in cfg.accepted_events:
+                return True
+        return False
 
     @property
     def workflow_name(self) -> str:
@@ -276,6 +690,18 @@ class Workflow(metaclass=WorkflowMeta):
         return {**get_steps_from_class(cls), **cls._step_functions}
 
     @classmethod
+    def _get_namespaced_steps_from_class(cls) -> dict[StepId, StepFunction]:
+        """Return class-declared steps keyed by namespaced ``StepId``."""
+        result: dict[StepId, StepFunction] = {
+            StepId((), name): func for name, func in cls._get_steps_from_class().items()
+        }
+        for field_name, child_type in cls._get_child_workflow_slots().items():
+            child_cls = cast("type[Workflow]", child_type)
+            for child_id, func in child_cls._get_namespaced_steps_from_class().items():
+                result[StepId((field_name, *child_id.namespace), child_id.name)] = func
+        return result
+
+    @classmethod
     def add_step(cls, func: StepFunction) -> None:
         """
         Adds a free function as step for this workflow instance.
@@ -297,6 +723,34 @@ class Workflow(metaclass=WorkflowMeta):
     def _get_steps(self) -> dict[str, StepFunction]:
         """Returns all the steps, whether defined as methods or free functions."""
         return {**get_steps_from_instance(self), **self.__class__._step_functions}
+
+    def _get_namespaced_steps(self) -> dict[StepId, StepFunction]:
+        """Return this workflow's steps keyed by namespaced ``StepId``."""
+        self._ensure_children_attached()
+        result: dict[StepId, StepFunction] = {
+            StepId((), name): func for name, func in self._get_steps().items()
+        }
+        for field_name, child in self._child_workflows.items():
+            for child_id, func in child._get_namespaced_steps().items():
+                result[StepId((field_name, *child_id.namespace), child_id.name)] = func
+        return result
+
+    def _child_namespace_timeout(self) -> float | None:
+        """Per-namespace deadline to arm when this instance runs as a child.
+
+        An unset child defers to its parent and gets no deadline of its own; an
+        explicit timeout — including ``None`` (no deadline) — is honored.
+        """
+        return self._timeout if self._timeout_set else None
+
+    def _namespace_instances(self) -> dict[tuple[str, ...], Workflow]:
+        """Map each namespace path to the workflow instance that owns it."""
+        self._ensure_children_attached()
+        result: dict[tuple[str, ...], Workflow] = {(): self}
+        for field_name, child in self._child_workflows.items():
+            for ns, inst in child._namespace_instances().items():
+                result[(field_name, *ns)] = inst
+        return result
 
     def _get_start_event_instance(
         self, start_event: StartEvent | None, **kwargs: Any
@@ -379,6 +833,8 @@ class Workflow(metaclass=WorkflowMeta):
         """
         from workflows.context import Context
 
+        self._ensure_children_attached()
+
         if not self._runtime_locked:
             # don't allow switching runtime after a workflow has been launched
             self._runtime_locked = True
@@ -446,6 +902,7 @@ class Workflow(metaclass=WorkflowMeta):
         validate_resources: bool = False,
         force: bool = False,
     ) -> bool:
+        self._ensure_children_attached()
         if self._disable_validation and not force:
             return False
         stale = self._validated_version != self.__class__._step_functions_version
@@ -454,14 +911,30 @@ class Workflow(metaclass=WorkflowMeta):
 
         # Inline import: ``representation`` transitively imports ``Workflow``.
         from .representation.validate import (
+            _validate_child_workflow_declarations,
             _validate_resource_configs,
             _validate_resources,
             _validate_workflow,
         )
 
         step_configs = self._step_configs()
+        # A child is "triggered" when some parent step emits its StartEvent; only
+        # then does it form a boundary in the parent graph (StartEvent crosses
+        # out, StopEvent crosses back in). Children attached but never triggered
+        # are inert and excluded so they don't trip reachability.
+        parent_return_types: set[type] = set()
+        for cfg in step_configs.values():
+            parent_return_types.update(cfg.return_types)
+        child_boundaries = [
+            (child._start_event_class, child._stop_event_class)
+            for child in self._child_workflows.values()
+            if child._start_event_class in parent_return_types
+        ]
         result = _validate_workflow(
-            step_configs, self.__class__.__name__, self._skip_graph_checks
+            step_configs,
+            self.__class__.__name__,
+            self._skip_graph_checks,
+            child_boundaries=child_boundaries,
         )
         self._start_event_class = result.start_event_class
         self._stop_event_class = result.stop_event_class
@@ -484,6 +957,14 @@ class Workflow(metaclass=WorkflowMeta):
                     "Resource validation failed:\n"
                     + "\n".join(f"  - {e}" for e in errors)
                 )
+
+        _validate_child_workflow_declarations(self)
+        for child in self._child_workflows.values():
+            child._validate(
+                validate_resource_configs=validate_resource_configs,
+                validate_resources=validate_resources,
+                force=force,
+            )
 
         self._validation_result = result.uses_hitl
         self._validated_version = self.__class__._step_functions_version

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -27,9 +27,12 @@ from workflows.context.serializers import JsonSerializer, PickleSerializer
 from workflows.context.state_store import (
     DictState,
     InMemoryStateStore,
+    build_namespaced_state,
     decode_state,
     deserialize_state_from_dict,
     encode_state,
+    in_memory_namespace_factory,
+    namespaced_state_types,
 )
 from workflows.decorators import step
 from workflows.errors import ContextSerdeError, ContextStateError, WorkflowRuntimeError
@@ -65,11 +68,15 @@ def internal_ctx(workflow: Workflow) -> Context:
     runtime = BasicRuntime()
     run_id = "test-run"
     init_state = BrokerState.from_workflow(workflow)
-    # Create queues with state store so get_internal_adapter() returns adapter with store
+    # Per-namespace stores so get_internal_adapter() returns an adapter with state
     queues = AsyncioAdapterQueues(
         run_id=run_id,
         init_state=init_state,
-        state_store=InMemoryStateStore(DictState()),
+        namespaced=build_namespaced_state(
+            workflow,
+            in_memory_namespace_factory(namespaced_state_types(workflow)),
+            JsonSerializer(),
+        ),
     )
     runtime._queues[run_id] = queues
     workflow._runtime = runtime

--- a/packages/llama-index-workflows/tests/runtime/conftest.py
+++ b/packages/llama-index-workflows/tests/runtime/conftest.py
@@ -192,7 +192,9 @@ class MockRunAdapter(
     def has_stream_events(self) -> bool:
         return not self._event_stream.empty()
 
-    def get_state_store(self) -> "InMemoryStateStore[Any] | None":
+    def get_state_store(
+        self, namespace: tuple[str, ...] = ()
+    ) -> "InMemoryStateStore[Any] | None":
         return self._state_store
 
     def set_state_store(self, state_store: "InMemoryStateStore[Any]") -> None:

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop.py
@@ -164,7 +164,7 @@ def run_control_loop(
     step_workers = {}
     for name, step_func in workflow._get_steps().items():
         unbound = getattr(step_func, "__func__", step_func)
-        step_workers[name] = as_step_worker_function(unbound)
+        step_workers[StepId.root(name)] = as_step_worker_function(unbound)
     run_id = str(uuid.uuid4())
     # Set up mock runtime with the test adapter
     mock_runtime = MockRuntime()
@@ -641,7 +641,7 @@ async def test_control_loop_defers_idle_behind_buffered_tick(
     step_workers = {}
     for name, step_func in workflow._get_steps().items():
         unbound = getattr(step_func, "__func__", step_func)
-        step_workers[name] = as_step_worker_function(unbound)
+        step_workers[StepId.root(name)] = as_step_worker_function(unbound)
 
     run_id = str(uuid.uuid4())
     mock_runtime = MockRuntime()

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
@@ -94,6 +94,11 @@ from workflows.runtime.types.ticks import (
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
 
 
+TEST_STEP = StepId.root("test_step")
+OTHER_STEP = StepId.root("other_step")
+UNKNOWN_STEP = StepId.root("unknown")
+
+
 class MyTestEvent(Event):
     value: int
 
@@ -118,7 +123,7 @@ def base_state() -> BrokerState:
         is_running=True,
         config=BrokerConfig(
             steps={
-                "test_step": InternalStepConfig(
+                TEST_STEP: InternalStepConfig(
                     accepted_events=[MyTestEvent, StartEvent],
                     retry_policy=None,
                     num_workers=1,
@@ -127,7 +132,7 @@ def base_state() -> BrokerState:
             timeout=None,
         ),
         workers={
-            "test_step": InternalStepWorkerState(
+            TEST_STEP: InternalStepWorkerState(
                 queue=[],
                 config=step_config,
                 in_progress=[],
@@ -146,7 +151,7 @@ def add_worker(
     snapshot_collected: dict[str, list[Event]] | None = None,
 ) -> None:
     """Helper to add an in-progress worker to state."""
-    state.workers["test_step"].in_progress.append(
+    state.workers[TEST_STEP].in_progress.append(
         InProgressState(
             event=event,
             worker_id=worker_id,
@@ -213,7 +218,7 @@ def test_add_event_matches_waiter_does_not_emit_unhandled(
     base_state: BrokerState,
 ) -> None:
     """Events that satisfy a waiter should not emit UnhandledEvent."""
-    base_state.workers["test_step"].collected_waiters.append(
+    base_state.workers[TEST_STEP].collected_waiters.append(
         StepWorkerWaiter(
             waiter_id="waiter-1",
             event=StartEvent(),
@@ -268,12 +273,12 @@ def test_step_worker_results(
             assert isinstance(commands[i], expected_type)
 
     # Worker should be removed from in_progress
-    assert len(new_state.workers["test_step"].in_progress) == 0
+    assert len(new_state.workers[TEST_STEP].in_progress) == 0
 
 
 def test_step_worker_failed_with_retry(base_state: BrokerState) -> None:
     """Test that failures with retry policy re-queue a retry in state."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=1.0
     )
     event = MyTestEvent(value=42)
@@ -289,7 +294,7 @@ def test_step_worker_failed_with_retry(base_state: BrokerState) -> None:
     new_state, commands = _process_step_result_tick(tick, base_state, now_seconds=110.0)
 
     # The retry lives in the worker queue with its eligibility time
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP].queue
     assert len(queue) == 1
     assert queue[0].attempts == 1
     assert queue[0].not_before == 111.0
@@ -335,14 +340,14 @@ def test_collected_events(base_state: BrokerState) -> None:
         result=[AddCollectedEvent(event_id="buf1", event=OtherEvent(data="e1"))],
     )
     new_state, _ = _process_step_result_tick(tick, base_state, now_seconds=110.0)
-    assert "buf1" in new_state.workers["test_step"].collected_events
+    assert "buf1" in new_state.workers[TEST_STEP].collected_events
 
     # Delete event from the matching legacy collect_events() snapshot.
     add_worker(
         new_state,
         event,
         snapshot_collected={
-            "buf1": list(new_state.workers["test_step"].collected_events["buf1"])
+            "buf1": list(new_state.workers[TEST_STEP].collected_events["buf1"])
         },
     )
     tick = TickStepResult(
@@ -355,7 +360,7 @@ def test_collected_events(base_state: BrokerState) -> None:
         ],
     )
     new_state, _ = _process_step_result_tick(tick, new_state, now_seconds=110.0)
-    assert "buf1" not in new_state.workers["test_step"].collected_events
+    assert "buf1" not in new_state.workers[TEST_STEP].collected_events
 
 
 def test_stale_collect_events_firing_reruns_without_deleting_buffer(
@@ -364,7 +369,7 @@ def test_stale_collect_events_firing_reruns_without_deleting_buffer(
     event = MyTestEvent(value=42)
     live = OtherEvent(data="live")
     stale = OtherEvent(data="stale")
-    base_state.workers["test_step"].collected_events["buf1"] = [live]
+    base_state.workers[TEST_STEP].collected_events["buf1"] = [live]
     add_worker(base_state, event, snapshot_collected={"buf1": [stale]})
 
     tick = TickStepResult(
@@ -379,7 +384,7 @@ def test_stale_collect_events_firing_reruns_without_deleting_buffer(
 
     new_state, commands = _process_step_result_tick(tick, base_state, now_seconds=110.0)
 
-    assert new_state.workers["test_step"].collected_events["buf1"] == [live]
+    assert new_state.workers[TEST_STEP].collected_events["buf1"] == [live]
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
     assert run_cmds[0].event is event
@@ -408,7 +413,7 @@ def test_waiters(base_state: BrokerState) -> None:
         ],
     )
     new_state, _ = _process_step_result_tick(tick, base_state, now_seconds=110.0)
-    assert len(new_state.workers["test_step"].collected_waiters) == 1
+    assert len(new_state.workers[TEST_STEP].collected_waiters) == 1
 
     # Delete waiter
     add_worker(new_state, event)
@@ -422,7 +427,7 @@ def test_waiters(base_state: BrokerState) -> None:
         ],
     )
     new_state, _ = _process_step_result_tick(tick, new_state, now_seconds=110.0)
-    assert len(new_state.workers["test_step"].collected_waiters) == 0
+    assert len(new_state.workers[TEST_STEP].collected_waiters) == 0
 
 
 def test_start_event_sets_running(base_state: BrokerState) -> None:
@@ -440,7 +445,7 @@ def test_event_routing(base_state: BrokerState) -> None:
 
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert str(run_cmds[0].step_id) == "test_step"
+    assert run_cmds[0].step_id == TEST_STEP
 
 
 def test_per_step_explicit_routing_accepts_only_matching_types(
@@ -471,10 +476,10 @@ def test_explicit_routing_requires_acceptance(base_state: BrokerState) -> None:
         num_workers=1,
         resources=[],
     )
-    base_state.config.steps["other_step"] = InternalStepConfig(
+    base_state.config.steps[OTHER_STEP] = InternalStepConfig(
         accepted_events=[StartEvent], retry_policy=None, num_workers=1
     )
-    base_state.workers["other_step"] = InternalStepWorkerState(
+    base_state.workers[OTHER_STEP] = InternalStepWorkerState(
         queue=[],
         config=other_step_cfg,
         in_progress=[],
@@ -486,16 +491,14 @@ def test_explicit_routing_requires_acceptance(base_state: BrokerState) -> None:
     tick = TickAddEvent(event=MyTestEvent(value=1), step_id=StepId.root("other_step"))
     _, commands = _process_add_event_tick(tick, base_state, now_seconds=100.0)
     assert not any(
-        isinstance(c, CommandRunWorker) and str(c.step_id) == "other_step"
-        for c in commands
+        isinstance(c, CommandRunWorker) and c.step_id == OTHER_STEP for c in commands
     )
 
     # Explicitly route to accepting step → should start
     tick_ok = TickAddEvent(event=MyTestEvent(value=2), step_id=StepId.root("test_step"))
     _, commands_ok = _process_add_event_tick(tick_ok, base_state, now_seconds=100.0)
     assert any(
-        isinstance(c, CommandRunWorker) and str(c.step_id) == "test_step"
-        for c in commands_ok
+        isinstance(c, CommandRunWorker) and c.step_id == TEST_STEP for c in commands_ok
     )
 
 
@@ -510,14 +513,12 @@ def test_waiter_resolution(base_state: BrokerState) -> None:
         has_requirements=True,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP].collected_waiters.append(waiter)
 
     tick = TickAddEvent(event=OtherEvent(data="expected"))
     new_state, commands = _process_add_event_tick(tick, base_state, now_seconds=100.0)
 
-    assert (
-        new_state.workers["test_step"].collected_waiters[0].resolved_event is not None
-    )
+    assert new_state.workers[TEST_STEP].collected_waiters[0].resolved_event is not None
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert any(c.event == original_event for c in run_cmds)
 
@@ -612,12 +613,12 @@ def test_add_when_capacity_available(base_state: BrokerState) -> None:
     event = MyTestEvent(value=42)
     commands = _add_or_enqueue_event(
         EventAttempt(event=event),
-        StepId.root("test_step"),
-        base_state.workers["test_step"],
+        TEST_STEP,
+        base_state.workers[TEST_STEP],
         now_seconds=100.0,
     )
 
-    assert len(base_state.workers["test_step"].in_progress) == 1
+    assert len(base_state.workers[TEST_STEP].in_progress) == 1
     assert any(isinstance(c, CommandRunWorker) for c in commands)
     assert any(
         isinstance(c, CommandPublishEvent)
@@ -636,12 +637,12 @@ def test_enqueue_when_no_capacity(base_state: BrokerState) -> None:
     event = MyTestEvent(value=42)
     commands = _add_or_enqueue_event(
         EventAttempt(event=event),
-        StepId.root("test_step"),
-        base_state.workers["test_step"],
+        TEST_STEP,
+        base_state.workers[TEST_STEP],
         now_seconds=100.0,
     )
 
-    assert len(base_state.workers["test_step"].queue) == 1
+    assert len(base_state.workers[TEST_STEP].queue) == 1
     # PREPARING should be published when we enqueue
     assert isinstance(commands[0], CommandPublishEvent)
     assert isinstance(commands[0].event, StepStateChanged)
@@ -650,8 +651,8 @@ def test_enqueue_when_no_capacity(base_state: BrokerState) -> None:
 
 def test_rewind_restarts_workers(base_state: BrokerState) -> None:
     """Test that in_progress workers are restarted."""
-    base_state.workers["test_step"].config.num_workers = 2
-    base_state.config.steps["test_step"].num_workers = 2
+    base_state.workers[TEST_STEP].config.num_workers = 2
+    base_state.config.steps[TEST_STEP].num_workers = 2
 
     add_worker(base_state, MyTestEvent(value=1), worker_id=0)
     add_worker(base_state, MyTestEvent(value=2), worker_id=1)
@@ -661,7 +662,7 @@ def test_rewind_restarts_workers(base_state: BrokerState) -> None:
     # Both should be restarted
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 2
-    assert len(new_state.workers["test_step"].in_progress) == 2
+    assert len(new_state.workers[TEST_STEP].in_progress) == 2
 
 
 def test_add_event_tick_preserves_retry_metadata(base_state: BrokerState) -> None:
@@ -683,7 +684,7 @@ def test_add_event_tick_preserves_retry_metadata(base_state: BrokerState) -> Non
     assert len(run_cmds) == 1
 
     # Verify retry metadata was preserved in the InProgressState
-    in_progress = new_state.workers["test_step"].in_progress
+    in_progress = new_state.workers[TEST_STEP].in_progress
     assert len(in_progress) == 1
     assert in_progress[0].attempts == attempts
     assert in_progress[0].first_attempt_at == first_attempt_time
@@ -699,7 +700,7 @@ def test_add_event_tick_uses_now_when_no_retry_metadata(
 
     new_state, _ = _process_add_event_tick(tick, base_state, now_seconds=now)
 
-    in_progress = new_state.workers["test_step"].in_progress
+    in_progress = new_state.workers[TEST_STEP].in_progress
     assert len(in_progress) == 1
     assert in_progress[0].attempts == 0
     assert in_progress[0].first_attempt_at == now
@@ -708,7 +709,7 @@ def test_add_event_tick_uses_now_when_no_retry_metadata(
 def test_step_worker_failed_retry_preserves_delay(base_state: BrokerState) -> None:
     """Test that the re-queued retry carries the delay as an absolute not_before."""
     retry_delay = 5.0
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=retry_delay
     )
     event = MyTestEvent(value=42)
@@ -723,28 +724,28 @@ def test_step_worker_failed_retry_preserves_delay(base_state: BrokerState) -> No
 
     new_state, commands = _process_step_result_tick(tick, base_state, now_seconds=110.0)
 
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP].queue
     assert len(queue) == 1
     assert queue[0].not_before == 110.0 + retry_delay
     assert queue[0].attempts == 1
     assert queue[0].first_attempt_at == 100.0  # from add_worker fixture
     # The retry must not be dispatched within this reduction
     assert not any(isinstance(c, CommandRunWorker) for c in commands)
-    assert len(new_state.workers["test_step"].in_progress) == 0
+    assert len(new_state.workers[TEST_STEP].in_progress) == 0
 
 
 def test_step_worker_failed_retry_preserves_first_attempt_at(
     base_state: BrokerState,
 ) -> None:
     """Test that first_attempt_at stays constant across retries."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=5, delay=1.0
     )
     event = MyTestEvent(value=42)
 
     original_first_attempt_at = 50.0
     # Simulate a worker that's already been retried twice
-    base_state.workers["test_step"].in_progress.append(
+    base_state.workers[TEST_STEP].in_progress.append(
         InProgressState(
             event=event,
             worker_id=0,
@@ -767,7 +768,7 @@ def test_step_worker_failed_retry_preserves_first_attempt_at(
 
     new_state, _ = _process_step_result_tick(tick, base_state, now_seconds=200.0)
 
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP].queue
     assert len(queue) == 1
     assert queue[0].attempts == 3  # incremented from 2
     assert queue[0].first_attempt_at == original_first_attempt_at  # preserved!
@@ -784,7 +785,7 @@ def test_step_worker_failed_exponential_jitter_deterministic(
         maximum_attempts=5,
         jitter=True,
     )
-    base_state.workers["test_step"].config.retry_policy = policy
+    base_state.workers[TEST_STEP].config.retry_policy = policy
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
 
@@ -819,8 +820,8 @@ def test_step_worker_failed_exponential_jitter_deterministic(
         tick, base_state, now_seconds=110.0, run_id=run_id
     )
 
-    first_not_before = state_first.workers["test_step"].queue[0].not_before
-    second_not_before = state_second.workers["test_step"].queue[0].not_before
+    first_not_before = state_first.workers[TEST_STEP].queue[0].not_before
+    second_not_before = state_second.workers[TEST_STEP].queue[0].not_before
     assert first_not_before is not None
     assert first_not_before == second_not_before == 110.0 + expected_delay
 
@@ -832,7 +833,7 @@ def test_step_worker_failed_exponential_jitter_deterministic(
 
 def test_wakeup_dispatches_eligible_attempt(base_state: BrokerState) -> None:
     """TickWakeup dispatches attempts whose not_before is covered by its due."""
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=110.0)
     )
 
@@ -841,14 +842,14 @@ def test_wakeup_dispatches_eligible_attempt(base_state: BrokerState) -> None:
         TickWakeup(due=105.0), base_state, 105.0
     )
     assert not any(isinstance(c, CommandRunWorker) for c in commands_before)
-    assert len(state_before.workers["test_step"].queue) == 1
+    assert len(state_before.workers[TEST_STEP].queue) == 1
 
     # Wakeup due at eligibility: dispatched
     state_after, commands_after = _reduce_tick(TickWakeup(due=110.0), base_state, 110.0)
     run_cmds = [c for c in commands_after if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert len(state_after.workers["test_step"].queue) == 0
-    assert state_after.workers["test_step"].in_progress[0].attempts == 1
+    assert len(state_after.workers[TEST_STEP].queue) == 0
+    assert state_after.workers[TEST_STEP].in_progress[0].attempts == 1
 
 
 def test_wakeup_eligibility_is_due_driven_not_clock_driven(
@@ -860,7 +861,7 @@ def test_wakeup_eligibility_is_due_driven_not_clock_driven(
     wakeup identically to the live run, even though the replay-time clock is
     far past every not_before.
     """
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=110.0)
     )
 
@@ -868,7 +869,7 @@ def test_wakeup_eligibility_is_due_driven_not_clock_driven(
     # still NOT dispatch — the live run didn't dispatch on it either.
     state, commands = _reduce_tick(TickWakeup(due=105.0), base_state, 99_999.0)
     assert not any(isinstance(c, CommandRunWorker) for c in commands)
-    queue = state.workers["test_step"].queue
+    queue = state.workers[TEST_STEP].queue
     assert len(queue) == 1
     assert queue[0].not_before == 110.0
 
@@ -877,7 +878,7 @@ def test_ineligible_attempt_does_not_block_eligible_behind_it(
     base_state: BrokerState,
 ) -> None:
     """An ineligible attempt at the queue head must not starve eligible work."""
-    worker_state = base_state.workers["test_step"]
+    worker_state = base_state.workers[TEST_STEP]
     worker_state.queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=999.0)
     )
@@ -890,21 +891,21 @@ def test_ineligible_attempt_does_not_block_eligible_behind_it(
     assert isinstance(run_cmds[0].event, MyTestEvent)
     assert run_cmds[0].event.value == 2
     # Delayed attempt remains queued, not consuming the worker slot
-    remaining = state.workers["test_step"].queue
+    remaining = state.workers[TEST_STEP].queue
     assert len(remaining) == 1
     assert remaining[0].not_before == 999.0
 
 
 def test_retry_with_zero_delay_dispatches_immediately(base_state: BrokerState) -> None:
     """A zero-delay retry is re-dispatched within the same reduction."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=0
     )
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
 
     tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -915,13 +916,13 @@ def test_retry_with_zero_delay_dispatches_immediately(base_state: BrokerState) -
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
     assert not any(isinstance(c, CommandScheduleWakeup) for c in commands)
-    assert len(new_state.workers["test_step"].queue) == 0
-    assert new_state.workers["test_step"].in_progress[0].attempts == 1
+    assert len(new_state.workers[TEST_STEP].queue) == 0
+    assert new_state.workers[TEST_STEP].in_progress[0].attempts == 1
 
 
 def test_rewind_rearms_wakeup_for_delayed_attempt(base_state: BrokerState) -> None:
     """Resume re-arms a wakeup for queued future-not_before attempts."""
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=2, not_before=150.0)
     )
 
@@ -929,7 +930,7 @@ def test_rewind_rearms_wakeup_for_delayed_attempt(base_state: BrokerState) -> No
 
     # Not dispatched, stays queued with retry info intact
     assert not any(isinstance(c, CommandRunWorker) for c in commands)
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP].queue
     assert len(queue) == 1
     assert queue[0].attempts == 2
     # Poke re-armed at the eligibility time
@@ -945,7 +946,7 @@ def test_rewind_rearms_wakeup_even_when_past_due(base_state: BrokerState) -> Non
     The runner fires a past-due wakeup immediately, so delivery is prompt —
     but it arrives as a journaled tick, keeping replay deterministic.
     """
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=2, not_before=110.0)
     )
 
@@ -955,7 +956,7 @@ def test_rewind_rearms_wakeup_even_when_past_due(base_state: BrokerState) -> Non
     wakeups = [c for c in commands if isinstance(c, CommandScheduleWakeup)]
     assert len(wakeups) == 1
     assert wakeups[0].at_time == 110.0
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP].queue
     assert len(queue) == 1
     assert queue[0].attempts == 2
 
@@ -963,8 +964,8 @@ def test_rewind_rearms_wakeup_even_when_past_due(base_state: BrokerState) -> Non
     final_state, wake_commands = _reduce_tick(TickWakeup(due=110.0), new_state, 120.0)
     run_cmds = [c for c in wake_commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert len(final_state.workers["test_step"].queue) == 0
-    assert final_state.workers["test_step"].in_progress[0].attempts == 2
+    assert len(final_state.workers[TEST_STEP].queue) == 0
+    assert final_state.workers[TEST_STEP].in_progress[0].attempts == 2
 
 
 def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
@@ -978,24 +979,24 @@ def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
     the TickAddEvent must consume that queued attempt instead of dispatching
     a duplicate that would re-run the step after a resume.
     """
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=1.0
     )
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
     )
     state, _ = _process_step_result_tick(fail_tick, base_state, now_seconds=110.0)
-    assert state.workers["test_step"].queue[0].not_before == 111.0
+    assert state.workers[TEST_STEP].queue[0].not_before == 111.0
 
     # Old-format journal re-delivers the retry after the delay elapsed
     add_tick = TickAddEvent(
         event=event,
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         attempts=1,
         first_attempt_at=100.0,
         last_failed_at=110.0,
@@ -1004,16 +1005,16 @@ def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
 
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert final_state.workers["test_step"].queue == []
-    assert len(final_state.workers["test_step"].in_progress) == 1
-    assert final_state.workers["test_step"].in_progress[0].attempts == 1
+    assert final_state.workers[TEST_STEP].queue == []
+    assert len(final_state.workers[TEST_STEP].in_progress) == 1
+    assert final_state.workers[TEST_STEP].in_progress[0].attempts == 1
 
 
 def test_plain_add_event_does_not_consume_queued_delayed_attempt(
     base_state: BrokerState,
 ) -> None:
     """A normal event (no retry metadata) leaves a queued delayed retry alone."""
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=999.0)
     )
 
@@ -1025,7 +1026,7 @@ def test_plain_add_event_does_not_consume_queued_delayed_attempt(
     assert len(run_cmds) == 1
     assert isinstance(run_cmds[0].event, MyTestEvent)
     assert run_cmds[0].event.value == 2
-    remaining = state.workers["test_step"].queue
+    remaining = state.workers[TEST_STEP].queue
     assert len(remaining) == 1
     assert remaining[0].not_before == 999.0
 
@@ -1041,14 +1042,14 @@ def test_replay_recomputes_jittered_not_before_with_run_id(
     step-result tick crashed with "Worker not found in in_progress".
     """
     run_id = "test-run-id"
-    base_state.workers["test_step"].config.retry_policy = retry_policy(
+    base_state.workers[TEST_STEP].config.retry_policy = retry_policy(
         wait=wait_exponential_jitter(initial=0.5, exp_base=2.0, max=60.0, jitter=10.0),
         stop=stop_after_attempt(5),
     )
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
@@ -1063,15 +1064,15 @@ def test_replay_recomputes_jittered_not_before_with_run_id(
     # so the journaled wakeup flips the attempt during replay
     replayed = rebuild_state_from_ticks(base_state, [fail_tick], run_id=run_id)
     assert (
-        replayed.workers["test_step"].queue[0].not_before
-        == live_state.workers["test_step"].queue[0].not_before
+        replayed.workers[TEST_STEP].queue[0].not_before
+        == live_state.workers[TEST_STEP].queue[0].not_before
         == live_wakeup.at_time
     )
     flipped, flip_commands = _reduce_tick(
         TickWakeup(due=live_wakeup.at_time), replayed, 99_999.0
     )
     assert any(isinstance(c, CommandRunWorker) for c in flip_commands)
-    assert flipped.workers["test_step"].queue == []
+    assert flipped.workers[TEST_STEP].queue == []
 
 
 class _MustNotBeInvokedPolicy:
@@ -1098,11 +1099,11 @@ def test_journaled_retry_decision_is_used_without_invoking_policy(
     The live runner stamps the decision into StepWorkerFailed before the tick
     is journaled; reduction (live and replay alike) consumes it as data.
     """
-    base_state.workers["test_step"].config.retry_policy = _MustNotBeInvokedPolicy()
+    base_state.workers[TEST_STEP].config.retry_policy = _MustNotBeInvokedPolicy()
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[
@@ -1116,7 +1117,7 @@ def test_journaled_retry_decision_is_used_without_invoking_policy(
 
     state, commands = _process_step_result_tick(fail_tick, base_state, 110.0)
 
-    assert state.workers["test_step"].queue[0].not_before == 111.0
+    assert state.workers[TEST_STEP].queue[0].not_before == 111.0
     wakeups = [c for c in commands if isinstance(c, CommandScheduleWakeup)]
     assert len(wakeups) == 1
     assert wakeups[0].at_time == 111.0
@@ -1126,13 +1127,13 @@ def test_journaled_stop_decision_fails_workflow_even_if_policy_would_retry(
     base_state: BrokerState,
 ) -> None:
     """RetryDecision(delay=None) means stop, regardless of current policy."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=10, delay=1.0
     )
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[
@@ -1146,7 +1147,7 @@ def test_journaled_stop_decision_fails_workflow_even_if_policy_would_retry(
 
     state, commands = _process_step_result_tick(fail_tick, base_state, 110.0)
 
-    assert state.workers["test_step"].queue == []
+    assert state.workers[TEST_STEP].queue == []
     assert any(isinstance(c, CommandFailWorkflow) for c in commands)
 
 
@@ -1163,7 +1164,7 @@ def test_replay_with_changed_policy_honors_journaled_decision(
     """
     event = MyTestEvent(value=42)
     fail_tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[
@@ -1176,18 +1177,18 @@ def test_replay_with_changed_policy_honors_journaled_decision(
     )
 
     # The policy was reconfigured between the live run and this replay
-    base_state.workers["test_step"].config.retry_policy = retry_policy(
+    base_state.workers[TEST_STEP].config.retry_policy = retry_policy(
         wait=wait_fixed(50.0), stop=stop_after_attempt(5)
     )
     add_worker(base_state, event)
 
     replayed = rebuild_state_from_ticks(base_state, [fail_tick], run_id="test-run-id")
-    assert replayed.workers["test_step"].queue[0].not_before == 111.0
+    assert replayed.workers[TEST_STEP].queue[0].not_before == 111.0
 
     flipped, commands = _reduce_tick(TickWakeup(due=111.0), replayed, 99_999.0)
     assert any(isinstance(c, CommandRunWorker) for c in commands)
-    assert flipped.workers["test_step"].queue == []
-    assert flipped.workers["test_step"].in_progress[0].attempts == 1
+    assert flipped.workers[TEST_STEP].queue == []
+    assert flipped.workers[TEST_STEP].in_progress[0].attempts == 1
 
 
 def test_journaled_first_attempt_at_survives_rebuilt_state(
@@ -1200,7 +1201,7 @@ def test_journaled_first_attempt_at_survives_rebuilt_state(
     rebuild clock, so elapsed-based retry budgets (stop_after_delay)
     silently restarted on every snapshot/resume.
     """
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=1.0
     )
     event = MyTestEvent(value=42)
@@ -1208,7 +1209,7 @@ def test_journaled_first_attempt_at_survives_rebuilt_state(
     # while the failure tick journaled the true dispatch time 100.0.
     add_worker(base_state, event, first_attempt_at=500.0)
     fail_tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[
@@ -1223,7 +1224,7 @@ def test_journaled_first_attempt_at_survives_rebuilt_state(
 
     state, _ = _process_step_result_tick(fail_tick, base_state, 110.0)
 
-    assert state.workers["test_step"].queue[0].first_attempt_at == 100.0
+    assert state.workers[TEST_STEP].queue[0].first_attempt_at == 100.0
 
 
 def test_journaled_first_attempt_at_used_for_elapsed_on_failure(
@@ -1234,7 +1235,7 @@ def test_journaled_first_attempt_at_used_for_elapsed_on_failure(
     event = MyTestEvent(value=42)
     add_worker(base_state, event, first_attempt_at=500.0)
     fail_tick: TickStepResult = TickStepResult(
-        step_id=StepId.root("test_step"),
+        step_id=TEST_STEP,
         worker_id=0,
         event=event,
         result=[
@@ -1272,9 +1273,7 @@ def test_check_idle_state_not_running(base_state: BrokerState) -> None:
 
 def test_check_idle_state_has_queued_events(base_state: BrokerState) -> None:
     """A workflow with queued events is not idle."""
-    base_state.workers["test_step"].queue.append(
-        EventAttempt(event=MyTestEvent(value=1))
-    )
+    base_state.workers[TEST_STEP].queue.append(EventAttempt(event=MyTestEvent(value=1)))
     assert _check_idle_state(base_state) is False
 
 
@@ -1285,7 +1284,7 @@ def test_check_idle_state_delayed_retry_is_pending_work(
 
     This is what defers idle release (e.g. DBOS) during a retry-delay window.
     """
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=10_000.0)
     )
     assert _check_idle_state(base_state) is False
@@ -1312,7 +1311,7 @@ def test_check_idle_state_is_idle_with_waiter(base_state: BrokerState) -> None:
         has_requirements=False,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP].collected_waiters.append(waiter)
     assert _check_idle_state(base_state) is True
 
 
@@ -1358,10 +1357,10 @@ def test_check_idle_state_multi_step_not_idle_if_one_has_work(
         num_workers=1,
         resources=[],
     )
-    base_state.config.steps["other_step"] = InternalStepConfig(
+    base_state.config.steps[OTHER_STEP] = InternalStepConfig(
         accepted_events=[OtherEvent], retry_policy=None, num_workers=1
     )
-    base_state.workers["other_step"] = InternalStepWorkerState(
+    base_state.workers[OTHER_STEP] = InternalStepWorkerState(
         queue=[],
         config=other_step_cfg,
         in_progress=[],
@@ -1378,13 +1377,13 @@ def test_check_idle_state_multi_step_not_idle_if_one_has_work(
         has_requirements=False,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP].collected_waiters.append(waiter)
 
     # Without work in other_step, workflow is idle
     assert _check_idle_state(base_state) is True
 
     # Add in_progress work to other_step - now not idle
-    base_state.workers["other_step"].in_progress.append(
+    base_state.workers[OTHER_STEP].in_progress.append(
         InProgressState(
             event=OtherEvent(data="test"),
             worker_id=0,
@@ -1400,8 +1399,8 @@ def test_check_idle_state_multi_step_not_idle_if_one_has_work(
     assert _check_idle_state(base_state) is False
 
     # Or with queued work
-    base_state.workers["other_step"].in_progress = []
-    base_state.workers["other_step"].queue.append(
+    base_state.workers[OTHER_STEP].in_progress = []
+    base_state.workers[OTHER_STEP].queue.append(
         EventAttempt(event=OtherEvent(data="queued"))
     )
     assert _check_idle_state(base_state) is False
@@ -1413,7 +1412,7 @@ def test_no_idle_event_when_work_remains(base_state: BrokerState) -> None:
     add_worker(base_state, event)
 
     # Queue another event so work remains after processing
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP].queue.append(
         EventAttempt(event=MyTestEvent(value=99))
     )
 
@@ -1448,7 +1447,7 @@ def test_no_idle_event_when_workflow_completes(base_state: BrokerState) -> None:
         has_requirements=False,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP].collected_waiters.append(waiter)
 
     # Complete the workflow with StopEvent
     tick: TickStepResult = TickStepResult(
@@ -1500,7 +1499,7 @@ def test_rebuild_state_from_ticks_clears_in_progress(base_state: BrokerState) ->
         collected_events={},
         collected_waiters=[],
     )
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP].in_progress = [
         InProgressState(
             event=event1,
             worker_id=1,  # Original worker ID from checkpoint
@@ -1546,7 +1545,7 @@ def test_rebuild_state_from_ticks_clears_in_progress(base_state: BrokerState) ->
 
     # Verify the workflow completed
     assert final_state.is_running is False
-    assert len(final_state.workers["test_step"].in_progress) == 0
+    assert len(final_state.workers[TEST_STEP].in_progress) == 0
 
 
 def test_rebuild_state_from_ticks_preserves_queue_order(
@@ -1569,7 +1568,7 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
         collected_events={},
         collected_waiters=[],
     )
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP].in_progress = [
         InProgressState(
             event=event1,
             worker_id=0,
@@ -1579,7 +1578,7 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
         ),
     ]
     # Also has queued event
-    base_state.workers["test_step"].queue = [
+    base_state.workers[TEST_STEP].queue = [
         EventAttempt(event=event2, attempts=0, first_attempt_at=None)
     ]
 
@@ -1588,13 +1587,13 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
 
     # rewind_in_progress re-starts workers, so event1 should be back in in_progress
     # with worker_id=0 (reassigned) and retry info preserved
-    assert len(result.workers["test_step"].in_progress) == 1
-    assert result.workers["test_step"].in_progress[0].event == event1
-    assert result.workers["test_step"].in_progress[0].worker_id == 0
-    assert result.workers["test_step"].in_progress[0].attempts == 2
+    assert len(result.workers[TEST_STEP].in_progress) == 1
+    assert result.workers[TEST_STEP].in_progress[0].event == event1
+    assert result.workers[TEST_STEP].in_progress[0].worker_id == 0
+    assert result.workers[TEST_STEP].in_progress[0].attempts == 2
     # Queue should have event2 (since num_workers=1, only 1 can be in_progress)
-    assert len(result.workers["test_step"].queue) == 1
-    assert result.workers["test_step"].queue[0].event == event2
+    assert len(result.workers[TEST_STEP].queue) == 1
+    assert result.workers[TEST_STEP].queue[0].event == event2
 
 
 async def _aiter(ticks: list[WorkflowTick]) -> AsyncIterator[WorkflowTick]:
@@ -1628,7 +1627,7 @@ async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) ->
         step_name="test_step", collected_events={}, collected_waiters=[]
     )
     event1 = MyTestEvent(value=1)
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP].in_progress = [
         InProgressState(
             event=event1,
             worker_id=0,
@@ -1641,9 +1640,9 @@ async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) ->
     streamed = await rebuild_state_from_ticks_stream(base_state, _aiter([]))
 
     # rewind_in_progress re-assigns worker_id=0 starting fresh; in_progress preserved.
-    assert len(streamed.workers["test_step"].in_progress) == 1
-    assert streamed.workers["test_step"].in_progress[0].worker_id == 0
-    assert streamed.workers["test_step"].in_progress[0].event == event1
+    assert len(streamed.workers[TEST_STEP].in_progress) == 1
+    assert streamed.workers[TEST_STEP].in_progress[0].worker_id == 0
+    assert streamed.workers[TEST_STEP].in_progress[0].event == event1
 
 
 async def test_rebuild_state_from_ticks_stream_single_tick(
@@ -1694,7 +1693,7 @@ async def test_rebuild_state_from_ticks_stream_clears_in_progress(
     shared_state = StepWorkerState(
         step_name="test_step", collected_events={}, collected_waiters=[]
     )
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP].in_progress = [
         InProgressState(
             event=event1,
             worker_id=1,
@@ -1730,7 +1729,7 @@ async def test_rebuild_state_from_ticks_stream_clears_in_progress(
     final_state = await rebuild_state_from_ticks_stream(base_state, _aiter(ticks))
 
     assert final_state.is_running is False
-    assert len(final_state.workers["test_step"].in_progress) == 0
+    assert len(final_state.workers[TEST_STEP].in_progress) == 0
 
 
 async def test_replay_ticks_stream_surfaces_stop_event(base_state: BrokerState) -> None:

--- a/packages/llama-index-workflows/tests/runtime/test_state.py
+++ b/packages/llama-index-workflows/tests/runtime/test_state.py
@@ -16,6 +16,7 @@ from workflows.runtime.types.internal_state import (
     InProgressState,
 )
 from workflows.runtime.types.results import StepWorkerState
+from workflows.runtime.types.step_id import StepId
 from workflows.workflow import Workflow
 
 
@@ -154,7 +155,8 @@ def test_in_progress_retry_state_survives_serialization() -> None:
     """In-flight work is requeued with its retry state on resume."""
     workflow = _RetryStateWorkflow()
     state = BrokerState.from_workflow(workflow)
-    state.workers["start"].in_progress.append(
+    step_id = StepId.root("start")
+    state.workers[step_id].in_progress.append(
         InProgressState(
             event=StartEvent(),
             worker_id=0,
@@ -174,7 +176,7 @@ def test_in_progress_retry_state_survives_serialization() -> None:
     serializer = JsonSerializer()
     serialized = state.to_serialized(serializer)
     restored = BrokerState.from_serialized(serialized, workflow, serializer)
-    attempt = restored.workers["start"].queue[0]
+    attempt = restored.workers[step_id].queue[0]
 
     assert serialized.version == CURRENT_SERIALIZED_VERSION
     assert attempt.attempts == 2
@@ -188,7 +190,8 @@ def test_queued_not_before_survives_serialization() -> None:
     """The v2 change preserves the delayed-retry field added to queued attempts."""
     workflow = _RetryStateWorkflow()
     state = BrokerState.from_workflow(workflow)
-    state.workers["start"].queue.append(
+    step_id = StepId.root("start")
+    state.workers[step_id].queue.append(
         EventAttempt(
             event=StartEvent(),
             attempts=1,
@@ -202,7 +205,7 @@ def test_queued_not_before_survives_serialization() -> None:
     restored = BrokerState.from_serialized(serialized, workflow, serializer)
 
     assert serialized.workers["start"].queue[0].not_before == 150.0
-    assert restored.workers["start"].queue[0].not_before == 150.0
+    assert restored.workers[step_id].queue[0].not_before == 150.0
 
 
 def test_deserialize_broken_state_raises_validation_error(workflow: Workflow) -> None:

--- a/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
+++ b/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
@@ -340,3 +340,22 @@ def test_workflow_tick_discriminated_union_roundtrip() -> None:
         roundtripped = json.loads(json.dumps(dumped))
         restored = adapter.validate_python(roundtripped)
         assert type(restored) is type(tick)
+
+
+def test_legacy_step_name_key_deserializes_to_step_id() -> None:
+    """Pre-StepId journals used a ``step_name`` key; it must still decode.
+
+    The wire format now serializes a root step id as the bare name under the
+    ``step_id`` key. The ``step_name`` alias keeps old journals readable: a
+    legacy dict deserializes to a tick whose ``step_id`` is the root StepId.
+    """
+    legacy = {
+        "type": "step_result",
+        "step_name": "foo",
+        "worker_id": 0,
+        "event": _serialize_event(StartEvent()),
+        "result": [],
+    }
+    restored = WorkflowTickAdapter.validate_python(legacy)
+    assert isinstance(restored, TickStepResult)
+    assert restored.step_id == StepId.root("foo")

--- a/packages/llama-index-workflows/tests/test_catch_error.py
+++ b/packages/llama-index-workflows/tests/test_catch_error.py
@@ -36,6 +36,7 @@ from workflows.retry_policy import (
     wait_fixed,
 )
 from workflows.runtime.types.internal_state import BrokerState, EventAttempt
+from workflows.runtime.types.step_id import StepId
 
 
 def _retry(attempts: int) -> Any:
@@ -118,7 +119,7 @@ def test_last_exception_serialization_roundtrip() -> None:
 
     wf = Flow()
     state = BrokerState.from_workflow(wf)
-    state.workers["a"].queue.append(
+    state.workers[StepId.root("a")].queue.append(
         EventAttempt(
             event=StartEvent(),
             attempts=1,
@@ -129,7 +130,7 @@ def test_last_exception_serialization_roundtrip() -> None:
     )
     serialized = state.to_serialized(JsonSerializer())
     restored = BrokerState.from_serialized(serialized, wf, JsonSerializer())
-    restored_attempt = restored.workers["a"].queue[0]
+    restored_attempt = restored.workers[StepId.root("a")].queue[0]
     assert isinstance(restored_attempt.last_exception, ValueError)
     assert str(restored_attempt.last_exception) == "boom"
     assert restored_attempt.last_failed_at == 123.456
@@ -517,7 +518,7 @@ def test_recovery_counts_serialization_roundtrip() -> None:
     wf = Flow()
     wf._validate()
     state = BrokerState.from_workflow(wf)
-    state.workers["a"].queue.append(
+    state.workers[StepId.root("a")].queue.append(
         EventAttempt(
             event=StartEvent(),
             attempts=1,
@@ -527,5 +528,5 @@ def test_recovery_counts_serialization_roundtrip() -> None:
     )
     serialized = state.to_serialized(JsonSerializer())
     restored = BrokerState.from_serialized(serialized, wf, JsonSerializer())
-    restored_attempt = restored.workers["a"].queue[0]
+    restored_attempt = restored.workers[StepId.root("a")].queue[0]
     assert restored_attempt.recovery_counts == {"handler": 1}

--- a/packages/llama-index-workflows/tests/test_child_workflow_catch_error.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_catch_error.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Namespace-aware ``@catch_error`` recovery for nested child workflows.
+
+A child's ``@catch_error`` handler recovers the child's own failing steps,
+within the child's namespace, on a recovery budget distinct from a same-named
+root handler. These tests pin that contract across the boundary and at the
+grandchild level.
+"""
+
+from __future__ import annotations
+
+import pytest
+from workflows import Workflow
+from workflows.decorators import catch_error, step
+from workflows.events import (
+    Event,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+    WorkflowFailedEvent,
+)
+from workflows.handler import WorkflowHandler
+
+
+class ChildStart(StartEvent):
+    pass
+
+
+class ChildStop(StopEvent):
+    pass
+
+
+async def _collect_until_done(handler: WorkflowHandler) -> list[Event]:
+    events: list[Event] = []
+    async for ev in handler.stream_events():
+        events.append(ev)
+    return events
+
+
+# --- Same handler name in two namespaces keeps separate recovery budgets ------
+#
+# ``recovery_counts`` travels with the event lineage and crosses the child
+# StopEvent boundary into the parent. If the budget were keyed by the bare
+# handler name, the child's ``recover`` would consume the root's ``recover``
+# budget and the parent failure would no longer be recoverable. StepId keys
+# keep the budgets distinct.
+
+
+class SharedNameChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        raise ValueError("child-boom")
+
+    @catch_error(max_recoveries=1)
+    async def recover(self, ev: StepFailedEvent) -> ChildStop:
+        return ChildStop()
+
+
+class SharedNameParent(Workflow):
+    child: SharedNameChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def after_child(self, ev: ChildStop) -> StopEvent:
+        raise ValueError("parent-boom")
+
+    @catch_error(max_recoveries=1)
+    async def recover(self, ev: StepFailedEvent) -> StopEvent:
+        return StopEvent(result="parent-recovered")
+
+
+@pytest.mark.asyncio
+async def test_same_handler_name_across_namespaces_has_separate_budgets() -> None:
+    handler = SharedNameParent(child=SharedNameChild()).run()
+    events = await _collect_until_done(handler)
+
+    result = await handler
+    # Child recovered its own failure (max 1) and the parent then recovered its
+    # own failure (max 1) on a separate budget despite the shared name.
+    assert result == "parent-recovered"
+    failed = [ev for ev in events if isinstance(ev, WorkflowFailedEvent)]
+    assert failed == []
+
+
+# --- Grandchild handler recovers a grandchild step ----------------------------
+
+
+class GrandStart(StartEvent):
+    pass
+
+
+class GrandStop(StopEvent):
+    pass
+
+
+class MidStart(StartEvent):
+    pass
+
+
+class MidStop(StopEvent):
+    pass
+
+
+class RecoveringGrandChild(Workflow):
+    @step
+    async def run_grand(self, ev: GrandStart) -> GrandStop:
+        raise ValueError("grand-boom")
+
+    @catch_error
+    async def recover(self, ev: StepFailedEvent) -> GrandStop:
+        return GrandStop()
+
+
+class MidPassthrough(Workflow):
+    grand: RecoveringGrandChild
+
+    @step
+    async def begin(self, ev: MidStart) -> GrandStart:
+        return GrandStart()
+
+    @step
+    async def finish(self, ev: GrandStop) -> MidStop:
+        return MidStop()
+
+
+class TopRecover(Workflow):
+    mid: MidPassthrough
+
+    @step
+    async def begin(self, ev: StartEvent) -> MidStart:
+        return MidStart()
+
+    @step
+    async def finish(self, ev: MidStop) -> StopEvent:
+        return StopEvent(result="grand-recovered")
+
+
+@pytest.mark.asyncio
+async def test_grandchild_catch_error_recovers_in_compound_namespace() -> None:
+    handler = TopRecover(mid=MidPassthrough(grand=RecoveringGrandChild())).run()
+    events = await _collect_until_done(handler)
+
+    result = await handler
+    assert result == "grand-recovered"
+    failed = [ev for ev in events if isinstance(ev, WorkflowFailedEvent)]
+    assert failed == []

--- a/packages/llama-index-workflows/tests/test_child_workflow_declaration.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_declaration.py
@@ -1,0 +1,349 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for declaring child workflows as typed class fields.
+
+``WorkflowMeta`` is a ``dataclass_transform``, so a parent's child fields and the
+base config kwargs both type-check on the constructor (``Parent(child=Child(),
+timeout=30)``) with no suppression. The only per-line ignore below is on a test
+that deliberately passes the wrong child type to exercise the runtime check.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import pytest
+from workflows import Workflow
+from workflows.decorators import step
+from workflows.errors import WorkflowValidationError
+from workflows.events import StartEvent, StopEvent
+from workflows.plugins import BasicRuntime
+from workflows.runtime.types.step_id import StepId
+
+
+class ChildStart(StartEvent):
+    payload: str = "x"
+
+
+class ChildStop(StopEvent):
+    out: str = "y"
+
+
+class Child(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        return ChildStop(out=ev.payload)
+
+
+class Parent(Workflow):
+    child: Child
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="parent done")
+
+
+def test_synthesized_init_constructs_and_forwards_kwargs() -> None:
+    parent = Parent(child=Child(), timeout=30)
+    assert isinstance(parent.child, Child)
+    assert parent._timeout == 30
+    assert parent.child_workflows == {"child": parent.child}
+
+
+def test_child_slots_resolved_from_annotations() -> None:
+    slots = Parent._get_child_workflow_slots()
+    assert slots == {"child": Child}
+
+
+def test_child_adopts_parent_runtime_and_is_tracked() -> None:
+    runtime = BasicRuntime()
+    with runtime.registering():
+        parent = Parent(child=Child())
+    assert parent.runtime is runtime
+    assert parent.child.runtime is runtime
+    assert parent.child in runtime._pending
+
+
+def test_child_constructed_under_different_runtime_is_reparented() -> None:
+    parent_rt = BasicRuntime()
+    other_rt = BasicRuntime()
+    with other_rt.registering():
+        child = Child()
+    assert child.runtime is other_rt
+    with parent_rt.registering():
+        parent = Parent(child=child)
+    assert parent.child.runtime is parent_rt
+    assert child not in other_rt._pending
+    assert child in parent_rt._pending
+
+
+def test_child_runtime_override_is_blocked() -> None:
+    parent = Parent(child=Child())
+    with pytest.raises(RuntimeError, match="Cannot reassign runtime"):
+        parent.child._switch_runtime(BasicRuntime())
+
+
+class PlainStartChild(Workflow):
+    @step
+    async def go(self, ev: StartEvent) -> ChildStop:
+        return ChildStop()
+
+
+class PlainStopChild(Workflow):
+    @step
+    async def go(self, ev: ChildStart) -> StopEvent:
+        return StopEvent()
+
+
+class ParentBadStart(Workflow):
+    child: PlainStartChild
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent()
+
+
+class ParentBadStop(Workflow):
+    child: PlainStopChild
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent()
+
+
+def test_child_without_custom_start_event_rejected() -> None:
+    with pytest.raises(WorkflowValidationError, match="custom StartEvent"):
+        ParentBadStart(child=PlainStartChild())
+
+
+def test_child_without_custom_stop_event_rejected() -> None:
+    with pytest.raises(WorkflowValidationError, match="custom StopEvent"):
+        ParentBadStop(child=PlainStopChild())
+
+
+def test_wrong_child_type_rejected() -> None:
+    class OtherStart(StartEvent):
+        pass
+
+    class OtherStop(StopEvent):
+        pass
+
+    class Other(Workflow):
+        @step
+        async def go(self, ev: OtherStart) -> OtherStop:
+            return OtherStop()
+
+    with pytest.raises(WorkflowValidationError, match="expects Child"):
+        Parent(child=Other())  # type: ignore  # wrong child type, rejected at runtime
+
+
+class ParentWithUserInit(Workflow):
+    child: Child
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.child = Child()
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent()
+
+
+def test_user_defined_init_attaches_children_at_construction() -> None:
+    parent = ParentWithUserInit()
+    # User-init path: the child is assigned as a plain attribute inside the
+    # user __init__, then WorkflowMeta.__call__ runs _finalize_construction
+    # (-> _ensure_children_attached) once the outermost __init__ returns, so
+    # the child is wired in by the time construction completes.
+    assert isinstance(parent.child, Child)
+    assert parent._child_workflows == {"child": parent.child}
+    assert parent.child.runtime is parent.runtime
+
+
+def test_childless_workflow_unaffected() -> None:
+    class NoChildren(Workflow):
+        @step
+        async def start(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="ok")
+
+    # No synthesized init: still inherits Workflow.__init__.
+    assert NoChildren.__init__ is Workflow.__init__
+    wf = NoChildren(timeout=10)
+    assert wf._timeout == 10
+    assert wf.child_workflows == {}
+
+
+def test_dead_child_config_warns() -> None:
+    """Run-level config set on a child is ignored once nested, so attaching it
+    emits a warning naming the dead params. ``timeout`` is NOT dead -- it bounds
+    the child's own execution -- so only ``verbose`` is flagged here."""
+    with pytest.warns(UserWarning, match="verbose=True"):
+        Parent(child=Child(timeout=10, verbose=True))
+
+
+def test_child_timeout_does_not_warn() -> None:
+    """A child ``timeout`` is honored (per-namespace deadline), not ignored, so
+    setting it alone attaches silently."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        Parent(child=Child(timeout=10))
+
+
+def test_honored_child_config_does_not_warn() -> None:
+    """A child with default run-level config attaches silently."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        Parent(child=Child())
+
+
+# ---------------------------------------------------------------------------
+# Tracking ordering: registration must see the full child tree.
+#
+# WorkflowMeta.__call__ runs _finalize_construction (-> _ensure_children_attached
+# then track_workflow) only after the outermost __init__ returns, so by the time
+# the runtime tracks a workflow its children are already attached. These tests
+# capture the namespaced step set at track time to prove the child steps are
+# present -- the precise condition a DBOS launch later freezes into the step set.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingRuntime(BasicRuntime):
+    """Records the namespaced step set observed at each ``track_workflow``."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.track_calls: list[tuple[int, frozenset[StepId]]] = []
+
+    def track_workflow(self, workflow: Workflow) -> None:
+        self.track_calls.append(
+            (id(workflow), frozenset(workflow._get_namespaced_steps().keys()))
+        )
+        super().track_workflow(workflow)
+
+
+class _NoChildRuntime(BasicRuntime):
+    _supports_child_workflows = False
+
+
+def _steps_at_track(rt: _RecordingRuntime, wf: Workflow) -> list[frozenset[StepId]]:
+    """The step sets captured each time ``wf`` was tracked (one per call)."""
+    return [steps for wf_id, steps in rt.track_calls if wf_id == id(wf)]
+
+
+def _has_child_steps(steps: frozenset[StepId]) -> bool:
+    return any(sid.namespace == ("child",) for sid in steps)
+
+
+def test_synthesized_init_tracks_after_children_attached() -> None:
+    rt = _RecordingRuntime()
+    with rt.registering():
+        parent = Parent(child=Child())
+    captures = _steps_at_track(rt, parent)
+    assert len(captures) == 1
+    assert _has_child_steps(captures[0])
+
+
+def test_user_init_tracks_after_children_attached() -> None:
+    rt = _RecordingRuntime()
+    with rt.registering():
+        parent = ParentWithUserInit()
+    captures = _steps_at_track(rt, parent)
+    assert len(captures) == 1
+    assert _has_child_steps(captures[0])
+
+
+def test_subclass_of_user_init_tracks_after_children_attached() -> None:
+    class SubOfUserInit(ParentWithUserInit):
+        """No own __init__: still instantiated through WorkflowMeta.__call__,
+        finalize resolves child slots from ``type(self)``."""
+
+    rt = _RecordingRuntime()
+    with rt.registering():
+        # dataclass_transform synthesizes a `child`-requiring __init__ for the
+        # subclass (it declares no __init__ of its own), but at runtime the
+        # inherited user __init__ constructs the child, so no arg is needed.
+        parent = SubOfUserInit()  # type: ignore  # synthesized init wants child; inherited user init supplies it
+    captures = _steps_at_track(rt, parent)
+    assert len(captures) == 1
+    assert _has_child_steps(captures[0])
+    assert isinstance(parent.child, Child)
+
+
+def test_childless_user_init_tracked_exactly_once() -> None:
+    class ChildlessUserInit(Workflow):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            # Work after super().__init__() must not disturb tracking.
+            self.marker = "after-super"
+
+        @step
+        async def start(self, ev: StartEvent) -> StopEvent:
+            return StopEvent(result="ok")
+
+    rt = _RecordingRuntime()
+    with rt.registering():
+        wf = ChildlessUserInit()
+    assert wf.marker == "after-super"
+    assert len(_steps_at_track(rt, wf)) == 1
+    assert wf in rt._pending
+
+
+def test_track_fires_once_per_workflow_in_tree() -> None:
+    rt = _RecordingRuntime()
+    with rt.registering():
+        child = Child()
+        parent = Parent(child=child)
+    # Parent and child each tracked exactly once; no double-track from
+    # _attach_child re-homing a same-runtime child.
+    assert len(_steps_at_track(rt, parent)) == 1
+    assert len(_steps_at_track(rt, child)) == 1
+
+
+def test_runtime_without_child_support_rejects_child_declaration() -> None:
+    rt = _NoChildRuntime()
+    child = Child(runtime=BasicRuntime())
+    with rt.registering():
+        with pytest.raises(
+            WorkflowValidationError, match="does not support child workflow"
+        ):
+            Parent(child=child)
+
+
+def test_switching_parent_to_runtime_without_child_support_rejected() -> None:
+    parent = Parent(child=Child())
+    with pytest.raises(WorkflowValidationError, match="does not support child"):
+        parent._switch_runtime(_NoChildRuntime())
+
+
+def test_init_raises_skips_finalize() -> None:
+    class Boom(Workflow):
+        def __init__(self, **kwargs: Any) -> None:
+            super().__init__(**kwargs)
+            raise ValueError("boom")
+
+        @step
+        async def start(self, ev: StartEvent) -> StopEvent:
+            return StopEvent()
+
+    rt = _RecordingRuntime()
+    with rt.registering():
+        with pytest.raises(ValueError, match="boom"):
+            Boom()
+    # __call__ propagates the exception; _finalize_construction never runs.
+    assert rt.track_calls == []
+
+
+def test_missing_super_init_raises_clear_error() -> None:
+    class NoSuper(Workflow):
+        def __init__(self, **kwargs: Any) -> None:
+            # Intentionally skips super().__init__(): _runtime never gets set,
+            # so finalize would otherwise raise an opaque private-attr error.
+            pass
+
+        @step
+        async def start(self, ev: StartEvent) -> StopEvent:
+            return StopEvent()
+
+    with pytest.raises(WorkflowValidationError, match="did not call super"):
+        NoSuper()

--- a/packages/llama-index-workflows/tests/test_child_workflow_declarations.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_declarations.py
@@ -1,0 +1,204 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import inspect
+import pickle
+from typing import Any, cast
+
+import pytest
+from workflows import Workflow, step
+from workflows.errors import WorkflowValidationError
+from workflows.events import StartEvent, StopEvent
+from workflows.runtime.types.internal_state import BrokerState
+from workflows.runtime.types.step_id import StepId
+
+
+class BareChild(Workflow):
+    @step
+    async def run_child(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="bare")
+
+
+class LegacyManualParent(Workflow):
+    child: BareChild
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.child = BareChild()
+
+    @step
+    async def run_parent(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="parent")
+
+
+def test_legacy_annotated_manual_composition_is_not_auto_attached() -> None:
+    parent = LegacyManualParent()
+
+    assert parent.child_workflows == {}
+    assert isinstance(parent.child, BareChild)
+
+
+class InheritedLegacyManualParent(LegacyManualParent):
+    pass
+
+
+def test_inherited_legacy_manual_composition_is_not_auto_attached() -> None:
+    parent = _construct_without_static_signature(InheritedLegacyManualParent)
+
+    assert parent.child_workflows == {}
+    assert isinstance(parent.child, BareChild)
+
+
+class ChildStart(StartEvent):
+    pass
+
+
+class ChildStop(StopEvent):
+    pass
+
+
+class TypedChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        return ChildStop()
+
+
+class TypedParent(Workflow):
+    child: TypedChild
+
+    @step
+    async def start(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="done")
+
+
+def test_typed_child_annotation_still_synthesizes_constructor_slot() -> None:
+    parent = TypedParent(child=TypedChild())
+
+    assert isinstance(parent.child_workflows["child"], TypedChild)
+
+
+def test_synthesized_constructor_signature_includes_child_and_config() -> None:
+    signature = inspect.signature(TypedParent)
+
+    assert "child" in signature.parameters
+    assert "timeout" in signature.parameters
+    assert "runtime" in signature.parameters
+
+
+def _construct_without_static_signature(cls: type[Any]) -> Any:
+    return cls()
+
+
+def test_missing_synthesized_child_slot_fails_at_construction() -> None:
+    with pytest.raises(WorkflowValidationError, match="Missing child workflow"):
+        _construct_without_static_signature(TypedParent)
+
+
+class CustomInitTypedParent(Workflow):
+    child: TypedChild
+
+    def __init__(self) -> None:
+        super().__init__()
+
+    @step
+    async def start(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="done")
+
+
+def test_missing_custom_init_typed_child_slot_fails_at_construction() -> None:
+    with pytest.raises(WorkflowValidationError, match="Missing child workflow"):
+        CustomInitTypedParent()
+
+
+def test_class_body_child_instance_is_rejected() -> None:
+    class SharedDefaultParent(Workflow):
+        child: TypedChild = TypedChild()
+
+        @step
+        async def start(self, ev: StartEvent) -> ChildStart:
+            return ChildStart()
+
+        @step
+        async def finish(self, ev: ChildStop) -> StopEvent:
+            return StopEvent(result="done")
+
+    with pytest.raises(WorkflowValidationError, match="shared class-body"):
+        SharedDefaultParent()
+
+
+class WithPlainAnnotation(Workflow):
+    retries: int = 3
+
+    @step
+    async def run_step(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="done")
+
+
+def test_non_child_annotations_are_not_constructor_fields() -> None:
+    with pytest.raises(TypeError):
+        WithPlainAnnotation(retries=5)  # type: ignore[call-arg]
+
+
+def test_pickled_broker_state_with_legacy_worker_keys_normalizes_on_load() -> None:
+    state = BrokerState.from_workflow(WithPlainAnnotation())
+    state.workers = cast(
+        Any, {str(step_id): worker for step_id, worker in state.workers.items()}
+    )
+
+    recovered = pickle.loads(pickle.dumps(state))
+
+    assert set(recovered.workers) == {StepId.root("run_step")}
+
+
+def test_pickled_broker_state_with_legacy_config_keys_normalizes_on_load() -> None:
+    state = BrokerState.from_workflow(WithPlainAnnotation())
+    state.workers = cast(
+        Any, {str(step_id): worker for step_id, worker in state.workers.items()}
+    )
+    object.__setattr__(
+        state.config,
+        "steps",
+        cast(
+            Any,
+            {str(step_id): config for step_id, config in state.config.steps.items()},
+        ),
+    )
+
+    recovered = pickle.loads(pickle.dumps(state))
+
+    assert set(recovered.workers) == {StepId.root("run_step")}
+    assert set(recovered.config.steps) == {StepId.root("run_step")}
+    assert set(recovered.deepcopy().config.steps) == {StepId.root("run_step")}
+
+
+def test_old_pickled_broker_state_without_namespace_started_recovers() -> None:
+    state = BrokerState.from_workflow(WithPlainAnnotation())
+    state.__dict__.pop("namespace_started")
+
+    recovered = pickle.loads(pickle.dumps(state))
+
+    assert recovered.namespace_started == {}
+    assert recovered.deepcopy().namespace_started == {}
+
+
+def test_broker_state_string_worker_keys_parse_namespaces() -> None:
+    state = BrokerState.from_workflow(WithPlainAnnotation())
+    worker = next(iter(state.workers.values()))
+
+    recovered = BrokerState(
+        is_running=True,
+        config=state.config,
+        workers=cast(Any, {"child/run_step": worker}),
+    )
+
+    assert set(recovered.workers) == {StepId(("child",), "run_step")}

--- a/packages/llama-index-workflows/tests/test_child_workflow_execution.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_execution.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Phase 4: namespaced child-workflow execution and the StopEvent boundary.
+
+A parent triggers a child by emitting the child's ``StartEvent``; the child runs
+namespaced inside the parent's single broker state, and its ``StopEvent`` surfaces
+back to the parent as an ordinary routable event. Only the *root* StopEvent
+completes the run.
+"""
+
+from __future__ import annotations
+
+import pytest
+from workflows import Workflow
+from workflows.decorators import step
+from workflows.events import Event, StartEvent, StopEvent
+from workflows.testing import WorkflowTestRunner
+
+
+class ChildStart(StartEvent):
+    payload: str = ""
+
+
+class ChildStop(StopEvent):
+    out: str = ""
+
+
+class Child(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        return ChildStop(out=ev.payload.upper())
+
+
+class Parent(Workflow):
+    child: Child
+
+    @step
+    async def start(self, ev: StartEvent) -> ChildStart:
+        return ChildStart(payload="hello")
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result=ev.out)
+
+
+def test_parent_with_boundary_child_validates() -> None:
+    Parent(child=Child()).validate()
+
+
+@pytest.mark.asyncio
+async def test_child_stop_event_surfaces_as_parent_event() -> None:
+    """Parent emits a child StartEvent; the child's StopEvent comes back as a
+    routable parent event, and the parent completes on its own StopEvent."""
+    result = await WorkflowTestRunner(Parent(child=Child())).run()
+    assert result.result == "HELLO"
+
+
+@pytest.mark.asyncio
+async def test_child_runs_standalone_unchanged() -> None:
+    """A child workflow still runs on its own."""
+    result = await WorkflowTestRunner(Child()).run(start_event=ChildStart(payload="hi"))
+    # ChildStop is a StopEvent *subclass*, so the handler returns the event itself.
+    assert isinstance(result.result, ChildStop)
+    assert result.result.out == "HI"
+
+
+# --- Grandchild (3-level) boundary --------------------------------------------
+
+
+class GrandStart(StartEvent):
+    payload: str = ""
+
+
+class GrandStop(StopEvent):
+    out: str = ""
+
+
+class Grand(Workflow):
+    @step
+    async def run_grand(self, ev: GrandStart) -> GrandStop:
+        return GrandStop(out=ev.payload + "!")
+
+
+class MidStart(StartEvent):
+    payload: str = ""
+
+
+class MidStop(StopEvent):
+    out: str = ""
+
+
+class Mid(Workflow):
+    grand: Grand
+
+    @step
+    async def begin(self, ev: MidStart) -> GrandStart:
+        return GrandStart(payload=ev.payload)
+
+    @step
+    async def end(self, ev: GrandStop) -> MidStop:
+        return MidStop(out=ev.out)
+
+
+class Top(Workflow):
+    mid: Mid
+
+    @step
+    async def start(self, ev: StartEvent) -> MidStart:
+        return MidStart(payload="g")
+
+    @step
+    async def finish(self, ev: MidStop) -> StopEvent:
+        return StopEvent(result=ev.out)
+
+
+@pytest.mark.asyncio
+async def test_grandchild_boundary_runs_namespaced() -> None:
+    result = await WorkflowTestRunner(Top(mid=Mid(grand=Grand()))).run()
+    assert result.result == "g!"
+
+
+# --- Namespace isolation of routing -------------------------------------------
+
+
+class SharedMid(Event):
+    """An intermediate event type *reused* by both parent and child namespaces.
+
+    Routing must keep each namespace's copy within that namespace.
+    """
+
+    tag: str = ""
+
+
+class IsoChildStart(StartEvent):
+    pass
+
+
+class IsoChildStop(StopEvent):
+    out: str = ""
+
+
+class IsoChild(Workflow):
+    @step
+    async def begin(self, ev: IsoChildStart) -> SharedMid:
+        return SharedMid(tag="child")
+
+    @step
+    async def end(self, ev: SharedMid) -> IsoChildStop:
+        return IsoChildStop(out=ev.tag)
+
+
+class IsoParent(Workflow):
+    child: IsoChild
+
+    @step
+    async def start(self, ev: StartEvent) -> SharedMid:
+        return SharedMid(tag="parent")
+
+    @step
+    async def middle(self, ev: SharedMid) -> IsoChildStart:
+        # Parent's own SharedMid must route here, not into the child.
+        assert ev.tag == "parent"
+        return IsoChildStart()
+
+    @step
+    async def finish(self, ev: IsoChildStop) -> StopEvent:
+        return StopEvent(result=ev.out)
+
+
+@pytest.mark.asyncio
+async def test_shared_event_type_routes_within_namespace() -> None:
+    result = await WorkflowTestRunner(IsoParent(child=IsoChild())).run()
+    # The child's SharedMid stays in the child; its end step sees tag="child".
+    assert result.result == "child"

--- a/packages/llama-index-workflows/tests/test_child_workflow_invocation_isolation.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_invocation_isolation.py
@@ -1,0 +1,288 @@
+# ty: ignore[unknown-argument]
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from workflows import Context, Workflow
+from workflows.context.state_store import CHILD_STATES_KEY
+from workflows.decorators import catch_error, step
+from workflows.errors import WorkflowRuntimeError
+from workflows.events import (
+    Event,
+    HumanResponseEvent,
+    InputRequiredEvent,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+    get_event_origin_namespace,
+)
+from workflows.testing import WorkflowTestRunner
+
+
+def _assert_child_invocation_namespace(namespace: tuple[str, ...]) -> None:
+    assert len(namespace) == 1
+    assert namespace[0].startswith("child#")
+    assert namespace[0] != "child"
+    assert namespace[0].removeprefix("child#")
+
+
+class _StreamStart(StartEvent):
+    pass
+
+
+class _StreamStop(StopEvent):
+    pass
+
+
+class _ChildProgress(Event):
+    pass
+
+
+class _StreamingChild(Workflow):
+    @step
+    async def run_child(self, ctx: Context, ev: _StreamStart) -> _StreamStop:
+        ctx.write_event_to_stream(_ChildProgress())
+        return _StreamStop()
+
+
+class _StreamingParent(Workflow):
+    child: _StreamingChild
+
+    @step
+    async def start(self, ev: StartEvent) -> _StreamStart:
+        return _StreamStart()
+
+    @step
+    async def finish(self, ev: _StreamStop) -> StopEvent:
+        return StopEvent(result="done")
+
+
+@pytest.mark.asyncio
+async def test_stream_origin_exposes_opaque_child_invocation_namespace() -> None:
+    handler = _StreamingParent(child=_StreamingChild()).run()
+    collected: list[Event] = []
+    async for ev in handler.stream_events(include_children=True):
+        collected.append(ev)
+    await handler
+
+    child_progress = next(ev for ev in collected if isinstance(ev, _ChildProgress))
+    _assert_child_invocation_namespace(get_event_origin_namespace(child_progress))
+
+
+class _CountingStart(StartEvent):
+    round: int
+
+
+class _CountingStop(StopEvent):
+    round: int
+    count: int
+
+
+class _CountingChild(Workflow):
+    @step
+    async def run_child(self, ctx: Context, ev: _CountingStart) -> _CountingStop:
+        count = await ctx.store.get("count", default=0) + 1
+        await ctx.store.set("count", count)
+        return _CountingStop(round=ev.round, count=count)
+
+
+class _SequentialParent(Workflow):
+    child: _CountingChild
+
+    @step
+    async def start(self, ev: StartEvent) -> _CountingStart:
+        return _CountingStart(round=1)
+
+    @step
+    async def continue_or_finish(
+        self, ctx: Context, ev: _CountingStop
+    ) -> _CountingStart | StopEvent:
+        counts = await ctx.store.get("counts", default=[])
+        counts = [*counts, ev.count]
+        await ctx.store.set("counts", counts)
+
+        if ev.round == 1:
+            return _CountingStart(round=2)
+        return StopEvent(result=counts)
+
+
+@pytest.mark.asyncio
+async def test_sequential_same_slot_child_invocations_get_fresh_store() -> None:
+    result = await WorkflowTestRunner(_SequentialParent(child=_CountingChild())).run()
+    assert result.result == [1, 1]
+
+
+class _ParallelStart(StartEvent):
+    label: str
+    delay: float
+
+
+class _ParallelStop(StopEvent):
+    label: str
+
+
+class _ParallelChild(Workflow):
+    @step
+    async def run_child(self, ev: _ParallelStart) -> _ParallelStop:
+        await asyncio.sleep(ev.delay)
+        return _ParallelStop(label=ev.label)
+
+
+class _RecoveringParallelChild(Workflow):
+    @step
+    async def run_child(self, ev: _ParallelStart) -> _ParallelStop:
+        await asyncio.sleep(ev.delay)
+        return _ParallelStop(label=ev.label)
+
+    @catch_error
+    async def recover(self, ev: StepFailedEvent) -> _ParallelStop:
+        assert isinstance(ev.input_event, _ParallelStart)
+        return _ParallelStop(label=f"{ev.input_event.label}-timeout")
+
+
+class _KeepAlive(Event):
+    pass
+
+
+class _ParallelParent(Workflow):
+    child: Workflow
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> _ParallelStart | _KeepAlive:
+        ctx.send_event(_ParallelStart(label="slow", delay=0.2))
+        ctx.send_event(_KeepAlive())
+        return _ParallelStart(label="fast", delay=0.01)
+
+    @step
+    async def collect(self, ctx: Context, ev: _ParallelStop) -> None:
+        labels = await ctx.store.get("labels", default=[])
+        await ctx.store.set("labels", [*labels, ev.label])
+        return None
+
+    @step
+    async def finish(self, ctx: Context, ev: _KeepAlive) -> StopEvent:
+        await asyncio.sleep(0.4)
+        labels = await ctx.store.get("labels", default=[])
+        return StopEvent(result=sorted(labels))
+
+
+@pytest.mark.asyncio
+async def test_overlapping_same_slot_child_invocations_do_not_cancel_each_other() -> (
+    None
+):
+    result = await asyncio.wait_for(
+        _ParallelParent(child=_ParallelChild(), timeout=30).run(),
+        timeout=10,
+    )
+    assert result == ["fast", "slow"]
+
+
+@pytest.mark.asyncio
+async def test_overlapping_same_slot_timeout_is_invocation_scoped() -> None:
+    result = await asyncio.wait_for(
+        _ParallelParent(
+            child=_RecoveringParallelChild(timeout=0.05),
+            timeout=30,
+        ).run(),
+        timeout=10,
+    )
+    assert result == ["fast", "slow-timeout"]
+
+
+class _HitlStart(StartEvent):
+    pass
+
+
+class _HitlStop(StopEvent):
+    answer: str = ""
+
+
+class _HitlChild(Workflow):
+    @step
+    async def ask(self, ctx: Context, ev: _HitlStart) -> InputRequiredEvent:
+        await ctx.store.set("asked", True)
+        return InputRequiredEvent(prefix="child?")  # type: ignore[reportCallIssue]
+
+    @step
+    async def answer(self, ev: HumanResponseEvent) -> _HitlStop:
+        return _HitlStop(answer=ev.response)
+
+
+class _HitlParent(Workflow):
+    child: _HitlChild
+
+    @step
+    async def start(self, ev: StartEvent) -> _HitlStart:
+        return _HitlStart()
+
+    @step
+    async def finish(self, ev: _HitlStop) -> StopEvent:
+        return StopEvent(result=ev.answer)
+
+
+@pytest.mark.asyncio
+async def test_static_child_target_without_invocation_fails_loudly() -> None:
+    handler = _HitlParent(child=_HitlChild()).run()
+    async for ev in handler.stream_events(include_children=True):
+        if isinstance(ev, InputRequiredEvent):
+            handler.ctx.send_event(
+                HumanResponseEvent(response="ok"),  # type: ignore[reportCallIssue]
+                step="child/answer",
+            )
+            break
+
+    with pytest.raises(WorkflowRuntimeError, match="concrete child invocation"):
+        await handler
+
+
+@pytest.mark.asyncio
+async def test_live_idle_child_invocation_state_is_snapshotted() -> None:
+    handler = _HitlParent(child=_HitlChild()).run()
+    child_origin: tuple[str, ...] | None = None
+    async for ev in handler.stream_events(include_children=True):
+        if isinstance(ev, InputRequiredEvent):
+            child_origin = get_event_origin_namespace(ev)
+            break
+
+    assert child_origin is not None
+    blob = handler.ctx.to_dict()
+    child_states = blob["state"][CHILD_STATES_KEY]
+    assert "/".join(child_origin) in child_states
+
+    handler.ctx.send_event(
+        HumanResponseEvent(response="ok"),  # type: ignore[reportCallIssue]
+        step=f"{child_origin[0]}/answer",
+    )
+    assert await handler == "ok"
+
+
+class _ContinuationParent(Workflow):
+    child: _CountingChild
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> _CountingStart:
+        await ctx.store.set("root_ran", True)
+        return _CountingStart(round=1)
+
+    @step
+    async def finish(self, ev: _CountingStop) -> StopEvent:
+        return StopEvent(result=ev.count)
+
+
+@pytest.mark.asyncio
+async def test_completed_context_continuation_drops_child_invocation_state() -> None:
+    workflow = _ContinuationParent(child=_CountingChild())
+
+    first = await WorkflowTestRunner(workflow).run()
+    assert first.result == 1
+    first_blob = first.ctx.to_dict()
+    child_states = first_blob["state"].get(CHILD_STATES_KEY, {})
+    assert not any(key.startswith("child") for key in child_states)
+
+    restored = Context.from_dict(workflow, first_blob)
+    second = await WorkflowTestRunner(workflow).run(ctx=restored)
+    assert second.result == 1

--- a/packages/llama-index-workflows/tests/test_child_workflow_namespace_consolidation.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_namespace_consolidation.py
@@ -1,0 +1,612 @@
+# ty: ignore[unknown-argument]
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Regression tests for the child-workflow namespace consolidation.
+
+The child-workflow feature added a ``namespace`` dimension but left several
+runtime consumers modelling a flat step space. These tests pin child
+``list[E]`` fan-in, cross-namespace stream accounting, child human-input
+round-trips, namespace teardown, and the ``max_recoveries`` bound on namespace
+timeout recovery.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from workflows import Context, Workflow
+from workflows.decorators import catch_error, step
+from workflows.errors import WorkflowRuntimeError, WorkflowTimeoutError
+from workflows.events import (
+    Event,
+    HumanResponseEvent,
+    InputRequiredEvent,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+    get_event_origin_namespace,
+)
+from workflows.runtime.control_loop.reduce import terminate_namespace
+from workflows.runtime.types.internal_state import (
+    BrokerState,
+    CollectionStreamInstance,
+    EventAttempt,
+    _binding_id,
+)
+from workflows.runtime.types.step_id import StepId
+from workflows.testing import WorkflowTestRunner
+
+# --- Phase 1: child fan-in + cross-namespace accounting -----------------------
+
+
+class _Item(Event):
+    n: int
+
+
+class _ChildFanStart(StartEvent):
+    pass
+
+
+class _ChildFanStop(StopEvent):
+    total: int = 0
+
+
+class _FanChild(Workflow):
+    @step
+    async def fan(self, ev: _ChildFanStart) -> list[_Item]:
+        return [_Item(n=1), _Item(n=2), _Item(n=3)]
+
+    @step
+    async def collect(self, events: list[_Item]) -> _ChildFanStop:
+        return _ChildFanStop(total=sum(e.n for e in events))
+
+
+class _FanParent(Workflow):
+    child: _FanChild
+
+    @step
+    async def start(self, ev: StartEvent) -> _ChildFanStart:
+        return _ChildFanStart()
+
+    @step
+    async def finish(self, ev: _ChildFanStop) -> StopEvent:
+        return StopEvent(result=ev.total)
+
+
+@pytest.mark.asyncio
+async def test_child_list_fan_in_joins_all_items() -> None:
+    """A ``list[E]`` fan-out/fan-in *inside a child* binds within the child
+    namespace and joins every item — previously the binding was computed
+    root-only, so the child collect never bound and every item was dropped.
+    """
+    result = await WorkflowTestRunner(_FanParent(child=_FanChild())).run()
+    assert result.result == 6
+
+
+class _Shared(Event):
+    pass
+
+
+class _ReuseChildStart(StartEvent):
+    pass
+
+
+class _ReuseChildStop(StopEvent):
+    pass
+
+
+class _ReuseChild(Workflow):
+    @step
+    async def run_child(self, ev: _ReuseChildStart) -> _Shared:
+        return _Shared()
+
+    @step
+    async def also_accepts_shared(self, ev: _Shared) -> _ReuseChildStop:
+        return _ReuseChildStop()
+
+
+class _ReuseParent(Workflow):
+    child: _ReuseChild
+
+    @step
+    async def fan(self, ev: StartEvent) -> list[_Shared]:
+        return [_Shared()]
+
+    @step
+    async def collect(self, events: list[_Shared]) -> StopEvent:
+        return StopEvent(result=len(events))
+
+
+@pytest.mark.asyncio
+async def test_root_stream_accounting_ignores_same_typed_child_step() -> None:
+    """A root collection stream must not wedge when a child step happens to
+    accept the streamed event type. Birth-count is namespace-scoped, so the
+    child's ``also_accepts_shared`` is not counted into the root stream's open
+    work items (which previously left a phantom item open forever).
+    """
+    result = await WorkflowTestRunner(_ReuseParent(child=_ReuseChild())).run()
+    assert result.result == 1
+
+
+def test_root_binding_id_is_byte_identical_to_pre_namespace_format() -> None:
+    """Root binding ids embed the bare step name (no namespace prefix), so a
+    snapshot written before the StepId conversion still resolves on resume.
+    """
+    state = BrokerState.from_workflow(_ReuseParent(child=_ReuseChild()))
+    root_bindings = [
+        b for b in state.config.collection_bindings.values() if b.source_step.is_root
+    ]
+    assert root_bindings, "expected a root fan->collect binding"
+    for binding in root_bindings:
+        expected = _binding_id(
+            StepId.root(binding.source_step.name),
+            StepId.root(binding.target_step.name),
+            binding.item_types,
+            binding.policy,
+        )
+        assert binding.id == expected
+        # The id string carries the bare names, never a "ns/name" projection.
+        assert binding.id.startswith(
+            f"{binding.source_step.name}->{binding.target_step.name}:"
+        )
+        assert "/" not in binding.id.split(":", 1)[0]
+
+
+# --- Grandchild (3-level) fan-in ----------------------------------------------
+
+
+class _GrandStart(StartEvent):
+    pass
+
+
+class _GrandStop(StopEvent):
+    total: int = 0
+
+
+class _GrandFanChild(Workflow):
+    @step
+    async def fan(self, ev: _GrandStart) -> list[_Item]:
+        return [_Item(n=2), _Item(n=5)]
+
+    @step
+    async def collect(self, events: list[_Item]) -> _GrandStop:
+        return _GrandStop(total=sum(e.n for e in events))
+
+
+class _MidStart(StartEvent):
+    pass
+
+
+class _MidStop(StopEvent):
+    total: int = 0
+
+
+class _MidChild(Workflow):
+    grand: _GrandFanChild
+
+    @step
+    async def start(self, ev: _MidStart) -> _GrandStart:
+        return _GrandStart()
+
+    @step
+    async def finish(self, ev: _GrandStop) -> _MidStop:
+        return _MidStop(total=ev.total)
+
+
+class _GrandParent(Workflow):
+    mid: _MidChild
+
+    @step
+    async def start(self, ev: StartEvent) -> _MidStart:
+        return _MidStart()
+
+    @step
+    async def finish(self, ev: _MidStop) -> StopEvent:
+        return StopEvent(result=ev.total)
+
+
+@pytest.mark.asyncio
+async def test_grandchild_fan_in_binds_within_its_own_namespace() -> None:
+    """A ``list[E]`` join three levels deep binds within the grandchild
+    namespace ``(mid, grand)``."""
+    result = await WorkflowTestRunner(
+        _GrandParent(mid=_MidChild(grand=_GrandFanChild()))
+    ).run()
+    assert result.result == 7
+
+
+# --- Phase 2: targeted child human-input round-trip ---------------------------
+
+
+class _HitlChildStart(StartEvent):
+    pass
+
+
+class _HitlChildStop(StopEvent):
+    answer: str = ""
+
+
+class _HitlChild(Workflow):
+    @step
+    async def ask(self, ev: _HitlChildStart) -> InputRequiredEvent:
+        return InputRequiredEvent(prefix="child?")  # type: ignore[reportCallIssue]
+
+    @step
+    async def answer(self, ev: HumanResponseEvent) -> _HitlChildStop:
+        return _HitlChildStop(answer=ev.response)
+
+
+class _HitlParent(Workflow):
+    child: _HitlChild
+
+    @step
+    async def start(self, ev: StartEvent) -> _HitlChildStart:
+        return _HitlChildStart()
+
+    @step
+    async def finish(self, ev: _HitlChildStop) -> StopEvent:
+        return StopEvent(result=ev.answer)
+
+
+@pytest.mark.asyncio
+async def test_child_human_input_resolves_via_targeted_send() -> None:
+    """A child surfaces an InputRequiredEvent; the caller answers it with a
+    targeted ``send_event(resp, step="child/answer")`` that descends into the
+    child namespace, and the run completes instead of timing out.
+    """
+    handler = _HitlParent(child=_HitlChild()).run()
+    saw_request = False
+    async for ev in handler.stream_events(include_children=True):
+        if isinstance(ev, InputRequiredEvent):
+            saw_request = True
+            child_origin = get_event_origin_namespace(ev)
+            handler.ctx.send_event(
+                HumanResponseEvent(response="ok"),  # type: ignore[reportCallIssue]
+                step=f"{child_origin[0]}/answer",
+            )
+    assert saw_request
+    result = await handler
+    assert result == "ok"
+
+
+def test_resolve_target_rejects_unknown_child_step_with_actionable_error() -> None:
+    """A bad child target names the valid namespaced steps, not just 'does not
+    exist'."""
+    wf = _HitlParent(child=_HitlChild())
+    with pytest.raises(WorkflowRuntimeError) as excinfo:
+        wf._resolve_target_step(
+            "child/nope",
+            HumanResponseEvent(response="x"),  # type: ignore[reportCallIssue]
+        )
+    message = str(excinfo.value)
+    assert "child/nope does not exist" in message
+    assert "child/answer" in message
+
+
+class _RootHitlParent(Workflow):
+    @step
+    async def ask(self, ev: StartEvent) -> InputRequiredEvent:
+        return InputRequiredEvent(prefix="root?")  # type: ignore[reportCallIssue]
+
+    @step
+    async def answer(self, ev: HumanResponseEvent) -> StopEvent:
+        return StopEvent(result=ev.response)
+
+
+@pytest.mark.asyncio
+async def test_root_targeted_send_unchanged() -> None:
+    """A bare step name still targets a root step (no namespace regression)."""
+    handler = _RootHitlParent().run()
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            handler.ctx.send_event(
+                HumanResponseEvent(response="root-ok"),  # type: ignore[reportCallIssue]
+                step="answer",
+            )
+    result = await handler
+    assert result == "root-ok"
+
+
+# --- Phase 3: one namespace lifecycle (teardown + bounded timeout recovery) ----
+
+
+def test_terminate_namespace_prefix_matches_descendants_only() -> None:
+    """One teardown clears a namespace and every descendant (prefix match),
+    leaving sibling/ancestor namespaces untouched."""
+    state = BrokerState.from_workflow(
+        _GrandParent(mid=_MidChild(grand=_GrandFanChild()))
+    )
+    root = StepId((), "start")
+    mid = StepId(("mid",), "start")
+    grand = StepId(("mid", "grand"), "fan")
+    mid_invocation = ("mid#abc",)
+    grand_invocation = ("mid#abc", "grand#def")
+    state.workers[root].queue.append(EventAttempt(event=_Item(n=1)))
+    state.workers[root].collected_events["buf"] = [_Item(n=1)]
+    state.workers[mid].queue.append(
+        EventAttempt(event=_Item(n=1), invocation_namespace=mid_invocation)
+    )
+    state.workers[mid].collected_events_by_invocation[mid_invocation] = {
+        "buf": [_Item(n=1)]
+    }
+    state.workers[grand].queue.append(
+        EventAttempt(event=_Item(n=1), invocation_namespace=grand_invocation)
+    )
+    state.workers[grand].collected_events_by_invocation[grand_invocation] = {
+        "buf": [_Item(n=1)]
+    }
+    state.streams["s-grand"] = CollectionStreamInstance(
+        stream_id="s-grand",
+        source_step=grand,
+        scope_path=(),
+        source_invocation_namespace=grand_invocation,
+        open_work_items=1,
+    )
+    state.namespace_started[()] = 1.0
+    state.namespace_started[mid_invocation] = 1.0
+    state.namespace_started[grand_invocation] = 1.0
+
+    terminate_namespace(state, mid_invocation)
+
+    # The child and grandchild are fully cleared.
+    for sid in (mid, grand):
+        assert not state.workers[sid].queue
+        assert not state.workers[sid].collected_events_by_invocation
+    assert mid_invocation not in state.namespace_started
+    assert grand_invocation not in state.namespace_started
+    assert "s-grand" not in state.streams
+    # The root (ancestor) is untouched.
+    assert state.workers[root].queue
+    assert state.workers[root].collected_events
+    assert () in state.namespace_started
+
+
+class _OrphanChildStart(StartEvent):
+    pass
+
+
+class _OrphanChildStop(StopEvent):
+    pass
+
+
+class _RecoveringSlowChild(Workflow):
+    @step
+    async def run_child(self, ev: _OrphanChildStart) -> _OrphanChildStop:
+        # Orphaned coroutine: still running well after the child's timeout fires.
+        await asyncio.sleep(2)
+        return _OrphanChildStop()
+
+    @catch_error
+    async def recover(self, ev: StepFailedEvent) -> _OrphanChildStop:
+        assert isinstance(ev.exception, WorkflowTimeoutError)
+        return _OrphanChildStop()
+
+
+class _SlowBranch(Event):
+    pass
+
+
+class _BranchDone(Event):
+    pass
+
+
+class _OrphanParent(Workflow):
+    child: _RecoveringSlowChild
+
+    @step
+    async def begin(
+        self, ctx: Context, ev: StartEvent
+    ) -> _OrphanChildStart | _SlowBranch:
+        # Fan out: trigger the child AND a parent branch that outlives the orphan.
+        ctx.send_event(_SlowBranch())
+        return _OrphanChildStart()
+
+    @step
+    async def slow_branch(self, ev: _SlowBranch) -> _BranchDone:
+        await asyncio.sleep(0.5)
+        return _BranchDone()
+
+    @step
+    async def finish(
+        self, ctx: Context, ev: _OrphanChildStop | _BranchDone
+    ) -> StopEvent | None:
+        got = ctx.collect_events(ev, [_OrphanChildStop, _BranchDone])
+        if got is None:
+            return None
+        return StopEvent(result="done")
+
+
+@pytest.mark.asyncio
+async def test_caught_child_timeout_cancels_orphan_no_loop_crash() -> None:
+    """A caught child timeout cancels the still-running child coroutine, so it
+    cannot later report into a torn-down worker slot and crash the loop with
+    'Worker not found in in_progress'. The run completes via recovery + the
+    parent branch."""
+    handler = _OrphanParent(child=_RecoveringSlowChild(timeout=0.05), timeout=30).run()
+    result = await asyncio.wait_for(handler, timeout=10)
+    assert result == "done"
+
+
+class _LeakChildStart(StartEvent):
+    pass
+
+
+class _LeakChildStop(StopEvent):
+    tag: str = ""
+
+
+class _FastPath(Event):
+    pass
+
+
+class _SlowPath(Event):
+    pass
+
+
+class _LeakChild(Workflow):
+    @step
+    async def begin(self, ctx: Context, ev: _LeakChildStart) -> _FastPath | _SlowPath:
+        ctx.send_event(_SlowPath())
+        return _FastPath()
+
+    @step
+    async def fast(self, ev: _FastPath) -> _LeakChildStop:
+        return _LeakChildStop(tag="fast")
+
+    @step
+    async def slow(self, ev: _SlowPath) -> _LeakChildStop:
+        await asyncio.sleep(0.3)
+        return _LeakChildStop(tag="slow")
+
+
+class _KeepAlive(Event):
+    pass
+
+
+class _LeakParent(Workflow):
+    child: _LeakChild
+
+    @step
+    async def begin(self, ctx: Context, ev: StartEvent) -> _LeakChildStart | _KeepAlive:
+        ctx.send_event(_KeepAlive())
+        return _LeakChildStart()
+
+    @step
+    async def observe(self, ctx: Context, ev: _LeakChildStop) -> None:
+        seen = await ctx.store.get("stops", default=0)
+        await ctx.store.set("stops", seen + 1)
+        return None
+
+    @step
+    async def keep_alive(self, ctx: Context, ev: _KeepAlive) -> StopEvent:
+        # Outlive the slow child sibling (0.3s); if a leak existed its second
+        # ChildStop would have surfaced by now.
+        await asyncio.sleep(0.6)
+        return StopEvent(result=await ctx.store.get("stops", default=0))
+
+
+@pytest.mark.asyncio
+async def test_child_stop_terminates_sibling_no_double_fire() -> None:
+    """A child that returns its StopEvent while a sibling branch is in flight
+    surfaces exactly one StopEvent to the parent — the boundary terminates the
+    whole child namespace, cancelling the slow sibling before it can fire a
+    second StopEvent."""
+    handler = _LeakParent(child=_LeakChild(), timeout=30).run()
+    result = await asyncio.wait_for(handler, timeout=10)
+    assert result == 1
+
+
+class _GTeardownGrandStart(StartEvent):
+    pass
+
+
+class _GTeardownGrandStop(StopEvent):
+    pass
+
+
+class _GTeardownGrand(Workflow):
+    @step
+    async def work(self, ev: _GTeardownGrandStart) -> _GTeardownGrandStop:
+        await asyncio.sleep(0.4)
+        return _GTeardownGrandStop()
+
+
+class _GTeardownChildStart(StartEvent):
+    pass
+
+
+class _GTeardownChildStop(StopEvent):
+    pass
+
+
+class _GTeardownFast(Event):
+    pass
+
+
+class _GTeardownChild(Workflow):
+    grand: _GTeardownGrand
+
+    @step
+    async def begin(
+        self, ctx: Context, ev: _GTeardownChildStart
+    ) -> _GTeardownGrandStart | _GTeardownFast:
+        # Trigger the slow grandchild AND a fast path that stops the child.
+        ctx.send_event(_GTeardownFast())
+        return _GTeardownGrandStart()
+
+    @step
+    async def stop_fast(self, ev: _GTeardownFast) -> _GTeardownChildStop:
+        return _GTeardownChildStop()
+
+    @step
+    async def absorb_grand(self, ctx: Context, ev: _GTeardownGrandStop) -> None:
+        # Would only fire if the grandchild leaked past the child's teardown.
+        await ctx.store.set("grand_leaked", True)
+        return None
+
+
+class _GTeardownParent(Workflow):
+    child: _GTeardownChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> _GTeardownChildStart:
+        return _GTeardownChildStart()
+
+    @step
+    async def finish(self, ev: _GTeardownChildStop) -> StopEvent:
+        return StopEvent(result="done")
+
+
+@pytest.mark.asyncio
+async def test_child_stop_tears_down_inflight_grandchild() -> None:
+    """When a child returns its StopEvent, an in-flight grandchild is torn down
+    with it (prefix teardown + task cancellation), so the grandchild's later
+    completion never surfaces and the run completes cleanly."""
+    handler = _GTeardownParent(child=_GTeardownChild(grand=_GTeardownGrand())).run()
+    result = await asyncio.wait_for(handler, timeout=10)
+    assert result == "done"
+    # Give a cancelled grandchild's 0.4s sleep time to (not) fire.
+    await asyncio.sleep(0.6)
+
+
+class _ReArmChildStart(StartEvent):
+    pass
+
+
+class _ReArmChildStop(StopEvent):
+    pass
+
+
+class _ReArmingChild(Workflow):
+    @step
+    async def run_child(self, ev: _ReArmChildStart) -> _ReArmChildStop:
+        await asyncio.sleep(2)  # always exceeds the child's own timeout
+        return _ReArmChildStop()
+
+    @catch_error(max_recoveries=2)
+    async def recover(self, ev: StepFailedEvent) -> _ReArmChildStart:
+        # Re-arm: re-trigger the child instead of stopping, so it times out
+        # again. Bounded by max_recoveries; otherwise it would loop forever.
+        return _ReArmChildStart()
+
+
+class _ReArmParent(Workflow):
+    child: _ReArmingChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> _ReArmChildStart:
+        return _ReArmChildStart()
+
+    @step
+    async def finish(self, ev: _ReArmChildStop) -> StopEvent:
+        return StopEvent(result="never")
+
+
+@pytest.mark.asyncio
+async def test_rearming_child_timeout_bounded_by_max_recoveries() -> None:
+    """A child whose @catch_error re-arms the timeout fails the run after
+    max_recoveries, instead of looping forever."""
+    handler = _ReArmParent(child=_ReArmingChild(timeout=0.05), timeout=30).run()
+    with pytest.raises(WorkflowTimeoutError):
+        await asyncio.wait_for(handler, timeout=10)

--- a/packages/llama-index-workflows/tests/test_child_workflow_namespaces.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_namespaces.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Tests for namespaced step enumeration across a child-workflow tree.
+
+The child-aware constructor is synthesized by ``WorkflowMeta`` at runtime, so
+the file-level pragmas suppress the expected static-typing diagnostics on the
+``child=`` keyword (see ``test_child_workflow_declaration.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from workflows import Workflow
+from workflows.decorators import step
+from workflows.errors import WorkflowValidationError
+from workflows.events import StartEvent, StopEvent
+from workflows.runtime.types.step_id import StepId
+
+
+class GrandStart(StartEvent):
+    payload: str = "g"
+
+
+class GrandStop(StopEvent):
+    out: str = "g"
+
+
+class GrandChild(Workflow):
+    @step
+    async def run_grand(self, ev: GrandStart) -> GrandStop:
+        return GrandStop(out=ev.payload)
+
+
+class MidStart(StartEvent):
+    payload: str = "m"
+
+
+class MidStop(StopEvent):
+    out: str = "m"
+
+
+class Mid(Workflow):
+    grand: GrandChild
+
+    @step
+    async def run_mid(self, ev: MidStart) -> MidStop:
+        return MidStop(out=ev.payload)
+
+
+class Root(Workflow):
+    mid: Mid
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="root done")
+
+
+class ChildStart(StartEvent):
+    payload: str = "c"
+
+
+class ChildStop(StopEvent):
+    out: str = "c"
+
+
+class Child(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        return ChildStop(out=ev.payload)
+
+
+class Parent(Workflow):
+    child: Child
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="parent done")
+
+
+def test_namespaced_steps_includes_child_under_field_path() -> None:
+    parent = Parent(child=Child())
+    assert set(parent._get_namespaced_steps()) == {
+        StepId.root("start"),
+        StepId(("child",), "run_child"),
+    }
+
+
+def test_namespace_instances_maps_paths_to_owning_instances() -> None:
+    child = Child()
+    parent = Parent(child=child)
+    instances = parent._namespace_instances()
+    assert instances[()] is parent
+    assert instances[("child",)] is child
+
+
+def test_grandchild_namespaced_as_flat_compound_tuple() -> None:
+    grand = GrandChild()
+    mid = Mid(grand=grand)
+    root = Root(mid=mid)
+
+    assert set(root._get_namespaced_steps()) == {
+        StepId.root("start"),
+        StepId(("mid",), "run_mid"),
+        StepId(("mid", "grand"), "run_grand"),
+    }
+    instances = root._namespace_instances()
+    assert instances[()] is root
+    assert instances[("mid",)] is mid
+    assert instances[("mid", "grand")] is grand
+
+
+def test_static_class_path_matches_runtime_set() -> None:
+    """The static (no-instantiation) walk derives the same StepId set."""
+    root = Root(mid=Mid(grand=GrandChild()))
+    assert set(Root._get_namespaced_steps_from_class()) == set(
+        root._get_namespaced_steps()
+    )
+
+
+def test_childless_workflow_only_root_namespace() -> None:
+    assert set(Child()._get_namespaced_steps()) == {StepId.root("run_child")}
+    assert set(GrandChild._get_namespaced_steps_from_class()) == {
+        StepId.root("run_grand")
+    }
+
+
+# --- graph validation -------------------------------------------------------
+
+
+def test_valid_child_tree_validates() -> None:
+    Parent(child=Child()).validate()
+    Root(mid=Mid(grand=GrandChild())).validate()
+
+
+class SelfReferential(Workflow):
+    me: SelfReferential
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="x")
+
+
+def test_self_referential_child_type_rejected() -> None:
+    with pytest.raises(WorkflowValidationError, match="type cycle"):
+        SelfReferential().validate()  # type: ignore  # self-referential child is uninstantiable
+
+
+class DupChildA(Workflow):
+    @step
+    async def a(self, ev: ChildStart) -> ChildStop:
+        return ChildStop()
+
+
+class DupChildB(Workflow):
+    @step
+    async def b(self, ev: ChildStart) -> ChildStop:
+        return ChildStop()
+
+
+class DupParent(Workflow):
+    x: DupChildA
+    y: DupChildB
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="x")
+
+
+def test_duplicate_child_start_event_type_rejected() -> None:
+    parent = DupParent(x=DupChildA(), y=DupChildB())
+    with pytest.raises(WorkflowValidationError, match="both accept StartEvent type"):
+        parent.validate()

--- a/packages/llama-index-workflows/tests/test_child_workflow_resume.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_resume.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Phase 4: one ``to_dict()`` blob checkpoints the whole child tree, and resume
+skips steps that already completed (children included)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from workflows import Context, Workflow
+from workflows.context.state_store import CHILD_STATES_KEY
+from workflows.decorators import step
+from workflows.events import (
+    HumanResponseEvent,
+    InputRequiredEvent,
+    StartEvent,
+    StopEvent,
+)
+from workflows.testing import WorkflowTestRunner
+
+# Module-level run counters; each test resets the keys it uses. Proving a step
+# was not re-run on resume requires counting executions across the run boundary,
+# which an instance attribute (kept alive across resume) would hide.
+RUN_COUNTS: dict[str, int] = {}
+
+
+class ChildStart(StartEvent):
+    payload: str = ""
+
+
+class ChildStop(StopEvent):
+    out: str = ""
+
+
+class CountingChild(Workflow):
+    @step
+    async def run_child(self, ctx: Context, ev: ChildStart) -> ChildStop:
+        RUN_COUNTS["child"] = RUN_COUNTS.get("child", 0) + 1
+        await ctx.store.set("child_ran", True)
+        return ChildStop(out=ev.payload.upper())
+
+
+class HitlParent(Workflow):
+    child: CountingChild
+
+    @step
+    async def start(self, ev: StartEvent) -> ChildStart:
+        return ChildStart(payload="hello")
+
+    @step
+    async def gather(self, ctx: Context, ev: ChildStop) -> InputRequiredEvent:
+        # Child has completed by now; stash its output and pause for a human.
+        await ctx.store.set("from_child", ev.out)
+        return InputRequiredEvent(prefix="continue?")  # type: ignore  # dynamic event kwarg
+
+    @step
+    async def complete(self, ctx: Context, ev: HumanResponseEvent) -> StopEvent:
+        from_child = await ctx.store.get("from_child")
+        return StopEvent(result=f"{from_child}:{ev.response}")
+
+
+@pytest.mark.asyncio
+async def test_kill_after_child_completes_resume_does_not_rerun_child() -> None:
+    RUN_COUNTS.pop("child", None)
+    workflow = HitlParent(child=CountingChild())
+
+    handler = workflow.run()
+    assert handler.ctx is not None
+
+    ctx_dict = None
+    async for event in handler.stream_events():
+        if isinstance(event, InputRequiredEvent):
+            ctx_dict = handler.ctx.to_dict()
+            await handler.cancel_run()
+            await asyncio.sleep(0.01)
+            break
+
+    assert ctx_dict is not None
+    # The child ran exactly once before the checkpoint.
+    assert RUN_COUNTS["child"] == 1
+
+    # Resume from the single blob and feed the human response.
+    new_handler = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))
+    new_handler.ctx.send_event(HumanResponseEvent(response="42"))  # type: ignore  # dynamic event kwarg
+    result = await new_handler
+    assert result == "HELLO:42"
+
+    # The already-completed child step did NOT re-run on resume.
+    assert RUN_COUNTS["child"] == 1
+
+
+# --- Grandchild single-blob round-trip ----------------------------------------
+
+
+class GrandStart(StartEvent):
+    payload: str = ""
+
+
+class GrandStop(StopEvent):
+    out: str = ""
+
+
+class Grand(Workflow):
+    @step
+    async def run_grand(self, ctx: Context, ev: GrandStart) -> GrandStop:
+        await ctx.store.set("grand_value", ev.payload + "!")
+        return GrandStop(out=ev.payload + "!")
+
+
+class MidStart(StartEvent):
+    payload: str = ""
+
+
+class MidStop(StopEvent):
+    out: str = ""
+
+
+class Mid(Workflow):
+    grand: Grand
+
+    @step
+    async def begin(self, ctx: Context, ev: MidStart) -> GrandStart:
+        await ctx.store.set("mid_value", ev.payload)
+        return GrandStart(payload=ev.payload)
+
+    @step
+    async def end(self, ev: GrandStop) -> MidStop:
+        return MidStop(out=ev.out)
+
+
+class Top(Workflow):
+    mid: Mid
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> MidStart:
+        await ctx.store.set("top_value", "g")
+        return MidStart(payload="g")
+
+    @step
+    async def finish(self, ev: MidStop) -> StopEvent:
+        return StopEvent(result=ev.out)
+
+
+@pytest.mark.asyncio
+async def test_completed_grandchild_state_is_not_carried_forward() -> None:
+    top = Top(mid=Mid(grand=Grand()))
+    ctx = Context(top)
+    result = await top.run(ctx=ctx)
+    assert result == "g!"
+
+    blob = ctx.to_dict()
+    assert CHILD_STATES_KEY not in blob["state"]
+
+    # from_dict round-trips the completed root context without stale child state.
+    restored = Context.from_dict(top, blob)
+    assert restored is not None
+
+
+@pytest.mark.asyncio
+async def test_grandchild_runs_end_to_end_with_explicit_context() -> None:
+    """Sanity: the 3-level tree runs with a user-provided Context."""
+    top = Top(mid=Mid(grand=Grand()))
+    res = await WorkflowTestRunner(top).run()
+    assert res.result == "g!"

--- a/packages/llama-index-workflows/tests/test_child_workflow_state.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_state.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Phase 4: each namespace gets its own state store, so a child's state writes
+are invisible to the parent (and vice versa)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+from workflows import Context, Workflow
+from workflows.decorators import step
+from workflows.events import StartEvent, StopEvent
+from workflows.testing import WorkflowTestRunner
+
+
+class CStart(StartEvent):
+    pass
+
+
+class CStop(StopEvent):
+    val: str = ""
+
+
+class IsoChild(Workflow):
+    @step
+    async def run_child(self, ctx: Context, ev: CStart) -> CStop:
+        # The parent's key must not be visible inside the child's store.
+        assert await ctx.store.get("parent_key", None) is None
+        await ctx.store.set("secret", "child-only")
+        return CStop(val="ok")
+
+
+class IsoParent(Workflow):
+    child: IsoChild
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> CStart:
+        await ctx.store.set("parent_key", "parent-only")
+        return CStart()
+
+    @step
+    async def finish(self, ctx: Context, ev: CStop) -> StopEvent:
+        # The child's key must not leak into the parent's store.
+        assert await ctx.store.get("secret", None) is None
+        return StopEvent(result=await ctx.store.get("parent_key"))
+
+
+@pytest.mark.asyncio
+async def test_child_state_invisible_to_parent() -> None:
+    result = await WorkflowTestRunner(IsoParent(child=IsoChild())).run()
+    assert result.result == "parent-only"
+    # The handler's (root) store sees only the parent's writes.
+    assert await result.ctx.store.get("parent_key") == "parent-only"
+    assert await result.ctx.store.get("secret", None) is None
+
+
+# --- Distinct typed state per namespace ---------------------------------------
+
+
+class ParentState(BaseModel):
+    p: int = 0
+
+
+class TypedChildState(BaseModel):
+    c: str = ""
+
+
+class TStart(StartEvent):
+    pass
+
+
+class TStop(StopEvent):
+    out: str = ""
+
+
+class TypedChild(Workflow):
+    @step
+    async def run_child(self, ctx: Context[TypedChildState], ev: TStart) -> TStop:
+        async with ctx.store.edit_state() as s:
+            s.c = "child-typed"
+        return TStop(out="done")
+
+
+class TypedParent(Workflow):
+    child: TypedChild
+
+    @step
+    async def start(self, ctx: Context[ParentState], ev: StartEvent) -> TStart:
+        async with ctx.store.edit_state() as s:
+            s.p = 7
+        return TStart()
+
+    @step
+    async def finish(self, ctx: Context[ParentState], ev: TStop) -> StopEvent:
+        s = await ctx.store.get_state()
+        return StopEvent(result=s.p)
+
+
+@pytest.mark.asyncio
+async def test_distinct_typed_state_per_namespace() -> None:
+    """Parent and child carry different typed state models in one run."""
+    result = await WorkflowTestRunner(TypedParent(child=TypedChild())).run()
+    assert result.result == 7
+    root_state = await result.ctx.store.get_state()
+    assert isinstance(root_state, ParentState)
+    assert root_state.p == 7

--- a/packages/llama-index-workflows/tests/test_child_workflow_step_names.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_step_names.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Public string projections of a child step's identity.
+
+A child step's :class:`StepId` stringifies to a ``/``-joined namespace path
+(``child/run_child``, ``mid/grand/run_grand``). The events that expose step
+identity as a plain ``str`` -- notably ``WorkflowFailedEvent.step_name`` -- now
+carry that compound form for child steps. These tests pin that contract so a
+consumer (logging, telemetry, a UI) knows what to expect, and so the projection
+is not silently changed back to a bare name.
+"""
+
+from __future__ import annotations
+
+import pytest
+from workflows import Context, Workflow
+from workflows.decorators import catch_error, step
+from workflows.events import (
+    Event,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+    WorkflowFailedEvent,
+)
+from workflows.handler import WorkflowHandler
+
+
+class ChildStart(StartEvent):
+    pass
+
+
+class ChildStop(StopEvent):
+    pass
+
+
+class FailingChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        raise ValueError("boom-in-child")
+
+
+class ParentOfFailingChild(Workflow):
+    child: FailingChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="never")
+
+
+async def _collect_until_done(handler: WorkflowHandler) -> list[Event]:
+    events: list[Event] = []
+    async for ev in handler.stream_events():
+        events.append(ev)
+    return events
+
+
+@pytest.mark.asyncio
+async def test_child_step_failure_event_carries_namespaced_step_name() -> None:
+    """A failing child step surfaces a (root-origin) WorkflowFailedEvent whose
+    ``step_name`` is the slash-joined ``child/run_child`` -- not the bare name."""
+    handler = ParentOfFailingChild(child=FailingChild()).run()
+    events = await _collect_until_done(handler)
+
+    with pytest.raises(ValueError, match="boom-in-child"):
+        await handler
+
+    failed = [ev for ev in events if isinstance(ev, WorkflowFailedEvent)]
+    assert len(failed) == 1
+    assert failed[0].step_name == "child/run_child"
+
+
+# --- Grandchild: compound namespace in the projection ------------------------
+
+
+class GrandStart(StartEvent):
+    pass
+
+
+class GrandStop(StopEvent):
+    pass
+
+
+class MidStart(StartEvent):
+    pass
+
+
+class MidStop(StopEvent):
+    pass
+
+
+class FailingGrandChild(Workflow):
+    @step
+    async def run_grand(self, ev: GrandStart) -> GrandStop:
+        raise ValueError("boom-in-grandchild")
+
+
+class MidWithGrandChild(Workflow):
+    grand: FailingGrandChild
+
+    @step
+    async def begin(self, ev: MidStart) -> GrandStart:
+        return GrandStart()
+
+    @step
+    async def finish(self, ev: GrandStop) -> MidStop:
+        return MidStop()
+
+
+class TopWithGrandChild(Workflow):
+    mid: MidWithGrandChild
+
+    @step
+    async def begin(self, ctx: Context, ev: StartEvent) -> MidStart:
+        return MidStart()
+
+    @step
+    async def finish(self, ev: MidStop) -> StopEvent:
+        return StopEvent(result="never")
+
+
+@pytest.mark.asyncio
+async def test_grandchild_step_failure_event_carries_compound_namespace() -> None:
+    """A failing grandchild step's ``step_name`` is the full compound path
+    ``mid/grand/run_grand``."""
+    handler = TopWithGrandChild(mid=MidWithGrandChild(grand=FailingGrandChild())).run()
+    events = await _collect_until_done(handler)
+
+    with pytest.raises(ValueError, match="boom-in-grandchild"):
+        await handler
+
+    failed = [ev for ev in events if isinstance(ev, WorkflowFailedEvent)]
+    assert len(failed) == 1
+    assert failed[0].step_name == "mid/grand/run_grand"
+
+
+# --- @catch_error on a child recovers the child's own steps -------------------
+
+
+class RecoveringChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        raise ValueError("boom-in-child")
+
+    @catch_error
+    async def recover(self, ev: StepFailedEvent) -> ChildStop:
+        # The child's handler recovers the child's failing step and emits the
+        # child's StopEvent, which crosses the boundary back into the parent.
+        return ChildStop()
+
+
+class ParentOfRecoveringChild(Workflow):
+    child: RecoveringChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="recovered")
+
+
+def test_child_catch_error_handler_attaches_without_warning() -> None:
+    """A child declaring @catch_error attaches silently; its handlers run when
+    nested (see the recovery test below)."""
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ParentOfRecoveringChild(child=RecoveringChild())
+
+
+@pytest.mark.asyncio
+async def test_child_catch_error_handler_recovers_when_nested() -> None:
+    """The child's @catch_error handler recovers its own failing step: the child
+    StopEvent crosses back into the parent and the run completes."""
+    handler = ParentOfRecoveringChild(child=RecoveringChild()).run()
+    events = await _collect_until_done(handler)
+
+    result = await handler
+    assert result == "recovered"
+
+    # No run-level failure: the child failure was caught within its namespace.
+    failed = [ev for ev in events if isinstance(ev, WorkflowFailedEvent)]
+    assert failed == []

--- a/packages/llama-index-workflows/tests/test_child_workflow_streaming.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_streaming.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Phase 5: child streams are tagged by namespace origin and filtered out of the
+parent stream by default.
+
+A parent consumer calling ``handler.stream_events()`` sees only root-origin
+events; ``stream_events(include_children=True)`` surfaces child events tagged
+with the namespace path of the child execution that produced them.
+"""
+
+from __future__ import annotations
+
+import pytest
+from workflows import Context, Workflow
+from workflows.decorators import step
+from workflows.events import (
+    Event,
+    StartEvent,
+    StopEvent,
+    get_event_origin_namespace,
+)
+
+
+class ChildStart(StartEvent):
+    pass
+
+
+class ChildStop(StopEvent):
+    pass
+
+
+class ChildPing(Event):
+    msg: str = ""
+
+
+class ParentPing(Event):
+    msg: str = ""
+
+
+class StreamChild(Workflow):
+    @step
+    async def run_child(self, ctx: Context, ev: ChildStart) -> ChildStop:
+        ctx.write_event_to_stream(ChildPing(msg="from-child"))
+        return ChildStop()
+
+
+class StreamParent(Workflow):
+    child: StreamChild
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> ChildStart:
+        ctx.write_event_to_stream(ParentPing(msg="from-parent"))
+        return ChildStart()
+
+    @step
+    async def finish(self, ctx: Context, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="done")
+
+
+@pytest.mark.asyncio
+async def test_child_events_hidden_from_parent_stream_by_default() -> None:
+    """The default stream is backward compatible: a parent consumer sees its own
+    streamed events but none published from inside the child."""
+    handler = StreamParent(child=StreamChild()).run()
+    collected: list[Event] = []
+    async for ev in handler.stream_events():
+        collected.append(ev)
+    await handler
+
+    assert any(isinstance(ev, ParentPing) for ev in collected)
+    assert not any(isinstance(ev, ChildPing) for ev in collected)
+    # Every surfaced event is root-origin.
+    assert all(get_event_origin_namespace(ev) == () for ev in collected)
+
+
+@pytest.mark.asyncio
+async def test_child_events_surfaced_tagged_with_include_children() -> None:
+    """Opt-in surfaces child events, tagged with the child's namespace path."""
+    handler = StreamParent(child=StreamChild()).run()
+    collected: list[Event] = []
+    async for ev in handler.stream_events(include_children=True):
+        collected.append(ev)
+    await handler
+
+    parent_ping = next(ev for ev in collected if isinstance(ev, ParentPing))
+    child_ping = next(ev for ev in collected if isinstance(ev, ChildPing))
+
+    assert get_event_origin_namespace(parent_ping) == ()
+    child_origin = get_event_origin_namespace(child_ping)
+    assert len(child_origin) == 1
+    assert child_origin[0].startswith("child#")
+
+
+# --- Grandchild: compound namespace tag ---------------------------------------
+
+
+class GrandStart(StartEvent):
+    pass
+
+
+class GrandStop(StopEvent):
+    pass
+
+
+class GrandPing(Event):
+    pass
+
+
+class MidStart(StartEvent):
+    pass
+
+
+class MidStop(StopEvent):
+    pass
+
+
+class GrandStream(Workflow):
+    @step
+    async def run_grand(self, ctx: Context, ev: GrandStart) -> GrandStop:
+        ctx.write_event_to_stream(GrandPing())
+        return GrandStop()
+
+
+class MidStream(Workflow):
+    grand: GrandStream
+
+    @step
+    async def begin(self, ev: MidStart) -> GrandStart:
+        return GrandStart()
+
+    @step
+    async def end(self, ev: GrandStop) -> MidStop:
+        return MidStop()
+
+
+class TopStream(Workflow):
+    mid: MidStream
+
+    @step
+    async def start(self, ev: StartEvent) -> MidStart:
+        return MidStart()
+
+    @step
+    async def finish(self, ev: MidStop) -> StopEvent:
+        return StopEvent(result="done")
+
+
+@pytest.mark.asyncio
+async def test_grandchild_event_tagged_with_compound_namespace() -> None:
+    handler = TopStream(mid=MidStream(grand=GrandStream())).run()
+    collected: list[Event] = []
+    async for ev in handler.stream_events(include_children=True):
+        collected.append(ev)
+    await handler
+
+    grand_ping = next(ev for ev in collected if isinstance(ev, GrandPing))
+    grand_origin = get_event_origin_namespace(grand_ping)
+    assert len(grand_origin) == 2
+    assert grand_origin[0].startswith("mid#")
+    assert grand_origin[1].startswith("grand#")
+
+
+@pytest.mark.asyncio
+async def test_grandchild_event_hidden_by_default() -> None:
+    handler = TopStream(mid=MidStream(grand=GrandStream())).run()
+    collected: list[Event] = []
+    async for ev in handler.stream_events():
+        collected.append(ev)
+    await handler
+
+    assert not any(isinstance(ev, GrandPing) for ev in collected)

--- a/packages/llama-index-workflows/tests/test_child_workflow_timeout.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_timeout.py
@@ -1,0 +1,287 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Per-child-namespace timeouts.
+
+A child's ``timeout`` bounds that child's execution on its own clock: expiry
+fails the child through the namespaced catch-error path (so the child's
+``@catch_error`` can recover it), and only an uncaught child timeout — or the
+root timeout — fails the whole run. The parent's (longer) timeout never
+pre-empts a child's shorter one, and vice versa.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from workflows import Context, Workflow
+from workflows.context.serializers import JsonSerializer
+from workflows.decorators import catch_error, step
+from workflows.errors import WorkflowTimeoutError
+from workflows.events import (
+    Event,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+    WorkflowTimedOutEvent,
+    get_event_origin_namespace,
+)
+from workflows.runtime.types.internal_state import BrokerState
+from workflows.workflow import DEFAULT_TIMEOUT
+
+RESUME_CHILD_STARTED: asyncio.Event | None = None
+
+
+class ChildStart(StartEvent):
+    pass
+
+
+class ChildStop(StopEvent):
+    pass
+
+
+class SlowChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        await asyncio.sleep(5)  # far exceeds the child's own timeout
+        return ChildStop()
+
+
+class ParentOfSlowChild(Workflow):
+    child: SlowChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="never")
+
+
+@pytest.mark.asyncio
+async def test_child_times_out_on_its_own_clock_and_fails_run_when_uncaught() -> None:
+    # Child bound to 0.1s; parent bound to a much longer 30s. The child must time
+    # out on its own clock (well before its 5s step and before the parent's 30s),
+    # and with no handler the uncaught timeout fails the whole run.
+    handler = ParentOfSlowChild(child=SlowChild(timeout=0.1), timeout=30).run()
+    with pytest.raises(WorkflowTimeoutError):
+        await handler
+
+
+@pytest.mark.asyncio
+async def test_uncaught_child_timeout_is_visible_on_default_stream() -> None:
+    handler = ParentOfSlowChild(child=SlowChild(timeout=0.1), timeout=30).run()
+    collected: list[Event] = []
+    async for ev in handler.stream_events():
+        collected.append(ev)
+
+    with pytest.raises(WorkflowTimeoutError):
+        await handler
+
+    timeout = next(ev for ev in collected if isinstance(ev, WorkflowTimedOutEvent))
+    assert get_event_origin_namespace(timeout) == ()
+
+
+class RecoveringSlowChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        await asyncio.sleep(5)
+        return ChildStop()
+
+    @catch_error
+    async def recover(self, ev: StepFailedEvent) -> ChildStop:
+        # Catches the WorkflowTimeoutError routed through the namespaced path and
+        # emits the child's StopEvent, which crosses back into the parent.
+        assert isinstance(ev.exception, WorkflowTimeoutError)
+        return ChildStop()
+
+
+class ParentOfRecoveringSlowChild(Workflow):
+    child: RecoveringSlowChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="recovered")
+
+
+@pytest.mark.asyncio
+async def test_child_timeout_is_caught_by_child_catch_error() -> None:
+    handler = ParentOfRecoveringSlowChild(
+        child=RecoveringSlowChild(timeout=0.1), timeout=30
+    ).run()
+    result = await handler
+    assert result == "recovered"
+
+
+class FastDoneChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        return ChildStop()
+
+
+class ParentOfFastChild(Workflow):
+    child: FastDoneChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="ok")
+
+
+@pytest.mark.asyncio
+async def test_child_under_its_timeout_completes_normally() -> None:
+    # Regression guard: a child that finishes well within its timeout is not
+    # spuriously failed, and the per-namespace deadline tick is a no-op.
+    handler = ParentOfFastChild(child=FastDoneChild(timeout=5), timeout=30).run()
+    assert await handler == "ok"
+
+
+# --- Grandchild: a compound namespace times out on its own clock --------------
+
+
+class GrandStart(StartEvent):
+    pass
+
+
+class GrandStop(StopEvent):
+    pass
+
+
+class MidStart(StartEvent):
+    pass
+
+
+class MidStop(StopEvent):
+    pass
+
+
+class SlowGrandchild(Workflow):
+    @step
+    async def run_grand(self, ev: GrandStart) -> GrandStop:
+        await asyncio.sleep(5)
+        return GrandStop()
+
+
+class MidWithSlowGrand(Workflow):
+    grand: SlowGrandchild
+
+    @step
+    async def begin(self, ev: MidStart) -> GrandStart:
+        return GrandStart()
+
+    @step
+    async def finish(self, ev: GrandStop) -> MidStop:
+        return MidStop()
+
+
+class TopOfSlowGrand(Workflow):
+    mid: MidWithSlowGrand
+
+    @step
+    async def begin(self, ev: StartEvent) -> MidStart:
+        return MidStart()
+
+    @step
+    async def finish(self, ev: MidStop) -> StopEvent:
+        return StopEvent(result="never")
+
+
+# --- Default resolution: root keeps 45s, an unset child gets no deadline -------
+
+
+def test_unset_child_arms_no_deadline_root_keeps_default() -> None:
+    # A child constructed without a timeout defers to its parent: no per-namespace
+    # deadline is armed, while the root still resolves to the 45s default.
+    state = BrokerState.from_workflow(ParentOfSlowChild(child=SlowChild()))
+    assert state.config.namespace_timeouts == {}
+    assert state.config.timeout == DEFAULT_TIMEOUT
+
+
+def test_explicit_child_timeout_arms_namespace_deadline() -> None:
+    state = BrokerState.from_workflow(ParentOfSlowChild(child=SlowChild(timeout=0.1)))
+    assert state.config.namespace_timeouts == {("child",): 0.1}
+
+
+def test_active_namespace_timeout_activation_round_trips() -> None:
+    workflow = ParentOfSlowChild(child=SlowChild(timeout=0.1))
+    state = BrokerState.from_workflow(workflow)
+    state.namespace_started[("child",)] = 123.0
+
+    serialized = state.to_serialized(JsonSerializer())
+    restored = BrokerState.from_serialized(serialized, workflow, JsonSerializer())
+
+    assert restored.namespace_started == {("child",): 123.0}
+
+
+def test_explicit_child_none_timeout_arms_no_deadline() -> None:
+    # Explicit None means "no deadline" — same armed state as unset, but chosen.
+    state = BrokerState.from_workflow(ParentOfSlowChild(child=SlowChild(timeout=None)))
+    assert state.config.namespace_timeouts == {}
+
+
+def test_root_timeout_resolution() -> None:
+    # Unset root → 45s default; explicit None → no root deadline.
+    assert (
+        BrokerState.from_workflow(ParentOfSlowChild(child=SlowChild())).config.timeout
+        == DEFAULT_TIMEOUT
+    )
+    explicit_none = ParentOfSlowChild(child=SlowChild(), timeout=None)
+    assert BrokerState.from_workflow(explicit_none).config.timeout is None
+
+
+@pytest.mark.asyncio
+async def test_grandchild_times_out_on_its_own_clock() -> None:
+    # The grandchild (compound namespace ("mid", "grand")) is bound to 0.1s while
+    # mid and top run with longer timeouts; the grandchild deadline fires first.
+    handler = TopOfSlowGrand(
+        mid=MidWithSlowGrand(grand=SlowGrandchild(timeout=0.1))
+    ).run()
+    with pytest.raises(WorkflowTimeoutError):
+        await handler
+
+
+class ResumeSlowChild(Workflow):
+    @step
+    async def run_child(self, ev: ChildStart) -> ChildStop:
+        assert RESUME_CHILD_STARTED is not None
+        RESUME_CHILD_STARTED.set()
+        await asyncio.sleep(5)
+        return ChildStop()
+
+
+class ParentOfResumeSlowChild(Workflow):
+    child: ResumeSlowChild
+
+    @step
+    async def begin(self, ev: StartEvent) -> ChildStart:
+        return ChildStart()
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result="never")
+
+
+@pytest.mark.asyncio
+async def test_child_timeout_is_rearmed_from_original_start_on_resume() -> None:
+    global RESUME_CHILD_STARTED
+    RESUME_CHILD_STARTED = asyncio.Event()
+    workflow = ParentOfResumeSlowChild(child=ResumeSlowChild(timeout=0.2), timeout=30)
+
+    handler = workflow.run()
+    await asyncio.wait_for(RESUME_CHILD_STARTED.wait(), timeout=1)
+    assert handler.ctx is not None
+    ctx_dict = handler.ctx.to_dict()
+    await handler.cancel_run()
+
+    await asyncio.sleep(0.3)
+    resumed = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))
+    with pytest.raises(WorkflowTimeoutError):
+        await asyncio.wait_for(resumed, timeout=0.1)

--- a/packages/llama-index-workflows/tests/test_child_workflow_validation.py
+++ b/packages/llama-index-workflows/tests/test_child_workflow_validation.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import pytest
+from workflows import Workflow, step
+from workflows.errors import WorkflowValidationError
+from workflows.events import StartEvent, StopEvent
+
+
+class ChildStart(StartEvent):
+    pass
+
+
+class ChildStop(StopEvent):
+    pass
+
+
+class OtherChildStop(StopEvent):
+    pass
+
+
+class FirstChild(Workflow):
+    @step
+    async def first(self, ev: ChildStart) -> ChildStop:
+        return ChildStop()
+
+
+class SecondChild(Workflow):
+    @step
+    async def second(self, ev: ChildStart) -> OtherChildStop:
+        return OtherChildStop()
+
+
+class ParentWithDuplicateChildStarts(Workflow):
+    first: FirstChild
+    second: SecondChild
+
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent()
+
+
+def test_duplicate_direct_child_start_event_validation_error() -> None:
+    wf = ParentWithDuplicateChildStarts(first=FirstChild(), second=SecondChild())
+
+    with pytest.raises(
+        WorkflowValidationError,
+        match=(
+            "Child workflows 'first' and 'second'.*"
+            "both accept StartEvent type 'ChildStart'"
+        ),
+    ):
+        wf.validate()
+
+
+class CycleAStart(StartEvent):
+    pass
+
+
+class CycleAStop(StopEvent):
+    pass
+
+
+class CycleBStart(StartEvent):
+    pass
+
+
+class CycleBStop(StopEvent):
+    pass
+
+
+class CycleA(Workflow):
+    @step
+    async def a_step(self, ev: CycleAStart) -> CycleAStop:
+        return CycleAStop()
+
+
+class CycleB(Workflow):
+    a: CycleA
+
+    @step
+    async def b_step(self, ev: CycleBStart) -> CycleBStop:
+        return CycleBStop()
+
+
+def test_child_workflow_type_cycle_validation_error() -> None:
+    CycleA.__annotations__["b"] = CycleB
+    CycleA._child_workflow_slots_cache = None
+    try:
+        with pytest.raises(
+            WorkflowValidationError,
+            match=("Child workflow type cycle detected: CycleA -> CycleB -> CycleA"),
+        ):
+            CycleA().validate()
+    finally:
+        CycleA.__annotations__.pop("b", None)
+        CycleA._child_workflow_slots_cache = None

--- a/packages/llama-index-workflows/tests/test_collection_stream_liveness_model.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_liveness_model.py
@@ -69,10 +69,11 @@ def _state() -> BrokerState:
 def _open_stream(state: BrokerState, open_work_items: int) -> CollectionStreamInstance:
     stream = CollectionStreamInstance(
         stream_id="stream-test",
-        source_step="fan_out",
+        source_step=StepId.root("fan_out"),
         scope_path=(),
         accepting_binding_ids=tuple(
-            binding.id for binding in state.config.bindings_for_source("fan_out")
+            binding.id
+            for binding in state.config.bindings_for_source(StepId.root("fan_out"))
         ),
         open_work_items=open_work_items,
     )
@@ -83,8 +84,8 @@ def _open_stream(state: BrokerState, open_work_items: int) -> CollectionStreamIn
 def test_count_accepting_steps_is_work_item_fan_out_factor() -> None:
     state = _state()
     # Task is accepted by exactly one step (work); Done by two collects.
-    assert _count_accepting_steps(state, Task) == 1
-    assert _count_accepting_steps(state, Done) == 2
+    assert _count_accepting_steps(state, Task(n=0), ()) == 1
+    assert _count_accepting_steps(state, Done(n=0), ()) == 2
 
 
 def _release_targets(commands: list[WorkflowCommand]) -> list[str]:
@@ -117,7 +118,7 @@ def test_full_two_collect_stream_drains_to_close() -> None:
     """
     state = _state()
     members = [Task(n=i) for i in range(3)]
-    seed = sum(_count_accepting_steps(state, type(m)) for m in members)
+    seed = sum(_count_accepting_steps(state, m, ()) for m in members)
     _open_stream(state, open_work_items=seed)
     assert seed == 3
 
@@ -125,7 +126,10 @@ def test_full_two_collect_stream_drains_to_close() -> None:
     for _ in range(3):
         assert (
             _adjust_open_work_items(
-                state, "stream-test", _count_accepting_steps(state, Done) - 1, 0.0
+                state,
+                "stream-test",
+                _count_accepting_steps(state, Done(n=0), ()) - 1,
+                0.0,
             )
             == []
         )
@@ -170,8 +174,8 @@ def test_unreleased_release_buffer_serializes_and_fires_on_close() -> None:
     stream = _open_stream(state, open_work_items=1)
     binding = next(
         b
-        for b in state.config.bindings_for_source("fan_out")
-        if b.target_step == "collect_a"
+        for b in state.config.bindings_for_source(StepId.root("fan_out"))
+        if b.target_step == StepId.root("collect_a")
     )
     key = f"{stream.stream_id}:{binding.id}"
     state.collection_release_states[key] = CollectionReleaseState(
@@ -190,7 +194,7 @@ def test_unreleased_release_buffer_serializes_and_fires_on_close() -> None:
     commands = _close_collection_stream(restored, stream.stream_id, 0.0)
     assert _release_targets(commands) == ["collect_a", "collect_b"]
     payload = (
-        restored.workers["collect_a"]
+        restored.workers[StepId.root("collect_a")]
         .in_progress[0]
         .shared_state.collection_release_payload
     )

--- a/packages/llama-index-workflows/tests/test_collection_stream_loudness.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_loudness.py
@@ -151,7 +151,7 @@ def _leaked_stream_state() -> BrokerState:
     state.is_running = True
     state.streams["stream-x"] = CollectionStreamInstance(
         stream_id="stream-x",
-        source_step="fan_out",
+        source_step=StepId.root("fan_out"),
         scope_path=("stream-x",),
         open_work_items=1,
     )
@@ -212,7 +212,7 @@ def _waiter(scope_path: tuple[str, ...]) -> StepWorkerWaiter:
 
 def test_idle_check_with_in_stream_waiter_publishes_idle_not_failure() -> None:
     state = _leaked_stream_state()
-    state.workers["work"].collected_waiters.append(_waiter(("stream-x",)))
+    state.workers[StepId.root("work")].collected_waiters.append(_waiter(("stream-x",)))
     _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
 
     assert not any(isinstance(c, CommandFailWorkflow) for c in commands), commands
@@ -233,7 +233,7 @@ def test_idle_check_with_out_of_stream_waiter_still_fails_run() -> None:
     attempt counters — this is not an exhausted step attempt.
     """
     state = _leaked_stream_state()
-    state.workers["work"].collected_waiters.append(_waiter(()))
+    state.workers[StepId.root("work")].collected_waiters.append(_waiter(()))
     _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
 
     failures = [c for c in commands if isinstance(c, CommandFailWorkflow)]

--- a/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
+++ b/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
@@ -12,6 +12,7 @@ from workflows.decorators import step as free_step
 from workflows.errors import WorkflowValidationError
 from workflows.events import Event, StartEvent, StepFailedEvent, StopEvent
 from workflows.runtime.types.internal_state import BrokerState, EventAttempt
+from workflows.runtime.types.step_id import StepId
 
 
 class Header(Event):
@@ -376,7 +377,7 @@ def test_collect_mode_state_serializes_static_buffers() -> None:
     workflow = SerializeWorkflow()
     serializer = JsonSerializer()
     state = BrokerState.from_workflow(workflow)
-    worker = state.workers["assemble"]
+    worker = state.workers[StepId.root("assemble")]
     worker.static_collect_events.append(Header(value="pending"))
     worker.queue.append(
         EventAttempt(
@@ -393,7 +394,7 @@ def test_collect_mode_state_serializes_static_buffers() -> None:
         workflow,
         serializer,
     )
-    restored_worker = restored.workers["assemble"]
+    restored_worker = restored.workers[StepId.root("assemble")]
 
     assert restored_worker.static_collect_events == [Header(value="pending")]
     assert restored_worker.queue[0].bound_events == {

--- a/packages/llama-index-workflows/tests/test_namespaced_state_builder.py
+++ b/packages/llama-index-workflows/tests/test_namespaced_state_builder.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Unit tests for the per-namespace state router and seed distribution."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel
+from workflows import Context, Workflow
+from workflows.context.serializers import JsonSerializer
+from workflows.context.state_store import (
+    CHILD_STATES_KEY,
+    DictState,
+    InMemoryStateStore,
+    NamespacedStateStores,
+    build_namespaced_state,
+    in_memory_namespace_factory,
+    namespaced_seed_payloads,
+    namespaced_state_types,
+)
+from workflows.decorators import step
+from workflows.events import StartEvent, StopEvent
+
+
+class RootState(BaseModel):
+    root_value: str = ""
+
+
+class ChildStart(StartEvent):
+    payload: str = ""
+
+
+class ChildStop(StopEvent):
+    out: str = ""
+
+
+class Child(Workflow):
+    @step
+    async def run_child(self, ctx: Context, ev: ChildStart) -> ChildStop:
+        await ctx.store.set("child_value", ev.payload)
+        return ChildStop(out=ev.payload.upper())
+
+
+class Parent(Workflow):
+    child: Child
+
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> ChildStart:
+        return ChildStart(payload="hi")
+
+    @step
+    async def finish(self, ev: ChildStop) -> StopEvent:
+        return StopEvent(result=ev.out)
+
+
+class TypedParent(Workflow):
+    child: Child
+
+    @step
+    async def start(self, ctx: Context[RootState], ev: StartEvent) -> StopEvent:
+        await ctx.store.set("root_value", "typed")
+        return StopEvent(result="done")
+
+
+class Childless(Workflow):
+    @step
+    async def go(self, ctx: Context[RootState], ev: StartEvent) -> StopEvent:
+        await ctx.store.set("root_value", "x")
+        return StopEvent(result="done")
+
+
+def _namespaced(wf: Workflow, serializer: JsonSerializer) -> NamespacedStateStores:
+    """Build an in-memory per-namespace router for *wf*."""
+    types = namespaced_state_types(wf)
+    return build_namespaced_state(wf, in_memory_namespace_factory(types), serializer)
+
+
+def test_state_types_for_childless() -> None:
+    wf = Childless()
+    types = namespaced_state_types(wf)
+    assert types == {(): RootState}
+
+
+def test_state_types_for_child_ful() -> None:
+    wf = Parent(child=Child())
+    types = namespaced_state_types(wf)
+    assert set(types) == {(), ("child",)}
+    # Each namespace carries its own inferred type; an untyped child is DictState.
+    assert types[("child",)] is DictState
+
+
+def test_single_namespace_router_is_flat() -> None:
+    wf = Childless()
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
+
+    assert namespaced.is_single_namespace
+    # view() is memoized per namespace.
+    assert namespaced.view(()) is namespaced.view(())
+    assert isinstance(namespaced.view(()), InMemoryStateStore)
+    assert CHILD_STATES_KEY not in namespaced.serialize_tree(serializer)
+
+
+@pytest.mark.asyncio
+async def test_multi_namespace_serialize_tree_is_per_slot_nested() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
+
+    assert not namespaced.is_single_namespace
+    await namespaced.view(()).set("root_value", "R")
+    await namespaced.view(("child",)).set("child_value", "C")
+
+    tree = namespaced.serialize_tree(serializer)
+    assert tree["state_data"]["_data"]["root_value"] == serializer.serialize("R")
+    child_states = tree[CHILD_STATES_KEY]
+    assert set(child_states) == {"child"}
+    assert child_states["child"]["_data"]["child_value"] == serializer.serialize("C")
+    # children carry only raw state_data, not a full record/payload.
+    assert "data" not in child_states["child"]
+    assert "state_type" not in child_states["child"]
+    assert "state_module" not in child_states["child"]
+
+
+@pytest.mark.asyncio
+async def test_namespaces_are_isolated() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
+
+    await namespaced.view(()).set("shared_key", "root")
+    await namespaced.view(("child",)).set("shared_key", "child")
+
+    # Same path, different records: no cross-namespace bleed.
+    assert await namespaced.view(()).get("shared_key") == "root"
+    assert await namespaced.view(("child",)).get("shared_key") == "child"
+
+
+@pytest.mark.asyncio
+async def test_seed_round_trip_rebuilds_slots() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
+    await namespaced.view(()).set("root_value", "R")
+    await namespaced.view(("child",)).set("child_value", "C")
+
+    tree = namespaced.serialize_tree(serializer)
+
+    rebuilt = _namespaced(wf, serializer)
+    rebuilt.add_seed_tree(tree, serializer)
+    assert await rebuilt.view(()).get("root_value") == "R"
+    assert await rebuilt.view(("child",)).get("child_value") == "C"
+
+
+@pytest.mark.asyncio
+async def test_typed_root_round_trip_keeps_root_metadata_with_children() -> None:
+    wf = TypedParent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
+
+    await namespaced.view(()).set("root_value", "R")
+    await namespaced.view(("child",)).set("child_value", "C")
+
+    tree = namespaced.serialize_tree(serializer)
+    assert tree["state_type"] == "RootState"
+    assert tree["state_module"] == __name__
+    assert CHILD_STATES_KEY in tree
+
+    rebuilt = _namespaced(wf, serializer)
+    rebuilt.add_seed_tree(tree, serializer)
+    root_state = await rebuilt.view(()).get_state()
+    assert isinstance(root_state, RootState)
+    assert root_state.root_value == "R"
+    assert await rebuilt.view(("child",)).get("child_value") == "C"
+
+
+@pytest.mark.asyncio
+async def test_child_view_uses_standard_facade_operations() -> None:
+    wf = Parent(child=Child())
+    serializer = JsonSerializer()
+    namespaced = _namespaced(wf, serializer)
+    child_store = namespaced.view(("child",))
+
+    await child_store.set_state(DictState(_data={"a": 1}))
+    async with child_store.edit_state() as state:
+        state._data["b"] = 2
+    assert await child_store.get("a") == 1
+    assert await child_store.get("b") == 2
+
+    await child_store.clear()
+    assert await child_store.get("a", None) is None
+    assert await child_store.get("b", None) is None
+
+
+def test_seed_payloads_none_for_empty_and_durable() -> None:
+    types = namespaced_state_types(Parent(child=Child()))
+    assert namespaced_seed_payloads(None, types) is None
+    assert namespaced_seed_payloads({}, types) is None
+    assert (
+        namespaced_seed_payloads({"store_type": "postgres", "run_id": "r"}, types)
+        is None
+    )
+
+
+def test_seed_payloads_flat_childless_is_root_only() -> None:
+    serializer = JsonSerializer()
+    flat = InMemoryStateStore(DictState(_data={"counter": 5})).to_dict(serializer)
+    assert CHILD_STATES_KEY not in flat
+
+    seeds = namespaced_seed_payloads(flat, namespaced_state_types(Childless()))
+    assert seeds is not None
+    assert set(seeds) == {()}
+    assert seeds[()] == flat
+
+
+def test_seed_payloads_splits_children_per_namespace() -> None:
+    serializer = JsonSerializer()
+    tree = {
+        "store_type": "in_memory",
+        "state_type": "DictState",
+        "state_module": "workflows.context.state_store",
+        "state_data": {"_data": {"root_value": serializer.serialize("R")}},
+        CHILD_STATES_KEY: {
+            "child": {"_data": {"child_value": serializer.serialize("C")}}
+        },
+    }
+    types = namespaced_state_types(Parent(child=Child()))
+    seeds = namespaced_seed_payloads(tree, types)
+    assert seeds is not None
+    assert set(seeds) == {(), ("child",)}
+    assert CHILD_STATES_KEY not in seeds[()]
+    assert seeds[()]["state_data"]["_data"]["root_value"] == serializer.serialize("R")
+    child_seed = seeds[("child",)]
+    assert child_seed["store_type"] == "in_memory"
+    assert child_seed["state_data"]["_data"]["child_value"] == serializer.serialize("C")
+
+
+@pytest.mark.asyncio
+async def test_flat_childless_checkpoint_carries_root_state_into_child_ful_run() -> (
+    None
+):
+    serializer = JsonSerializer()
+    flat = InMemoryStateStore(DictState(_data={"counter": 5})).to_dict(serializer)
+    assert CHILD_STATES_KEY not in flat
+
+    wf = Parent(child=Child())
+    rebuilt = _namespaced(wf, serializer)
+    rebuilt.add_seed_tree(flat, serializer)
+    assert await rebuilt.view(()).get("counter") == 5
+    assert await rebuilt.view(("child",)).get("child_value", None) is None
+
+
+@pytest.mark.asyncio
+async def test_childless_dict_state_to_dict_stays_flat() -> None:
+    class W(Workflow):
+        @step
+        async def go(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            await ctx.store.set("k", "v")
+            return StopEvent(result="ok")
+
+    wf = W()
+    ctx = Context(wf)
+    await wf.run(ctx=ctx)
+
+    state = ctx.to_dict()["state"]
+    serializer = JsonSerializer()
+    assert state == {
+        "store_type": "in_memory",
+        "state_type": "DictState",
+        "state_module": "workflows.context.state_store",
+        "state_data": {"_data": {"k": serializer.serialize("v")}},
+    }
+    assert CHILD_STATES_KEY not in state
+
+
+@pytest.mark.asyncio
+async def test_childless_typed_state_to_dict_stays_flat() -> None:
+    wf = Childless()
+    ctx = Context(wf)
+    await wf.run(ctx=ctx)
+
+    state = ctx.to_dict()["state"]
+    assert state["store_type"] == "in_memory"
+    assert state["state_type"] == "RootState"
+    assert CHILD_STATES_KEY not in state
+    assert Context.from_dict(wf, ctx.to_dict()) is not None

--- a/uv.lock
+++ b/uv.lock
@@ -2198,6 +2198,7 @@ dependencies = [
     { name = "llama-agents-appserver" },
     { name = "llama-agents-core" },
     { name = "llama-agents-server" },
+    { name = "llama-index-workflows" },
 ]
 
 [package.dev-dependencies]
@@ -2219,6 +2220,7 @@ requires-dist = [
     { name = "llama-agents-appserver", editable = "packages/llama-agents-appserver" },
     { name = "llama-agents-core", editable = "packages/llama-agents-core" },
     { name = "llama-agents-server", editable = "packages/llama-agents-server" },
+    { name = "llama-index-workflows", editable = "packages/llama-index-workflows" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
The workflow runtime had namespace-aware state plumbing, but the broker still treated child workflow steps as static slots. A parent could route into a typed child workflow, but repeated calls through the same child field reused the same worker buffers, timeout clock, stream origin, and child state. This branch gives child workflows an in-process run boundary with a separate runtime invocation id for each call.

A parent declares a child as a typed `Workflow` field, emits the child's custom `StartEvent`, and consumes the child's custom `StopEvent` as an ordinary parent event:

```python
class Child(Workflow):
    @step
    async def run_child(self, ev: ChildStart) -> ChildStop:
        return ChildStop(out=ev.payload.upper())

class Parent(Workflow):
    child: Child

    @step
    async def start(self, ev: StartEvent) -> ChildStart:
        return ChildStart(payload="hello")

    @step
    async def finish(self, ev: ChildStop) -> StopEvent:
        return StopEvent(result=ev.out)
```

## Runtime shape

Step configuration stays static: child steps are keyed by `StepId(("child",), "run_child")`, and root step names still stringify exactly as before. Runtime work gets a separate invocation namespace such as `("child#abc123",)`. The reducer uses the static slot namespace for graph validation, handler lookup, and timeout configuration, while queues, in-progress workers, waiters, collect buffers, task cancellation, stream origins, and `ctx.store` use the concrete invocation namespace.

That means two overlapping calls to the same child field now behave like two child runs. One child `StopEvent` tears down only that invocation and its descendants, one child timeout expires only that invocation, and child state from a completed call is not copied into the next call.

## State and streams

Running context snapshots preserve live child invocation state, including idle child invocations that are waiting for an external response. Completed context continuations carry root state only, so stale child invocation stores do not seed later runs.

Child stream events expose the concrete invocation namespace. `handler.stream_events()` still hides child-origin events by default, and `handler.stream_events(include_children=True)` surfaces them with origins like `child#abc123`. Targeted external sends into a child use that concrete path, for example `child#abc123/answer`; a static `child/answer` target fails instead of accidentally running a child step in the root invocation.

## Runtime support boundary

The in-process runtime owns child workflow execution here. Server and DBOS runtimes reject child workflow attachment early until they can persist and replay invocation-scoped child runs deliberately. The durable state-store changes in this branch keep namespace records separate, but they do not imply durable child workflow support yet.

Smaller replacement for #648.