### PR TITLE
fix(workflows): keep implicit waiters distinct across fan-out

### DIFF
--- a/.changeset/implicit-waiter-fanout.md
+++ b/.changeset/implicit-waiter-fanout.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Keep implicit waiters distinct across parallel workflow fan-out branches.

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -100,6 +100,9 @@ class SerializedEventAttempt(BaseModel):
     # Explicit collect invocation payload, serialized only for queued/in-progress
     # list[E] collect executions.
     collection_release_payload: SerializedCollectionReleasePayload | None = None
+    # Stable identity of this queued or in-progress work item. Additive:
+    # older payloads validate with None and get fresh ids on requeue.
+    work_item_id: str | None = None
 
 
 class SerializedCollectionReleasePayload(BaseModel):
@@ -131,6 +134,8 @@ class SerializedWaiter(BaseModel):
     scope_path: list[str] = Field(default_factory=list)
     # For a suspended collect invocation, the release batch to re-invoke with.
     collection_release_payload: SerializedCollectionReleasePayload | None = None
+    # Stable identity for the suspended work item, if available.
+    work_item_id: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -203,6 +208,9 @@ class SerializedContext(BaseModel):
     # Monotonic stream-id counter. Persisted so a resumed run keeps minting
     # unique, deterministic stream ids.
     stream_seq: int = Field(default=0)
+    # Monotonic work-item counter. Persisted so implicit waiter ids remain
+    # stable and unique across serialize/resume boundaries.
+    work_item_seq: int = Field(default=0)
     streams: dict[str, SerializedCollectionStreamInstance] = Field(default_factory=dict)
     collection_release_states: dict[str, SerializedCollectionReleaseState] = Field(
         default_factory=dict

--- a/packages/llama-index-workflows/src/workflows/context/internal_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/internal_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import time
 from collections import Counter, defaultdict
@@ -107,6 +108,37 @@ class InternalContext(Generic[MODEL_T]):
                 f"{fn} may only be called from within a step function"
             )
 
+    @classmethod
+    def _stable_requirements_str(cls, requirements: dict[str, Any]) -> str:
+        """Return a deterministic representation for waiter requirements."""
+
+        def normalize(value: Any) -> Any:
+            if isinstance(value, dict):
+                return {
+                    str(k): normalize(v)
+                    for k, v in sorted(value.items(), key=lambda item: repr(item[0]))
+                }
+            if isinstance(value, (list, tuple)):
+                return [normalize(v) for v in value]
+            if isinstance(value, set):
+                return sorted((normalize(v) for v in value), key=repr)
+            if hasattr(value, "model_dump"):
+                try:
+                    return normalize(value.model_dump())
+                except Exception:
+                    pass
+            return value
+
+        try:
+            return json.dumps(
+                normalize(requirements),
+                sort_keys=True,
+                separators=(",", ":"),
+                default=repr,
+            )
+        except Exception:
+            return repr(requirements)
+
     @property
     def store(self) -> StateStore[MODEL_T]:
         """Access workflow state store."""
@@ -191,8 +223,23 @@ class InternalContext(Generic[MODEL_T]):
 
         # Generate a unique key for the waiter
         event_str = f"{event_type.__module__}.{event_type.__name__}"
-        requirements_str = str(requirements)
-        waiter_id = waiter_id or f"waiter_{event_str}_{requirements_str}"
+        if waiter_id is None:
+            requirements_str = self._stable_requirements_str(requirements)
+            legacy_waiter_id = f"waiter_{event_str}_{str(requirements)}"
+            base_waiter_id = f"waiter_{event_str}_{requirements_str}"
+            work_item_id = step_ctx.state.work_item_id
+            work_item_waiter_id = (
+                f"{base_waiter_id}_{work_item_id}"
+                if work_item_id is not None
+                else base_waiter_id
+            )
+            existing_waiter_ids = {w.waiter_id for w in collected_waiters}
+            if legacy_waiter_id in existing_waiter_ids:
+                waiter_id = legacy_waiter_id
+            elif base_waiter_id in existing_waiter_ids:
+                waiter_id = base_waiter_id
+            else:
+                waiter_id = work_item_waiter_id
 
         waiter = next((w for w in collected_waiters if w.waiter_id == waiter_id), None)
         if waiter is not None and waiter.timed_out:

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -261,6 +261,12 @@ def _is_eligible(attempt: EventAttempt) -> bool:
     return attempt.not_before is None
 
 
+def _next_work_item_id(state: BrokerState) -> str:
+    """Mint a deterministic identity for one routed work item."""
+    state.work_item_seq += 1
+    return f"work_item_{state.work_item_seq}"
+
+
 def _decide_retry_delay(
     policy: RetryPolicy | None,
     *,
@@ -346,6 +352,7 @@ def rewind_in_progress(
                     recovery_counts=dict(in_progress.recovery_counts),
                     scope_path=in_progress.scope_path,
                     collection_release_payload=in_progress.shared_state.collection_release_payload,
+                    work_item_id=in_progress.work_item_id,
                 ),
             )
         step_state.in_progress = []
@@ -629,6 +636,7 @@ def _apply_step_result(
             # it whole: same stream scope, same collect batch.
             scope_path=this_execution.scope_path,
             collection_release_payload=this_execution.shared_state.collection_release_payload,
+            work_item_id=this_execution.work_item_id,
         )
         if existing is not None:
             worker_state.collected_waiters[existing] = new_waiter
@@ -716,6 +724,7 @@ def _schedule_retry_or_route_failure(
                 not_before=not_before,
                 scope_path=this_execution.scope_path,
                 collection_release_payload=this_execution.shared_state.collection_release_payload,
+                work_item_id=this_execution.work_item_id,
             ),
         )
         if not_before is not None:
@@ -1022,6 +1031,7 @@ def _add_or_enqueue_event(
             if event.collection_release_payload is not None
             else None,
             scope_path=event.scope_path,
+            work_item_id=event.work_item_id,
         )
         state.in_progress.append(
             InProgressState(
@@ -1035,6 +1045,7 @@ def _add_or_enqueue_event(
                 last_failed_at=event.last_failed_at,
                 recovery_counts=dict(event.recovery_counts),
                 scope_path=event.scope_path,
+                work_item_id=event.work_item_id,
             )
         )
         commands.append(
@@ -1114,6 +1125,7 @@ def _redeliver_collection_payload(
             recovery_counts=dict(tick.recovery_counts),
             scope_path=tuple(tick.scope_path),
             collection_release_payload=payload,
+            work_item_id=tick.work_item_id,
         ),
         StepId.root(binding.target_step),
         state.workers[binding.target_step],
@@ -1157,6 +1169,7 @@ def _resolve_waiters(
                             bound_events=wait_condition.bound_events,
                             scope_path=wait_condition.scope_path,
                             collection_release_payload=wait_condition.collection_release_payload,
+                            work_item_id=wait_condition.work_item_id,
                         ),
                         step_id,
                         state.workers[step_name],
@@ -1322,6 +1335,7 @@ def _route_to_accepting_steps(
                     last_failed_at=tick.last_failed_at,
                     recovery_counts=dict(tick.recovery_counts),
                     scope_path=tuple(tick.scope_path),
+                    work_item_id=tick.work_item_id,
                 ),
                 step_id,
                 state.workers[step_name],
@@ -1363,6 +1377,8 @@ def _process_add_event_tick(
     an UnhandledEvent.
     """
     state = init.deepcopy()
+    if tick.work_item_id is None:
+        tick = tick.model_copy(update={"work_item_id": _next_work_item_id(state)})
     if isinstance(tick.event, StartEvent):
         state.is_running = True
 
@@ -1508,6 +1524,7 @@ def _process_waiter_timeout_tick(
             bound_events=waiter.bound_events,
             scope_path=waiter.scope_path,
             collection_release_payload=waiter.collection_release_payload,
+            work_item_id=waiter.work_item_id,
         ),
         step_id,
         worker_state,

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -1378,7 +1378,16 @@ def _process_add_event_tick(
     """
     state = init.deepcopy()
     if tick.work_item_id is None:
-        tick = tick.model_copy(update={"work_item_id": _next_work_item_id(state)})
+        # A collect re-delivery derives its id from the payload's stable
+        # stream+binding key so it matches the invocation fired at release time
+        # and never re-mints a fresh id on resume; everything else mints from the
+        # monotonic counter.
+        work_item_id = (
+            tick.collection_release_payload.work_item_id()
+            if tick.collection_release_payload is not None
+            else _next_work_item_id(state)
+        )
+        tick = tick.model_copy(update={"work_item_id": work_item_id})
     if isinstance(tick.event, StartEvent):
         state.is_running = True
 

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
@@ -350,6 +350,7 @@ def _fire_collection_release(
             event=payload.as_event(),
             scope_path=output_stack,
             collection_release_payload=payload,
+            work_item_id=payload.work_item_id(),
         ),
         StepId.root(binding.target_step),
         worker_state,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -114,6 +114,7 @@ class BrokerState:
     config: BrokerConfig
     workers: dict[str, InternalStepWorkerState]
     stream_seq: int = 0
+    work_item_seq: int = 0
     streams: dict[str, CollectionStreamInstance] = field(default_factory=dict)
     collection_release_states: dict[str, CollectionReleaseState] = field(
         default_factory=dict
@@ -131,6 +132,7 @@ class BrokerState:
                 for name, worker_state in self.workers.items()
             },
             stream_seq=self.stream_seq,
+            work_item_seq=self.work_item_seq,
             streams={sid: stream._copy() for sid, stream in self.streams.items()},
             collection_release_states={
                 key: state._copy()
@@ -190,6 +192,7 @@ class BrokerState:
                             bound_events=waiter.bound_events,
                             scope_path=waiter.scope_path,
                             collection_release_payload=waiter.collection_release_payload,
+                            work_item_id=waiter.work_item_id,
                         )
                     )
         return commands
@@ -219,6 +222,7 @@ class BrokerState:
                     collection_release_payload=_serialize_release_payload(
                         attempt.collection_release_payload, serializer
                     ),
+                    work_item_id=attempt.work_item_id,
                 )
                 for attempt in worker_state.queue
             ]
@@ -241,6 +245,7 @@ class BrokerState:
                     collection_release_payload=_serialize_release_payload(
                         ip.shared_state.collection_release_payload, serializer
                     ),
+                    work_item_id=ip.work_item_id,
                 )
                 for ip in worker_state.in_progress
             ]
@@ -272,6 +277,7 @@ class BrokerState:
                     collection_release_payload=_serialize_release_payload(
                         waiter.collection_release_payload, serializer
                     ),
+                    work_item_id=waiter.work_item_id,
                 )
                 for waiter in worker_state.collected_waiters
             ]
@@ -293,6 +299,7 @@ class BrokerState:
             is_running=self.is_running,
             workers=workers_dict,
             stream_seq=self.stream_seq,
+            work_item_seq=self.work_item_seq,
             streams={
                 sid: SerializedCollectionStreamInstance(
                     stream_id=stream.stream_id,
@@ -330,6 +337,7 @@ class BrokerState:
         # whether to create a start_event from kwargs (it only constructs and passes a start event if not already running)
         base_state.is_running = serialized.is_running
         base_state.stream_seq = serialized.stream_seq
+        base_state.work_item_seq = serialized.work_item_seq
         base_state.streams = {
             sid: CollectionStreamInstance(
                 stream_id=stream.stream_id,
@@ -408,6 +416,7 @@ class BrokerState:
                         else None,
                         scope_path=tuple(waiter_data.scope_path),
                         collection_release_payload=waiter_payload,
+                        work_item_id=waiter_data.work_item_id,
                     )
                 )
 
@@ -444,6 +453,7 @@ def _deserialize_event_attempt(
         not_before=attempt.not_before,
         scope_path=tuple(attempt.scope_path),
         collection_release_payload=payload,
+        work_item_id=attempt.work_item_id,
     )
 
 
@@ -606,6 +616,7 @@ class EventAttempt:
     not_before: float | None = None
     scope_path: tuple[str, ...] = field(default_factory=tuple)
     collection_release_payload: CollectionReleasePayload | None = None
+    work_item_id: str | None = None
 
 
 @dataclass()
@@ -674,6 +685,7 @@ class InProgressState:
     recovery_counts: dict[str, int] = field(default_factory=dict)
     bound_events: dict[str, Event] | None = None
     scope_path: tuple[str, ...] = field(default_factory=tuple)
+    work_item_id: str | None = None
 
     def _deepcopy(self) -> InProgressState:
         return InProgressState(
@@ -687,6 +699,7 @@ class InProgressState:
             last_failed_at=self.last_failed_at,
             recovery_counts=dict(self.recovery_counts),
             scope_path=self.scope_path,
+            work_item_id=self.work_item_id,
         )
 
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -131,6 +131,18 @@ class CollectionReleasePayload:
             binding_id=self.binding_id,
         )
 
+    def work_item_id(self) -> str:
+        """Stable work item id for this collect invocation.
+
+        Collect invocations are fired directly (not via a routed tick), so the
+        monotonic work-item counter never sees them. Their stream+binding key is
+        already unique and carried on the payload across serialize/resume, so use
+        it as the work item id. This keeps two collect invocations of the same
+        step distinct and lets a suspended collect invocation recreate the same
+        implicit waiter id on resume.
+        """
+        return f"work_item_collect_{self.stream_id}:{self.binding_id}"
+
 
 # Tick wire format for the payload's member events: the same SerializableEvent
 # codec every other tick/result event field uses (events.py).

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -66,6 +66,8 @@ class StepWorkerContext:
     Base state passed to step functions and returned by step functions.
     """
 
+    # event currently being processed by this step invocation
+    event: Event
     # immutable state of the step events at start of the step function execution
     state: StepWorkerState
     # add commands here to mutate the internal worker state after step execution
@@ -84,6 +86,7 @@ class StepWorkerState:
     collected_waiters: list[StepWorkerWaiter]
     collection_release_payload: CollectionReleasePayload | None = None
     scope_path: tuple[str, ...] = ()
+    work_item_id: str | None = None
 
     def _deepcopy(self) -> StepWorkerState:
         return StepWorkerState(
@@ -94,6 +97,7 @@ class StepWorkerState:
             if self.collection_release_payload is not None
             else None,
             scope_path=self.scope_path,
+            work_item_id=self.work_item_id,
         )
 
 
@@ -191,6 +195,9 @@ class StepWorkerWaiter(Generic[EventType]):
     scope_path: tuple[str, ...] = ()
     # For a suspended collect invocation, the release batch to re-invoke with.
     collection_release_payload: CollectionReleasePayload | None = None
+    # Stable identity for the suspended work item. Used to rebuild implicit
+    # waiter IDs across retries, serialization, and resume.
+    work_item_id: str | None = None
 
 
 @dataclass()

--- a/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/step_function.py
@@ -183,6 +183,7 @@ def as_step_worker_function(
         returns = Returns(return_values=[])
 
         step_ctx = StepWorkerContext(
+            event=event,
             state=state,
             returns=returns,
             retry=retry,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -59,6 +59,8 @@ class TickAddEvent(BaseModel):
     # directly to the binding's target step, before waiter matching and the
     # member-arrival path.
     collection_release_payload: SerializableCollectionReleasePayload = None
+    # Stable identity for this work item when re-delivering suspended work.
+    work_item_id: str | None = None
 
 
 class TickCancelRun(BaseModel):

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -45,6 +45,7 @@ from workflows.plugins.basic import (
     BasicRuntime,
     setting_run_id,
 )
+from workflows.retry_policy import retry_policy, stop_after_attempt, wait_fixed
 from workflows.runtime.types.internal_state import BrokerState
 from workflows.runtime.types.ticks import TickAddEvent
 from workflows.testing import WorkflowTestRunner
@@ -697,6 +698,109 @@ async def test_parallel_identical_implicit_waiters_are_not_collapsed() -> None:
     assert input_required_count == 3
     result = await handler
     assert result == ["approved", "approved", "approved"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_implicit_waiters_survive_snapshot_resume() -> None:
+    """The per-invocation waiter ids must round-trip: snapshot three suspended
+    fan-out branches, restore, and every branch still resolves."""
+    workflow = ParallelImplicitWaiterWorkflow(timeout=5.0)
+    handler = workflow.run()
+    prefixes: set[str] = set()
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prefixes.add(ev.prefix)
+            if len(prefixes) == 3:
+                break
+
+    assert prefixes == {"approve a", "approve b", "approve c"}
+    ctx_dict = handler.ctx.to_dict()
+    total_waiters = sum(
+        len(worker_data["collected_waiters"])
+        for worker_data in ctx_dict["workers"].values()
+    )
+    assert total_waiters == 3
+    await handler.cancel_run()
+
+    resumed = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))
+    resumed.ctx.send_event(HumanResponseEvent(response="approved"))  # type: ignore
+    result = await resumed
+    assert result == [
+        ("a", "approved"),
+        ("b", "approved"),
+        ("c", "approved"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_implicit_waiter_survives_retry() -> None:
+    """A retry is the same invocation, a new attempt. After a step acquires its
+    waiter response then fails once, the replay must re-acquire the same resolved
+    waiter (it survives until the step completes) instead of re-prompting."""
+    attempts = 0
+
+    class RetryWaiterWorkflow(Workflow):
+        @step(retry_policy=retry_policy(wait=wait_fixed(0), stop=stop_after_attempt(3)))
+        async def ask(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            nonlocal attempts
+            response = await ctx.wait_for_event(
+                HumanResponseEvent, waiter_event=InputRequiredEvent()
+            )
+            attempts += 1
+            if attempts == 1:
+                raise RuntimeError("transient failure after acquiring the waiter")
+            return StopEvent(result=response.response)
+
+    workflow = RetryWaiterWorkflow(timeout=5.0)
+    handler = workflow.run()
+    prompts = 0
+    answered = False
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prompts += 1
+            if not answered:
+                handler.ctx.send_event(HumanResponseEvent(response="once"))  # type: ignore
+                answered = True
+
+    result = await handler
+    assert result == "once"
+    assert attempts == 2  # one failure, then one success — same invocation
+    assert prompts == 1  # the human is asked exactly once across the retry
+
+
+@pytest.mark.asyncio
+async def test_requirements_waiter_survives_snapshot_resume() -> None:
+    """A waiter created with requirements is re-pinged on resume (via
+    rehydrate_with_ticks). The invocation id must ride along on that re-ping so
+    the replayed step regenerates the same waiter id and resolves once."""
+
+    class ReqWaiterWorkflow(Workflow):
+        @step
+        async def ask(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            response = await ctx.wait_for_event(
+                HumanResponseEvent,
+                waiter_event=InputRequiredEvent(),
+                requirements={"response": "go"},
+            )
+            return StopEvent(result=response.response)
+
+    workflow = ReqWaiterWorkflow(timeout=5.0)
+    handler = workflow.run()
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            break
+
+    ctx_dict = handler.ctx.to_dict()
+    await handler.cancel_run()
+
+    resumed = workflow.run(ctx=Context.from_dict(workflow, ctx_dict))
+    # The mismatched response is ignored by the requirement; the matching one
+    # resolves the re-pinged waiter.
+    resumed.ctx.send_event(HumanResponseEvent(response="nope"))  # type: ignore
+    resumed.ctx.send_event(HumanResponseEvent(response="go"))  # type: ignore
+    result = await resumed
+    assert result == "go"
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -425,7 +425,7 @@ async def test_to_dict_after_stream_events_break_resumes() -> None:
             )
             return StopEvent(result=response.response)
 
-    workflow = WaiterWorkflow()
+    workflow = WaiterWorkflow(timeout=1.0)
     handler = workflow.run()
 
     async for ev in handler.stream_events():
@@ -438,6 +438,14 @@ async def test_to_dict_after_stream_events_break_resumes() -> None:
         for worker_data in ctx_dict["workers"].values()
     )
     assert total_waiters == 1
+    waiters = [
+        waiter
+        for worker_data in ctx_dict["workers"].values()
+        for waiter in worker_data["collected_waiters"]
+    ]
+    work_item_id = waiters[0]["work_item_id"]
+    assert work_item_id
+    assert waiters[0]["waiter_id"].endswith(f"_{work_item_id}")
     await handler.cancel_run()
 
     new_ctx = Context.from_dict(workflow, ctx_dict)
@@ -445,6 +453,45 @@ async def test_to_dict_after_stream_events_break_resumes() -> None:
     new_handler.ctx.send_event(NamedResponseEvent(response="bob"))
     result = await new_handler
     assert result == "bob"
+
+
+@pytest.mark.asyncio
+async def test_legacy_implicit_waiter_id_survives_serialization_resume() -> None:
+    """Implicit waiters serialized before work item IDs should still resume."""
+
+    class WaiterWorkflow(Workflow):
+        @step
+        async def ask(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            response = await ctx.wait_for_event(
+                NamedResponseEvent,
+                waiter_event=InputRequiredEvent(),
+            )
+            return StopEvent(result=response.response)
+
+    workflow = WaiterWorkflow(timeout=1.0)
+    handler = workflow.run()
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            break
+
+    ctx_dict = handler.ctx.to_dict()
+    legacy_waiter_id = (
+        f"waiter_{NamedResponseEvent.__module__}.{NamedResponseEvent.__name__}_"
+        f"{str({})}"
+    )
+    for worker_data in ctx_dict["workers"].values():
+        for waiter in worker_data["collected_waiters"]:
+            waiter["waiter_id"] = legacy_waiter_id
+            waiter.pop("work_item_id", None)
+    ctx_dict.pop("work_item_seq", None)
+    await handler.cancel_run()
+
+    new_ctx = Context.from_dict(workflow, ctx_dict)
+    new_handler = workflow.run(ctx=new_ctx)
+    new_handler.ctx.send_event(NamedResponseEvent(response="legacy"))
+    result = await new_handler
+    assert result == "legacy"
 
 
 class Waiter1(Event):
@@ -537,6 +584,119 @@ async def test_wait_for_multiple_events_in_workflow() -> None:
     result = await handler
     # Order is non-deterministic since waiters run concurrently
     assert sorted(result) == ["buzz", "fizz"]
+
+
+class ParallelWaitEvent(Event):
+    branch: str
+
+
+class ParallelWaitDone(Event):
+    branch: str
+    response: str
+
+
+class ParallelImplicitWaiterWorkflow(Workflow):
+    @step
+    async def dispatch(self, ctx: Context, ev: StartEvent) -> ParallelWaitEvent:
+        for branch in ("a", "b", "c"):
+            ctx.send_event(ParallelWaitEvent(branch=branch))
+        return None  # type: ignore
+
+    @step(num_workers=3)
+    async def wait_branch(
+        self, ctx: Context, ev: ParallelWaitEvent
+    ) -> ParallelWaitDone:
+        response = await ctx.wait_for_event(
+            HumanResponseEvent,
+            waiter_event=InputRequiredEvent(prefix=f"approve {ev.branch}"),
+        )
+        return ParallelWaitDone(branch=ev.branch, response=response.response)
+
+    @step
+    async def collect(self, ctx: Context, ev: ParallelWaitDone) -> StopEvent:
+        events: list[ParallelWaitDone] | None = ctx.collect_events(
+            ev, [ParallelWaitDone, ParallelWaitDone, ParallelWaitDone]
+        )
+        if events is None:
+            return None  # type: ignore
+
+        return StopEvent(result=sorted((e.branch, e.response) for e in events))
+
+
+@pytest.mark.asyncio
+async def test_parallel_implicit_waiters_are_not_collapsed() -> None:
+    workflow = ParallelImplicitWaiterWorkflow(timeout=1.0)
+    handler = workflow.run()
+    prefixes: set[str] = set()
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prefixes.add(ev.prefix)
+            if len(prefixes) == 3:
+                handler.ctx.send_event(HumanResponseEvent(response="approved"))
+                break
+
+    assert prefixes == {"approve a", "approve b", "approve c"}
+    result = await handler
+    assert result == [
+        ("a", "approved"),
+        ("b", "approved"),
+        ("c", "approved"),
+    ]
+
+
+class IdenticalWaitEvent(Event):
+    pass
+
+
+class IdenticalWaitDone(Event):
+    response: str
+
+
+class IdenticalImplicitWaiterWorkflow(Workflow):
+    @step
+    async def dispatch(self, ctx: Context, ev: StartEvent) -> IdenticalWaitEvent:
+        for _ in range(3):
+            ctx.send_event(IdenticalWaitEvent())
+        return None  # type: ignore
+
+    @step(num_workers=3)
+    async def wait_branch(
+        self, ctx: Context, ev: IdenticalWaitEvent
+    ) -> IdenticalWaitDone:
+        response = await ctx.wait_for_event(
+            HumanResponseEvent,
+            waiter_event=InputRequiredEvent(prefix="approve"),
+        )
+        return IdenticalWaitDone(response=response.response)
+
+    @step
+    async def collect(self, ctx: Context, ev: IdenticalWaitDone) -> StopEvent:
+        events: list[IdenticalWaitDone] | None = ctx.collect_events(
+            ev, [IdenticalWaitDone, IdenticalWaitDone, IdenticalWaitDone]
+        )
+        if events is None:
+            return None  # type: ignore
+
+        return StopEvent(result=[e.response for e in events])
+
+
+@pytest.mark.asyncio
+async def test_parallel_identical_implicit_waiters_are_not_collapsed() -> None:
+    workflow = IdenticalImplicitWaiterWorkflow(timeout=1.0)
+    handler = workflow.run()
+    input_required_count = 0
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            input_required_count += 1
+            if input_required_count == 3:
+                handler.ctx.send_event(HumanResponseEvent(response="approved"))
+                break
+
+    assert input_required_count == 3
+    result = await handler
+    assert result == ["approved", "approved", "approved"]
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -608,13 +608,13 @@ class ParallelImplicitWaiterWorkflow(Workflow):
     ) -> ParallelWaitDone:
         response = await ctx.wait_for_event(
             HumanResponseEvent,
-            waiter_event=InputRequiredEvent(prefix=f"approve {ev.branch}"),
+            waiter_event=InputRequiredEvent(prefix=f"approve {ev.branch}"),  # type: ignore
         )
         return ParallelWaitDone(branch=ev.branch, response=response.response)
 
     @step
     async def collect(self, ctx: Context, ev: ParallelWaitDone) -> StopEvent:
-        events: list[ParallelWaitDone] | None = ctx.collect_events(
+        events: list[ParallelWaitDone] | None = ctx.collect_events(  # type: ignore
             ev, [ParallelWaitDone, ParallelWaitDone, ParallelWaitDone]
         )
         if events is None:
@@ -633,7 +633,7 @@ async def test_parallel_implicit_waiters_are_not_collapsed() -> None:
         if isinstance(ev, InputRequiredEvent):
             prefixes.add(ev.prefix)
             if len(prefixes) == 3:
-                handler.ctx.send_event(HumanResponseEvent(response="approved"))
+                handler.ctx.send_event(HumanResponseEvent(response="approved"))  # type: ignore
                 break
 
     assert prefixes == {"approve a", "approve b", "approve c"}
@@ -666,13 +666,13 @@ class IdenticalImplicitWaiterWorkflow(Workflow):
     ) -> IdenticalWaitDone:
         response = await ctx.wait_for_event(
             HumanResponseEvent,
-            waiter_event=InputRequiredEvent(prefix="approve"),
+            waiter_event=InputRequiredEvent(prefix="approve"),  # type: ignore
         )
         return IdenticalWaitDone(response=response.response)
 
     @step
     async def collect(self, ctx: Context, ev: IdenticalWaitDone) -> StopEvent:
-        events: list[IdenticalWaitDone] | None = ctx.collect_events(
+        events: list[IdenticalWaitDone] | None = ctx.collect_events(  # type: ignore
             ev, [IdenticalWaitDone, IdenticalWaitDone, IdenticalWaitDone]
         )
         if events is None:
@@ -691,7 +691,7 @@ async def test_parallel_identical_implicit_waiters_are_not_collapsed() -> None:
         if isinstance(ev, InputRequiredEvent):
             input_required_count += 1
             if input_required_count == 3:
-                handler.ctx.send_event(HumanResponseEvent(response="approved"))
+                handler.ctx.send_event(HumanResponseEvent(response="approved"))  # type: ignore
                 break
 
     assert input_required_count == 3

--- a/packages/llama-index-workflows/tests/test_collection_stream_regressions.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_regressions.py
@@ -18,7 +18,14 @@ import pytest
 from workflows import Context, Workflow, catch_error, step
 from workflows.collect import Collect, Take
 from workflows.errors import WorkflowValidationError
-from workflows.events import Event, StartEvent, StepFailedEvent, StopEvent
+from workflows.events import (
+    Event,
+    HumanResponseEvent,
+    InputRequiredEvent,
+    StartEvent,
+    StepFailedEvent,
+    StopEvent,
+)
 from workflows.retry_policy import retry_policy, stop_after_attempt, wait_fixed
 
 _CONTROL_LOOP_LOGGER = "workflows.runtime.control_loop"
@@ -171,6 +178,58 @@ async def test_distinct_fan_out_sources_share_collect_target_without_merging() -
 
     result = await _run(WF(timeout=8))
     assert result == [[0, 1], [10, 11]]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_collect_invocations_keep_distinct_implicit_waiters() -> None:
+    """Two collect invocations of the same join step (one per fan-out source)
+    each wait for the same event type with an implicit waiter id. Collect
+    invocations are fired directly rather than through a routed tick, so they
+    must still get distinct work item ids — otherwise both waiters collapse onto
+    one and only one invocation resumes."""
+
+    class Batch(Event):
+        nums: list[int]
+
+    batches: list[list[int]] = []
+
+    class WF(Workflow):
+        @step
+        async def fan_a(self, ev: StartEvent) -> list[Done]:
+            return [Done(n=0), Done(n=1)]
+
+        @step
+        async def fan_b(self, ev: StartEvent) -> list[Done]:
+            return [Done(n=10), Done(n=11)]
+
+        @step
+        async def join(self, ctx: Context, events: list[Done]) -> Batch:
+            response = await ctx.wait_for_event(
+                HumanResponseEvent,
+                waiter_event=InputRequiredEvent(),
+            )
+            return Batch(nums=sorted(e.n for e in events) + [int(response.response)])
+
+        @step
+        async def finish(self, ev: Batch) -> StopEvent | None:
+            batches.append(ev.nums)
+            if len(batches) < 2:
+                return None
+            return StopEvent(result=sorted(batches))
+
+    workflow = WF(timeout=8.0)
+    handler = workflow.run()
+    prompts = 0
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prompts += 1
+            if prompts == 2:
+                handler.ctx.send_event(HumanResponseEvent(response="7"))  # type: ignore
+                break
+
+    assert prompts == 2
+    result = await handler
+    assert result == [[0, 1, 7], [10, 11, 7]]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- include the current trigger event in generated implicit waiter IDs
- keep explicit `waiter_id` behavior unchanged
- add a regression test for parallel branches that all wait for `HumanResponseEvent` with implicit waiter IDs

## Root cause
`Context.wait_for_event()` generated the default waiter ID from only the awaited event type and requirements. When multiple workers handled different fan-out events and waited for the same event type without an explicit `waiter_id`, each branch produced the same default ID, so later waiters overwrote earlier ones in the control loop. Only one `InputRequiredEvent` was emitted and one branch resumed.

The fix adds a stable fingerprint of the step invocation trigger event to implicit waiter IDs, so different fan-out branches get distinct generated IDs while a suspended invocation can recreate the same ID when resumed. Explicit waiter IDs still behave exactly as before.

Fixes run-llama/llama_index#22070.

## Validation
- `uv run ruff format --check packages/llama-index-workflows/src/workflows/context/internal_context.py packages/llama-index-workflows/src/workflows/runtime/types/results.py packages/llama-index-workflows/src/workflows/runtime/types/step_function.py packages/llama-index-workflows/tests/context/test_context.py`
- `uv run ruff check packages/llama-index-workflows/src/workflows/context/internal_context.py packages/llama-index-workflows/src/workflows/runtime/types/results.py packages/llama-index-workflows/src/workflows/runtime/types/step_function.py packages/llama-index-workflows/tests/context/test_context.py`
- `uv run --project packages/llama-index-workflows pytest packages/llama-index-workflows/tests/context/test_context.py::test_parallel_implicit_waiters_are_not_collapsed -q`
- `uv run --project packages/llama-index-workflows pytest packages/llama-index-workflows/tests/context/test_context.py::test_wait_for_multiple_events_in_workflow packages/llama-index-workflows/tests/context/test_context.py::test_to_dict_after_stream_events_break_resumes -q`
- `uv run --project packages/llama-index-workflows pytest packages/llama-index-workflows/tests/runtime/test_control_loop.py -k 'wait_for_event or InputRequiredEvent' -q`
- `uv run --project packages/llama-index-workflows pytest packages/llama-index-workflows/tests/context/test_context.py -q`
- `git diff --check`