### PR TITLE
Reload workflow failures without crashing on un-reconstructable exceptions

### DIFF
--- a/.changeset/exception-deserialize-hardening.md
+++ b/.changeset/exception-deserialize-hardening.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Reloading a persisted workflow failure no longer crashes when the original exception cannot be faithfully rebuilt; it degrades to an UnreconstructedException carrying the original type name and message, and exception type imports now honor the serializer's allowed_types allowlist.

--- a/.changeset/exception-deserialize-hardening.md
+++ b/.changeset/exception-deserialize-hardening.md
@@ -2,4 +2,4 @@
 "llama-index-workflows": patch
 ---
 
-Reloading a persisted workflow failure no longer crashes when the original exception cannot be faithfully rebuilt; it degrades to an UnreconstructedException carrying the original type name and message, and exception type imports now honor the serializer's allowed_types allowlist.
+Reloading a failed workflow no longer crashes when the failure exception can't be rebuilt.

--- a/packages/llama-index-workflows/src/workflows/context/serializers.py
+++ b/packages/llama-index-workflows/src/workflows/context/serializers.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import contextvars
 import json
 import pickle
 from abc import ABC, abstractmethod
@@ -13,6 +14,16 @@ from typing import Any
 from pydantic import BaseModel
 
 from .utils import get_qualified_name, import_module_from_qualified_name
+
+# Threads the active serializer's allowlist into nested field validators during
+# deserialization. Pydantic's `model_validate(context=...)` is not a reliable
+# channel here: the event models (`DictLikeModel`) define a custom `__init__`,
+# which makes pydantic drop the validation context before nested field
+# validators run. A ContextVar is set around `model_validate` and read by the
+# exception reconstruction in `events.py`.
+allowed_type_names_var: contextvars.ContextVar[frozenset[str] | None] = (
+    contextvars.ContextVar("allowed_type_names", default=None)
+)
 
 
 class BaseSerializer(ABC):
@@ -149,7 +160,11 @@ class JsonSerializer(BaseSerializer):
             if data.get("__is_pydantic") and data.get("qualified_name"):
                 self._validate_qualified_name(data["qualified_name"])
                 module_class = import_module_from_qualified_name(data["qualified_name"])
-                return module_class.model_validate(data["value"])
+                token = allowed_type_names_var.set(self._allowed_type_names)
+                try:
+                    return module_class.model_validate(data["value"])
+                finally:
+                    allowed_type_names_var.reset(token)
             elif data.get("__is_component") and data.get("qualified_name"):
                 self._validate_qualified_name(data["qualified_name"])
                 module_class = import_module_from_qualified_name(data["qualified_name"])

--- a/packages/llama-index-workflows/src/workflows/events.py
+++ b/packages/llama-index-workflows/src/workflows/events.py
@@ -18,7 +18,7 @@ from pydantic import (
     model_serializer,
 )
 
-from workflows.context.serializers import JsonSerializer
+from workflows.context.serializers import JsonSerializer, allowed_type_names_var
 from workflows.context.utils import import_module_from_qualified_name
 
 
@@ -200,15 +200,77 @@ def _serialize_exception(exc: Exception) -> dict[str, Any]:
     }
 
 
+class UnreconstructedException(Exception):
+    """Stand-in for an exception that could not be faithfully rebuilt after a
+    serialization boundary.
+
+    Reconstructing a persisted exception only ever has its type name and message
+    to work with. When the original type cannot be imported, is disallowed by the
+    serializer's allowlist, or rejects a single-argument ``cls(message)`` call,
+    this type is returned instead so the reload never crashes. The original
+    qualified type name is kept on ``original_type`` as a diagnostic breadcrumb.
+
+    ``str(exc)`` equals the original message (no type prefix) so a re-serialize ->
+    re-deserialize cycle does not double-wrap the message. ``original_type`` is
+    attribute-only and is dropped on re-serialization, since serialization keeps
+    only the type name and message.
+    """
+
+    def __init__(self, message: str, *, original_type: str | None = None) -> None:
+        super().__init__(message)
+        self.original_type = original_type
+
+    def __repr__(self) -> str:
+        return (
+            f"UnreconstructedException(original_type={self.original_type!r}, "
+            f"{self.args[0]!r})"
+        )
+
+
+_UNRECONSTRUCTED_EXCEPTION_NAME = (
+    f"{UnreconstructedException.__module__}.{UnreconstructedException.__qualname__}"
+)
+
+
+def _exception_type_permitted(exc_type: str) -> bool:
+    """Whether an exception type may be imported for reconstruction.
+
+    ``builtins.*`` exceptions are always permitted (already loaded, no import side
+    effects). The framework's own breadcrumb type is always permitted so a
+    degraded exception round-trips stably under any allowlist rather than
+    degrading into a self-referential breadcrumb. With no allowlist active the
+    check is permissive, matching the opt-in nature of ``allowed_types``.
+    Otherwise the type must be in the allowlist; a miss returns ``False`` so the
+    caller degrades without ever importing the type.
+    """
+    if exc_type.startswith("builtins."):
+        return True
+    if exc_type == _UNRECONSTRUCTED_EXCEPTION_NAME:
+        return True
+    allowed = allowed_type_names_var.get()
+    if allowed is None:
+        return True
+    return exc_type in allowed
+
+
 def _deserialize_exception(data: Any) -> Exception:
     if isinstance(data, Exception):
         return data
+    exc_type = data["exception_type"]
     exc_message = data["exception_message"]
+    if not _exception_type_permitted(exc_type):
+        return UnreconstructedException(exc_message, original_type=exc_type)
     try:
-        exc_cls = import_module_from_qualified_name(data["exception_type"])
+        exc_cls = import_module_from_qualified_name(exc_type)
+        # Only construct genuine exception types. The qualified name comes from a
+        # serialized blob and could resolve to any callable (e.g. ``builtins.eval``,
+        # which the ``builtins`` allowlist exemption would otherwise permit) —
+        # calling it with the message would be arbitrary code execution.
+        if not (isinstance(exc_cls, type) and issubclass(exc_cls, Exception)):
+            return UnreconstructedException(exc_message, original_type=exc_type)
         return exc_cls(exc_message)
-    except (ImportError, AttributeError, ValueError):
-        return Exception(exc_message)
+    except Exception:
+        return UnreconstructedException(exc_message, original_type=exc_type)
 
 
 SerializableException = Annotated[

--- a/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
+++ b/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
@@ -12,6 +12,7 @@ from workflows.events import (
     Event,
     StartEvent,
     StopEvent,
+    UnreconstructedException,
     _deserialize_event,
     _deserialize_event_type,
     _deserialize_exception,
@@ -130,7 +131,8 @@ def test_exception_roundtrip_unimportable() -> None:
     exc = CustomError("oops")
     serialized = _serialize_exception(exc)
     result = _deserialize_exception(serialized)
-    assert type(result) is Exception
+    assert isinstance(result, UnreconstructedException)
+    assert result.original_type == serialized["exception_type"]
     assert str(result) == "oops"
 
 
@@ -272,7 +274,7 @@ def test_tick_step_result_with_failed_unimportable_exception() -> None:
     assert isinstance(result, TickStepResult)
     r = result.result[0]
     assert isinstance(r, StepWorkerFailed)
-    assert type(r.exception) is Exception
+    assert isinstance(r.exception, UnreconstructedException)
     assert str(r.exception) == "oops"
     assert r.failed_at == failed_at
 

--- a/packages/llama-index-workflows/tests/test_event.py
+++ b/packages/llama-index-workflows/tests/test_event.py
@@ -1,15 +1,18 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
 
+import json
 from http.client import HTTPException
 from typing import Any, cast
 
 import pytest
 from pydantic import PrivateAttr
 from workflows.context import JsonSerializer
+from workflows.context.utils import import_module_from_qualified_name
 from workflows.events import (
     Event,
     StopEvent,
+    UnreconstructedException,
     WorkflowCancelledEvent,
     WorkflowFailedEvent,
     WorkflowTimedOutEvent,
@@ -320,3 +323,145 @@ def test_workflow_failed_event_with_nested_exception_type() -> None:
     assert isinstance(ev.exception, HTTPException)
     assert ev.attempts == 5
     assert ev.elapsed_seconds == 10.0
+
+
+def _failed_event(exception: Exception) -> WorkflowFailedEvent:
+    return WorkflowFailedEvent(
+        step_name="step",
+        exception=exception,
+        attempts=1,
+        elapsed_seconds=0.1,
+    )
+
+
+def _roundtrip(
+    ev: WorkflowFailedEvent, serializer: JsonSerializer | None = None
+) -> WorkflowFailedEvent:
+    serializer = serializer or JsonSerializer()
+    return cast(WorkflowFailedEvent, serializer.deserialize(serializer.serialize(ev)))
+
+
+def test_message_only_exception_roundtrips_by_type() -> None:
+    """Importable single-arg exceptions still reconstruct as their real type."""
+    restored = _roundtrip(_failed_event(HTTPException("Connection refused")))
+    assert type(restored.exception) is HTTPException
+    assert str(restored.exception) == "Connection refused"
+
+
+def test_multi_arg_ctor_exception_degrades_to_breadcrumb() -> None:
+    """An importable exception whose ctor rejects ``cls(message)`` degrades
+    instead of crashing the reload (the old uncaught-TypeError path)."""
+    exc = json.JSONDecodeError("Expecting value", "doc", 0)
+    restored = _roundtrip(_failed_event(exc))
+    assert isinstance(restored.exception, UnreconstructedException)
+    assert restored.exception.original_type == "json.decoder.JSONDecodeError"
+    assert str(restored.exception) == str(exc)
+
+
+def test_unimportable_exception_degrades_to_breadcrumb() -> None:
+    """A type that cannot be re-imported (``<locals>`` qualname) degrades to the
+    breadcrumb type rather than a bare ``Exception``."""
+
+    def make_local_exception() -> type[Exception]:
+        class LocalError(Exception):
+            pass
+
+        return LocalError
+
+    local_exc = make_local_exception()("boom")
+    restored = _roundtrip(_failed_event(local_exc))
+    assert isinstance(restored.exception, UnreconstructedException)
+    assert restored.exception.original_type is not None
+    assert "LocalError" in restored.exception.original_type
+    assert str(restored.exception) == "boom"
+
+
+def test_unreconstructed_exception_reserializes_without_double_wrapping() -> None:
+    """Re-serializing a degraded exception keeps the message intact; the
+    breadcrumb type itself reconstructs cleanly with ``original_type`` reset."""
+    serializer = JsonSerializer()
+    once = _roundtrip(_failed_event(json.JSONDecodeError("Expecting value", "doc", 0)))
+    assert isinstance(once.exception, UnreconstructedException)
+
+    twice = _roundtrip(once, serializer)
+    assert isinstance(twice.exception, UnreconstructedException)
+    assert str(twice.exception) == str(once.exception)
+    # serialize keeps only type + message, so original_type is dropped on re-roundtrip
+    assert twice.exception.original_type is None
+
+
+def test_unreconstructed_exception_reserializes_under_active_allowlist() -> None:
+    """The breadcrumb type itself is always permitted, so a degraded exception
+    round-trips stably even under an allowlist that does not list it (rather than
+    degrading into a self-referential breadcrumb)."""
+    serializer = JsonSerializer(allowed_types=[WorkflowFailedEvent])
+    once = _roundtrip(
+        _failed_event(json.JSONDecodeError("Expecting value", "doc", 0)), serializer
+    )
+    assert isinstance(once.exception, UnreconstructedException)
+
+    twice = _roundtrip(once, serializer)
+    assert isinstance(twice.exception, UnreconstructedException)
+    assert str(twice.exception) == str(once.exception)
+    assert twice.exception.original_type is None
+
+
+def test_allowlist_set_still_reconstructs_builtin_exceptions() -> None:
+    """builtins are exempt from the allowlist and reconstruct as their real type."""
+    serializer = JsonSerializer(allowed_types=[WorkflowFailedEvent])
+    restored = _roundtrip(_failed_event(ValueError("bad value")), serializer)
+    assert type(restored.exception) is ValueError
+    assert str(restored.exception) == "bad value"
+
+
+def test_no_allowlist_reconstructs_non_builtin_exception() -> None:
+    """With no allowlist, non-builtin exception reconstruction stays permissive."""
+    restored = _roundtrip(_failed_event(HTTPException("Connection refused")))
+    assert type(restored.exception) is HTTPException
+
+
+def test_disallowed_non_builtin_exception_degrades_without_importing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-builtin exception outside the allowlist degrades and is never
+    imported — the allowlist is a real boundary for exception types."""
+    serializer = JsonSerializer(allowed_types=[WorkflowFailedEvent])
+    blob = serializer.serialize(_failed_event(HTTPException("nope")))
+
+    imported: list[str] = []
+
+    def spy(name: str) -> Any:
+        imported.append(name)
+        return import_module_from_qualified_name(name)
+
+    monkeypatch.setattr("workflows.events.import_module_from_qualified_name", spy)
+
+    restored = cast(WorkflowFailedEvent, serializer.deserialize(blob))
+    assert isinstance(restored.exception, UnreconstructedException)
+    assert restored.exception.original_type == "http.client.HTTPException"
+    assert str(restored.exception) == "nope"
+    assert "http.client.HTTPException" not in imported
+
+
+def test_non_exception_type_is_never_called() -> None:
+    """A serialized blob naming a non-exception builtin (e.g. ``builtins.eval``)
+    must not be invoked — reconstruction only ever constructs real exceptions."""
+    blob = json.dumps(
+        {
+            "__is_pydantic": True,
+            "qualified_name": "workflows.events.WorkflowFailedEvent",
+            "value": {
+                "step_name": "x",
+                "exception": {
+                    "exception_type": "builtins.eval",
+                    "exception_message": "1 + 1",
+                },
+                "attempts": 1,
+                "elapsed_seconds": 0.1,
+            },
+        }
+    )
+    restored = cast(WorkflowFailedEvent, JsonSerializer().deserialize(blob))
+    assert isinstance(restored.exception, UnreconstructedException)
+    assert restored.exception.original_type == "builtins.eval"
+    assert str(restored.exception) == "1 + 1"


### PR DESCRIPTION
Rehydrating a persisted `WorkflowFailedEvent` could take down the whole event/context reload. `_deserialize_exception` rebuilt the original exception with `cls(message)`, but only caught `(ImportError, AttributeError, ValueError)`. Any exception whose constructor doesn't take a single positional message raised `TypeError`, which escaped `model_validate` and crashed `JsonSerializer.deserialize`. `json.JSONDecodeError(msg, doc, pos)` and `LLMError(error_type, message)` are the common cases. One awkward exception type on a failed run made that run unloadable.

Reconstruction is now total. It returns an `Exception` for any input and never raises. When the real type can't be rebuilt, it degrades to a new `UnreconstructedException` carrying the original qualified type name and message. A type can't be rebuilt when it is unimportable, disallowed by the allowlist, or has a constructor that rejects `cls(message)`.

```python
exc = json.JSONDecodeError("Expecting value", "doc", 0)
reloaded = roundtrip(WorkflowFailedEvent(exception=exc, ...))
# before: TypeError escapes, the whole reload dies
# after:  UnreconstructedException, .original_type == "json.decoder.JSONDecodeError",
#         str(reloaded.exception) == str(exc)
```

`str(UnreconstructedException(msg))` is the original message with no type prefix, so a re-serialize cycle doesn't double-wrap it. Importable single-argument exceptions still round-trip by type identity.

## Allowlist gating

The same code path had an asymmetry worth closing. Every other deserialized type runs through `JsonSerializer`'s `allowed_types` gate, but the exception path called `import_module_from_qualified_name` directly. A checkpoint blob could name any importable `module.Class` and the loader would import and call it. Exception types now honor the same allowlist. `builtins.*` is exempt, an unset allowlist stays permissive to match how `allowed_types` already works, and anything else has to be a member or it degrades without importing.

Reconstruction also only constructs genuine `Exception` subclasses. The qualified name comes from the blob and could resolve to any callable. Without that check the `builtins` exemption would run `builtins.eval(message)` on an attacker-controlled message even under a strict allowlist. A blob naming a non-exception builtin now degrades instead of being called.

The allowlist reaches the validator through a `ContextVar` set around `model_validate`, not pydantic's `model_validate(context=...)`. The event models (`DictLikeModel`) define a custom `__init__`, and pydantic drops the validation context before the nested field validators run, so the context never arrives at the exception field.

Gating is best-effort by design. It covers the top-level failure carriers (`WorkflowFailedEvent`, `StepFailedEvent`, `StepWorkerFailed`). Serialization still stores only type and message, so `original_type` is a breadcrumb that is dropped on re-serialization.