### PR TITLE
AgentDataClient retries transient read failures

### DIFF
--- a/.changeset/agent-data-client-timeout.md
+++ b/.changeset/agent-data-client-timeout.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-server": patch
+---
+
+Retry transient Agent Data read failures and use a longer default timeout.

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_client.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_client.py
@@ -23,6 +23,14 @@ _RETRY_BACKOFF_BASE = 0.5
 _RETRYABLE_STATUS = frozenset({500, 502, 503, 504})
 
 
+def _normalize_timeout(timeout: httpx.Timeout | float | None) -> httpx.Timeout:
+    if timeout is None:
+        return _DEFAULT_TIMEOUT
+    if isinstance(timeout, httpx.Timeout):
+        return timeout
+    return httpx.Timeout(timeout)
+
+
 class AgentDataClient:
     """HTTP client for the LlamaCloud Agent Data API.
 
@@ -48,7 +56,9 @@ class AgentDataClient:
         self._api_key = api_key
         self._project_id = project_id
         self._deployment_name = deployment_name
-        self._timeout = _DEFAULT_TIMEOUT if timeout is None else timeout
+        self._timeout = _normalize_timeout(timeout)
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least 1")
         self._max_attempts = max_attempts
         self._shared_client: httpx.AsyncClient | None = None
 
@@ -84,45 +94,59 @@ class AgentDataClient:
             self._shared_client = None
 
     async def _request(
-        self, method: str, url: str, *, retry: bool = False, **kwargs: Any
+        self,
+        method: str,
+        url: str,
+        *,
+        retry_transient_errors: bool = False,
+        **kwargs: Any,
     ) -> httpx.Response:
         """Issue a request under the configured timeout.
 
-        When ``retry`` is set (idempotent reads only), transient failures
-        (connection/read errors and 5xx) are retried with exponential backoff so
-        a brief backend slowdown does not become a hard, undiagnosable error.
-        Writes pass ``retry=False`` because the API has no idempotency keys yet.
-        Non-retryable responses (4xx) and the final failure are raised.
+        When ``retry_transient_errors`` is set (idempotent reads only),
+        connection/read errors and 5xx responses are retried with exponential
+        backoff. Writes do not opt in because the API has no idempotency keys.
         """
         client = self.http_client()
-        attempts = self._max_attempts if retry else 1
-        last_exc: Exception
-        for attempt in range(attempts):
+        attempts = self._max_attempts if retry_transient_errors else 1
+        for attempt in range(1, attempts + 1):
             try:
                 resp = await client.request(method, url, **kwargs)
                 resp.raise_for_status()
                 return resp
             except httpx.HTTPStatusError as exc:
-                if not retry or exc.response.status_code not in _RETRYABLE_STATUS:
+                if (
+                    not retry_transient_errors
+                    or exc.response.status_code not in _RETRYABLE_STATUS
+                    or attempt == attempts
+                ):
                     raise
-                last_exc = exc
+                await self._sleep_before_retry(method, url, attempt, attempts, exc)
             except httpx.TransportError as exc:
-                if not retry:
+                if not retry_transient_errors or attempt == attempts:
                     raise
-                last_exc = exc
-            if attempt < attempts - 1:
-                delay = _RETRY_BACKOFF_BASE * (2**attempt)
-                logger.warning(
-                    "Agent Data %s %s failed (attempt %d/%d), retrying in %.1fs: %r",
-                    method,
-                    url,
-                    attempt + 1,
-                    attempts,
-                    delay,
-                    last_exc,
-                )
-                await asyncio.sleep(delay)
-        raise last_exc
+                await self._sleep_before_retry(method, url, attempt, attempts, exc)
+        raise RuntimeError("unreachable retry loop exit")
+
+    async def _sleep_before_retry(
+        self,
+        method: str,
+        url: str,
+        attempt: int,
+        attempts: int,
+        exc: Exception,
+    ) -> None:
+        delay = _RETRY_BACKOFF_BASE * (2 ** (attempt - 1))
+        logger.warning(
+            "Agent Data %s %s failed (attempt %d/%d), retrying in %.1fs: %r",
+            method,
+            url,
+            attempt,
+            attempts,
+            delay,
+            exc,
+        )
+        await asyncio.sleep(delay)
 
     async def search(
         self,
@@ -142,7 +166,10 @@ class AgentDataClient:
         if order_by:
             body["order_by"] = order_by
         resp = await self._request(
-            "POST", "/api/v1/beta/agent-data/:search", json=body, retry=True
+            "POST",
+            "/api/v1/beta/agent-data/:search",
+            json=body,
+            retry_transient_errors=True,
         )
         return resp.json().get("items", [])
 

--- a/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_client.py
+++ b/packages/llama-agents-server/src/llama_agents/server/_store/agent_data_client.py
@@ -4,12 +4,23 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# A slow-but-alive backend should not be cut at httpx's 5s default, and a
+# transient blip on a *read* should not surface as a hard, permanent-looking
+# failure. Writes are not retried: the Agent Data API has no idempotency keys
+# yet, so replaying a create/update/delete after an ambiguous timeout could
+# duplicate or clobber data. Only idempotent reads opt in to retries.
+_DEFAULT_TIMEOUT = httpx.Timeout(30.0, connect=5.0)
+_MAX_ATTEMPTS = 3
+_RETRY_BACKOFF_BASE = 0.5
+_RETRYABLE_STATUS = frozenset({500, 502, 503, 504})
 
 
 class AgentDataClient:
@@ -30,11 +41,15 @@ class AgentDataClient:
         api_key: str,
         project_id: str,
         deployment_name: str,
+        timeout: httpx.Timeout | float | None = None,
+        max_attempts: int = _MAX_ATTEMPTS,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._project_id = project_id
         self._deployment_name = deployment_name
+        self._timeout = _DEFAULT_TIMEOUT if timeout is None else timeout
+        self._max_attempts = max_attempts
         self._shared_client: httpx.AsyncClient | None = None
 
     @property
@@ -58,6 +73,7 @@ class AgentDataClient:
                 base_url=self._base_url,
                 headers=self._headers(),
                 params={"project_id": self._project_id},
+                timeout=self._timeout,
             )
         return self._shared_client
 
@@ -66,6 +82,47 @@ class AgentDataClient:
         if self._shared_client is not None and not self._shared_client.is_closed:
             await self._shared_client.aclose()
             self._shared_client = None
+
+    async def _request(
+        self, method: str, url: str, *, retry: bool = False, **kwargs: Any
+    ) -> httpx.Response:
+        """Issue a request under the configured timeout.
+
+        When ``retry`` is set (idempotent reads only), transient failures
+        (connection/read errors and 5xx) are retried with exponential backoff so
+        a brief backend slowdown does not become a hard, undiagnosable error.
+        Writes pass ``retry=False`` because the API has no idempotency keys yet.
+        Non-retryable responses (4xx) and the final failure are raised.
+        """
+        client = self.http_client()
+        attempts = self._max_attempts if retry else 1
+        last_exc: Exception
+        for attempt in range(attempts):
+            try:
+                resp = await client.request(method, url, **kwargs)
+                resp.raise_for_status()
+                return resp
+            except httpx.HTTPStatusError as exc:
+                if not retry or exc.response.status_code not in _RETRYABLE_STATUS:
+                    raise
+                last_exc = exc
+            except httpx.TransportError as exc:
+                if not retry:
+                    raise
+                last_exc = exc
+            if attempt < attempts - 1:
+                delay = _RETRY_BACKOFF_BASE * (2**attempt)
+                logger.warning(
+                    "Agent Data %s %s failed (attempt %d/%d), retrying in %.1fs: %r",
+                    method,
+                    url,
+                    attempt + 1,
+                    attempts,
+                    delay,
+                    last_exc,
+                )
+                await asyncio.sleep(delay)
+        raise last_exc
 
     async def search(
         self,
@@ -84,9 +141,9 @@ class AgentDataClient:
             body["filter"] = filters
         if order_by:
             body["order_by"] = order_by
-        client = self.http_client()
-        resp = await client.post("/api/v1/beta/agent-data/:search", json=body)
-        resp.raise_for_status()
+        resp = await self._request(
+            "POST", "/api/v1/beta/agent-data/:search", json=body, retry=True
+        )
         return resp.json().get("items", [])
 
     async def create(self, collection: str, data: dict[str, Any]) -> dict[str, Any]:
@@ -96,26 +153,21 @@ class AgentDataClient:
             "collection": collection,
             "data": data,
         }
-        client = self.http_client()
-        resp = await client.post("/api/v1/beta/agent-data", json=body)
-        resp.raise_for_status()
+        resp = await self._request("POST", "/api/v1/beta/agent-data", json=body)
         return resp.json()
 
     async def update_item(self, item_id: str, data: dict[str, Any]) -> dict[str, Any]:
         """Update an existing item by its Agent Data API ID."""
-        client = self.http_client()
-        resp = await client.put(
+        resp = await self._request(
+            "PUT",
             f"/api/v1/beta/agent-data/{item_id}",
             json={"data": data},
         )
-        resp.raise_for_status()
         return resp.json()
 
     async def delete_item(self, item_id: str) -> None:
         """Delete an item by its Agent Data API ID."""
-        client = self.http_client()
-        resp = await client.delete(f"/api/v1/beta/agent-data/{item_id}")
-        resp.raise_for_status()
+        await self._request("DELETE", f"/api/v1/beta/agent-data/{item_id}")
 
     async def delete_many(
         self,
@@ -128,7 +180,5 @@ class AgentDataClient:
             "collection": collection,
             "filter": filters,
         }
-        client = self.http_client()
-        resp = await client.post("/api/v1/beta/agent-data/:delete", json=body)
-        resp.raise_for_status()
+        resp = await self._request("POST", "/api/v1/beta/agent-data/:delete", json=body)
         return resp.json().get("deleted_count", 0)

--- a/packages/llama-agents-server/tests/server/test_agent_data_client.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_client.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+"""Timeout and (read-only) retry behavior for AgentDataClient."""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import httpx
+import pytest
+from llama_agents.server._store import agent_data_client as adc_module
+from llama_agents.server._store.agent_data_client import AgentDataClient
+
+Handler = Callable[[httpx.Request], httpx.Response]
+
+
+def _client(handler: Handler, **kwargs: Any) -> AgentDataClient:
+    client = AgentDataClient(
+        base_url="http://backend",
+        api_key="k",
+        project_id="p",
+        deployment_name="d",
+        **kwargs,
+    )
+    client._shared_client = httpx.AsyncClient(
+        base_url="http://backend",
+        transport=httpx.MockTransport(handler),
+    )
+    return client
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _instant(_delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(adc_module.asyncio, "sleep", _instant)
+
+
+async def test_search_retries_5xx_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return httpx.Response(503, json={"detail": "slow"})
+        return httpx.Response(200, json={"items": [{"id": "x"}]})
+
+    items = await _client(handler).search("col")
+
+    assert items == [{"id": "x"}]
+    assert calls["n"] == 3
+
+
+async def test_search_retries_transport_error_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise httpx.ConnectError("boom")
+        return httpx.Response(200, json={"items": []})
+
+    items = await _client(handler).search("col")
+
+    assert items == []
+    assert calls["n"] == 2
+
+
+async def test_search_does_not_retry_4xx() -> None:
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(404, json={"detail": "nope"})
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await _client(handler).search("col")
+
+    assert calls["n"] == 1
+
+
+async def test_search_raises_after_exhausting_attempts() -> None:
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(500, json={"detail": "down"})
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await _client(handler, max_attempts=2).search("col")
+
+    assert calls["n"] == 2
+
+
+async def test_writes_are_not_retried() -> None:
+    """create/update/delete must not replay: the API has no idempotency keys."""
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(503, json={"detail": "slow"})
+
+    with pytest.raises(httpx.HTTPStatusError):
+        await _client(handler).create("col", {"a": 1})
+
+    assert calls["n"] == 1
+
+
+async def test_default_timeout_is_applied() -> None:
+    client = AgentDataClient(
+        base_url="http://backend", api_key="k", project_id="p", deployment_name="d"
+    )
+    assert client._timeout.connect == 5.0
+    assert client._timeout.read == 30.0

--- a/packages/llama-agents-server/tests/server/test_agent_data_client.py
+++ b/packages/llama-agents-server/tests/server/test_agent_data_client.py
@@ -4,11 +4,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, Callable
 
 import httpx
 import pytest
-from llama_agents.server._store import agent_data_client as adc_module
 from llama_agents.server._store.agent_data_client import AgentDataClient
 
 Handler = Callable[[httpx.Request], httpx.Response]
@@ -29,15 +29,21 @@ def _client(handler: Handler, **kwargs: Any) -> AgentDataClient:
     return client
 
 
-@pytest.fixture(autouse=True)
-def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
-    async def _instant(_delay: float) -> None:
+@pytest.fixture
+def retry_delays(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    delays: list[float] = []
+
+    async def _instant(delay: float) -> None:
+        delays.append(delay)
         return None
 
-    monkeypatch.setattr(adc_module.asyncio, "sleep", _instant)
+    monkeypatch.setattr(asyncio, "sleep", _instant)
+    return delays
 
 
-async def test_search_retries_5xx_then_succeeds() -> None:
+async def test_search_retries_5xx_then_succeeds(
+    retry_delays: list[float],
+) -> None:
     calls = {"n": 0}
 
     def handler(_request: httpx.Request) -> httpx.Response:
@@ -50,9 +56,12 @@ async def test_search_retries_5xx_then_succeeds() -> None:
 
     assert items == [{"id": "x"}]
     assert calls["n"] == 3
+    assert retry_delays == [0.5, 1.0]
 
 
-async def test_search_retries_transport_error_then_succeeds() -> None:
+async def test_search_retries_transport_error_then_succeeds(
+    retry_delays: list[float],
+) -> None:
     calls = {"n": 0}
 
     def handler(_request: httpx.Request) -> httpx.Response:
@@ -65,6 +74,7 @@ async def test_search_retries_transport_error_then_succeeds() -> None:
 
     assert items == []
     assert calls["n"] == 2
+    assert retry_delays == [0.5]
 
 
 async def test_search_does_not_retry_4xx() -> None:
@@ -80,7 +90,9 @@ async def test_search_does_not_retry_4xx() -> None:
     assert calls["n"] == 1
 
 
-async def test_search_raises_after_exhausting_attempts() -> None:
+async def test_search_raises_after_exhausting_attempts(
+    retry_delays: list[float],
+) -> None:
     calls = {"n": 0}
 
     def handler(_request: httpx.Request) -> httpx.Response:
@@ -91,9 +103,11 @@ async def test_search_raises_after_exhausting_attempts() -> None:
         await _client(handler, max_attempts=2).search("col")
 
     assert calls["n"] == 2
+    assert retry_delays == [0.5]
 
 
-async def test_writes_are_not_retried() -> None:
+@pytest.mark.parametrize("operation", ["create", "update", "delete", "delete_many"])
+async def test_writes_are_not_retried(operation: str) -> None:
     """create/update/delete must not replay: the API has no idempotency keys."""
     calls = {"n": 0}
 
@@ -102,7 +116,15 @@ async def test_writes_are_not_retried() -> None:
         return httpx.Response(503, json={"detail": "slow"})
 
     with pytest.raises(httpx.HTTPStatusError):
-        await _client(handler).create("col", {"a": 1})
+        client = _client(handler)
+        if operation == "create":
+            await client.create("col", {"a": 1})
+        elif operation == "update":
+            await client.update_item("id", {"a": 1})
+        elif operation == "delete":
+            await client.delete_item("id")
+        else:
+            await client.delete_many("col", {"a": 1})
 
     assert calls["n"] == 1
 
@@ -113,3 +135,26 @@ async def test_default_timeout_is_applied() -> None:
     )
     assert client._timeout.connect == 5.0
     assert client._timeout.read == 30.0
+
+
+async def test_float_timeout_is_normalized() -> None:
+    client = AgentDataClient(
+        base_url="http://backend",
+        api_key="k",
+        project_id="p",
+        deployment_name="d",
+        timeout=10.0,
+    )
+    assert client._timeout.connect == 10.0
+    assert client._timeout.read == 10.0
+
+
+async def test_max_attempts_must_be_positive() -> None:
+    with pytest.raises(ValueError, match="max_attempts"):
+        AgentDataClient(
+            base_url="http://backend",
+            api_key="k",
+            project_id="p",
+            deployment_name="d",
+            max_attempts=0,
+        )


### PR DESCRIPTION
AgentDataClient used the default httpx timeout on its shared client, so a slow Agent Data search could fail after 5 seconds as a `ReadTimeout` with little useful message. Cloud persistence reads through this path, and search is the only idempotent Agent Data operation in this client.

This branch gives the shared client a 30 second read timeout with a 5 second connect timeout, then retries transient search failures with bounded exponential backoff. The retry path covers transport failures and 500/502/503/504 responses. Create, update, and delete paths still make one attempt because Agent Data writes do not have idempotency keys; replaying an ambiguous write timeout could duplicate or overwrite data.

The retry code keeps timeout and attempt config type-stable, validates attempt counts, and has server coverage for retryable reads, final failure, 4xx handling, and all write methods as non-retried. It also adds a patch changeset for `llama-agents-server`.