### PR TITLE
Handle AgentWorkflow memory in in-memory state edits

### DIFF
--- a/packages/llama-agents-integration-tests/tests/test_context_store.py
+++ b/packages/llama-agents-integration-tests/tests/test_context_store.py
@@ -10,7 +10,23 @@ from llama_agents_integration_tests.helpers import (
     make_text_response,
     make_tool_call_response,
 )
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.memory import Memory
 from workflows import Context
+
+
+async def test_agent_workflow_accepts_memory_object(
+    create_workflow: WorkflowFactory,
+) -> None:
+    """Test that workflow.run accepts the public Memory implementation."""
+    workflow = create_workflow(responses=[make_text_response("Done")])
+    memory = Memory.from_defaults(
+        chat_history=[ChatMessage(role=MessageRole.USER, content="earlier turn")]
+    )
+
+    result = await workflow.run(user_msg="hi", memory=memory)
+
+    assert result.response.content == "Done"
 
 
 async def test_initial_state_accessible_in_tool(

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -9,6 +9,7 @@ import json
 import uuid
 import warnings
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -562,6 +563,25 @@ class DictState(DictLikeModel):
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
 
+def copy_state_for_edit(
+    state: MODEL_T,
+    known_unserializable_keys: tuple[str, ...] = KNOWN_UNSERIALIZABLE_KEYS,
+) -> MODEL_T:
+    """Copy state for isolated in-memory edits.
+
+    DictState can hold live workflow objects such as memory. Those objects are
+    intentionally skipped by state serialization and may not be deepcopy-able,
+    so preserve them by reference while deep-copying ordinary state entries.
+    """
+    if isinstance(state, DictState):
+        copied = {
+            key: value if key in known_unserializable_keys else deepcopy(value)
+            for key, value in state.items()
+        }
+        return cast(MODEL_T, DictState(**copied))
+    return state.model_copy(deep=True)
+
+
 @runtime_checkable
 class StateStore(Protocol[MODEL_T]):
     """Protocol defining the public async state store interface.
@@ -999,7 +1019,7 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         # the block commits (matching durable backends, where each load
         # decodes a fresh instance from the committed row).
         state = await self._load_state(storage)
-        return state.model_copy(deep=True)
+        return copy_state_for_edit(state)
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
         """Serialize the state and model metadata for persistence.

--- a/packages/llama-index-workflows/tests/context/test_state_store_facade.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_facade.py
@@ -156,6 +156,24 @@ async def test_edit_state_isolates_nested_mutables_until_commit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_edit_state_preserves_known_unserializable_keys() -> None:
+    class Undeepcopyable:
+        def __deepcopy__(self, memo: dict[int, Any]) -> Undeepcopyable:
+            raise TypeError("cannot copy")
+
+    memory = Undeepcopyable()
+    store = InMemoryStateStore(DictState(memory=memory, nums=[1]))
+
+    async with store.edit_state() as state:
+        assert state["memory"] is memory
+        state["nums"].append(2)
+        assert await store.get("nums") == [1]
+
+    assert await store.get("memory") is memory
+    assert await store.get("nums") == [1, 2]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("durable", [False, True])
 async def test_get_inside_edit_state(durable: bool) -> None:
     store: Any = (


### PR DESCRIPTION
AgentWorkflow stores the public `Memory` object under the `memory` state key before it initializes the rest of the context. On main, the in-memory state store deep-copies the whole `DictState` for every edit, so `workflow.run(..., memory=Memory.from_defaults(...))` can recurse into the live chat store and fail while copying objects that are not meant to be copied.

This keeps edit isolation for ordinary `DictState` entries, but treats known unserializable keys the same way serialization already does. The in-memory edit copy preserves those live objects by reference and deep-copies the rest. The new integration coverage runs an `AgentWorkflow` with `llama_index.core.memory.Memory`; the state-store coverage keeps nested mutable isolation in place while proving the `memory` key can hold a non-deepcopyable object.

Fixes https://github.com/run-llama/llama-agents/issues/709