### PR TITLE
Add organization switching to llamactl

### DIFF
--- a/.changeset/smooth-organizations-switch.md
+++ b/.changeset/smooth-organizations-switch.md
@@ -1,0 +1,5 @@
+---
+"llamactl": patch
+---
+
+Add organization switching to llamactl.

--- a/packages/llamactl/src/llama_agents/cli/commands/organizations.py
+++ b/packages/llamactl/src/llama_agents/cli/commands/organizations.py
@@ -3,14 +3,23 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import click
+from llama_agents.cli.interactive import select_or_exit
 from llama_agents.cli.output import status, warning
+from llama_agents.cli.param_types import OrgType
 from llama_agents.cli.utils.capabilities import probe_organizations_support
 
 from ..app import app
 from ..display import OrgDisplay
 from ..options import global_options, render_output, simple_output_option
-from .auth import _get_service, _list_organizations
+from .auth import (
+    _get_service,
+    _list_organizations,
+    _list_projects,
+    validate_authenticated_profile,
+)
 
 
 @app.group(
@@ -20,6 +29,20 @@ from .auth import _get_service, _list_organizations
 @global_options
 def organizations() -> None:
     pass
+
+
+def _active_org_id(
+    auth_svc: Any, *, current_project_id: str, fallback_org_id: str | None
+) -> str | None:
+    try:
+        projects = _list_projects(auth_svc)
+    except Exception:
+        return fallback_org_id
+    active_project = next(
+        (project for project in projects if project.project_id == current_project_id),
+        None,
+    )
+    return active_project.org_id if active_project is not None else fallback_org_id
 
 
 @organizations.command("get")
@@ -42,10 +65,82 @@ def get_organizations(output: str) -> None:
             return
 
         default_org = next((o.org_id for o in orgs if o.is_default), None)
+        current_org_id = default_org
+        profile = auth_svc.get_current_profile()
+        if profile is not None:
+            current_org_id = _active_org_id(
+                auth_svc,
+                current_project_id=profile.project_id,
+                fallback_org_id=default_org,
+            )
         displays = [
-            OrgDisplay.from_org_summary(org, current_org_id=default_org) for org in orgs
+            OrgDisplay.from_org_summary(org, current_org_id=current_org_id)
+            for org in orgs
         ]
         render_output(displays, output)
 
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
+
+
+@organizations.command("use")
+@click.argument("org_id", required=False, type=OrgType())
+@global_options
+def use_organization(org_id: str | None) -> None:
+    """Set the active project to one from the selected organization."""
+    auth_svc = _get_service().current_auth_service()
+
+    try:
+        if not probe_organizations_support():
+            raise click.ClickException("this server does not support organizations")
+
+        profile = validate_authenticated_profile()
+        orgs = _list_organizations(auth_svc)
+        if not orgs:
+            status("no organizations found")
+            return
+
+        if org_id:
+            selected_org = next((org for org in orgs if org.org_id == org_id), None)
+            if selected_org is None:
+                raise click.ClickException(f"Organization {org_id} not found")
+        else:
+            current_idx = next(
+                (i for i, org in enumerate(orgs) if org.is_default),
+                0,
+            )
+            selected_org = select_or_exit(
+                [
+                    (
+                        org,
+                        f"{org.org_name}  {org.org_id}"
+                        f"{' [default]' if org.is_default else ''}",
+                    )
+                    for org in orgs
+                ],
+                "Select an organization",
+                hint_flag="<org_id>",
+                hint_command="llamactl organizations get",
+                selected=current_idx,
+            )
+
+        projects = _list_projects(auth_svc, org_id=selected_org.org_id)
+        if not projects:
+            raise click.ClickException(
+                f"Organization {selected_org.org_id} has no projects"
+            )
+
+        project = projects[0]
+        if profile.project_id == project.project_id:
+            status(f"already using organization {selected_org.org_name}")
+            return
+
+        auth_svc.set_project(profile.name, project.project_id)
+        status(
+            f"switched organization {selected_org.org_name} "
+            f"and project {project.project_name}"
+        )
+    except click.ClickException:
+        raise
     except Exception as e:
         raise click.ClickException(str(e)) from e

--- a/packages/llamactl/tests/test_organizations_cli.py
+++ b/packages/llamactl/tests/test_organizations_cli.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import yaml
@@ -19,6 +20,8 @@ def test_organizations_get_text_lists_orgs() -> None:
         OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
         OrgSummary(org_id="org-b", org_name="Beta"),
     ]
+    auth_svc = MagicMock()
+    auth_svc.get_current_profile.return_value = SimpleNamespace(project_id="proj-b")
     with (
         patch(
             "llama_agents.cli.commands.organizations.probe_organizations_support",
@@ -28,9 +31,15 @@ def test_organizations_get_text_lists_orgs() -> None:
             "llama_agents.cli.commands.organizations._list_organizations",
             return_value=orgs,
         ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=[
+                SimpleNamespace(project_id="proj-b", org_id="org-b"),
+            ],
+        ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
-        mock_service.current_auth_service.return_value = MagicMock()
+        mock_service.current_auth_service.return_value = auth_svc
         result = runner.invoke(app, ["organizations", "get"])
     assert result.exit_code == 0, result.output
     assert "ORG_ID" in result.output
@@ -42,6 +51,7 @@ def test_organizations_get_text_lists_orgs() -> None:
     assert "Acme" in result.output
     assert "yes" in result.output
     assert "no" in result.output
+    assert "org-b" in result.output
     # ANSI / Rich markup should not leak.
     assert "\x1b[" not in result.output
 
@@ -52,6 +62,8 @@ def test_organizations_get_json() -> None:
         OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
         OrgSummary(org_id="org-b", org_name="Beta"),
     ]
+    auth_svc = MagicMock()
+    auth_svc.get_current_profile.return_value = SimpleNamespace(project_id="proj-b")
     with (
         patch(
             "llama_agents.cli.commands.organizations.probe_organizations_support",
@@ -61,9 +73,15 @@ def test_organizations_get_json() -> None:
             "llama_agents.cli.commands.organizations._list_organizations",
             return_value=orgs,
         ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=[
+                SimpleNamespace(project_id="proj-b", org_id="org-b"),
+            ],
+        ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
-        mock_service.current_auth_service.return_value = MagicMock()
+        mock_service.current_auth_service.return_value = auth_svc
         result = runner.invoke(app, ["organizations", "get", "-o", "json"])
     assert result.exit_code == 0, result.output
     data = json.loads(result.output)
@@ -71,13 +89,17 @@ def test_organizations_get_json() -> None:
     assert list(data[0]) == ["org_id", "org_name", "is_default", "active"]
     assert {d["org_id"] for d in data} == {"org-a", "org-b"}
     default = next(d for d in data if d["org_id"] == "org-a")
+    active = next(d for d in data if d["org_id"] == "org-b")
     assert default["is_default"] is True
-    assert default["active"] is True
+    assert default["active"] is False
+    assert active["active"] is True
 
 
 def test_organizations_get_yaml() -> None:
     runner = CliRunner()
     orgs = [OrgSummary(org_id="org-a", org_name="Acme", is_default=True)]
+    auth_svc = MagicMock()
+    auth_svc.get_current_profile.return_value = SimpleNamespace(project_id="proj-a")
     with (
         patch(
             "llama_agents.cli.commands.organizations.probe_organizations_support",
@@ -87,14 +109,60 @@ def test_organizations_get_yaml() -> None:
             "llama_agents.cli.commands.organizations._list_organizations",
             return_value=orgs,
         ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=[
+                SimpleNamespace(project_id="proj-a", org_id="org-a"),
+            ],
+        ),
         patch("llama_agents.cli.config.env_service.service") as mock_service,
     ):
-        mock_service.current_auth_service.return_value = MagicMock()
+        mock_service.current_auth_service.return_value = auth_svc
         result = runner.invoke(app, ["organizations", "get", "-o", "yaml"])
     assert result.exit_code == 0, result.output
     data = yaml.safe_load(result.output)
     assert isinstance(data, list)
     assert data[0]["org_id"] == "org-a"
+
+
+def test_organizations_get_falls_back_to_default_org_when_project_org_unknown() -> None:
+    runner = CliRunner()
+    orgs = [
+        OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
+        OrgSummary(org_id="org-b", org_name="Beta"),
+    ]
+    auth_svc = MagicMock()
+    auth_svc.get_current_profile.return_value = SimpleNamespace(
+        project_id="proj-missing"
+    )
+    with (
+        patch(
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
+            return_value=True,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=[
+                SimpleNamespace(project_id="proj-b", org_id="org-b"),
+            ],
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.validate_authenticated_profile",
+        ) as mock_validate,
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = auth_svc
+        result = runner.invoke(app, ["organizations", "get", "-o", "json"])
+
+    assert result.exit_code == 0, result.output
+    mock_validate.assert_not_called()
+    data = json.loads(result.output)
+    assert next(d for d in data if d["org_id"] == "org-a")["active"] is True
+    assert next(d for d in data if d["org_id"] == "org-b")["active"] is False
 
 
 def test_organizations_get_unsupported_text_warns() -> None:
@@ -132,3 +200,204 @@ def test_organizations_get_does_not_offer_wide_output() -> None:
     result = CliRunner().invoke(app, ["organizations", "get", "-o", "wide"])
     assert result.exit_code != 0
     assert "'wide' is not one of 'text', 'json', 'yaml'" in result.output
+
+
+def test_organizations_use_switches_to_first_project_for_org() -> None:
+    runner = CliRunner()
+    orgs = [
+        OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
+        OrgSummary(org_id="org-b", org_name="Beta"),
+    ]
+    projects = [
+        MagicMock(
+            project_id="proj-b-default",
+            project_name="Beta Default",
+            deployment_count=0,
+        )
+    ]
+    auth_svc = MagicMock()
+    with (
+        patch(
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
+            return_value=True,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.validate_authenticated_profile",
+            return_value=SimpleNamespace(name="default", project_id="proj-a"),
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=projects,
+        ) as mock_list_projects,
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = auth_svc
+        result = runner.invoke(app, ["organizations", "use", "org-b"])
+
+    assert result.exit_code == 0, result.output
+    mock_list_projects.assert_called_once_with(auth_svc, org_id="org-b")
+    auth_svc.set_project.assert_called_once_with("default", "proj-b-default")
+    assert "switched organization Beta and project Beta Default" in result.output
+
+
+def test_organizations_use_selects_org_when_argument_missing() -> None:
+    runner = CliRunner()
+    orgs = [
+        OrgSummary(org_id="org-a", org_name="Acme", is_default=True),
+        OrgSummary(org_id="org-b", org_name="Beta"),
+    ]
+    projects = [
+        MagicMock(
+            project_id="proj-b-default",
+            project_name="Beta Default",
+            deployment_count=0,
+        )
+    ]
+    auth_svc = MagicMock()
+    with (
+        patch(
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
+            return_value=True,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.validate_authenticated_profile",
+            return_value=SimpleNamespace(name="default", project_id="proj-a"),
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=projects,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.select_or_exit",
+            return_value=orgs[1],
+        ) as mock_select,
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = auth_svc
+        result = runner.invoke(app, ["organizations", "use"])
+
+    assert result.exit_code == 0, result.output
+    mock_select.assert_called_once()
+    auth_svc.set_project.assert_called_once_with("default", "proj-b-default")
+
+
+def test_organizations_use_current_project_noops() -> None:
+    runner = CliRunner()
+    orgs = [OrgSummary(org_id="org-b", org_name="Beta")]
+    projects = [
+        MagicMock(
+            project_id="proj-b-default",
+            project_name="Beta Default",
+            deployment_count=0,
+        )
+    ]
+    auth_svc = MagicMock()
+    with (
+        patch(
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
+            return_value=True,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.validate_authenticated_profile",
+            return_value=SimpleNamespace(name="default", project_id="proj-b-default"),
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=projects,
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = auth_svc
+        result = runner.invoke(app, ["organizations", "use", "org-b"])
+
+    assert result.exit_code == 0, result.output
+    assert "already using organization Beta" in result.output
+    auth_svc.set_project.assert_not_called()
+
+
+def test_organizations_use_missing_org_errors() -> None:
+    runner = CliRunner()
+    orgs = [OrgSummary(org_id="org-a", org_name="Acme", is_default=True)]
+    with (
+        patch(
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
+            return_value=True,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.validate_authenticated_profile",
+            return_value=SimpleNamespace(name="default", project_id="proj-a"),
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["organizations", "use", "org-missing"])
+
+    assert result.exit_code != 0
+    assert "Organization org-missing not found" in result.output
+
+
+def test_organizations_use_errors_when_org_has_no_projects() -> None:
+    runner = CliRunner()
+    orgs = [OrgSummary(org_id="org-a", org_name="Acme", is_default=True)]
+    auth_svc = MagicMock()
+    with (
+        patch(
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
+            return_value=True,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.validate_authenticated_profile",
+            return_value=SimpleNamespace(name="default", project_id="proj-a"),
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_organizations",
+            return_value=orgs,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations._list_projects",
+            return_value=[],
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = auth_svc
+        result = runner.invoke(app, ["organizations", "use", "org-a"])
+
+    assert result.exit_code != 0
+    assert "Organization org-a has no projects" in result.output
+    auth_svc.set_project.assert_not_called()
+
+
+def test_organizations_use_unsupported_server_errors() -> None:
+    runner = CliRunner()
+    with (
+        patch(
+            "llama_agents.cli.commands.organizations.probe_organizations_support",
+            return_value=False,
+        ),
+        patch(
+            "llama_agents.cli.commands.organizations.validate_authenticated_profile",
+            return_value=SimpleNamespace(name="default", project_id="proj-a"),
+        ),
+        patch("llama_agents.cli.config.env_service.service") as mock_service,
+    ):
+        mock_service.current_auth_service.return_value = MagicMock()
+        result = runner.invoke(app, ["organizations", "use", "org-a"])
+
+    assert result.exit_code != 0
+    assert "does not support organizations" in result.output


### PR DESCRIPTION
`llamactl organizations` could list organizations, but it had no command that made one active. Users had to infer a project id in that organization and switch with `llamactl projects use` instead.

This adds `llamactl organizations use [org_id]`. The command validates the selected organization, resolves it to an available project in that organization, and stores that project on the current profile. The organization list also marks the active org from the current profile's project when that can be resolved, falling back to the server default when it cannot.

Unsupported servers keep the existing structured-output behavior for `organizations get`, and `organizations use` returns a direct unsupported-server error.