### PR TITLE
Clarify core workflow docs

### DIFF
--- a/docs/src/content/docs/llamaagents/workflows/async_workflows.md
+++ b/docs/src/content/docs/llamaagents/workflows/async_workflows.md
@@ -23,14 +23,14 @@ import requests
 class SyncStepWorkflow(Workflow):
     @step
     def fetch_data(self, ev: StartEvent) -> StopEvent:
-        # This runs in a thread automatically — the event loop stays free
+        # This runs in a thread automatically, so the event loop stays free
         response = requests.get("https://api.example.com/data")
         return StopEvent(result=response.json())
 ```
 
 This is the simplest option when your step body is entirely synchronous. The framework handles the thread-offloading for you, including preserving `contextvars` across the thread boundary.
 
-However, there are cases where you still need finer-grained control inside an `async def` step — for example, when only part of the step is blocking, or when you want to use a dedicated executor for CPU-heavy work. The sections below cover those scenarios.
+However, there are cases where you still need finer-grained control inside an `async def` step, for example, when only part of the step is blocking, or when you want to use a dedicated executor for CPU-heavy work. The sections below cover those scenarios.
 
 ## Blocking I/O in async steps
 
@@ -58,7 +58,7 @@ class BlockingIOWorkflow(Workflow):
 
 `asyncio.to_thread` schedules the function on the default `ThreadPoolExecutor` and returns an awaitable. While the blocking call runs in a separate thread, the event loop continues processing other steps and workflows.
 
-This applies to any synchronous library call that performs I/O — reading files, querying databases, calling external APIs, and so on:
+This applies to any synchronous library call that performs I/O: reading files, querying databases, calling external APIs, and so on:
 
 ```python
 import asyncio
@@ -82,7 +82,7 @@ class FileReaderWorkflow(Workflow):
 
 ## CPU-intensive operations
 
-CPU-bound work — data transformation, image processing, numerical computation — presents a different challenge. Even when run on a thread, CPU-intensive Python code can contend with the event loop due to the GIL (Global Interpreter Lock).
+CPU-bound work, such as data transformation, image processing, or numerical computation, presents a different challenge. Even when run on a thread, CPU-intensive Python code can contend with the event loop due to the GIL (Global Interpreter Lock).
 
 For CPU-heavy work, use a dedicated, smaller thread pool (or process pool) so that these tasks are queued and do not saturate the default executor:
 
@@ -128,7 +128,7 @@ Key differences from the I/O case:
 
 - **Use `loop.run_in_executor`** with an explicit executor instead of `asyncio.to_thread` so you can control the pool size and type.
 - **Keep the pool small.** A pool of 1–2 workers means CPU tasks queue up rather than competing for CPU time. Adjust based on your workload and available cores.
-- **Consider a `ProcessPoolExecutor`** for truly CPU-bound work that you want to run outside the GIL. The API is the same — just swap the executor type:
+- **Consider a `ProcessPoolExecutor`** for truly CPU-bound work that you want to run outside the GIL. The API is the same, just swap the executor type:
 
 ```python
 from concurrent.futures import ProcessPoolExecutor

--- a/docs/src/content/docs/llamaagents/workflows/branches_and_loops.md
+++ b/docs/src/content/docs/llamaagents/workflows/branches_and_loops.md
@@ -105,3 +105,34 @@ Our imports are the same as before, but we've created 4 new event types. `start`
 ![A simple branch](./assets/branching.png)
 
 You can of course combine branches and loops in any order to fulfill the needs of your application. Later in this tutorial you'll learn how to run multiple branches in parallel using `send_event` and synchronize them using `collect_events`.
+
+## Event subclass routing
+
+Event routing is exact by default. A step annotated with `ParentEvent` does not automatically receive `ChildEvent`, even if `ChildEvent` subclasses it. This keeps accidental broad matches from changing a workflow as the event model grows.
+
+Opt in per step when a parent event really is the routing contract:
+
+```python
+from workflows import Workflow, step
+from workflows.events import Event, StartEvent, StopEvent
+
+
+class ToolEvent(Event):
+    tool_name: str
+
+
+class SearchEvent(ToolEvent):
+    query: str
+
+
+class ToolWorkflow(Workflow):
+    @step
+    async def start(self, ev: StartEvent) -> SearchEvent:
+        return SearchEvent(tool_name="search", query=ev.query)
+
+    @step(accept_event_subclasses=True)
+    async def handle_tool(self, ev: ToolEvent) -> StopEvent:
+        return StopEvent(result=ev.tool_name)
+```
+
+Use this sparingly. In most workflows, concrete event types make the branch structure clearer and give better validation errors.

--- a/docs/src/content/docs/llamaagents/workflows/client.md
+++ b/docs/src/content/docs/llamaagents/workflows/client.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 18
+  order: 19
 title: Python Client
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -206,9 +206,9 @@ Each join stays at its own level. `per_inner` runs three times, once per outer `
 
 ## The dynamic API
 
-When the events you emit do not follow from the step's signature, send them yourself with `ctx.send_event` and collect them with `ctx.collect_events`. Use this when you only emit some events depending on a condition, when you do not know in advance how many events you will emit, or when you want to emit them one at a time instead of in one batch.
+When a step needs to emit events before it returns, send them yourself with `ctx.send_event` and collect them with `ctx.collect_events`. Use this when you only emit some events depending on a condition, when you do not know in advance how many events you will emit, or when you want downstream work to start while the producer is still running.
 
-There is a trade-off here. A `list` return is all or nothing. It goes out as one batch when the step returns, so if the step raises an error first, nothing is emitted. `ctx.send_event` fires the moment you call it. Downstream steps can start before the producer step is done. But anything you already sent stays out even if the step later fails.
+There is a trade-off here. A `list` return is all or nothing. It goes out as one batch when the step returns, so if the step raises an error first, nothing is emitted. `ctx.send_event` fires the moment you call it. Downstream steps can start before the producer step is done, but anything already sent stays out even if the step later fails.
 
 `ctx.send_event` emits one event at a time:
 
@@ -237,7 +237,9 @@ class ParallelFlow(Workflow):
         return StopEvent(result=ev.query)
 ```
 
-`start` emits the events with `ctx.send_event` instead of returning them, so its return type is `StepTwoEvent | None` and the fan-out never appears in the signature. The downside is that nothing links `start` to the events it sends, so it appears as a disconnected node in the diagram. To wait for several of these events before moving on, use `ctx.collect_events`:
+`start` emits the events with `ctx.send_event` instead of returning them. The return annotation still includes `StepTwoEvent`, even though the function returns `None`, so validation and diagrams know this step can produce that event. If you omit the sent event from the signature, the runtime can still send it, but static validation and visualization cannot infer that edge.
+
+To wait for several manually sent events before moving on, use `ctx.collect_events`:
 
 ```python
 import asyncio

--- a/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
+++ b/docs/src/content/docs/llamaagents/workflows/customizing_entry_exit_points.md
@@ -4,115 +4,98 @@ sidebar:
 title: Custom start and stop events
 ---
 
-Most of the time, the default `StartEvent` and `StopEvent` we have seen in the [Getting Started](/python/llamaagents/workflows/) section are enough.
-But you can define your own start and stop events where you would normally expect `StartEvent` and `StopEvent`, let's see how.
+Most workflows can use the default `StartEvent` and `StopEvent` from the [Getting Started](/python/llamaagents/workflows/) section. Define custom start and stop events when the workflow boundary itself has a useful schema: a typed request object at the beginning, or a typed result object at the end.
 
 ## Using a custom `StartEvent`
 
-When we call the `run()` method on a workflow instance, the keyword arguments passed become fields of a `StartEvent`
-instance that's automatically created under the hood. In case we want to pass complex data to start a workflow, this
-approach might become cumbersome, and it's when we can introduce a custom start event.
-
-To be able to use a custom start event, the first step is creating a custom class that inherits from `StartEvent`:
+When you call `run()` with keyword arguments, Workflows builds the workflow's start event from those arguments. With the default `StartEvent`, any extra field is accepted:
 
 ```python
-from pathlib import Path
-
-from workflows.events import StartEvent
-from llama_index.indices.managed.llama_cloud import LlamaCloudIndex
-from llama_index.llms.openai import OpenAI
-
-
-class MyCustomStartEvent(StartEvent):
-    a_string_field: str
-    a_path_to_somewhere: Path
-    an_index: LlamaCloudIndex
-    an_llm: OpenAI
+result = await workflow.run(topic="pirates")
 ```
 
-All we have to do now is using `MyCustomStartEvent` as event type in the steps that act as entry points.
-Take this artificially complex step for example:
+That is convenient for small inputs. For production code, a custom `StartEvent` gives the entry point a real schema and lets Pydantic validate missing or malformed input before the first step runs.
+
+Create a custom class that inherits from `StartEvent`:
+
+```python
+from workflows.events import StartEvent
+
+
+class JokeStartEvent(StartEvent):
+    topic: str
+    tone: str = "funny"
+```
+
+Then use that event type in the step that starts the workflow:
 
 ```python
 class JokeFlow(Workflow):
-    ...
-
     @step
-    async def generate_joke_from_index(
-        self, ev: MyCustomStartEvent
-    ) -> JokeEvent:
-        # Build a query engine using the index and the llm from the start event
-        query_engine = ev.an_index.as_query_engine(llm=ev.an_llm)
-        topic = await query_engine.aquery(
-            f"What is the closest topic to {ev.a_string_field}"
-        )
-        # Use the llm attached to the start event to instruct the model
-        prompt = f"Write your best joke about {topic}."
-        response = await ev.an_llm.acomplete(prompt)
-        # Dump the response on disk using the Path object from the event
-        ev.a_path_to_somewhere.write_text(str(response))
-        # Finally, pass the JokeEvent along
+    async def generate_joke(self, ev: JokeStartEvent) -> JokeEvent:
+        prompt = f"Write a {ev.tone} joke about {ev.topic}."
+        response = await self.llm.acomplete(prompt)
         return JokeEvent(joke=str(response))
 ```
 
-We could still pass the fields of `MyCustomStartEvent` as keyword arguments to the `run` method of our workflow, but
-that would be, again, cumbersome. A better approach is to use pass the event instance through the `start_event`
-keyword argument like this:
+You can still pass the fields as keyword arguments:
 
 ```python
-custom_start_event = MyCustomStartEvent(...)
-w = JokeFlow(timeout=60, verbose=False)
-result = await w.run(start_event=custom_start_event)
-print(str(result))
+w = JokeFlow(timeout=60)
+result = await w.run(topic="pirates", tone="dry")
 ```
 
-This approach makes the code cleaner and more explicit and allows autocompletion in IDEs to work properly.
+For a larger input object, pass the event instance through `start_event`:
+
+```python
+start_event = JokeStartEvent(topic="pirates", tone="dry")
+w = JokeFlow(timeout=60)
+result = await w.run(start_event=start_event)
+```
+
+Use events for serializable data. If the workflow needs an LLM client, an index, a database connection, or a file handle, inject it as a [resource](/python/llamaagents/workflows/resources) instead of putting it on the start event. Start events can be serialized when you snapshot or serve workflows, and heavyweight runtime objects usually cannot.
 
 ## Using a custom `StopEvent`
 
-Similarly to `StartEvent`, relying on the built-in `StopEvent` works most of the times but not always. In fact, when we
-use `StopEvent`, the result of a workflow must be set to the `result` field of the event instance. Since a result can
-be any Python object, the `result` field of `StopEvent` is typed as `Any`, losing any advantage from the typing system.
-Additionally, returning more than one object is cumbersome: we usually stuff a bunch of unrelated objects into a
-dictionary that we then assign to `StopEvent.result`.
+The built-in `StopEvent` returns whatever you put in `result`:
 
-First step to support custom stop events, we need to create a subclass of `StopEvent`:
+```python
+return StopEvent(result={"critique": critique, "score": score})
+```
+
+That is fine for quick workflows, but the result is typed as `Any`. A custom stop event makes the output shape explicit.
+
+Create a subclass of `StopEvent`:
 
 ```python
 from workflows.events import StopEvent
 
 
-class MyStopEvent(StopEvent):
-    critique: CompletionResponse
+class JokeResult(StopEvent):
+    joke: str
+    critique: str
 ```
 
-We can now replace `StopEvent` with `MyStopEvent` in our workflow:
+We can now replace `StopEvent` with `JokeResult` in our workflow:
 
 ```python
 class JokeFlow(Workflow):
     ...
 
     @step
-    async def critique_joke(self, ev: JokeEvent) -> MyStopEvent:
-        joke = ev.joke
-
-        prompt = f"Give a thorough analysis and critique of the following joke: {joke}"
+    async def critique_joke(self, ev: JokeEvent) -> JokeResult:
+        prompt = f"Give a thorough analysis and critique of the following joke: {ev.joke}"
         response = await self.llm.acomplete(prompt)
-        return MyStopEvent(critique=response)
-
-    ...
+        return JokeResult(joke=ev.joke, critique=str(response))
 ```
 
-The one important thing we need to remember when using a custom stop events, is that the result of a workflow run
-will be the instance of the event:
+When a step returns the base `StopEvent`, `await workflow.run(...)` returns `stop_event.result`. When a step returns a custom `StopEvent` subclass, `await workflow.run(...)` returns the event instance:
 
 ```python
-w = JokeFlow(timeout=60, verbose=False)
-# Warning! `result` now contains an instance of MyStopEvent!
+w = JokeFlow(timeout=60)
 result = await w.run(topic="pirates")
-# We can now access the event fields as any normal Event
-print(result.critique.text)
+print(result.joke)
+print(result.critique)
 ```
 
-This approach takes advantage of the Python typing system, is friendly to autocompletion in IDEs and allows
-introspection from outer applications that now know exactly what a workflow run will return.
+That makes the result friendly to type checkers, editor autocomplete, and callers that introspect workflow schemas.

--- a/docs/src/content/docs/llamaagents/workflows/deployment.md
+++ b/docs/src/content/docs/llamaagents/workflows/deployment.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 17
+  order: 18
 title: Run Your Workflow as a Server
 ---
 
@@ -73,7 +73,7 @@ The library also provides a convenient CLI to run a server from a file containin
 Given the `my_server.py` file from the example above, you can start the server with the following command:
 
 ```bash
-python -m workflows.server my_server.py
+python -m llama_agents.server my_server.py
 ```
 
 The server will start on `0.0.0.0:8080` by default. You can configure the host and port using the
@@ -177,7 +177,7 @@ To stream events either as Server-Sent Events (SSE) or as multi-line JSON payloa
 
 - `sse` (set to either "true" or "false", not required): stream the events as Server Sent Events (`text/event-stream`) if true, else stream them as a multi-line JSON payload (`application/x-ndjson`). Defaults to true.
 - `acquire_timeout` (a float-convertible string, not required): timeout for acquiring the lock to iterate over events
-- `include_internal` (set to either "true" or "false", not required): stream internal workfloe events if set to true. Defaults to false.
+- `include_internal` (set to either "true" or "false", not required): stream internal workflow events if set to true. Defaults to false.
 - `include_qualified_name` (set to either "true" or "false", not required): include the qualified name of the event in the response body. Defaults to true.
 
 **Example request**
@@ -315,7 +315,7 @@ from dbos import DBOS
 from llama_agents.dbos import DBOSRuntime
 from llama_agents.server import WorkflowServer
 
-# Configure DBOS — uses SQLite by default, or set system_database_url for Postgres
+# Configure DBOS. It uses SQLite by default, or set system_database_url for Postgres.
 DBOS(config={"name": "my-app", "run_admin_server": False})
 
 runtime = DBOSRuntime()

--- a/docs/src/content/docs/llamaagents/workflows/drawing.md
+++ b/docs/src/content/docs/llamaagents/workflows/drawing.md
@@ -4,11 +4,11 @@ sidebar:
 title: Drawing a Workflow
 ---
 
-Workflows can be visualized, using the power of type annotations in your step definitions.
+Workflows can be visualized from the same type annotations the runtime uses for validation. That makes diagrams useful in two different moments: before a run, to see every possible path, and after a run, to see what actually happened.
 
-There are two main ways to visualize your workflows.
+There are two main ways to visualize a workflow.
 
-## 1. Converting a Workflow to HTML
+## Generate diagram files
 
 First install:
 
@@ -21,24 +21,42 @@ Then import and use:
 ```python
 from llama_index.utils.workflow import (
     draw_all_possible_flows,
+    draw_all_possible_flows_mermaid,
     draw_most_recent_execution,
+    draw_most_recent_execution_mermaid,
 )
 
-# Draw all
+# Draw every statically possible path as HTML
 draw_all_possible_flows(MyWorkflow, filename="all_paths.html")
 
-# Draw an execution
+# Draw the same static graph as Mermaid
+mermaid = draw_all_possible_flows_mermaid(MyWorkflow)
+
+# Draw one completed execution as HTML
 w = MyWorkflow()
 handler = w.run(topic="Pirates")
 await handler
 draw_most_recent_execution(handler, filename="most_recent.html")
+
+# Draw the same completed execution as Mermaid
+execution_mermaid = draw_most_recent_execution_mermaid(handler)
 ```
 
-## 2. Using the `workflow-debugger`
+`draw_all_possible_flows` accepts either a workflow class or a workflow instance. The execution functions take a `WorkflowHandler`, so you need to run the workflow first.
 
-Workflows ship with a [`WorkflowServer`](/python/llamaagents/workflows/deployment) that allows you to convert workflows to API's. As part of the `WorkflowServer`, a debugging UI is provided as the home `/` page.
+Long event names can make diagrams hard to read. Pass `max_label_length=...` to truncate node labels:
 
-Using this server app, you can visualize and run your workflows.
+```python
+draw_all_possible_flows(MyWorkflow, filename="all_paths.html", max_label_length=24)
+```
+
+By default, static diagrams include child workflows. Pass `include_child_workflows=False` if you want only the parent workflow graph.
+
+## Use the debugger UI
+
+The [`WorkflowServer`](/python/llamaagents/workflows/deployment) serves a debugger UI at `/`. Use it when you want to run a workflow, inspect events, and send human-in-the-loop responses from a browser.
+
+Using this server app, you can visualize and run your workflows:
 
 ![workflow debugger](./assets/ui_sample.png)
 
@@ -48,17 +66,19 @@ Setting up the server is straightforward:
 import asyncio
 from workflows import Workflow, step
 from workflows.events import StartEvent, StopEvent
-from workflows.server import WorkflowServer
+from llama_agents.server import WorkflowServer
+
 
 class MyWorkflow(Workflow):
     @step
     async def my_step(self, ev: StartEvent) -> StopEvent:
         return StopEvent(result="Done!")
 
+
 async def main():
     server = WorkflowServer()
     server.add_workflow("my_workflow", MyWorkflow())
-    await server.serve("0.0.0.0", "8080")
+    await server.serve("0.0.0.0", 8080)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
+++ b/docs/src/content/docs/llamaagents/workflows/human_in_the_loop.md
@@ -4,76 +4,68 @@ sidebar:
 title: Human in the Loop
 ---
 
-Since workflows are so flexible, there are many possible ways to implement human-in-the-loop patterns.
+Human-in-the-loop workflows need to pause, tell the caller what input is needed, and continue when the caller sends a response. Workflows support that with normal events.
 
-The easiest way to implement a human-in-the-loop is to use the `InputRequiredEvent` and `HumanResponseEvent` events during event streaming.
+The most direct pattern is a pair of steps: one returns `InputRequiredEvent`, and another consumes `HumanResponseEvent`. The caller watches the stream and sends the response back into the same handler.
 
 ```python
 from workflows import Workflow, step
 from workflows.events import StartEvent, StopEvent, InputRequiredEvent, HumanResponseEvent
 
 
-class HumanInTheLoopWorkflow(Workflow):
+class NumberWorkflow(Workflow):
     @step
-    async def step1(self, ev: StartEvent) -> InputRequiredEvent:
+    async def ask(self, ev: StartEvent) -> InputRequiredEvent:
         return InputRequiredEvent(prefix="Enter a number: ")
 
     @step
-    async def step2(self, ev: HumanResponseEvent) -> StopEvent:
+    async def answer(self, ev: HumanResponseEvent) -> StopEvent:
         return StopEvent(result=ev.response)
 
 
-# workflow should work with streaming
-workflow = HumanInTheLoopWorkflow()
+workflow = NumberWorkflow()
 
 handler = workflow.run()
 async for event in handler.stream_events():
     if isinstance(event, InputRequiredEvent):
-        # here, we can handle human input however you want
-        # this means using input(), websockets, accessing async state, etc.
-        # here, we just use input()
+        # This could be input(), a websocket reply, a web form submission, etc.
         response = input(event.prefix)
-        handler.ctx.send_event(HumanResponseEvent(response=response))
+        await handler.send_event(HumanResponseEvent(response=response))
 
 final_result = await handler
 ```
 
-Here, the workflow will wait until the `HumanResponseEvent` is emitted.
-
-If needed, you can also subclass these two events to add custom payloads.
+Here, the workflow waits until the `HumanResponseEvent` is emitted. You can subclass both events when the prompt or response needs more structure.
 
 ## Stopping/Resuming Between Human Responses
 
-You can break out of the event loop and resume later. This is useful when you want to pause the workflow to wait for a human response asynchronously (e.g., from a web request).
+In a web app, the process that sees the prompt is often not the same request that receives the answer. Snapshot the context after the prompt, store it, and restore it when the response arrives.
 
 ```python
+import json
 from workflows import Context
 
 handler = workflow.run()
 async for event in handler.stream_events():
     if isinstance(event, InputRequiredEvent):
-        # Serialize the context, store it anywhere as a JSON blob
-        ctx_dict = handler.ctx.to_dict()
+        await db.save("run-123", json.dumps(handler.ctx.to_dict()))
         await handler.cancel_run()
         break
 
-...
-
-# now we handle the human response once it comes in
-response = input(event.prefix)
-
+# Later, when the human response arrives:
+response = form_data["response"]
+ctx_dict = json.loads(await db.load("run-123"))
 restored_ctx = Context.from_dict(workflow, ctx_dict)
 handler = workflow.run(ctx=restored_ctx)
 
-# Send the event to resume the workflow
-handler.ctx.send_event(HumanResponseEvent(response=response))
-
-# now we resume the workflow streaming with our restored context
+await handler.send_event(HumanResponseEvent(response=response))
 async for event in handler.stream_events():
     continue
 
 final_result = await handler
 ```
+
+Cancel the original handler after snapshotting if you are intentionally handing the run off to another request or process. That avoids leaving the in-memory run waiting for an answer that will be delivered to the restored run.
 
 ## Using `wait_for_event`
 
@@ -90,7 +82,18 @@ async def ask_user(self, ctx: Context, ev: StartEvent) -> StopEvent:
     return StopEvent(result=response.response)
 ```
 
-**Important**: `wait_for_event` replays all code preceding it whenever the step receives its triggering event _or_ a matching waiting event. The step always runs at least once up to the waiter, which then raises an internal exception to pause execution. Because of this, any code before the `wait_for_event` call must be idempotent (safe to repeat).
+Use `waiter_id` when the same step may wait more than once. Use `requirements` when several waiters consume the same event type and you need to route the right response to the right waiter:
+
+```python
+response = await ctx.wait_for_event(
+    HumanResponseEvent,
+    waiter_event=InputRequiredEvent(prefix="Approve draft? "),
+    waiter_id="approve-draft",
+    requirements={"request_id": ev.request_id},
+)
+```
+
+`wait_for_event` replays all code preceding it whenever the step receives its triggering event or a matching waiting event. The step always runs at least once up to the waiter, which then raises an internal exception to pause execution. Any code before the `wait_for_event` call must be safe to repeat.
 
 Due to this complexity, the event-based approach with separate steps is generally recommended.
 

--- a/docs/src/content/docs/llamaagents/workflows/index.md
+++ b/docs/src/content/docs/llamaagents/workflows/index.md
@@ -8,7 +8,9 @@ title: Introduction
 
 A workflow is an event-driven, step-based way to control the execution flow of an application.
 
-Your application is divided into sections called Steps which are triggered by Events, and themselves emit Events which trigger further steps. By combining steps and events, you can create arbitrarily complex flows that encapsulate logic and make your application more maintainable and easier to understand. A step can be anything from a single line of code to a complex agent. They can have arbitrary inputs and outputs, which are passed around by Events.
+Your application is divided into sections called steps. A step receives an event, does some work, and returns another event. That returned event triggers the next step whose type annotation accepts it.
+
+That is the whole model. A step can call an LLM, run retrieval, ask for human input, update shared state, or dispatch a batch of work. The event types describe the edges of the workflow, and regular Python describes the logic inside each edge.
 
 ## Why workflows?
 
@@ -18,10 +20,11 @@ Other frameworks and LlamaIndex itself have attempted to solve this problem prev
 
 - Logic like loops and branches needed to be encoded into the edges of graphs, which made them hard to read and understand.
 - Passing data between nodes in a DAG created complexity around optional and default values and which parameters should be passed.
-- DAGs did not feel natural to developers trying to developing complex, looping, branching AI applications.
+- DAGs did not feel natural to developers trying to develop complex, looping, branching AI applications.
 
-The event-based pattern and vanilla python approach of Workflows resolves these problems.
+The event-based pattern and plain Python approach of Workflows resolves these problems.
 
+Branches are ordinary `if` statements that return different event types. Loops are steps that return an event handled by an earlier step. Concurrent work is a step that returns `list[Event]`, paired with another step that accepts `list[Event]`. When the flow needs to become dynamic, you can send events directly from the `Context`.
 
 :::note
 The Workflows library can be installed standalone, via `pip install llama-index-workflows`. However,
@@ -36,7 +39,7 @@ the `llama-index` umbrella package, Workflows can be accessed with the import pa
 :::tip
 Workflows make async a first-class citizen, and this page assumes you are running in an async environment. What this means for you is setting up your code for async properly. If you are already running in a server like FastAPI, or in a notebook, you can freely use await already!
 
-If you are running your own python scripts, its best practice to have a single async entry point.
+If you are running your own Python scripts, it's best practice to have a single async entry point.
 
 ```python
 async def main():
@@ -52,7 +55,7 @@ if __name__ == "__main__":
 ```
 :::
 
-As an illustrative example, let's consider a naive workflow where a joke is generated and then critiqued.
+Here is the smallest useful shape: generate something, pass it to another step, then stop with a result.
 
 ```python
 from workflows import Workflow, step
@@ -97,7 +100,7 @@ print(str(result))
 
 ![joke](./assets/joke.png)
 
-There's a few moving pieces here, so let's go through this piece by piece.
+There are a few moving pieces here, so let's go through them one at a time.
 
 ### Defining Workflow Events
 
@@ -106,7 +109,7 @@ class JokeEvent(Event):
     joke: str
 ```
 
-Events are user-defined pydantic objects. You control the attributes and any other auxiliary methods. In this case, our workflow relies on a single user-defined event, the `JokeEvent`.
+Events are user-defined Pydantic objects. You control the attributes and any other auxiliary methods. In this case, our workflow relies on a single user-defined event, the `JokeEvent`.
 
 ### Setting up the Workflow Class
 
@@ -116,7 +119,7 @@ class JokeFlow(Workflow):
     ...
 ```
 
-Our workflow is implemented by subclassing the `Workflow` class. For simplicity, we attached a static `OpenAI` llm instance.
+Our workflow is implemented by subclassing the `Workflow` class. For simplicity, we attached a static `OpenAI` LLM instance.
 
 ### Workflow Entry Points
 
@@ -135,7 +138,7 @@ class JokeFlow(Workflow):
     ...
 ```
 
-Here, we come to the entry-point of our workflow. While most events are use-defined, there are two special-case events,
+Here, we come to the entry-point of our workflow. While most events are user-defined, there are two special-case events,
 the `StartEvent` and the `StopEvent` that the framework provides out of the box. Here, the `StartEvent` signifies where
 to send the initial workflow input.
 
@@ -166,7 +169,7 @@ class JokeFlow(Workflow):
     ...
 ```
 
-Here, we have our second, and last step, in the workflow. We know its the last step because the special `StopEvent` is
+Here, we have our second, and last step, in the workflow. We know it's the last step because the special `StopEvent` is
 returned. When the workflow encounters a returned `StopEvent`, it immediately stops the workflow and returns whatever
 we passed in the `result` parameter.
 
@@ -185,9 +188,68 @@ print(str(result))
 Lastly, we create and run the workflow. There are some settings like timeouts (in seconds) and verbosity to help with
 debugging.
 
-The `.run()` method is async, so we use await here to wait for the result. The keyword arguments passed to `run()` will
-become fields of the special `StartEvent` that will be automatically emitted and start the workflow. As we have seen,
-in this case `topic` will be accessed from the step with `ev.topic`.
+The `.run()` method starts the workflow and returns a `WorkflowHandler`. The handler is awaitable, so `await w.run(...)`
+waits for the final result. If you need streamed events while the workflow is running, keep the handler:
+
+```python
+handler = w.run(topic="pirates")
+async for ev in handler.stream_events():
+    ...
+result = await handler
+```
+
+The keyword arguments passed to `run()` become fields of the special `StartEvent` that is automatically emitted to start
+the workflow. As we have seen, in this case `topic` is accessed from the step with `ev.topic`.
+
+## How to choose the right workflow API
+
+Most workflow code should use typed step inputs and typed returns. That gives validation, diagrams, and readable code:
+
+```python
+@step
+async def retrieve(self, ev: StartEvent) -> Retrieved:
+    ...
+
+@step
+async def synthesize(self, ev: Retrieved) -> StopEvent:
+    ...
+```
+
+Use the other APIs when the shape of the work asks for them:
+
+| Use this | When |
+|---|---|
+| Return `A | B` | A step chooses one branch at runtime. |
+| Return `list[A]` | A step has a finite batch and can produce all work items before downstream workers start. |
+| Accept `list[A]` | A step needs the full batch of results before continuing. |
+| `ctx.send_event(...)` | A step needs to emit events incrementally, emit an unknown number of events, or send an event from outside the workflow while it is running. |
+| `ctx.collect_events(...)` | You used `ctx.send_event` and need to manually wait for a known set of events. |
+| `ctx.store` | Steps need shared per-run state. |
+| `Resource(...)` | Steps need clients, indexes, models, config, or other dependencies that should not live in serialized state. |
+
+The type-first APIs are easier to validate and visualize. The context APIs are more flexible, but they make you own more of the bookkeeping.
+
+## Validation
+
+Before a workflow runs, Workflows validates the event graph described by your step signatures. It checks that start and stop events are present, produced events have consumers, consumed events have producers, and the graph does not contain accidental dead ends.
+
+Most validation failures are useful design feedback. They usually mean one of these is true:
+
+| Symptom | Usual cause |
+|---|---|
+| A step consumes an event that is never produced | A return annotation is missing, or the event is only sent dynamically with `ctx.send_event`. |
+| A step produces an event that nobody consumes | The next step has the wrong event type, or the branch is unfinished. |
+| The workflow has no terminal event | No reachable step returns `StopEvent` or a custom `StopEvent` subclass. |
+
+For intentionally dynamic workflows, keep as much as possible in the type annotations and use `ctx.send_event` for the timing. If a step is intentionally unreachable from static analysis, skip that specific check on the step:
+
+```python
+@step(skip_graph_checks=["reachability"])
+async def receive_webhook(self, ev: WebhookEvent) -> StopEvent:
+    ...
+```
+
+You can also call `workflow.validate()` directly in tests or startup code. Resource config files are validated by default; resource factories are only resolved if you call `validate(validate_resources=True)`.
 
 ## Examples
 
@@ -199,7 +261,7 @@ like looping and state management using simple workflows. It's usually a great p
 simple workflow that performs both ingestion and querying.
 - [Citation Query Engine](/python/examples/workflow/citation_query_engine/) similar to RAG + Reranking, the
 notebook focuses on how to implement intermediate steps in between retrieval and generation. A good example of how to
-use the [`Context`](#working-with-global-context-state) object in a workflow.
+use the [`Context`](/python/llamaagents/workflows/managing_state) object in a workflow.
 - [Corrective RAG](/python/examples/workflow/corrective_rag_pack/) adds some more complexity on top of a RAG
 workflow, showcasing how to query a web search engine after an evaluation step.
 - [Utilizing Concurrency](/python/examples/workflow/parallel_execution/) explains how to manage the parallel
@@ -222,7 +284,7 @@ workflow, in this case to improve structured output through reflection.
 - [Query Planning with Workflows](/python/examples/workflow/planning_workflow/) is an example of a workflow
 that plans a query by breaking it down into smaller items, and executing those smaller items. It highlights how
 to stream events from a workflow, execute steps in parallel, and looping until a condition is met.
-- [Checkpointing Workflows](/python/examples/workflow/checkpointing_workflows/) is a more exhaustive demonstration of how to make full use of `WorkflowCheckpointer` to checkpoint Workflow runs.
+- [Writing Durable Workflows](/python/llamaagents/workflows/durable_workflows) shows how to checkpoint workflow context and resume a run after a restart.
 
 Last but not least, a few more advanced use cases that demonstrate how workflows can be extremely handy if you need
 to quickly implement prototypes, for example from literature:

--- a/docs/src/content/docs/llamaagents/workflows/managing_state.md
+++ b/docs/src/content/docs/llamaagents/workflows/managing_state.md
@@ -4,46 +4,52 @@ sidebar:
 title: Managing State
 ---
 
-By default, workflows automatically initialize and untyped state store. You can access this as needed to share information between workflow steps through the `Context` object.
+Each workflow run has a `Context`, and each context has a state store. Use it for values that steps need to share during a run, or for values you intentionally carry into a later run by reusing or restoring the same context.
+
+State is not a place for heavyweight clients, indexes, file handles, or other runtime dependencies. Put those in [resources](/python/llamaagents/workflows/resources). State should be data you are willing to serialize when you snapshot or resume a workflow.
+
+By default, workflows initialize an untyped state store. You can read and write it through `ctx.store`:
 
 ```python
 from workflows import Workflow, Context, step
 from workflows.events import StartEvent, StopEvent
 
+
 class MyWorkflow(Workflow):
 
     @step
     async def my_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
-       current_count = await ctx.store.get("count", default=0)
-       current_count += 1
-       await ctx.store.set("count", current_count)
-       return StopEvent()
+        current_count = await ctx.store.get("count", default=0)
+        current_count += 1
+        await ctx.store.set("count", current_count)
+        return StopEvent(result=current_count)
 ```
 
 ## Locking the State
 
-There are cases where the state might be manipulated by multiple steps running at the same time. In these cases, in can be useful **lock** the state to prevent race conditions. You can do this by using the `Context` object's `edit_state` method:
+There are cases where state can be manipulated by multiple steps running at the same time. In these cases, lock the state with `edit_state()` so the update is atomic:
 
 ```python
 @step
 async def my_step(self, ctx: Context, ev: StartEvent) -> StopEvent:
-   # No other steps can access the state while the `with` block is running
-   async with ctx.store.edit_state() as ctx_state:
-       if "count" not in ctx_state:
-           ctx_state["count"] = 0
-       ctx_state["count"] += 1
-   return StopEvent()
+    async with ctx.store.edit_state() as state:
+        current_count = state.get("count", 0)
+        state["count"] = current_count + 1
+        result = state["count"]
+    return StopEvent(result=result)
 ```
+
+No other step can edit the state while the block is running. Keep the block small: do the read-modify-write work inside it, and keep slow LLM or network calls outside it.
 
 ## Adding Typed State
 
-Often, you'll have some pre-set shape that you want to use as the state for your workflow. The best way to do this is to use a `Pydantic` model to define the state. This way, you:
+Often, you'll have a known shape for your workflow state. Use a `Pydantic` model for that. This gives you:
 
 - Get type hints for your state
 - Get automatic validation of your state
 - (Optionally) Have full control over the serialization and deserialization of your state using [validators](https://docs.pydantic.dev/latest/concepts/validators/) and [serializers](https://docs.pydantic.dev/latest/concepts/serialization/#custom-serializers)
 
-**NOTE:** You should use a pydantic model that has defaults for all fields. This enables the `Context` object to automatically initialize the state with the defaults.
+**NOTE:** Use a Pydantic model with defaults for all fields. This lets the `Context` automatically initialize the state.
 
 Here's a quick example of how you can leverage workflows + pydantic to take advantage of all these features:
 
@@ -69,21 +75,29 @@ class MyWorkflow(Workflow):
     @step
     async def start(
         self,
-        ctx: Context[CounterState],
-        ev: StartEvent
+        ctx: Context[CounterState], ev: StartEvent
     ) -> StopEvent:
         # Allows for atomic state updates
-        async with ctx.store.edit_state() as ctx_state:
-            ctx_state.count += 1
+        async with ctx.store.edit_state() as state:
+            state.count += 1
 
         return StopEvent(result="Done!")
 ```
 
+You can also work with typed state one field at a time:
+
+```python
+@step
+async def start(self, ctx: Context[CounterState], ev: StartEvent) -> StopEvent:
+    current = await ctx.store.get("count")
+    await ctx.store.set("count", current + 1)
+    state = await ctx.store.get_state()
+    return StopEvent(result=state.count)
+```
+
 ## Maintaining Context Across Runs
 
-As you have seen, workflows have a `Context` object that can be used to maintain state across steps.
-
-If you want to maintain state across multiple runs of a workflow, you can pass a previous context into the `.run()` method.
+If you want to maintain state across multiple runs of a workflow, create a context and pass the same one into `.run()`:
 
 ```python
 workflow = MyWorkflow()
@@ -101,9 +115,13 @@ handler = workflow.run(ctx=ctx)
 result = await handler
 ```
 
+If the context is still running, `run(ctx=ctx)` resumes that run and does not send a new `StartEvent`. If the previous run has completed, `run(ctx=ctx)` starts a new run with the same stored state.
+
 ## Serializable state
 
 State you keep here is serialized when you snapshot a run to make it
 [durable](/python/llamaagents/workflows/durable_workflows), so keep it to values a JSON serializer
 can encode. Put clients and other non-serializable objects in
 [resources](/python/llamaagents/workflows/resources) instead.
+
+For custom values, either make them Pydantic-serializable or provide a custom serializer when calling `Context.to_dict()` and `Context.from_dict()`.

--- a/docs/src/content/docs/llamaagents/workflows/observability.md
+++ b/docs/src/content/docs/llamaagents/workflows/observability.md
@@ -1,6 +1,6 @@
 ---
 sidebar:
-  order: 16
+  order: 17
 title: Observability
 ---
 

--- a/docs/src/content/docs/llamaagents/workflows/resources.md
+++ b/docs/src/content/docs/llamaagents/workflows/resources.md
@@ -6,7 +6,9 @@ title: Resource Objects
 
 Resources are external dependencies you can inject into the steps of a workflow.
 
-As a simple example, look at `memory` from llama-index in the following workflow:
+Use resources for objects that should be created by the runtime instead of passed around as events or stored in `ctx.store`: LLM clients, retrievers, indexes, database handles, model configuration, and other dependencies that are expensive, stateful, or not JSON-serializable.
+
+As a simple example, look at `Memory` from LlamaIndex in the following workflow:
 
 ```python
 from typing import Annotated
@@ -18,7 +20,7 @@ from llama_index.core.llms import ChatMessage
 from llama_index.core.memory import Memory
 
 
-def get_memory(*args, **kwargs):
+def get_memory() -> Memory:
     return Memory.from_defaults("user_id_123", token_limit=60000)
 
 
@@ -50,20 +52,23 @@ class WorkflowWithResource(Workflow):
         return StopEvent(result="Messages put into memory")
 ```
 
-To inject a resource into a workflow step, you have to add a parameter to the step signature and define its type,
-using `Annotated` and invoke the `Resource()` wrapper passing a function or callable returning the actual Resource
-object. The return type of the wrapped function must match the declared type, ensuring consistency between what’s
-expected and what’s provided during execution. In the example above, `memory: Annotated[Memory, Resource(get_memory)`
-defines a resource of type `Memory` that will be provided by the `get_memory()` function and passed to the step in the
-`memory` parameter when the workflow runs.
+To inject a resource, add a parameter to the step signature, wrap the type in `Annotated`, and pass a factory to `Resource()`:
 
-Resources are shared among steps of a workflow, and the `Resource()` wrapper will invoke the factory function only once.
-In case this is not the desired behavior, passing `cache=False` to `Resource()` will inject different resource objects
-in different steps, invoking the factory function as many times.
+```python
+memory: Annotated[Memory, Resource(get_memory)]
+```
+
+The factory return type should match the annotated parameter type. By default, the resource is cached for the workflow run, so both steps receive the same `Memory` object and the factory is called once. If a step needs a fresh object each time, pass `cache=False`:
+
+```python
+memory: Annotated[Memory, Resource(get_memory, cache=False)]
+```
+
+Factories can be synchronous or async.
 
 ## Config-backed Resources
 
-For configuration data stored in JSON files, use `ResourceConfig` instead of `Resource`. It automatically loads a JSON file and parses it into a Pydantic model.
+For configuration data stored in JSON files, use `ResourceConfig` instead of `Resource`. It loads the JSON file and parses it into a Pydantic model.
 
 ```python
 from typing import Annotated
@@ -95,7 +100,7 @@ class DocumentClassifier(Workflow):
 ### Parameters
 
 - `config_file`: Path to the JSON file containing the configuration.
-- `path_selector`: Optional "." delimited JSON path to extract a nested value from the json in the config file (e.g., `"settings.classifier"`).
+- `path_selector`: Optional "."-delimited JSON path to extract a nested value from the JSON file (for example, `"settings.classifier"`).
 - `label`: Optional display name for workflow visualizations.
 - `description`: Optional description for workflow visualizations.
 

--- a/docs/src/content/docs/llamaagents/workflows/retry_steps.md
+++ b/docs/src/content/docs/llamaagents/workflows/retry_steps.md
@@ -12,6 +12,8 @@ For all those situations where you want the step to try again, you can use a **r
 instructs the workflow to execute a step multiple times, controlling how long to wait before each new attempt,
 which errors are retryable, and when to give up.
 
+Retries re-run the whole step body for the same input event. Keep side effects before the failing call idempotent, or move them after the retryable work. If the step wrote state or called an external service before raising, that work may happen again.
+
 The retry module is built from three families of composable building blocks:
 
 - **Retry conditions** decide whether an exception is retryable.
@@ -149,24 +151,34 @@ protocol:
 
 ```python
 def next(
-    self, elapsed_time: float, attempts: int, error: Exception
-) -> Optional[float]:
+    self,
+    elapsed_time: float,
+    attempts: int,
+    error: Exception,
+    *,
+    seed: int | None = None,
+) -> float | None:
     ...
 ```
 
 Return the number of seconds to wait before retrying, or `None` to stop.
+The optional `seed` is used by durable runtimes to make jitter deterministic during replay.
 
 For example, this policy only retries on Fridays:
 
 ```python
 from datetime import datetime
-from typing import Optional
 
 
 class RetryOnFridayPolicy:
     def next(
-        self, elapsed_time: float, attempts: int, error: Exception
-    ) -> Optional[float]:
+        self,
+        elapsed_time: float,
+        attempts: int,
+        error: Exception,
+        *,
+        seed: int | None = None,
+    ) -> float | None:
         if datetime.today().strftime("%A") == "Friday":
             return 5  # retry in 5 seconds
         return None  # don't retry
@@ -183,7 +195,7 @@ composable API and are kept for backwards compatibility only. Prefer
 ```python
 from workflows.retry_policy import ConstantDelayRetryPolicy
 
-# Deprecated — equivalent to:
+# Deprecated, equivalent to:
 #   retry_policy(wait=wait_fixed(5), stop=stop_after_attempt(10))
 policy = ConstantDelayRetryPolicy(delay=5, maximum_attempts=10)
 ```
@@ -191,7 +203,7 @@ policy = ConstantDelayRetryPolicy(delay=5, maximum_attempts=10)
 ```python
 from workflows.retry_policy import ExponentialBackoffRetryPolicy
 
-# Deprecated — equivalent to:
+# Deprecated, equivalent to:
 #   retry_policy(wait=wait_random_exponential(multiplier=1, exp_base=2, max=30),
 #                stop=stop_after_attempt(5))
 policy = ExponentialBackoffRetryPolicy(
@@ -202,7 +214,7 @@ policy = ExponentialBackoffRetryPolicy(
 ## Inspecting retry state inside a step
 
 `Context.retry_info()` returns a `RetryInfo` describing the current attempt.
-Use it to adapt behavior between retries — widen a search, shorten a timeout,
+Use it to adapt behavior between retries: widen a search, shorten a timeout,
 log a warning:
 
 ```python
@@ -227,7 +239,7 @@ are `None` until the first failure, then describe the most recent prior failure.
 
 ## Recovering when retries are exhausted
 
-When a policy gives up, the exception propagates and fails the workflow — unless
+When a policy gives up, the exception propagates and fails the workflow, unless
 a `@catch_error` handler is declared. A handler is a step that accepts
 `StepFailedEvent`; it can return a `StopEvent` to end the run gracefully, return
 some other event to re-route the workflow, or raise to fail with a new
@@ -255,7 +267,7 @@ class Pipeline(Workflow):
         )
 ```
 
-A bare `@catch_error` is a **wildcard** — it catches any step whose retries are
+A bare `@catch_error` is a **wildcard**. It catches any step whose retries are
 exhausted and isn't claimed by a more specific handler. Only one wildcard is
 allowed per workflow.
 
@@ -279,7 +291,7 @@ class Pipeline(Workflow):
     ) -> StopEvent:
         return StopEvent(result={"fallback": True})
 
-    @catch_error  # wildcard — covers `parse` and anything else
+    @catch_error  # wildcard; covers `parse` and anything else
     async def on_any_failure(
         self, ctx: Context, ev: StepFailedEvent
     ) -> StopEvent:

--- a/docs/src/content/docs/llamaagents/workflows/streaming.mdx
+++ b/docs/src/content/docs/llamaagents/workflows/streaming.mdx
@@ -4,7 +4,16 @@ sidebar:
 title: Streaming events
 ---
 
-Workflows can be complex -- they are designed to handle complex, branching, concurrent logic -- which means they can take time to fully execute. To provide your user with a good experience, you may want to provide an indication of progress by streaming events as they occur. Workflows have built-in support for this on the `Context` object.
+Workflows often take time to finish. They may call slow providers, branch, fan out over a batch, or wait for a human response. Streaming lets you surface progress while the run is still moving.
+
+There are two sides to streaming:
+
+| Side | API |
+|---|---|
+| Inside a step | `ctx.write_event_to_stream(...)` |
+| Outside the workflow | `handler.stream_events()` |
+
+`workflow.run(...)` starts the workflow and returns a `WorkflowHandler`. The handler is awaitable for the final result, and it also owns the event stream for that run.
 
 To get this done, let's bring in all the deps we need:
 
@@ -77,7 +86,7 @@ class MyWorkflow(Workflow):
   You could also pass one in using the `api_key` parameter.
 </Aside>
 
-In `step_one` and `step_three` we write individual events to the event stream. In `step_two` we use `astream_complete` to produce an iterable generator of the LLM's response, then we produce an event for each chunk of data the LLM sends back to us -- roughly one per word -- before returning the final response to `step_three`.
+In `step_one` and `step_three` we write individual events to the event stream. In `step_two` we use `astream_complete` to produce an iterable generator of the LLM's response, then we produce an event for each chunk of data the LLM sends back to us before returning the final response to `step_three`.
 
 To actually get this output, we need to run the workflow asynchronously and listen for the events, like this:
 
@@ -98,11 +107,13 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
-`run` runs the workflow in the background, while `stream_events` will provide any event that gets written to the stream. It stops when the stream delivers a `StopEvent`, after which you can get the final result of the workflow as you normally would.
+`run` schedules the workflow in the background. `stream_events()` yields every event written to the stream and stops when the stream delivers a `StopEvent`. After that, await the handler to get the final result.
+
+A handler stream can be consumed once. If you need to broadcast workflow events to multiple clients, consume the stream once in your application and fan those events out yourself.
 
 ## Handling workflow termination
 
-When a workflow ends abnormally (timeout, cancellation, or step failure), a specific `StopEvent` subclass is published to the stream before the exception is raised:
+When a workflow ends abnormally, a specific `StopEvent` subclass is published to the stream before the exception is raised from `await handler`:
 
 - **`WorkflowTimedOutEvent`** - Published when the workflow exceeds its timeout. Contains `timeout` (seconds) and `active_steps` (list of step names that were running).
 - **`WorkflowCancelledEvent`** - Published when the workflow is cancelled by the user.

--- a/docs/src/content/docs/llamaagents/workflows/testing.md
+++ b/docs/src/content/docs/llamaagents/workflows/testing.md
@@ -1,0 +1,145 @@
+---
+sidebar:
+  order: 16
+title: Testing Workflows
+---
+
+Workflows are easiest to test as event-driven systems. Run the workflow, collect the events it streamed, assert the final result, and inspect the context state when state matters.
+
+The `workflows.testing` module includes a small runner for this:
+
+```python
+from workflows.testing import WorkflowTestRunner
+```
+
+## End-to-end tests
+
+`WorkflowTestRunner` starts the workflow, drains its event stream, awaits the final result, and returns everything in one object:
+
+```python
+import pytest
+
+from workflows import Context, Workflow, step
+from workflows.events import Event, StartEvent, StopEvent
+from workflows.testing import WorkflowTestRunner
+
+
+class Progress(Event):
+    message: str
+
+
+class Done(Event):
+    value: str
+
+
+class ExampleWorkflow(Workflow):
+    @step
+    async def start(self, ctx: Context, ev: StartEvent) -> Done:
+        ctx.write_event_to_stream(Progress(message="started"))
+        return Done(value=ev.topic.upper())
+
+    @step
+    async def finish(self, ev: Done) -> StopEvent:
+        return StopEvent(result=ev.value)
+
+
+@pytest.mark.asyncio
+async def test_workflow_streams_progress_and_returns_result() -> None:
+    result = await WorkflowTestRunner(ExampleWorkflow()).run(
+        start_event=StartEvent(topic="docs")
+    )
+
+    assert result.result == "DOCS"
+    assert result.event_types[Progress] == 1
+    assert any(
+        isinstance(ev, Progress) and ev.message == "started"
+        for ev in result.collected
+    )
+```
+
+The returned object has:
+
+| Field | Meaning |
+|---|---|
+| `result` | The final value returned by awaiting the workflow handler. |
+| `collected` | Every streamed event that was not excluded. |
+| `event_types` | A count of collected events by event class. |
+| `ctx` | The final `Context`, useful for state assertions or snapshots. |
+
+## Internal events
+
+By default the runner exposes internal events, including `StepStateChanged`. That is useful when you want to assert execution shape:
+
+```python
+from workflows.events import StepStateChanged
+
+
+@pytest.mark.asyncio
+async def test_step_state_events_are_emitted() -> None:
+    result = await WorkflowTestRunner(ExampleWorkflow()).run(
+        start_event=StartEvent(topic="docs")
+    )
+
+    assert result.event_types[StepStateChanged] > 0
+```
+
+If a test only cares about user events, turn internal events off:
+
+```python
+result = await WorkflowTestRunner(ExampleWorkflow()).run(
+    start_event=StartEvent(topic="docs"),
+    expose_internal=False,
+)
+```
+
+Or keep internal events available but exclude the noisy ones from the collected list:
+
+```python
+result = await WorkflowTestRunner(ExampleWorkflow()).run(
+    start_event=StartEvent(topic="docs"),
+    exclude_events=[StepStateChanged]
+)
+```
+
+## State assertions
+
+Use the returned context when a workflow writes to `ctx.store`:
+
+```python
+from pydantic import BaseModel, Field
+
+
+class CounterState(BaseModel):
+    count: int = Field(default=0)
+
+
+class CounterWorkflow(Workflow):
+    @step
+    async def count(self, ctx: Context[CounterState], ev: StartEvent) -> StopEvent:
+        async with ctx.store.edit_state() as state:
+            state.count += 1
+        return StopEvent(result="done")
+
+
+@pytest.mark.asyncio
+async def test_workflow_updates_state() -> None:
+    result = await WorkflowTestRunner(CounterWorkflow()).run()
+
+    state = await result.ctx.store.get_state()
+    assert state.count == 1
+```
+
+For durable workflow code, prefer asserting behavior after a real snapshot and restore:
+
+```python
+workflow = CounterWorkflow()
+first = await WorkflowTestRunner(workflow).run()
+
+ctx_dict = first.ctx.to_dict()
+restored_workflow = CounterWorkflow()
+restored = Context.from_dict(restored_workflow, ctx_dict)
+
+resumed = await WorkflowTestRunner(restored_workflow).run(ctx=restored)
+```
+
+That catches the mistakes unit tests often miss: state that cannot serialize, events that are not importable when restored, and side effects that are not safe to repeat.

--- a/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
+++ b/docs/src/content/docs/llamaagents/workflows/unbound_functions.md
@@ -4,12 +4,13 @@ sidebar:
 title: Workflows from unbound functions
 ---
 
-Throughout these docs, we have been showing workflows defined as classes. However, this is not the only way to define a workflow: you can also define the steps in your workflow through independent or "unbound" functions and assign them to a workflow using the `@step()` decorator. Let's see how that works.
+Most examples define steps as methods on a `Workflow` subclass. You can also attach standalone functions to a workflow class with `@step(workflow=...)`. This is useful when a workflow is assembled from reusable functions, or when an integration wants to add a step without subclassing the workflow.
 
 First we create an empty class to hold the steps:
 
 ```python
 from workflows import Workflow
+
 
 class TestWorkflow(Workflow):
     pass
@@ -21,11 +22,12 @@ Now we can add steps to the workflow by defining functions and decorating them w
 from workflows import step
 from workflows.events import StartEvent, StopEvent
 
+
 @step(workflow=TestWorkflow)
-def some_step(ev: StartEvent) -> StopEvent:
+async def some_step(ev: StartEvent) -> StopEvent:
     return StopEvent()
 ```
 
-In this example, we're adding a starting step to the `TestWorkflow` class. The `@step()` decorator takes the `workflow` argument, which is the class to which the step will be added. The function signature is the same as for a regular step, with the exception of the `workflow` argument.
+In this example, the decorator registers `some_step` on the `TestWorkflow` class. The function signature is the same as a method step, except there is no `self` parameter.
 
-You can also add steps this way to any existing workflow class! This can be handy if you just need one extra step in your workflow and don't want to subclass an entire workflow to do it.
+The registration happens at import time. Make sure the module that defines the function is imported before you instantiate or validate the workflow. Step names still have to be unique: registering a free function with the same name as an existing method or free-function step raises a validation error.


### PR DESCRIPTION
The workflows docs had a solid API tour, but several pages taught stale or partial contracts: custom start events carried runtime objects, human-in-the-loop examples used older event injection patterns, retry policy docs omitted the durable jitter seed, and the top-level guide did not give readers a clear path through events, state, resources, streaming, validation, and testing.

This tightens the core workflow docs around the contracts users actually need:

- reshapes the landing guide around event flow, validation, and when to use typed returns, `list[E]`, `ctx.send_event`, state, and resources
- adds a testing guide for `WorkflowTestRunner`, streamed events, final results, and context state assertions
- clarifies the boundary between serializable state, durable snapshots, and injected resources
- updates streaming docs for `WorkflowHandler`, single-consumer streams, and abnormal workflow termination events
- fixes advanced pages for custom start/stop events, human-in-the-loop resume, retry policy authoring, workflow drawing, and free-function step registration
- corrects stale imports and commands for workflow server docs
- moves testing before observability/deployment/client in the sidebar so readers hit local development guidance before server/client material
