### PR TITLE
Don't crash ctx.store edits on non-deepcopyable state values

### DIFF
--- a/.changeset/issue-709-710-memory-deepcopy.md
+++ b/.changeset/issue-709-710-memory-deepcopy.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Stop crashing on `ctx.store` edits when state holds non-deepcopyable live objects (e.g. a `Memory` or an LLM client). Such values are now preserved by reference during edit isolation instead of raising `TypeError: cannot pickle ...`.

--- a/.changeset/issue-709-710-memory-deepcopy.md
+++ b/.changeset/issue-709-710-memory-deepcopy.md
@@ -2,4 +2,4 @@
 "llama-index-workflows": patch
 ---
 
-Stop crashing on ctx.store edits when state holds non-deepcopyable objects like memory or LLM clients.
+Fix crashes during ctx.store edits when state holds non-deepcopyable objects

--- a/.changeset/issue-709-710-memory-deepcopy.md
+++ b/.changeset/issue-709-710-memory-deepcopy.md
@@ -2,4 +2,4 @@
 "llama-index-workflows": patch
 ---
 
-Stop crashing on `ctx.store` edits when state holds non-deepcopyable live objects (e.g. a `Memory` or an LLM client). Such values are now preserved by reference during edit isolation instead of raising `TypeError: cannot pickle ...`.
+Stop crashing on ctx.store edits when state holds non-deepcopyable objects like memory or LLM clients.

--- a/packages/llama-agents-integration-tests/tests/test_context_store.py
+++ b/packages/llama-agents-integration-tests/tests/test_context_store.py
@@ -5,12 +5,69 @@ by llama-index agents, including state persistence across steps and
 access from within tool functions.
 """
 
+import threading
+
 from conftest import WorkflowFactory
 from llama_agents_integration_tests.helpers import (
     make_text_response,
     make_tool_call_response,
 )
+from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.memory import Memory
 from workflows import Context
+
+
+async def test_agent_workflow_accepts_memory_object(
+    create_workflow: WorkflowFactory,
+) -> None:
+    """Regression for issue 709: workflow.run(memory=...) with a live Memory.
+
+    The in-memory edit copy deep-copies the whole live state, which recurses
+    into the Memory object's unserializable internals (sqlalchemy/aiosqlite/
+    tiktoken) and raises ``TypeError: cannot pickle 'module' object``.
+    """
+    workflow = create_workflow(responses=[make_text_response("Done")])
+    memory = Memory.from_defaults(
+        chat_history=[ChatMessage(role=MessageRole.USER, content="earlier turn")]
+    )
+
+    result = await workflow.run(user_msg="hi", memory=memory)
+
+    assert result.response.content == "Done"
+
+
+async def test_store_set_accepts_non_serializable_object(
+    create_workflow: WorkflowFactory,
+) -> None:
+    """Regression for issue 710: ctx.store.set with an unpicklable live object.
+
+    Storing an object that wraps a thread lock (e.g. an LLM client) used to
+    raise ``TypeError: cannot pickle '_thread.lock' object`` from the edit-time
+    whole-state deep copy. The object is kept by reference instead.
+    """
+    lock = threading.Lock()
+    captured = None
+
+    async def stash_client(ctx: Context) -> str:
+        nonlocal captured
+        await ctx.store.set("client", lock)
+        captured = await ctx.store.get("client")
+        return "stored"
+
+    workflow = create_workflow(
+        tools=[stash_client],
+        responses=[
+            make_tool_call_response("stash_client"),
+            make_text_response("Done"),
+        ],
+    )
+
+    handler = workflow.run(user_msg="stash it")
+    async for _ in handler.stream_events():
+        pass
+    await handler
+
+    assert captured is lock
 
 
 async def test_initial_state_accessible_in_tool(

--- a/packages/llama-agents-integration-tests/tests/test_context_store.py
+++ b/packages/llama-agents-integration-tests/tests/test_context_store.py
@@ -11,29 +11,93 @@ from conftest import WorkflowFactory
 from llama_agents_integration_tests.helpers import (
     make_text_response,
     make_tool_call_response,
+    response_generator_from_list,
+)
+from llama_index.core.agent.workflow import (
+    AgentInput,
+    AgentStream,
+    AgentWorkflow,
+    FunctionAgent,
+    ToolCall,
 )
 from llama_index.core.base.llms.types import ChatMessage, MessageRole
+from llama_index.core.llms.mock import MockFunctionCallingLLM
 from llama_index.core.memory import Memory
 from workflows import Context
 
 
-async def test_agent_workflow_accepts_memory_object(
-    create_workflow: WorkflowFactory,
-) -> None:
-    """Regression for issue 709: workflow.run(memory=...) with a live Memory.
+def _mock_agent(
+    name: str,
+    description: str,
+    responses: list[ChatMessage],
+    can_handoff_to: list[str] | None = None,
+) -> FunctionAgent:
+    """Build a FunctionAgent whose mock LLM cycles through fixed responses."""
+    llm = MockFunctionCallingLLM(
+        response_generator=response_generator_from_list(responses)
+    )
+    return FunctionAgent(
+        name=name,
+        description=description,
+        llm=llm,
+        can_handoff_to=can_handoff_to or [],
+    )
 
-    The in-memory edit copy deep-copies the whole live state, which recurses
-    into the Memory object's unserializable internals (sqlalchemy/aiosqlite/
-    tiktoken) and raises ``TypeError: cannot pickle 'module' object``.
+
+async def test_multi_agent_handoff_streams_with_memory() -> None:
+    """End-to-end regression for issue 709.
+
+    The reported failure was a router-to-specialist handoff in a streamed
+    multi-agent chat that passed a ``Memory`` object to ``run()``. The handoff
+    tool and agent setup write to ``ctx.store``, which deep-copies state for
+    edit isolation, and the live ``Memory`` (sqlalchemy/aiosqlite/tiktoken
+    internals) used to crash that copy with ``cannot pickle 'module' object``.
+
+    This drives the whole pattern at once: a router hands off to a specialist,
+    the specialist streams the final answer, and a ``Memory`` rides through
+    ``run()`` the way the original repro had it.
     """
-    workflow = create_workflow(responses=[make_text_response("Done")])
+    router = _mock_agent(
+        "router",
+        "Routes the chat to a specialist.",
+        responses=[
+            make_tool_call_response(
+                "handoff",
+                {"to_agent": "specialist", "reason": "needs specialist"},
+            ),
+        ],
+        can_handoff_to=["specialist"],
+    )
+    specialist = _mock_agent(
+        "specialist",
+        "Answers the question.",
+        responses=[make_text_response("specialist answer")],
+    )
+    workflow = AgentWorkflow(agents=[router, specialist], root_agent="router")
     memory = Memory.from_defaults(
         chat_history=[ChatMessage(role=MessageRole.USER, content="earlier turn")]
     )
 
-    result = await workflow.run(user_msg="hi", memory=memory)
+    handler = workflow.run(user_msg="help me", memory=memory)
+    active_agents: list[str] = []
+    handoff_tool_calls: list[str] = []
+    specialist_stream = ""
+    async for event in handler.stream_events():
+        if isinstance(event, AgentInput):
+            active_agents.append(event.current_agent_name)
+        elif isinstance(event, ToolCall):
+            handoff_tool_calls.append(event.tool_name)
+        elif (
+            isinstance(event, AgentStream) and event.current_agent_name == "specialist"
+        ):
+            specialist_stream += event.delta
+    result = await handler
 
-    assert result.response.content == "Done"
+    # Router runs, hands off, then the specialist takes over and answers.
+    assert active_agents == ["router", "specialist"]
+    assert "handoff" in handoff_tool_calls
+    assert specialist_stream == "specialist answer"
+    assert result.response.content == "specialist answer"
 
 
 async def test_store_set_accepts_non_serializable_object(

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -9,6 +9,7 @@ import json
 import uuid
 import warnings
 from contextlib import asynccontextmanager
+from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -562,6 +563,40 @@ class DictState(DictLikeModel):
 MODEL_T = TypeVar("MODEL_T", bound=BaseModel, default=DictState)  # type: ignore[reportGeneralTypeIssues]
 
 
+def _copy_value_for_edit(value: Any) -> Any:
+    """Deep-copy a single state value, or keep the live reference if it can't be.
+
+    State can hold live workflow objects (memory, LLM clients) that wrap thread
+    locks, modules, or sockets and raise on ``deepcopy``. Those are shared live
+    handles, so there is nothing to isolate by copying — preserve the reference
+    instead of failing the edit.
+    """
+    try:
+        return deepcopy(value)
+    except Exception:
+        return value
+
+
+def copy_state_for_edit(state: MODEL_T) -> MODEL_T:
+    """Return an isolated copy of state for an ``edit_state`` block.
+
+    ``edit_state`` mutates a copy so lockless readers keep seeing committed
+    state until the block commits. Ordinary data entries are deep-copied for
+    that isolation; entries holding non-deepcopyable live objects are kept by
+    reference (see ``_copy_value_for_edit``) so the edit cannot crash on them.
+
+    Typed (non-``DictState``) state copies whole-model; if that model holds a
+    non-deepcopyable field, fall back to a shallow copy rather than crash.
+    """
+    if isinstance(state, DictState):
+        copied = {key: _copy_value_for_edit(value) for key, value in state.items()}
+        return cast(MODEL_T, DictState(**copied))
+    try:
+        return state.model_copy(deep=True)
+    except Exception:
+        return state.model_copy()
+
+
 @runtime_checkable
 class StateStore(Protocol[MODEL_T]):
     """Protocol defining the public async state store interface.
@@ -999,7 +1034,7 @@ class InMemoryStateStore(StateStoreFacade[MODEL_T]):
         # the block commits (matching durable backends, where each load
         # decodes a fresh instance from the committed row).
         state = await self._load_state(storage)
-        return state.model_copy(deep=True)
+        return copy_state_for_edit(state)
 
     def to_dict(self, serializer: "BaseSerializer") -> dict[str, Any]:
         """Serialize the state and model metadata for persistence.

--- a/packages/llama-index-workflows/tests/context/test_state_store_facade.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_facade.py
@@ -156,6 +156,33 @@ async def test_edit_state_isolates_nested_mutables_until_commit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_edit_state_preserves_non_deepcopyable_values_by_reference() -> None:
+    """Edits must not crash on live objects that cannot be deep-copied.
+
+    Regression for issues 709/710: an unpicklable value (memory, an LLM client
+    wrapping a thread lock) stored in state used to blow up the whole-state deep
+    copy with ``TypeError: cannot pickle ...``. Such values are shared live
+    handles, so they are kept by reference while ordinary entries stay isolated.
+    """
+
+    class Undeepcopyable:
+        def __deepcopy__(self, memo: dict[int, Any]) -> Undeepcopyable:
+            raise TypeError("cannot pickle this object")
+
+    client = Undeepcopyable()
+    store = InMemoryStateStore(DictState(client=client, nums=[1]))
+
+    async with store.edit_state() as state:
+        assert state["client"] is client
+        state["nums"].append(2)
+        # Ordinary entries are still isolated: the read sees committed state.
+        assert await store.get("nums") == [1]
+
+    assert await store.get("client") is client
+    assert await store.get("nums") == [1, 2]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("durable", [False, True])
 async def test_get_inside_edit_state(durable: bool) -> None:
     store: Any = (


### PR DESCRIPTION
Every `ctx.store` write copies the whole live state before the edit, so a concurrent reader keeps seeing the committed state until the `edit_state` block finishes. The copy is a deep copy, and that is the problem. State often holds live objects that cannot be deep-copied. A `Memory` wraps sqlalchemy, aiosqlite, and tiktoken modules. An LLM client wraps a `threading.Lock`. Deep-copying either one throws:

- `wf.run(memory=Memory.from_defaults(...))` raises `TypeError: cannot pickle 'module' object` (#709)
- `await ctx.store.set("client", some_client)` raises `TypeError: cannot pickle '_thread.lock' object` (#710)

The deep copy only exists to isolate data a reader could otherwise catch mid-edit. A live handle like memory or an LLM client is shared by reference across the whole run anyway, so copying it gains no isolation. It just crashes. So copy each entry on its own, and when one will not deep-copy, keep the reference instead.

Plain data like dicts, lists, and scalars still deep-copies, so edit isolation is unchanged for anything a reader could actually observe torn. Typed state that is not a `DictState` still copies whole-model, falling back to a shallow copy if some field refuses to deep-copy instead of raising.

Fixes #709, fixes #710.