### PR TITLE
Keep implicit waiters distinct per step invocation

### DIFF
--- a/.changeset/invocation-id-waiters.md
+++ b/.changeset/invocation-id-waiters.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Keep implicit waiters distinct across parallel fan-out branches and stable across resume and retries.

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -100,6 +100,9 @@ class SerializedEventAttempt(BaseModel):
     # Explicit collect invocation payload, serialized only for queued/in-progress
     # list[E] collect executions.
     collection_release_payload: SerializedCollectionReleasePayload | None = None
+    # Stable invocation id. Additive: None for payloads written before this
+    # field, which fall back to the legacy implicit waiter id on resume.
+    invocation_id: str | None = None
 
 
 class SerializedCollectionReleasePayload(BaseModel):
@@ -131,6 +134,9 @@ class SerializedWaiter(BaseModel):
     scope_path: list[str] = Field(default_factory=list)
     # For a suspended collect invocation, the release batch to re-invoke with.
     collection_release_payload: SerializedCollectionReleasePayload | None = None
+    # Stable invocation id of the work item that created this waiter. Additive:
+    # None for waiters persisted before this field existed.
+    invocation_id: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -203,6 +209,9 @@ class SerializedContext(BaseModel):
     # Monotonic stream-id counter. Persisted so a resumed run keeps minting
     # unique, deterministic stream ids.
     stream_seq: int = Field(default=0)
+    # Monotonic invocation-id counter. Persisted so a resumed run keeps minting
+    # unique, deterministic step-invocation ids. Additive: defaults to 0.
+    invocation_seq: int = Field(default=0)
     streams: dict[str, SerializedCollectionStreamInstance] = Field(default_factory=dict)
     collection_release_states: dict[str, SerializedCollectionReleaseState] = Field(
         default_factory=dict

--- a/packages/llama-index-workflows/src/workflows/context/internal_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/internal_context.py
@@ -189,19 +189,41 @@ class InternalContext(Generic[MODEL_T]):
         collected_waiters = step_ctx.state.collected_waiters
         requirements = requirements or {}
 
-        # Generate a unique key for the waiter
+        # Generate a unique key for the waiter. The implicit (default) id is
+        # suffixed with this invocation's stable id so parallel fan-out branches
+        # that wait for the same event type without an explicit waiter_id stay
+        # distinct instead of collapsing onto one shared waiter.
         event_str = f"{event_type.__module__}.{event_type.__name__}"
         requirements_str = str(requirements)
-        waiter_id = waiter_id or f"waiter_{event_str}_{requirements_str}"
+        if waiter_id is None:
+            legacy_id = f"waiter_{event_str}_{requirements_str}"
+            invocation_id = step_ctx.state.invocation_id
+            new_id = (
+                f"{legacy_id}_{invocation_id}"
+                if invocation_id is not None
+                else legacy_id
+            )
+            # Prefer the invocation-scoped id; fall back to the pre-upgrade id so
+            # a waiter persisted before this change still resolves on resume.
+            # Under current code every implicit waiter carries the suffixed id,
+            # so the legacy fallback can only match an old persisted waiter.
+            candidate_ids = (new_id, legacy_id)
+        else:
+            candidate_ids = (waiter_id,)
 
-        waiter = next((w for w in collected_waiters if w.waiter_id == waiter_id), None)
+        waiter = next(
+            (w for w in collected_waiters if w.waiter_id in candidate_ids), None
+        )
+        # Target whichever id actually exists (the matched waiter's, else the
+        # preferred id) so AddWaiter/DeleteWaiter act on the right record.
+        effective_id = waiter.waiter_id if waiter is not None else candidate_ids[0]
         if waiter is not None and waiter.timed_out:
-            step_ctx.returns.return_values.append(DeleteWaiter(waiter_id=waiter_id))
+            step_ctx.returns.return_values.append(DeleteWaiter(waiter_id=effective_id))
             raise asyncio.TimeoutError(f"Timed out waiting for {event_type.__name__}")
         if waiter is None or waiter.resolved_event is None:
             raise WaitingForEvent(
                 AddWaiter(
-                    waiter_id=waiter_id,
+                    waiter_id=effective_id,
                     requirements=requirements,
                     timeout=timeout,
                     event_type=event_type,
@@ -209,7 +231,7 @@ class InternalContext(Generic[MODEL_T]):
                 )
             )
         else:
-            step_ctx.returns.return_values.append(DeleteWaiter(waiter_id=waiter_id))
+            step_ctx.returns.return_values.append(DeleteWaiter(waiter_id=effective_id))
             return cast(T, waiter.resolved_event)
 
     def write_event_to_stream(self, ev: Event | None) -> None:

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -346,6 +346,7 @@ def rewind_in_progress(
                     recovery_counts=dict(in_progress.recovery_counts),
                     scope_path=in_progress.scope_path,
                     collection_release_payload=in_progress.shared_state.collection_release_payload,
+                    invocation_id=in_progress.invocation_id,
                 ),
             )
         step_state.in_progress = []
@@ -626,9 +627,11 @@ def _apply_step_result(
             has_requirements=bool(len(result.requirements)),
             resolved_event=None,
             # Store the suspended work item's record so resume re-delivers
-            # it whole: same stream scope, same collect batch.
+            # it whole: same stream scope, same collect batch, same invocation
+            # id (so the replay regenerates the same implicit waiter id).
             scope_path=this_execution.scope_path,
             collection_release_payload=this_execution.shared_state.collection_release_payload,
+            invocation_id=this_execution.invocation_id,
         )
         if existing is not None:
             worker_state.collected_waiters[existing] = new_waiter
@@ -716,6 +719,9 @@ def _schedule_retry_or_route_failure(
                 not_before=not_before,
                 scope_path=this_execution.scope_path,
                 collection_release_payload=this_execution.shared_state.collection_release_payload,
+                # A retry is the same invocation, a new attempt: keep the id so
+                # the replay re-acquires the same (still-resolved) waiter.
+                invocation_id=this_execution.invocation_id,
             ),
         )
         if not_before is not None:
@@ -990,6 +996,18 @@ def _select_static_collect_batch(
     return search(0, set())
 
 
+def _mint_invocation_id(state: BrokerState) -> str:
+    """Mint a deterministic, replay-stable id for a fresh step invocation.
+
+    Mirrors _mint_stream_id: the counter lives on BrokerState, is advanced only
+    inside the single-threaded reducer, and is persisted, so replay/resume
+    reproduce identical ids and only genuinely new work items consume the counter.
+    """
+    seq = state.invocation_seq
+    state.invocation_seq = seq + 1
+    return f"inv-{seq}"
+
+
 def _add_or_enqueue_event(
     event: EventAttempt,
     step_id: StepId,
@@ -1022,6 +1040,7 @@ def _add_or_enqueue_event(
             if event.collection_release_payload is not None
             else None,
             scope_path=event.scope_path,
+            invocation_id=event.invocation_id,
         )
         state.in_progress.append(
             InProgressState(
@@ -1035,6 +1054,7 @@ def _add_or_enqueue_event(
                 last_failed_at=event.last_failed_at,
                 recovery_counts=dict(event.recovery_counts),
                 scope_path=event.scope_path,
+                invocation_id=event.invocation_id,
             )
         )
         commands.append(
@@ -1114,6 +1134,9 @@ def _redeliver_collection_payload(
             recovery_counts=dict(tick.recovery_counts),
             scope_path=tuple(tick.scope_path),
             collection_release_payload=payload,
+            # Re-delivery of a collect invocation: prefer a carried id, else the
+            # payload's stable natural key (matches the initial release).
+            invocation_id=tick.invocation_id or payload.invocation_id(),
         ),
         StepId.root(binding.target_step),
         state.workers[binding.target_step],
@@ -1157,6 +1180,7 @@ def _resolve_waiters(
                             bound_events=wait_condition.bound_events,
                             scope_path=wait_condition.scope_path,
                             collection_release_payload=wait_condition.collection_release_payload,
+                            invocation_id=wait_condition.invocation_id,
                         ),
                         step_id,
                         state.workers[step_name],
@@ -1322,6 +1346,9 @@ def _route_to_accepting_steps(
                     last_failed_at=tick.last_failed_at,
                     recovery_counts=dict(tick.recovery_counts),
                     scope_path=tuple(tick.scope_path),
+                    # Carry the id on a resume re-ping; mint a fresh one per
+                    # accepting step for a genuinely new external delivery.
+                    invocation_id=tick.invocation_id or _mint_invocation_id(state),
                 ),
                 step_id,
                 state.workers[step_name],
@@ -1508,6 +1535,7 @@ def _process_waiter_timeout_tick(
             bound_events=waiter.bound_events,
             scope_path=waiter.scope_path,
             collection_release_payload=waiter.collection_release_payload,
+            invocation_id=waiter.invocation_id,
         ),
         step_id,
         worker_state,

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
@@ -350,6 +350,7 @@ def _fire_collection_release(
             event=payload.as_event(),
             scope_path=output_stack,
             collection_release_payload=payload,
+            invocation_id=payload.invocation_id(),
         ),
         StepId.root(binding.target_step),
         worker_state,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -106,6 +106,7 @@ class BrokerState:
         config: Immutable configuration for the workflow and all steps
         workers: Mutable state for each step's worker pool, queues, and in-progress executions
         stream_seq: Monotonic counter used to mint deterministic collection stream ids
+        invocation_seq: Monotonic counter used to mint deterministic step-invocation ids
         streams: Open collection streams keyed by stream id
         collection_release_states: Per-binding release buffers keyed by stream and binding
     """
@@ -114,6 +115,7 @@ class BrokerState:
     config: BrokerConfig
     workers: dict[str, InternalStepWorkerState]
     stream_seq: int = 0
+    invocation_seq: int = 0
     streams: dict[str, CollectionStreamInstance] = field(default_factory=dict)
     collection_release_states: dict[str, CollectionReleaseState] = field(
         default_factory=dict
@@ -131,6 +133,7 @@ class BrokerState:
                 for name, worker_state in self.workers.items()
             },
             stream_seq=self.stream_seq,
+            invocation_seq=self.invocation_seq,
             streams={sid: stream._copy() for sid, stream in self.streams.items()},
             collection_release_states={
                 key: state._copy()
@@ -190,6 +193,10 @@ class BrokerState:
                             bound_events=waiter.bound_events,
                             scope_path=waiter.scope_path,
                             collection_release_payload=waiter.collection_release_payload,
+                            # Carry the invocation id so the re-pinged step
+                            # regenerates the same implicit waiter id and re-finds
+                            # this waiter instead of registering a duplicate.
+                            invocation_id=waiter.invocation_id,
                         )
                     )
         return commands
@@ -219,6 +226,7 @@ class BrokerState:
                     collection_release_payload=_serialize_release_payload(
                         attempt.collection_release_payload, serializer
                     ),
+                    invocation_id=attempt.invocation_id,
                 )
                 for attempt in worker_state.queue
             ]
@@ -241,6 +249,7 @@ class BrokerState:
                     collection_release_payload=_serialize_release_payload(
                         ip.shared_state.collection_release_payload, serializer
                     ),
+                    invocation_id=ip.invocation_id,
                 )
                 for ip in worker_state.in_progress
             ]
@@ -272,6 +281,7 @@ class BrokerState:
                     collection_release_payload=_serialize_release_payload(
                         waiter.collection_release_payload, serializer
                     ),
+                    invocation_id=waiter.invocation_id,
                 )
                 for waiter in worker_state.collected_waiters
             ]
@@ -293,6 +303,7 @@ class BrokerState:
             is_running=self.is_running,
             workers=workers_dict,
             stream_seq=self.stream_seq,
+            invocation_seq=self.invocation_seq,
             streams={
                 sid: SerializedCollectionStreamInstance(
                     stream_id=stream.stream_id,
@@ -330,6 +341,7 @@ class BrokerState:
         # whether to create a start_event from kwargs (it only constructs and passes a start event if not already running)
         base_state.is_running = serialized.is_running
         base_state.stream_seq = serialized.stream_seq
+        base_state.invocation_seq = serialized.invocation_seq
         base_state.streams = {
             sid: CollectionStreamInstance(
                 stream_id=stream.stream_id,
@@ -408,6 +420,7 @@ class BrokerState:
                         else None,
                         scope_path=tuple(waiter_data.scope_path),
                         collection_release_payload=waiter_payload,
+                        invocation_id=waiter_data.invocation_id,
                     )
                 )
 
@@ -444,6 +457,7 @@ def _deserialize_event_attempt(
         not_before=attempt.not_before,
         scope_path=tuple(attempt.scope_path),
         collection_release_payload=payload,
+        invocation_id=attempt.invocation_id,
     )
 
 
@@ -594,6 +608,9 @@ class EventAttempt:
         recovery_counts: Per-handler recovery counts on this event's lineage.
         scope_path: Collection stream scope path, innermost stream id last.
         collection_release_payload: Explicit payload for queued list[E] collect invocations.
+        invocation_id: Stable id for this step invocation, minted at work-item
+            birth and carried across retries/resume so implicit waiters stay
+            distinct per invocation. None for state persisted before this field.
     """
 
     event: Event
@@ -606,6 +623,7 @@ class EventAttempt:
     not_before: float | None = None
     scope_path: tuple[str, ...] = field(default_factory=tuple)
     collection_release_payload: CollectionReleasePayload | None = None
+    invocation_id: str | None = None
 
 
 @dataclass()
@@ -674,6 +692,7 @@ class InProgressState:
     recovery_counts: dict[str, int] = field(default_factory=dict)
     bound_events: dict[str, Event] | None = None
     scope_path: tuple[str, ...] = field(default_factory=tuple)
+    invocation_id: str | None = None
 
     def _deepcopy(self) -> InProgressState:
         return InProgressState(
@@ -687,6 +706,7 @@ class InProgressState:
             last_failed_at=self.last_failed_at,
             recovery_counts=dict(self.recovery_counts),
             scope_path=self.scope_path,
+            invocation_id=self.invocation_id,
         )
 
 

--- a/packages/llama-index-workflows/src/workflows/runtime/types/results.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/results.py
@@ -84,6 +84,9 @@ class StepWorkerState:
     collected_waiters: list[StepWorkerWaiter]
     collection_release_payload: CollectionReleasePayload | None = None
     scope_path: tuple[str, ...] = ()
+    # Stable id of the invocation that owns this worker snapshot. Read by
+    # wait_for_event to keep implicit waiters distinct per invocation.
+    invocation_id: str | None = None
 
     def _deepcopy(self) -> StepWorkerState:
         return StepWorkerState(
@@ -94,6 +97,7 @@ class StepWorkerState:
             if self.collection_release_payload is not None
             else None,
             scope_path=self.scope_path,
+            invocation_id=self.invocation_id,
         )
 
 
@@ -126,6 +130,15 @@ class CollectionReleasePayload:
             stream_id=self.stream_id,
             binding_id=self.binding_id,
         )
+
+    def invocation_id(self) -> str:
+        """Deterministic invocation id for this collect release.
+
+        A collect invocation has a natural stable key (stream + binding) that is
+        carried on the payload across resume, so its implicit-waiter id needs no
+        counter and matches at both the initial release and any re-delivery.
+        """
+        return f"inv-collect-{self.stream_id}:{self.binding_id}"
 
 
 # Tick wire format for the payload's member events: the same SerializableEvent
@@ -191,6 +204,10 @@ class StepWorkerWaiter(Generic[EventType]):
     scope_path: tuple[str, ...] = ()
     # For a suspended collect invocation, the release batch to re-invoke with.
     collection_release_payload: CollectionReleasePayload | None = None
+    # Stable id of the invocation that created this waiter. Carried back into the
+    # re-delivered work item on resolve/timeout so the replay regenerates the same
+    # implicit waiter id. None for waiters persisted before this field existed.
+    invocation_id: str | None = None
 
 
 @dataclass()

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -55,6 +55,10 @@ class TickAddEvent(BaseModel):
     last_failed_at: float | None = None
     recovery_counts: dict[str, int] = Field(default_factory=dict)
     scope_path: tuple[str, ...] = Field(default_factory=tuple)
+    # Stable invocation id carried when this tick re-pings an existing suspended
+    # work item (rehydrate_with_ticks resume). None for genuinely new external
+    # events, which mint a fresh id when routed to a step.
+    invocation_id: str | None = None
     # Collect-invocation work record. A payload-carrying tick is routed
     # directly to the binding's target step, before waiter matching and the
     # member-arrival path.

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -45,6 +45,7 @@ from workflows.plugins.basic import (
     BasicRuntime,
     setting_run_id,
 )
+from workflows.retry_policy import retry_policy, stop_after_attempt, wait_fixed
 from workflows.runtime.types.internal_state import BrokerState
 from workflows.runtime.types.ticks import TickAddEvent
 from workflows.testing import WorkflowTestRunner
@@ -1324,3 +1325,274 @@ def test_basic_runtime_rejects_durable_state_handle(workflow: Workflow) -> None:
             serialized_state={"store_type": "postgres", "run_id": "run-1"},
             serializer=JsonSerializer(),
         )
+
+
+# ---------------------------------------------------------------------------
+# Implicit waiter ids: distinct across fan-out, stable across resume + retry,
+# and back-compatible with waiters persisted before invocation ids existed.
+# ---------------------------------------------------------------------------
+
+
+class _BranchEvent(Event):
+    branch: str
+
+
+class _BranchDone(Event):
+    branch: str
+    response: str
+
+
+class _BranchParallelWorkflow(Workflow):
+    """Fan-out where every branch waits for the same event type with an
+    implicit (default) waiter id. Branch payloads are distinct."""
+
+    @step
+    async def dispatch(self, ctx: Context, ev: StartEvent) -> _BranchEvent:
+        for branch in ("a", "b", "c"):
+            ctx.send_event(_BranchEvent(branch=branch))
+        return None  # type: ignore
+
+    @step(num_workers=3)
+    async def wait_branch(self, ctx: Context, ev: _BranchEvent) -> _BranchDone:
+        response = await ctx.wait_for_event(
+            HumanResponseEvent,
+            waiter_event=InputRequiredEvent(prefix=f"approve {ev.branch}"),  # type: ignore
+        )
+        return _BranchDone(branch=ev.branch, response=response.response)
+
+    @step
+    async def collect(self, ctx: Context, ev: _BranchDone) -> StopEvent:
+        done = ctx.collect_events(ev, [_BranchDone, _BranchDone, _BranchDone])
+        if done is None:
+            return None  # type: ignore
+        return StopEvent(result=sorted((e.branch, e.response) for e in done))
+
+
+@pytest.mark.asyncio
+async def test_parallel_implicit_waiters_distinct_payloads() -> None:
+    """Three branches with distinct payloads each get their own waiter and
+    InputRequiredEvent; a single HumanResponseEvent resolves them all."""
+    workflow = _BranchParallelWorkflow(timeout=5.0)
+    handler = workflow.run()
+    prefixes: set[str] = set()
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prefixes.add(ev.prefix)
+            if len(prefixes) == 3:
+                handler.ctx.send_event(HumanResponseEvent(response="approved"))  # type: ignore
+                break
+
+    assert prefixes == {"approve a", "approve b", "approve c"}
+    result = await handler
+    assert result == [("a", "approved"), ("b", "approved"), ("c", "approved")]
+
+
+class _SameEvent(Event):
+    """No distinguishing fields: every fan-out branch is byte-identical."""
+
+
+class _SameDone(Event):
+    response: str
+
+
+class _IdenticalPayloadWorkflow(Workflow):
+    @step
+    async def dispatch(self, ctx: Context, ev: StartEvent) -> _SameEvent:
+        for _ in range(3):
+            ctx.send_event(_SameEvent())
+        return None  # type: ignore
+
+    @step(num_workers=3)
+    async def wait_branch(self, ctx: Context, ev: _SameEvent) -> _SameDone:
+        response = await ctx.wait_for_event(
+            HumanResponseEvent,
+            waiter_event=InputRequiredEvent(prefix="approve"),  # type: ignore
+        )
+        return _SameDone(response=response.response)
+
+    @step
+    async def collect(self, ctx: Context, ev: _SameDone) -> StopEvent:
+        done = ctx.collect_events(ev, [_SameDone, _SameDone, _SameDone])
+        if done is None:
+            return None  # type: ignore
+        return StopEvent(result=[e.response for e in done])
+
+
+@pytest.mark.asyncio
+async def test_parallel_implicit_waiters_identical_payloads() -> None:
+    """The case a content-hash waiter id cannot handle: three branches whose
+    trigger events are byte-identical must still get three distinct waiters
+    (three InputRequiredEvents) rather than collapsing onto one."""
+    workflow = _IdenticalPayloadWorkflow(timeout=5.0)
+    handler = workflow.run()
+    prompts = 0
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prompts += 1
+            if prompts == 3:
+                handler.ctx.send_event(HumanResponseEvent(response="ok"))  # type: ignore
+                break
+
+    assert prompts == 3
+    result = await handler
+    assert result == ["ok", "ok", "ok"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_implicit_waiters_resume_after_snapshot() -> None:
+    """Snapshot mid-wait, restore, and resume: the suffixed implicit waiter ids
+    must survive to_dict/from_dict so every branch still resolves."""
+    workflow = _BranchParallelWorkflow(timeout=5.0)
+    handler = workflow.run()
+    prefixes: set[str] = set()
+
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prefixes.add(ev.prefix)
+            if len(prefixes) == 3:
+                break
+
+    assert prefixes == {"approve a", "approve b", "approve c"}
+    ctx_dict = handler.ctx.to_dict()
+    total_waiters = sum(
+        len(worker_data["collected_waiters"])
+        for worker_data in ctx_dict["workers"].values()
+    )
+    assert total_waiters == 3
+    await handler.cancel_run()
+
+    new_ctx = Context.from_dict(workflow, ctx_dict)
+    new_handler = workflow.run(ctx=new_ctx)
+    new_handler.ctx.send_event(HumanResponseEvent(response="resumed"))  # type: ignore
+    result = await new_handler
+    assert result == [
+        ("a", "resumed"),
+        ("b", "resumed"),
+        ("c", "resumed"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_legacy_implicit_waiter_resumes() -> None:
+    """A waiter persisted before invocation ids existed has a legacy, unsuffixed
+    waiter_id and no invocation_id. The back-compat lookup must still resolve it
+    on resume rather than re-suspending and dropping the response."""
+
+    class WaiterWorkflow(Workflow):
+        @step
+        async def ask(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            response = await ctx.wait_for_event(
+                NamedResponseEvent,
+                waiter_event=InputRequiredEvent(),
+            )
+            return StopEvent(result=response.response)
+
+    workflow = WaiterWorkflow(timeout=5.0)
+    handler = workflow.run()
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            break
+
+    ctx_dict = handler.ctx.to_dict()
+    await handler.cancel_run()
+
+    # Rewrite the snapshot to look like a pre-invocation-id payload: legacy
+    # waiter_id (no suffix) and all invocation ids stripped.
+    legacy_id = (
+        f"waiter_{NamedResponseEvent.__module__}.{NamedResponseEvent.__name__}_{{}}"
+    )
+    ctx_dict.pop("invocation_seq", None)
+    rewrote = False
+    for worker_data in ctx_dict["workers"].values():
+        for waiter in worker_data["collected_waiters"]:
+            waiter["waiter_id"] = legacy_id
+            waiter.pop("invocation_id", None)
+            rewrote = True
+        for attempt in (
+            *worker_data.get("queue", []),
+            *worker_data.get("in_progress", []),
+        ):
+            attempt.pop("invocation_id", None)
+    assert rewrote
+
+    new_ctx = Context.from_dict(workflow, ctx_dict)
+    new_handler = workflow.run(ctx=new_ctx)
+    new_handler.ctx.send_event(NamedResponseEvent(response="legacy-ok"))
+    result = await new_handler
+    assert result == "legacy-ok"
+
+
+@pytest.mark.asyncio
+async def test_implicit_waiter_stable_across_retry() -> None:
+    """A retry is the same invocation, a new attempt: after a step acquires its
+    waiter response then fails and retries, the replay must re-acquire the same
+    resolved waiter instead of re-prompting the human."""
+    attempts = {"n": 0}
+    prompts = {"n": 0}
+
+    class FlakyWaiterWorkflow(Workflow):
+        @step(retry_policy=retry_policy(wait=wait_fixed(0), stop=stop_after_attempt(3)))
+        async def ask(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            response = await ctx.wait_for_event(
+                HumanResponseEvent,
+                waiter_event=InputRequiredEvent(),
+            )
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise RuntimeError("transient failure after acquiring the waiter")
+            return StopEvent(result=response.response)
+
+    workflow = FlakyWaiterWorkflow(timeout=5.0)
+    handler = workflow.run()
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            prompts["n"] += 1
+            handler.ctx.send_event(HumanResponseEvent(response="once"))  # type: ignore
+            break
+
+    result = await handler
+    assert result == "once"
+    # The step ran twice (one failure + one success) but the human was prompted
+    # exactly once: the resolved waiter survived the retry.
+    assert attempts["n"] == 2
+    assert prompts["n"] == 1
+
+
+class _ReqDone(Event):
+    response: str
+
+
+@pytest.mark.asyncio
+async def test_requirements_waiter_resumes_after_reping() -> None:
+    """A waiter created with requirements is re-pinged by rehydrate_with_ticks on
+    resume. The invocation id must ride along on that re-ping tick so the
+    replayed step regenerates the same waiter id and resolves once."""
+
+    class ReqWaiterWorkflow(Workflow):
+        @step
+        async def ask(self, ctx: Context, ev: StartEvent) -> StopEvent:
+            response = await ctx.wait_for_event(
+                HumanResponseEvent,
+                waiter_event=InputRequiredEvent(),
+                requirements={"response": "go"},
+            )
+            return StopEvent(result=response.response)
+
+    workflow = ReqWaiterWorkflow(timeout=5.0)
+    handler = workflow.run()
+    async for ev in handler.stream_events():
+        if isinstance(ev, InputRequiredEvent):
+            break
+
+    ctx_dict = handler.ctx.to_dict()
+    await handler.cancel_run()
+
+    new_ctx = Context.from_dict(workflow, ctx_dict)
+    new_handler = workflow.run(ctx=new_ctx)
+    # Mismatched requirement is ignored; the matching one resolves the waiter.
+    new_handler.ctx.send_event(HumanResponseEvent(response="nope"))  # type: ignore
+    new_handler.ctx.send_event(HumanResponseEvent(response="go"))  # type: ignore
+    result = await new_handler
+    assert result == "go"


### PR DESCRIPTION
On the base branch, `Context.wait_for_event()` derives the implicit (default) waiter id from only the awaited event type and requirements:

```python
waiter_id = waiter_id or f"waiter_{event_str}_{requirements_str}"
```

So when several fan-out branches each `wait_for_event(SameType)` without an explicit `waiter_id`, every branch computes the same id. The later waiters overwrite the earlier ones in the control loop, only one `InputRequiredEvent` is emitted, and only one branch ever resumes.

This keys the implicit id to the **step invocation** instead of the event payload. Each work item gets a stable id, minted from a deterministic `BrokerState` counter when an event is routed to a step (collect invocations derive theirs from the stream+binding key). The id folds into the implicit waiter id:

```python
# before: all fan-out branches collapse onto one id
waiter_id = f"waiter_{event_str}_{requirements_str}"
# after: distinct per invocation
waiter_id = f"waiter_{event_str}_{requirements_str}_{invocation_id}"
```

Distinguishing by invocation rather than payload also fixes the case a content fingerprint can't: fan-out branches whose trigger events are byte-identical still get distinct waiters.

The id is carried, never re-minted, across every replay of the same invocation:

- **retries** — a retry is the same invocation, a new attempt. A step that acquires its waiter response, then fails partway and retries, must regenerate the same id to re-acquire the same resolved waiter rather than re-prompting.
- **waiter resolve / timeout re-delivery** and **serialize/resume** (including the `requirements`-waiter re-ping on rehydrate) carry the id on the work record so the replayed step regenerates the same waiter id.

The counter is persisted and minted only in the reducer, so replay and resume reproduce identical ids — the same guarantee the existing stream-id counter relies on.

## Back-compat

A waiter persisted before this change has the legacy unsuffixed id and no invocation id. `wait_for_event` matches an existing waiter by either the invocation-scoped id or the legacy id, and targets whichever actually exists for its `AddWaiter`/`DeleteWaiter`:

```python
candidate_ids = (new_id, legacy_id)
waiter = next((w for w in collected_waiters if w.waiter_id in candidate_ids), None)
effective_id = waiter.waiter_id if waiter is not None else candidate_ids[0]
```

Under current code every implicit waiter carries the suffixed id, so the legacy fallback can only ever match an old persisted waiter — and a pre-upgrade fan-out was already collapsed to a single waiter, so it cannot match more than one. The new serialized fields default to `None`/`0`, so old snapshots deserialize unchanged with no format version bump. Explicit `waiter_id` behavior is untouched.

Fixes run-llama/llama_index#22070.