### PR TITLE
Make the workflow checkpoint/resume durability story clear

### DIFF
--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -305,8 +305,8 @@ You can wait for any mix of types, not just one type repeated. The order you pas
 
 ## Making a fan-out durable
 
-A concurrent fan-out like this is exactly the kind of long, expensive run you don't want to restart
-from zero. Because the partial fan-in buffer and the still-pending events are part of the workflow's
-serializable state, a fan-out can be **checkpointed and resumed** so a kill mid-run doesn't redo
-completed items. See [writing durable workflows](/python/llamaagents/workflows/durable_workflows)
-for the checkpoint loop and a worked fan-out-survives-a-restart example.
+A long fan-out like this is the kind of run you don't want to restart from zero. The partial fan-in
+buffer and the still-pending events are part of the workflow's serializable state, so a fan-out can
+be checkpointed and resumed, and a kill mid-run won't redo completed items. See
+[writing durable workflows](/python/llamaagents/workflows/durable_workflows) for the checkpoint loop
+and a worked example.

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -305,8 +305,7 @@ You can wait for any mix of types, not just one type repeated. The order you pas
 
 ## Making a fan-out durable
 
-A long fan-out like this is the kind of run you don't want to restart from zero. The partial fan-in
-buffer and the still-pending events are part of the workflow's serializable state, so a fan-out can
-be checkpointed and resumed, and a kill mid-run won't redo completed items. See
+A long fan-out is a good fit for checkpointing: pending events and partial fan-in state can be
+serialized and resumed after a restart. See
 [writing durable workflows](/python/llamaagents/workflows/durable_workflows) for the checkpoint loop
 and a worked example.

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -302,3 +302,11 @@ You can wait for any mix of types, not just one type repeated. The order you pas
             return None
         return StopEvent(result="Done")
 ```
+
+## Making a fan-out durable
+
+A concurrent fan-out like this is exactly the kind of long, expensive run you don't want to restart
+from zero. Because the partial fan-in buffer and the still-pending events are part of the workflow's
+serializable state, a fan-out can be **checkpointed and resumed** so a kill mid-run doesn't redo
+completed items. See [writing durable workflows](/python/llamaagents/workflows/durable_workflows)
+for the checkpoint loop and a worked fan-out-survives-a-restart example.

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -4,129 +4,244 @@ sidebar:
 title: Writing durable workflows
 ---
 
-Workflows are ephemeral by default, meaning that once the `run()` method returns its result, the workflow state is lost. A subsequent call to `run()` on the same workflow instance will start from a fresh state.
+Workflows are ephemeral by default: once `run()` returns, the state is gone, and the next `run()`
+starts fresh. But a workflow is often where you've expressed an ad-hoc, concurrent,
+hard-to-reason-about process — fan out over a hundred documents, call an LLM per chunk, collect the
+results. That's exactly the kind of run you don't want to start over from zero when the process is
+killed halfway through.
 
-If the use case requires to persist the workflow state  across multiple runs and possibly different processes, there are a few strategies that can be used to make workflows more durable.
+This page shows how to make such a workflow **best-effort checkpoint and resume across a restart —
+in a few lines, with no external durable runtime.** If you'd rather not write any checkpoint code
+at all and can afford a backing database, skip to [DBOS](/python/llamaagents/workflows/dbos); this
+page is the lightweight path.
 
-## Storing data in the workflow instance
+## The mental model: events are the state
 
-Workflows are regular Python classes, and data can be stored in class or instance variables, so that subsequent `run()` invocations can access it.
+What makes checkpointing cheap here is that a workflow's runtime state *is* its in-flight events.
+At any instant, "where the workflow is" comes down to: which events sit in step input queues, which
+events a fan-in is still collecting, which steps are mid-execution, and the contents of the
+[state store](/python/llamaagents/workflows/managing_state).
+
+`Context.to_dict()` captures all of that as a single **point-in-time snapshot** — the pending event
+queues, the `collect_events` buffers, any `wait_for_event` waiters, and the state store.
+`Context.from_dict()` rebuilds a context from that snapshot, and passing it to `run()` resumes from
+there. It's a snapshot, **not** a journal: it carries the events that are *currently relevant*, not
+a log of everything that ever happened.
+
+Resume has two behaviors worth internalizing, because together they make a snapshot safe to restart
+from:
+
+- **Completed steps don't re-run.** A step that already finished consumed its triggering event; that
+  event is no longer in the snapshot, so it's never re-dispatched. Its output already lives
+  downstream (in the next step's queue or a collect buffer), so the work is preserved.
+- **In-flight steps are rewound and re-run.** A step that had consumed its event but hadn't finished
+  when the snapshot was taken is rewound — its event goes back on the queue, and on resume the
+  **entire step body executes again from the top.**
+
+The consequence, and the one rule you must design around: **resume re-executes in-flight steps, so
+steps must be safe to repeat.** This is at-least-once execution. If a step performs an external side
+effect (a DB write, a payment, an email) before it returns, that effect can happen again on resume.
+Make those effects idempotent, or guard them with a marker in the state store.
+
+## Three strategies, increasing durability
+
+| Strategy | Persists over `run()` calls | Survives process restart | Survives a crash mid-run |
+|---|---|---|---|
+| Data on the workflow instance | ✅ | ❌ | ❌ |
+| `Context.to_dict()` once at the end | ✅ | ✅ | ❌ |
+| Checkpoint loop: snapshot at each step boundary | ✅ | ✅ | ✅ |
+
+The first two are below; the third — the one that actually survives a kill mid-run — is the rest of
+this page.
+
+### Data on the workflow instance
+
+A workflow is a regular Python class, so you can stash data in instance variables and reuse it
+across `run()` calls on the same instance:
 
 ```python
 class DbWorkflow(Workflow):
-    def __init__(self, db: Client, *args, **kwargs):
+    def __init__(self, db, *args, **kwargs):
         self.db = db
         super().__init__(*args, **kwargs)
 
     @step
-    def count(self, ev: StartEvent) -> StopEvent:
-        num_rows = self.db.exec("select COUNT(*) from t;")
-        return StopEvent(result=num_rows)
+    async def count(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result=self.db.exec("select COUNT(*) from t;"))
 ```
 
-In this case, multiple calls to `run()` will reuse the same database client.
+This survives neither a process restart nor a crash — it's just shared state between runs.
 
-| Persists over `run` calls | ✅ |
-| --- | --- |
-| Persists over process restarts | ❌ |
-| Survives runtime errors | ❌ |
+### Snapshot the context
 
-## Storing data in the context object
-
-Each workflow comes with a special object responsible for its runtime operations called `Context`. The context instance is available to any step of a workflow and comes with a `store` property that can be used to store and load state data. Using the state store has two major advantages compared to class and instance variables:
-
-- It’s async safe and supports concurrent access
-- It can be serialized
+The context's [state store](/python/llamaagents/workflows/managing_state) is async-safe and, unlike
+instance variables, **serializable**. Snapshot it after a run and restore it later — even in a
+different process:
 
 ```python
 w = MyWorkflow()
 handler = w.run()
-context = handler.ctx
-# Save the context to a database
-db.save("id", context.to_dict())
+result = await handler
 
-#
-# Restart the Python process...
-#
+# Persist the snapshot
+db.save("my-run", json.dumps(handler.ctx.to_dict()))
 
+# ...new process...
 w = MyWorkflow()
-# Load the context from the database
-context = Context.from_dict(w, db.load("id"))
-# Pass the context containing the state to the workflow
-result = await w.run(ctx=context)
+ctx = Context.from_dict(w, json.loads(db.load("my-run")))
+result = await w.run(ctx=ctx)   # continues with the restored state
 ```
 
-| Persists over `run` calls | ✅ |
-| --- | --- |
-| Persists over process restarts | ✅ |
-| Survives runtime errors | ❌ |
+This survives a restart, but not a crash *during* the run — you only have the state as of the last
+explicit `to_dict()`. To survive a crash, snapshot as the run progresses.
 
-## Using external resources to checkpoint execution
+## The checkpoint loop
 
-To avoid any overhead, workflows don’t take snapshots of the current state automatically, so they can’t survive a fatal error on their own. However, any step can rely on some external database like Redis and snapshot the current context on sensitive parts of the code.
-
-For example, given a long running workflow processing hundreds of documents, we could save the id of the last document successfully processed in the state store:
+There's no built-in checkpointer to enable. Instead, the workflow stream emits an internal event
+every time a step changes state, and you snapshot when you see one finish.
+`stream_events(expose_internal=True)` surfaces these internal events; `StepStateChanged` with
+`StepState.NOT_RUNNING` marks a step instance completing:
 
 ```python
-class DurableWorkflow(Workflow):
-    def __init__(self, r: Redis):
-        self.redis = r
+from workflows.events import StepStateChanged, StepState
 
-    @step
-    async def convert_documents(self, ev: StartEvent, ctx: Context) -> StopEvent:
-        # Get the workflow input
-        document_ids = ev.ids
-        # Get the list of processed documents from the state store
-        converted_ids = await ctx.store.get("converted_ids", default=[])
-        for doc_id in document_ids:
-		        # Ignore documents that were alredy processed
-		        if doc_id in converted_ids:
-		            continue
-            convert()
-            # Update the state store
-            converted_ids.append(doc_id)
-            await ctx.store.set("converted_ids", converted_ids)
-            # Create a snapshot of the current context
-            self.redis.hset("ctx", mapping=ctx.to_dict())
+handler = w.run()
+async for ev in handler.stream_events(expose_internal=True):
+    if isinstance(ev, StepStateChanged) and ev.step_state == StepState.NOT_RUNNING:
+        db.save("my-run", json.dumps(handler.ctx.to_dict()))
+result = await handler
 ```
 
-The workflow will use a Redis collection to store a snapshot of the current context after every conversion. If the process running the workflow crashes, the process can be safely restarted with the same input. In fact, `ctx.store` will contain the list of documents already processed and the `for` loop will be able to skip them and continue to process the remaining work.
-
-### Bonus: inject dependencies into the workflow to reduce boilerplate
-
-Using the Resource feature of workflows, the Redis client can be injected into the step directly:
+That's the whole mechanism: observe step boundaries, snapshot the context at each one. To resume
+after a crash, load the last snapshot and pass it to `run()`:
 
 ```python
-def get_redis_client(*args, **kwargs):
-		"""This can be reused across several workflows to reduce boilerplate"""
-    return Redis(host='localhost', port=6379, decode_responses=True)
-
-
-class DurableWorkflow(Workflow):
-    @step
-    async def convert_documents(
-        self,
-        ev: StartEvent,
-        ctx: Context,
-        redis: Annotated[Redis, Resource(get_redis_client)]
-    ) -> StopEvent:
-        # Get the workflow input
-        document_ids = ev.ids
-        # Get the list of processed documents from the state store
-        converted_ids = await ctx.store.get("converted_ids", default=[])
-        for doc_id in document_ids:
-		        # Ignore documents that were alredy processed
-		        if doc_id in converted_ids:
-		            continue
-            convert()
-            # Update the state store
-            converted_ids.append(doc_id)
-            await ctx.store.set("converted_ids", converted_ids)
-            # Create a snapshot of the current context
-            redis.hset("ctx", mapping=ctx.to_dict())
+w = MyWorkflow()
+ctx = Context.from_dict(w, json.loads(db.load("my-run")))
+result = await w.run(ctx=ctx)
 ```
 
-| Persists over `run` calls | ✅ |
-| --- | --- |
-| Persists over process restarts | ✅ |
-| Survives runtime errors | ✅ |
+A few honest caveats about the snapshot point:
+
+- `NOT_RUNNING` fires **per step execution**, not per logical step. A `@step(num_workers=N)` step or
+  a fan-out emits one event per item, so you'll checkpoint many times in a concurrent run. `ev.name`
+  and `ev.worker_id` tell you which.
+- The snapshot you take when you observe the event is "the state right now," not a freeze of the
+  instant that step finished — other concurrent workers may have advanced. That's fine: it's still a
+  consistent, resumable checkpoint. It just isn't a deterministic per-step freeze unless the
+  workflow is single-worker.
+- Snapshotting on every boundary has a cost (serialize + write). For a long run you may snapshot
+  only on the steps whose completion is expensive to lose, e.g. `if ev.name == "process_document"`.
+
+## A concurrent fan-out that survives a restart
+
+This is the case the page exists for: a workflow that fans out work, processes items concurrently,
+and collects the results — checkpointed so a kill mid-run doesn't redo completed items.
+
+```python
+import asyncio, json, os
+from typing import Annotated
+from workflows import Workflow, Context, step
+from workflows.events import Event, StartEvent, StopEvent, StepStateChanged, StepState
+from workflows.resource import Resource
+
+
+class WorkItem(Event):
+    item_id: int
+
+class WorkDone(Event):
+    item_id: int
+    result: str
+
+
+# Heavy / non-serializable inputs come from a Resource (see next section), so
+# they never land in the snapshot — they're re-created on resume.
+def get_client() -> MyApiClient:
+    return MyApiClient(...)
+
+
+class EnrichBatch(Workflow):
+    @step
+    async def dispatch(self, ctx: Context, ev: StartEvent) -> WorkItem | None:
+        await ctx.store.set("n", len(ev.item_ids))
+        for item_id in ev.item_ids:
+            ctx.send_event(WorkItem(item_id=item_id))
+
+    @step(num_workers=8)
+    async def enrich(
+        self, ctx: Context, ev: WorkItem,
+        client: Annotated[MyApiClient, Resource(get_client)],
+    ) -> WorkDone:
+        result = await client.enrich(ev.item_id)   # the expensive, repeatable work
+        return WorkDone(item_id=ev.item_id, result=result)
+
+    @step
+    async def collect(self, ctx: Context, ev: WorkDone) -> StopEvent | None:
+        n = await ctx.store.get("n")
+        done = ctx.collect_events(ev, [WorkDone] * n)
+        if done is None:
+            return None
+        return StopEvent(result={d.item_id: d.result for d in done})
+```
+
+Drive it with the checkpoint loop, and resume from the last snapshot if the process died:
+
+```python
+CKPT = "enrich-batch.json"
+
+async def run_batch(item_ids):
+    wf = EnrichBatch()
+    if os.path.exists(CKPT):
+        # Resume: completed items are already in the collect buffer and won't re-run.
+        # Don't re-send the StartEvent — dispatch already ran in the previous process.
+        handler = wf.run(ctx=Context.from_dict(wf, json.load(open(CKPT))))
+    else:
+        handler = wf.run(item_ids=item_ids)
+
+    async for ev in handler.stream_events(expose_internal=True):
+        if isinstance(ev, StepStateChanged) and ev.step_state == StepState.NOT_RUNNING \
+           and ev.name == "enrich":
+            json.dump(handler.ctx.to_dict(), open(CKPT, "w"))
+    return await handler
+```
+
+When this is killed after, say, 60 of 100 items: the 60 finished `enrich` calls have their
+`WorkDone` events sitting in the collect buffer, which is part of the snapshot. On resume, `dispatch`
+does not re-run, the 60 done items are not re-enriched, and only the remaining `WorkItem` events —
+still in the queue — are processed. The collect step fires once all 100 distinct `WorkDone`s are
+present, across both runs, so the **final result is correct**.
+
+What *does* get repeated is the in-flight work. At any instant up to `num_workers` `enrich`
+executions are running but not yet complete; every one of those is rewound and re-enriched on
+resume. So with `num_workers=8` you might re-run as many as 8 items — wasted compute, not wrong
+output, and precisely why `enrich` must be safe to repeat. (If a step both completed *and* was
+captured in the snapshot, it is not rewound — only genuinely in-flight executions are.)
+
+## Keeping snapshots cheap and correct
+
+The snapshot is only as cheap and reliable as what you put in events and state. Two rules:
+
+**Heavy and non-serializable inputs belong in a [Resource](/python/llamaagents/workflows/resources),
+not in events or state.** A `Resource` factory is resolved once, cached on the workflow, and is
+**never serialized into the context** — on resume it's simply re-created by calling the factory
+again. So API clients, model handles, large reference data, byte buffers: inject them as resources,
+and let your events carry small identifiers (an id, a key, a plan) instead. This keeps the snapshot
+small and keeps you clear of the serialization rule below.
+
+**Everything on an in-flight event and in the state store must be serializable.** Snapshots use a
+JSON serializer (Pydantic models included); if it hits a value it can't encode, `to_dict()` raises
+and the *whole* snapshot fails — not just that field. So don't put raw bytes, open connections, or
+arbitrary objects on events. (One escape hatch: state-store keys the runtime knows can't be
+serialized — currently `"memory"` — are skipped with a warning and must be re-set after a restore.)
+
+And the rule from the mental model, restated because it's the one that bites: **steps re-run on
+resume if they were in flight, so make their side effects safe to repeat.**
+
+## When to reach for DBOS instead
+
+The checkpoint loop is best-effort durability you control: you choose when to snapshot, and resume
+is a couple of lines. If you instead want **fully automatic, every-transition durability** — no
+snapshot code, crash recovery that resumes exactly where it stopped — use the
+[DBOS runtime](/python/llamaagents/workflows/dbos). It persists every step transition to a backing
+database (SQLite by default), at the cost of running that database and runtime. Same workflow code;
+different durability/effort trade-off.

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -169,12 +169,13 @@ Everything on an in-flight event and in the state store has to be serializable. 
 serializer, Pydantic models included. If it hits a value it can't encode, `to_dict()` raises and the
 whole snapshot fails, not just that field. So don't put raw bytes or open connections on events.
 
-## When you want durability handled for you
+## Runtime plugins for durability
 
 The checkpoint loop is durability you control. You decide when to snapshot, and resume is a couple of
-lines. If you'd rather not manage that, the runtime can persist and restore state for you.
+lines. If you'd rather not manage that, use a runtime plugin that owns persistence and recovery.
 
-Running a workflow as a [server](/python/llamaagents/workflows/deployment) persists its state across
-requests and restarts. The [DBOS runtime](/python/llamaagents/workflows/dbos) journals every step
-transition to a database, so a crashed workflow resumes on its own. Both run the same workflow code
-you have already written.
+The default runtime runs workflows in-process. A plugin runtime can swap in a different execution
+model without changing the workflow code. For example, the
+[DBOS runtime](/python/llamaagents/workflows/dbos) journals step transitions to a database, so a
+crashed workflow can resume without your checkpoint loop. `WorkflowServer` can run workflows with the
+same runtime plugin, so served workflows get the same persistence and recovery behavior.

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -9,7 +9,7 @@ starts fresh. But a workflow is often where you've written an ad hoc concurrent 
 over a hundred documents, call an LLM per chunk, and collect the results. That is the kind of run you
 don't want to start over from zero when the process is killed halfway through.
 
-This page shows how to checkpoint such a workflow and resume it after a restart, in a few lines.
+This page shows how to checkpoint that run and resume it after a restart.
 
 ## Three strategies, increasing durability
 
@@ -63,16 +63,12 @@ result = await w.run(ctx=ctx)   # continues with the restored state
 ```
 
 This survives a restart, but not a crash during the run. You only have the state as of the last
-`to_dict()`. To survive a crash, snapshot as the run progresses. That is the next section.
+`to_dict()`. To survive a crash, snapshot as the run progresses.
 
 On resume, the restored run re-dispatches the events that were still pending and rebuilds the partial
 fan-in buffers. Completed steps don't re-run, because their output is already in the restored state.
-A step that was mid-execution when you captured the state is rewound and runs again from the top. So
-resume is at-least-once, and step side effects need to be safe to repeat.
-
-Snapshotting the state yourself is one way to make it durable. The state can also be persisted as the
-event journal, which is what a durable backend or a server runtime does for you. Either way it
-rebuilds to the same state. This page covers the snapshot path.
+A step that was mid-execution when you captured the state is rewound and runs again from the top.
+Resume is at-least-once, and step side effects need to be safe to repeat.
 
 ## The checkpoint loop
 
@@ -91,8 +87,7 @@ async for ev in handler.stream_events(expose_internal=True):
 result = await handler
 ```
 
-That is the whole mechanism. You observe step boundaries and snapshot the context at each one. To
-resume after a crash, load the last snapshot and pass it to `run()`:
+To resume after a crash, load the last snapshot and pass it to `run()`:
 
 ```python
 w = MyWorkflow()
@@ -100,18 +95,12 @@ ctx = Context.from_dict(w, json.loads(db.load("my-run")))
 result = await w.run(ctx=ctx)
 ```
 
-How the checkpoints behave in a concurrent run:
+In a busy run, you usually don't need to write on every boundary. Each snapshot is a serialize and a
+write, so throttle it if the workflow is noisy. A crash then costs you at most that interval of
+redone work.
 
-- Checkpointing is naturally granular. `NOT_RUNNING` fires per step execution, not per logical step,
-  so a `@step(num_workers=N)` step or a fan-out gives you a checkpoint per item finished. `ev.name`
-  and `ev.worker_id` tell you which one.
-- The snapshot is the state at the moment you take it, not a freeze of the instant that step
-  finished. Other concurrent workers may have advanced. It is still a consistent, resumable
-  checkpoint. It just isn't a deterministic per-step freeze unless the workflow runs one worker at a
-  time.
-- Each snapshot is a serialize and a write, so in a busy run you don't need one on every boundary.
-  Throttle to a fixed interval, and a crash costs you at most that interval of redone work. Skip the
-  snapshot if you took one in the last 10 seconds, for example.
+The snapshot is the state at the moment you take it. Other workers may have advanced since the event
+that triggered the write, but the state is still consistent and resumable.
 
 ## A concurrent fan-out that survives a restart
 
@@ -119,10 +108,10 @@ A workflow that fans out work, runs items concurrently, and collects the results
 kill mid-run doesn't redo completed items:
 
 ```python
-import asyncio, json, os
+import json, os
 from typing import Annotated
-from workflows import Workflow, Context, step
-from workflows.events import Event, StartEvent, StopEvent, StepStateChanged, StepState
+from workflows import Context, Workflow, step
+from workflows.events import Event, StartEvent, StepState, StepStateChanged, StopEvent
 from workflows.resource import Resource
 
 
@@ -142,26 +131,21 @@ def get_client() -> MyApiClient:
 
 class EnrichBatch(Workflow):
     @step
-    async def dispatch(self, ctx: Context, ev: StartEvent) -> WorkItem | None:
-        await ctx.store.set("n", len(ev.item_ids))
-        for item_id in ev.item_ids:
-            ctx.send_event(WorkItem(item_id=item_id))
+    async def dispatch(self, ev: StartEvent) -> list[WorkItem]:
+        return [WorkItem(item_id=item_id) for item_id in ev.item_ids]
 
     @step(num_workers=8)
     async def enrich(
-        self, ctx: Context, ev: WorkItem,
+        self,
+        ev: WorkItem,
         client: Annotated[MyApiClient, Resource(get_client)],
     ) -> WorkDone:
         result = await client.enrich(ev.item_id)   # the expensive, repeatable work
         return WorkDone(item_id=ev.item_id, result=result)
 
     @step
-    async def collect(self, ctx: Context, ev: WorkDone) -> StopEvent | None:
-        n = await ctx.store.get("n")
-        done = ctx.collect_events(ev, [WorkDone] * n)
-        if done is None:
-            return None
-        return StopEvent(result={d.item_id: d.result for d in done})
+    async def collect(self, events: list[WorkDone]) -> StopEvent:
+        return StopEvent(result={ev.item_id: ev.result for ev in events})
 ```
 
 Drive it with the checkpoint loop, and resume from the last snapshot if the process died:
@@ -172,8 +156,8 @@ CKPT = "enrich-batch.json"
 async def run_batch(item_ids):
     wf = EnrichBatch()
     if os.path.exists(CKPT):
-        # Resume from the snapshot. Don't re-send the StartEvent; dispatch
-        # already ran, and completed items are in the collect buffer.
+        # Resume from the snapshot. The pending work and partial fan-in state
+        # are already in the context, so don't send the StartEvent again.
         handler = wf.run(ctx=Context.from_dict(wf, json.load(open(CKPT))))
     else:
         handler = wf.run(item_ids=item_ids)
@@ -185,10 +169,10 @@ async def run_batch(item_ids):
     return await handler
 ```
 
-Say this is killed after 60 of 100 items. The 60 finished `enrich` calls have their `WorkDone`
-events in the collect buffer, which is part of the snapshot. On resume, `dispatch` does not re-run,
-the 60 done items are not re-enriched, and only the remaining `WorkItem` events get processed. The
-collect step fires once all 100 `WorkDone`s are present, across both runs, so the result is correct.
+Say this is killed after 60 of 100 items. The finished `enrich` calls are part of the restored
+workflow state, and the pending `WorkItem`s are still pending. On resume, `dispatch` does not re-run,
+the completed items are not re-enriched, and the list fan-in fires once all 100 `WorkDone`s are
+present across both runs.
 
 The in-flight work does get repeated. At any moment up to `num_workers` `enrich` calls are running
 but not finished, and each of those is rewound and re-enriched on resume. With `num_workers=8` that

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -4,14 +4,12 @@ sidebar:
 title: Writing durable workflows
 ---
 
-Workflows are ephemeral by default: once `run()` returns, the state is gone, and the next `run()`
-starts fresh. But a workflow is often where you've expressed an ad-hoc, concurrent,
-hard-to-reason-about process — fan out over a hundred documents, call an LLM per chunk, collect the
-results. That's exactly the kind of run you don't want to start over from zero when the process is
-killed halfway through.
+Workflows are ephemeral by default. Once `run()` returns, the state is gone, and the next `run()`
+starts fresh. But a workflow is often where you've written an ad hoc concurrent process. You fan out
+over a hundred documents, call an LLM per chunk, and collect the results. That is the kind of run you
+don't want to start over from zero when the process is killed halfway through.
 
-This page shows how to make such a workflow **best-effort checkpoint and resume across a restart**,
-in a few lines.
+This page shows how to checkpoint such a workflow and resume it after a restart, in a few lines.
 
 ## Three strategies, increasing durability
 
@@ -21,13 +19,13 @@ in a few lines.
 | `Context.to_dict()` once at the end | ✅ | ✅ | ❌ |
 | Checkpoint loop: snapshot at each step boundary | ✅ | ✅ | ✅ |
 
-The first two are below; the third — the one that actually survives a kill mid-run — is the rest of
-this page.
+The first two are quick to show. The checkpoint loop is the one that survives a crash mid-run, and
+it is most of this page.
 
 ### Data on the workflow instance
 
-A workflow is a regular Python class, so you can stash data in instance variables and reuse it
-across `run()` calls on the same instance:
+A workflow is a regular Python class, so you can keep data in instance variables and reuse it across
+`run()` calls on the same instance:
 
 ```python
 class DbWorkflow(Workflow):
@@ -40,15 +38,15 @@ class DbWorkflow(Workflow):
         return StopEvent(result=self.db.exec("select COUNT(*) from t;"))
 ```
 
-This survives neither a process restart nor a crash — it's just shared state between runs.
+This is shared state between runs. It survives neither a restart nor a crash.
 
 ### Snapshot the context
 
-A run advances by reducing events in a controlled way, so its state is well-defined at every step
-boundary: the events still in flight (pending in step queues, partial fan-in buffers, waiters) plus
-the [state store](/python/llamaagents/workflows/managing_state). `Context.to_dict()` serializes that
-state; `Context.from_dict()` rebuilds it and `run(ctx=...)` continues from there — even in a
-different process:
+A run advances by reducing events in a controlled way, so its state is well defined at every step
+boundary. That state is the events still in flight plus the
+[state store](/python/llamaagents/workflows/managing_state). `Context.to_dict()` serializes it,
+`Context.from_dict()` rebuilds it, and `run(ctx=...)` continues from there, even in a different
+process:
 
 ```python
 w = MyWorkflow()
@@ -64,24 +62,24 @@ ctx = Context.from_dict(w, json.loads(db.load("my-run")))
 result = await w.run(ctx=ctx)   # continues with the restored state
 ```
 
-This survives a restart, but not a crash *during* the run — you only have the state as of the last
-explicit `to_dict()`. To survive a crash, snapshot as the run progresses (next section).
+This survives a restart, but not a crash during the run. You only have the state as of the last
+`to_dict()`. To survive a crash, snapshot as the run progresses. That is the next section.
 
-**How resume behaves.** A restored run re-dispatches the events that were still pending and rebuilds
-the partial fan-in buffers, so completed steps are *not* re-run — their output is already in the
-restored state. Any step that was mid-execution when you captured the state is rewound and runs
-again from the top. That makes resume at-least-once: keep step side effects safe to repeat.
+On resume, the restored run re-dispatches the events that were still pending and rebuilds the partial
+fan-in buffers. Completed steps don't re-run, because their output is already in the restored state.
+A step that was mid-execution when you captured the state is rewound and runs again from the top. So
+resume is at-least-once, and step side effects need to be safe to repeat.
 
-(Snapshotting the state yourself is one way to make it durable. The same state can instead be
-persisted as the event journal — what a durable backend or server runtime does for you — and
-rebuilt the same way. This page covers the do-it-yourself snapshot path.)
+Snapshotting the state yourself is one way to make it durable. The state can also be persisted as the
+event journal, which is what a durable backend or a server runtime does for you. Either way it
+rebuilds to the same state. This page covers the snapshot path.
 
 ## The checkpoint loop
 
-There's no built-in checkpointer to enable. Instead, the workflow stream emits an internal event
-every time a step changes state, and you snapshot when you see one finish.
-`stream_events(expose_internal=True)` surfaces these internal events; `StepStateChanged` with
-`StepState.NOT_RUNNING` marks a step instance completing:
+There is no built-in checkpointer to enable. The workflow stream emits an internal event every time
+a step changes state, and you snapshot when you see one finish. `stream_events(expose_internal=True)`
+surfaces those internal events, and `StepStateChanged` with `StepState.NOT_RUNNING` marks a step
+finishing:
 
 ```python
 from workflows.events import StepStateChanged, StepState
@@ -93,8 +91,8 @@ async for ev in handler.stream_events(expose_internal=True):
 result = await handler
 ```
 
-That's the whole mechanism: observe step boundaries, snapshot the context at each one. To resume
-after a crash, load the last snapshot and pass it to `run()`:
+That is the whole mechanism. You observe step boundaries and snapshot the context at each one. To
+resume after a crash, load the last snapshot and pass it to `run()`:
 
 ```python
 w = MyWorkflow()
@@ -102,23 +100,23 @@ ctx = Context.from_dict(w, json.loads(db.load("my-run")))
 result = await w.run(ctx=ctx)
 ```
 
-A few things worth knowing about where these checkpoints land:
+How the checkpoints behave in a concurrent run:
 
-- Checkpointing is naturally granular: `NOT_RUNNING` fires **per step execution**, not per logical
-  step, so a `@step(num_workers=N)` step or a fan-out gives you a checkpoint per item finished.
-  `ev.name` and `ev.worker_id` tell you which one.
-- The snapshot you take when you observe the event is "the state right now," not a freeze of the
-  instant that step finished — other concurrent workers may have advanced. That's still a
-  consistent, resumable checkpoint; it just isn't a deterministic per-step freeze unless the
-  workflow is single-worker.
-- Each snapshot is a serialize + write, so in a hot concurrent run you don't need one on every
-  boundary. Throttling to a fixed interval (skip if you snapshotted in the last 10s, say) bounds a
-  crash to at most that interval of redone work.
+- Checkpointing is naturally granular. `NOT_RUNNING` fires per step execution, not per logical step,
+  so a `@step(num_workers=N)` step or a fan-out gives you a checkpoint per item finished. `ev.name`
+  and `ev.worker_id` tell you which one.
+- The snapshot is the state at the moment you take it, not a freeze of the instant that step
+  finished. Other concurrent workers may have advanced. It is still a consistent, resumable
+  checkpoint. It just isn't a deterministic per-step freeze unless the workflow runs one worker at a
+  time.
+- Each snapshot is a serialize and a write, so in a busy run you don't need one on every boundary.
+  Throttle to a fixed interval, and a crash costs you at most that interval of redone work. Skip the
+  snapshot if you took one in the last 10 seconds, for example.
 
 ## A concurrent fan-out that survives a restart
 
-A workflow that fans out work, processes items concurrently, and collects the results — checkpointed
-so a kill mid-run doesn't redo completed items:
+A workflow that fans out work, runs items concurrently, and collects the results. Checkpointed so a
+kill mid-run doesn't redo completed items:
 
 ```python
 import asyncio, json, os
@@ -136,8 +134,8 @@ class WorkDone(Event):
     result: str
 
 
-# Heavy / non-serializable inputs come from a Resource (see next section), so
-# they never land in the snapshot — they're re-created on resume.
+# Heavy inputs come from a Resource (see below). They aren't serialized into
+# the snapshot; they're re-created on resume.
 def get_client() -> MyApiClient:
     return MyApiClient(...)
 
@@ -174,8 +172,8 @@ CKPT = "enrich-batch.json"
 async def run_batch(item_ids):
     wf = EnrichBatch()
     if os.path.exists(CKPT):
-        # Resume: completed items are already in the collect buffer and won't re-run.
-        # Don't re-send the StartEvent — dispatch already ran in the previous process.
+        # Resume from the snapshot. Don't re-send the StartEvent; dispatch
+        # already ran, and completed items are in the collect buffer.
         handler = wf.run(ctx=Context.from_dict(wf, json.load(open(CKPT))))
     else:
         handler = wf.run(item_ids=item_ids)
@@ -187,42 +185,37 @@ async def run_batch(item_ids):
     return await handler
 ```
 
-When this is killed after, say, 60 of 100 items: the 60 finished `enrich` calls have their
-`WorkDone` events sitting in the collect buffer, which is part of the snapshot. On resume, `dispatch`
-does not re-run, the 60 done items are not re-enriched, and only the remaining `WorkItem` events —
-still in the queue — are processed. The collect step fires once all 100 distinct `WorkDone`s are
-present, across both runs, so the **final result is correct**.
+Say this is killed after 60 of 100 items. The 60 finished `enrich` calls have their `WorkDone`
+events in the collect buffer, which is part of the snapshot. On resume, `dispatch` does not re-run,
+the 60 done items are not re-enriched, and only the remaining `WorkItem` events get processed. The
+collect step fires once all 100 `WorkDone`s are present, across both runs, so the result is correct.
 
-What *does* get repeated is the in-flight work. At any instant up to `num_workers` `enrich`
-executions are running but not yet complete; every one of those is rewound and re-enriched on
-resume. So with `num_workers=8` you might re-run as many as 8 items — wasted compute, not wrong
-output, and precisely why `enrich` must be safe to repeat. (If a step both completed *and* was
-captured in the snapshot, it is not rewound — only genuinely in-flight executions are.)
+The in-flight work does get repeated. At any moment up to `num_workers` `enrich` calls are running
+but not finished, and each of those is rewound and re-enriched on resume. With `num_workers=8` that
+is up to 8 items run again. It is wasted compute, not wrong output, and it is why `enrich` has to be
+safe to repeat.
 
 ## Keeping snapshots cheap and correct
 
-The snapshot is only as cheap and reliable as what you put in events and state. Two rules:
+The snapshot is only as cheap and reliable as what you put in events and state. Two rules.
 
-**Heavy and non-serializable inputs belong in a [Resource](/python/llamaagents/workflows/resources),
-not in events or state.** A `Resource` factory is resolved once, cached on the workflow, and is
-**never serialized into the context** — on resume it's simply re-created by calling the factory
-again. So API clients, model handles, large reference data, byte buffers: inject them as resources,
-and let your events carry small identifiers (an id, a key, a plan) instead. This keeps the snapshot
-small and keeps you clear of the serialization rule below.
+Keep heavy or non-serializable inputs in a [Resource](/python/llamaagents/workflows/resources), not
+in events or state. A `Resource` factory is resolved once, cached on the workflow, and never
+serialized into the context. On resume it is re-created by calling the factory again. So put API
+clients, model handles, and large reference data in resources, and let your events carry small
+identifiers instead. This keeps the snapshot small, and keeps you clear of the serialization rule
+below.
 
-**Everything on an in-flight event and in the state store must be serializable.** Snapshots use a
-JSON serializer (Pydantic models included); if it hits a value it can't encode, `to_dict()` raises
-and the *whole* snapshot fails — not just that field. So don't put raw bytes, open connections, or
-arbitrary objects on events.
+Everything on an in-flight event and in the state store has to be serializable. Snapshots use a JSON
+serializer, Pydantic models included. If it hits a value it can't encode, `to_dict()` raises and the
+whole snapshot fails, not just that field. So don't put raw bytes or open connections on events.
 
-And the rule that bites, once more: **steps re-run on resume if they were in flight, so make their
-side effects safe to repeat.**
+## When you want durability handled for you
 
-## When to reach for DBOS instead
+The checkpoint loop is durability you control. You decide when to snapshot, and resume is a couple of
+lines. If you'd rather not manage that, the runtime can persist and restore state for you.
 
-The checkpoint loop is best-effort durability you control: you choose when to snapshot, and resume
-is a couple of lines. If you instead want **fully automatic, every-transition durability** — no
-snapshot code, crash recovery that resumes exactly where it stopped — use the
-[DBOS runtime](/python/llamaagents/workflows/dbos). It persists every step transition to a backing
-database (SQLite by default), at the cost of running that database and runtime. Same workflow code;
-different durability/effort trade-off.
+Running a workflow as a [server](/python/llamaagents/workflows/deployment) persists its state across
+requests and restarts. The [DBOS runtime](/python/llamaagents/workflows/dbos) journals every step
+transition to a database, so a crashed workflow resumes on its own. Both run the same workflow code
+you have already written.

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -28,14 +28,15 @@ A workflow is a regular Python class, so you can keep data in instance variables
 `run()` calls on the same instance:
 
 ```python
-class DbWorkflow(Workflow):
-    def __init__(self, db, *args, **kwargs):
-        self.db = db
-        super().__init__(*args, **kwargs)
+class CounterWorkflow(Workflow):
+    def __init__(self):
+        super().__init__()
+        self.run_count = 0
 
     @step
     async def count(self, ev: StartEvent) -> StopEvent:
-        return StopEvent(result=self.db.exec("select COUNT(*) from t;"))
+        self.run_count += 1
+        return StopEvent(result=self.run_count)
 ```
 
 This is shared state between runs. It survives neither a restart nor a crash.

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -11,37 +11,7 @@ don't want to start over from zero when the process is killed halfway through.
 
 This page shows how to checkpoint that run and resume it after a restart.
 
-## Three strategies, increasing durability
-
-| Strategy | Persists over `run()` calls | Survives process restart | Survives a crash mid-run |
-|---|---|---|---|
-| Data on the workflow instance | ✅ | ❌ | ❌ |
-| `Context.to_dict()` once at the end | ✅ | ✅ | ❌ |
-| Checkpoint loop: snapshot at each step boundary | ✅ | ✅ | ✅ |
-
-The first two are quick to show. The checkpoint loop is the one that survives a crash mid-run, and
-it is most of this page.
-
-### Data on the workflow instance
-
-A workflow is a regular Python class, so you can keep data in instance variables and reuse it across
-`run()` calls on the same instance:
-
-```python
-class CounterWorkflow(Workflow):
-    def __init__(self):
-        super().__init__()
-        self.run_count = 0
-
-    @step
-    async def count(self, ev: StartEvent) -> StopEvent:
-        self.run_count += 1
-        return StopEvent(result=self.run_count)
-```
-
-This is shared state between runs. It survives neither a restart nor a crash.
-
-### Snapshot the context
+## Snapshot the context
 
 A run advances by reducing events in a controlled way, so its state is well defined at every step
 boundary. That state is the events still in flight plus the
@@ -182,7 +152,11 @@ safe to repeat.
 
 ## Keeping snapshots cheap and correct
 
-The snapshot is only as cheap and reliable as what you put in events and state. Two rules.
+The snapshot is only as cheap and reliable as what you put in events and state.
+
+Workflow instance attributes are not part of the snapshot. They can be useful for ordinary Python
+objects that live as long as the workflow instance does, but they are not durable state. If a value
+needs to survive restart, put it in an event or the state store.
 
 Keep heavy or non-serializable inputs in a [Resource](/python/llamaagents/workflows/resources), not
 in events or state. A `Resource` factory is resolved once, cached on the workflow, and never

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -10,10 +10,8 @@ hard-to-reason-about process — fan out over a hundred documents, call an LLM p
 results. That's exactly the kind of run you don't want to start over from zero when the process is
 killed halfway through.
 
-This page shows how to make such a workflow **best-effort checkpoint and resume across a restart —
-in a few lines, with no external durable runtime.** If you'd rather not write any checkpoint code
-at all and can afford a backing database, skip to [DBOS](/python/llamaagents/workflows/dbos); this
-page is the lightweight path.
+This page shows how to make such a workflow **best-effort checkpoint and resume across a restart**,
+in a few lines.
 
 ## The mental model: events are the state
 

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -102,22 +102,23 @@ ctx = Context.from_dict(w, json.loads(db.load("my-run")))
 result = await w.run(ctx=ctx)
 ```
 
-A few honest caveats about the snapshot point:
+A few things worth knowing about where these checkpoints land:
 
-- `NOT_RUNNING` fires **per step execution**, not per logical step. A `@step(num_workers=N)` step or
-  a fan-out emits one event per item, so you'll checkpoint many times in a concurrent run. `ev.name`
-  and `ev.worker_id` tell you which.
+- Checkpointing is naturally granular: `NOT_RUNNING` fires **per step execution**, not per logical
+  step, so a `@step(num_workers=N)` step or a fan-out gives you a checkpoint per item finished.
+  `ev.name` and `ev.worker_id` tell you which one.
 - The snapshot you take when you observe the event is "the state right now," not a freeze of the
-  instant that step finished — other concurrent workers may have advanced. That's fine: it's still a
-  consistent, resumable checkpoint. It just isn't a deterministic per-step freeze unless the
+  instant that step finished — other concurrent workers may have advanced. That's still a
+  consistent, resumable checkpoint; it just isn't a deterministic per-step freeze unless the
   workflow is single-worker.
-- Snapshotting on every boundary has a cost (serialize + write). For a long run you may snapshot
-  only on the steps whose completion is expensive to lose, e.g. `if ev.name == "process_document"`.
+- Each snapshot is a serialize + write, so in a hot concurrent run you don't need one on every
+  boundary. Throttling to a fixed interval (skip if you snapshotted in the last 10s, say) bounds a
+  crash to at most that interval of redone work.
 
 ## A concurrent fan-out that survives a restart
 
-This is the case the page exists for: a workflow that fans out work, processes items concurrently,
-and collects the results — checkpointed so a kill mid-run doesn't redo completed items.
+A workflow that fans out work, processes items concurrently, and collects the results — checkpointed
+so a kill mid-run doesn't redo completed items:
 
 ```python
 import asyncio, json, os

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -231,8 +231,7 @@ small and keeps you clear of the serialization rule below.
 **Everything on an in-flight event and in the state store must be serializable.** Snapshots use a
 JSON serializer (Pydantic models included); if it hits a value it can't encode, `to_dict()` raises
 and the *whole* snapshot fails — not just that field. So don't put raw bytes, open connections, or
-arbitrary objects on events. (One escape hatch: state-store keys the runtime knows can't be
-serialized — currently `"memory"` — are skipped with a warning and must be re-set after a restore.)
+arbitrary objects on events.
 
 And the rule from the mental model, restated because it's the one that bites: **steps re-run on
 resume if they were in flight, so make their side effects safe to repeat.**

--- a/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/durable_workflows.md
@@ -13,34 +13,6 @@ killed halfway through.
 This page shows how to make such a workflow **best-effort checkpoint and resume across a restart**,
 in a few lines.
 
-## The mental model: events are the state
-
-What makes checkpointing cheap here is that a workflow's runtime state *is* its in-flight events.
-At any instant, "where the workflow is" comes down to: which events sit in step input queues, which
-events a fan-in is still collecting, which steps are mid-execution, and the contents of the
-[state store](/python/llamaagents/workflows/managing_state).
-
-`Context.to_dict()` captures all of that as a single **point-in-time snapshot** — the pending event
-queues, the `collect_events` buffers, any `wait_for_event` waiters, and the state store.
-`Context.from_dict()` rebuilds a context from that snapshot, and passing it to `run()` resumes from
-there. It's a snapshot, **not** a journal: it carries the events that are *currently relevant*, not
-a log of everything that ever happened.
-
-Resume has two behaviors worth internalizing, because together they make a snapshot safe to restart
-from:
-
-- **Completed steps don't re-run.** A step that already finished consumed its triggering event; that
-  event is no longer in the snapshot, so it's never re-dispatched. Its output already lives
-  downstream (in the next step's queue or a collect buffer), so the work is preserved.
-- **In-flight steps are rewound and re-run.** A step that had consumed its event but hadn't finished
-  when the snapshot was taken is rewound — its event goes back on the queue, and on resume the
-  **entire step body executes again from the top.**
-
-The consequence, and the one rule you must design around: **resume re-executes in-flight steps, so
-steps must be safe to repeat.** This is at-least-once execution. If a step performs an external side
-effect (a DB write, a payment, an email) before it returns, that effect can happen again on resume.
-Make those effects idempotent, or guard them with a marker in the state store.
-
 ## Three strategies, increasing durability
 
 | Strategy | Persists over `run()` calls | Survives process restart | Survives a crash mid-run |
@@ -72,8 +44,10 @@ This survives neither a process restart nor a crash — it's just shared state b
 
 ### Snapshot the context
 
-The context's [state store](/python/llamaagents/workflows/managing_state) is async-safe and, unlike
-instance variables, **serializable**. Snapshot it after a run and restore it later — even in a
+A run advances by reducing events in a controlled way, so its state is well-defined at every step
+boundary: the events still in flight (pending in step queues, partial fan-in buffers, waiters) plus
+the [state store](/python/llamaagents/workflows/managing_state). `Context.to_dict()` serializes that
+state; `Context.from_dict()` rebuilds it and `run(ctx=...)` continues from there — even in a
 different process:
 
 ```python
@@ -91,7 +65,16 @@ result = await w.run(ctx=ctx)   # continues with the restored state
 ```
 
 This survives a restart, but not a crash *during* the run — you only have the state as of the last
-explicit `to_dict()`. To survive a crash, snapshot as the run progresses.
+explicit `to_dict()`. To survive a crash, snapshot as the run progresses (next section).
+
+**How resume behaves.** A restored run re-dispatches the events that were still pending and rebuilds
+the partial fan-in buffers, so completed steps are *not* re-run — their output is already in the
+restored state. Any step that was mid-execution when you captured the state is rewound and runs
+again from the top. That makes resume at-least-once: keep step side effects safe to repeat.
+
+(Snapshotting the state yourself is one way to make it durable. The same state can instead be
+persisted as the event journal — what a durable backend or server runtime does for you — and
+rebuilt the same way. This page covers the do-it-yourself snapshot path.)
 
 ## The checkpoint loop
 
@@ -231,8 +214,8 @@ JSON serializer (Pydantic models included); if it hits a value it can't encode, 
 and the *whole* snapshot fails — not just that field. So don't put raw bytes, open connections, or
 arbitrary objects on events.
 
-And the rule from the mental model, restated because it's the one that bites: **steps re-run on
-resume if they were in flight, so make their side effects safe to repeat.**
+And the rule that bites, once more: **steps re-run on resume if they were in flight, so make their
+side effects safe to repeat.**
 
 ## When to reach for DBOS instead
 

--- a/docs/src/content/docs/llamaagents/workflows/managing_state.md
+++ b/docs/src/content/docs/llamaagents/workflows/managing_state.md
@@ -110,6 +110,3 @@ state store must be serializable** — the snapshot uses a JSON serializer (Pyda
 and a value it can't encode makes `to_dict()` fail. Keep non-serializable things (clients, byte
 buffers, open connections) out of the store and inject them as
 [resources](/python/llamaagents/workflows/resources) instead.
-
-One escape hatch: the key `"memory"` is recognized as non-serializable, skipped on snapshot with a
-warning, and must be re-set after a restore.

--- a/docs/src/content/docs/llamaagents/workflows/managing_state.md
+++ b/docs/src/content/docs/llamaagents/workflows/managing_state.md
@@ -100,3 +100,16 @@ result = await handler
 handler = workflow.run(ctx=ctx)
 result = await handler
 ```
+
+## State, serialization, and durability
+
+`ctx.to_dict()` is what makes [durable workflows](/python/llamaagents/workflows/durable_workflows)
+possible: it serializes the state store (alongside the in-flight events) into a snapshot you can
+persist and later restore with `Context.from_dict()`. Because of this, **everything you put in the
+state store must be serializable** — the snapshot uses a JSON serializer (Pydantic models included),
+and a value it can't encode makes `to_dict()` fail. Keep non-serializable things (clients, byte
+buffers, open connections) out of the store and inject them as
+[resources](/python/llamaagents/workflows/resources) instead.
+
+One escape hatch: the key `"memory"` is recognized as non-serializable, skipped on snapshot with a
+warning, and must be re-set after a restore.

--- a/docs/src/content/docs/llamaagents/workflows/managing_state.md
+++ b/docs/src/content/docs/llamaagents/workflows/managing_state.md
@@ -101,12 +101,9 @@ handler = workflow.run(ctx=ctx)
 result = await handler
 ```
 
-## State, serialization, and durability
+## Serializable state
 
-`ctx.to_dict()` is what makes [durable workflows](/python/llamaagents/workflows/durable_workflows)
-possible: it serializes the state store (alongside the in-flight events) into a snapshot you can
-persist and later restore with `Context.from_dict()`. Because of this, **everything you put in the
-state store must be serializable** — the snapshot uses a JSON serializer (Pydantic models included),
-and a value it can't encode makes `to_dict()` fail. Keep non-serializable things (clients, byte
-buffers, open connections) out of the store and inject them as
+State you keep here is serialized when you snapshot a run to make it
+[durable](/python/llamaagents/workflows/durable_workflows), so keep it to values a JSON serializer
+can encode. Put clients and other non-serializable objects in
 [resources](/python/llamaagents/workflows/resources) instead.

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -8,6 +8,36 @@ Observability is key for debugging workflows. Beyond just adding `print()` state
 
 Furthermore, you can leverage this instrumentation system to add observability to any function outside of workflow steps! More in-depth examples for all of this information can be found in the [examples folder for observability](https://github.com/run-llama/llama-agents/tree/main/examples/observability).
 
+## Observing step state with internal events
+
+Beyond the events your steps emit, the runtime publishes **internal** events describing its own
+execution. They're filtered out of `stream_events()` by default; pass `expose_internal=True` to see
+them:
+
+```python
+from workflows.events import InternalDispatchEvent, StepStateChanged, StepState
+
+handler = workflow.run()
+async for ev in handler.stream_events(expose_internal=True):
+    if isinstance(ev, StepStateChanged):
+        print(ev.name, ev.step_state, ev.worker_id)
+```
+
+The most useful is `StepStateChanged`, emitted whenever a step execution changes state. Its
+`step_state` is a `StepState`:
+
+- `PREPARING` — enqueued, waiting for a free worker slot
+- `RUNNING` — dispatched and executing on a worker
+- `NOT_RUNNING` — that execution finished
+
+It also carries `name` (the step), `worker_id`, `input_event_name`, and `output_event_name`. Note
+that it fires **per step execution**: a `@step(num_workers=N)` step or a fan-out emits one event per
+item, each with its own `worker_id`.
+
+This is the hook the [durable workflows](/python/llamaagents/workflows/durable_workflows) checkpoint
+loop uses — snapshotting `handler.ctx.to_dict()` on each `NOT_RUNNING` to persist progress at step
+boundaries.
+
 ## OpenTelemetry Integration
 
 Workflows integrate with OpenTelemetry for exporting traces. Install the `llama-index-observability-otel` package:

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -30,7 +30,7 @@ async for ev in handler.stream_events(expose_internal=True):
 emits one event per item.
 
 The [durable workflows](/python/llamaagents/workflows/durable_workflows) checkpoint loop uses this
-event, snapshotting `handler.ctx.to_dict()` on each `NOT_RUNNING`.
+event to snapshot after step executions finish.
 
 ## OpenTelemetry Integration
 

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -10,12 +10,12 @@ Furthermore, you can leverage this instrumentation system to add observability t
 
 ## Observing step state with internal events
 
-Beyond the events your steps emit, the runtime publishes **internal** events describing its own
-execution. They're filtered out of `stream_events()` by default; pass `expose_internal=True` to see
+Beyond the events your steps emit, the runtime publishes internal events describing its own
+execution. They are filtered out of `stream_events()` by default. Pass `expose_internal=True` to see
 them:
 
 ```python
-from workflows.events import InternalDispatchEvent, StepStateChanged, StepState
+from workflows.events import StepStateChanged, StepState
 
 handler = workflow.run()
 async for ev in handler.stream_events(expose_internal=True):
@@ -23,20 +23,14 @@ async for ev in handler.stream_events(expose_internal=True):
         print(ev.name, ev.step_state, ev.worker_id)
 ```
 
-The most useful is `StepStateChanged`, emitted whenever a step execution changes state. Its
-`step_state` is a `StepState`:
+`StepStateChanged` fires whenever a step execution changes state. Its `step_state` is one of
+`StepState.PREPARING` (enqueued, waiting for a worker slot), `StepState.RUNNING` (executing), or
+`StepState.NOT_RUNNING` (finished). It also carries `name`, `worker_id`, `input_event_name`, and
+`output_event_name`. It fires once per step execution, so a `@step(num_workers=N)` step or a fan-out
+emits one event per item.
 
-- `PREPARING` — enqueued, waiting for a free worker slot
-- `RUNNING` — dispatched and executing on a worker
-- `NOT_RUNNING` — that execution finished
-
-It also carries `name` (the step), `worker_id`, `input_event_name`, and `output_event_name`. Note
-that it fires **per step execution**: a `@step(num_workers=N)` step or a fan-out emits one event per
-item, each with its own `worker_id`.
-
-This is the hook the [durable workflows](/python/llamaagents/workflows/durable_workflows) checkpoint
-loop uses — snapshotting `handler.ctx.to_dict()` on each `NOT_RUNNING` to persist progress at step
-boundaries.
+The [durable workflows](/python/llamaagents/workflows/durable_workflows) checkpoint loop uses this
+event, snapshotting `handler.ctx.to_dict()` on each `NOT_RUNNING`.
 
 ## OpenTelemetry Integration
 

--- a/docs/src/content/docs/llamaagents/workflows/resources.md
+++ b/docs/src/content/docs/llamaagents/workflows/resources.md
@@ -174,15 +174,3 @@ The dependency chain is resolved automatically. In this example, when the workfl
 3. The resulting client is passed to the step
 
 This pattern works with any combination of `Resource` and `ResourceConfig` dependencies.
-
-## Resources and durability
-
-Resources are resolved by calling their factory and are **never serialized into the workflow
-context**. When you [checkpoint a workflow](/python/llamaagents/workflows/durable_workflows), the
-snapshot contains the in-flight events and the state store — not your resources. On resume, the
-factory simply runs again and re-creates the resource.
-
-That makes resources the right home for anything heavy or non-serializable: API clients, model
-handles, database connections, large reference data, byte buffers. Keep those out of your events
-and state store (which must be serializable to snapshot), inject them as resources, and let events
-carry small identifiers instead. This is what keeps a checkpoint small and cheap to take.

--- a/docs/src/content/docs/llamaagents/workflows/resources.md
+++ b/docs/src/content/docs/llamaagents/workflows/resources.md
@@ -174,3 +174,15 @@ The dependency chain is resolved automatically. In this example, when the workfl
 3. The resulting client is passed to the step
 
 This pattern works with any combination of `Resource` and `ResourceConfig` dependencies.
+
+## Resources and durability
+
+Resources are resolved by calling their factory and are **never serialized into the workflow
+context**. When you [checkpoint a workflow](/python/llamaagents/workflows/durable_workflows), the
+snapshot contains the in-flight events and the state store — not your resources. On resume, the
+factory simply runs again and re-creates the resource.
+
+That makes resources the right home for anything heavy or non-serializable: API clients, model
+handles, database connections, large reference data, byte buffers. Keep those out of your events
+and state store (which must be serializable to snapshot), inject them as resources, and let events
+carry small identifiers instead. This is what keeps a checkpoint small and cheap to take.


### PR DESCRIPTION
The durable workflow docs currently describe persistence mechanically, but they do not lead with the checkpoint loop a user would actually write for a long concurrent run. This rewrites the page around that path: snapshot the context at step boundaries, restore it with `Context.from_dict()`, and let pending events plus partial fan-in state continue after restart.

The worked example uses the typed fan-out/fan-in form:

```python
async def dispatch(self, ev: StartEvent) -> list[WorkItem]:
    return [WorkItem(item_id=item_id) for item_id in ev.item_ids]

async def collect(self, events: list[WorkDone]) -> StopEvent:
    return StopEvent(result={ev.item_id: ev.result for ev in events})
```

The page states the resume contract directly: completed work is restored, pending work stays pending, and in-flight step executions may run again, so repeated side effects need to be safe. The snapshot caveats now sit with the snapshot rules: workflow instance attributes are not durable state, event/state values must be serializable, and heavy clients belong in `Resource` factories.

Related pages now point at the same model instead of restating it: `observability.md` documents `StepStateChanged`, `managing_state.md` calls out serializable state, and `concurrent_execution.md` links fan-out readers to the durability guide. The managed-durability path is framed as a runtime plugin concern, with DBOS as the durable runtime example.