### PR TITLE
Restructure control loop around a recursive broker tree

### DIFF
--- a/.changeset/broker-tree-refactor.md
+++ b/.changeset/broker-tree-refactor.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Internal control-loop restructuring to a recursive broker model; no behavior change.

--- a/packages/llama-index-workflows/src/workflows/context/external_context.py
+++ b/packages/llama-index-workflows/src/workflows/context/external_context.py
@@ -132,7 +132,9 @@ class ExternalContext(Generic[MODEL_T, RunResultT]):
         """Get list of currently running step names."""
         state = self._state
         return [
-            step for step in state.workers.keys() if state.workers[step].in_progress
+            str(step)
+            for step in state.workers.keys()
+            if state.workers[step].in_progress
         ]
 
     def _require_v2_runtime_compatibility(self) -> V2RuntimeCompatibilityShim:

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -102,6 +102,10 @@ def _root_step_key(step_id: StepId) -> str:
     return str(step_id)
 
 
+def _static_step_name(path: tuple[str, ...], step_id: StepId) -> str:
+    return "/".join((*path, str(step_id))) if path else str(step_id)
+
+
 def rebuild_state_from_ticks(
     state: BrokerState,
     ticks: list[WorkflowTick],
@@ -221,7 +225,7 @@ def _reduce_tick(
     elif isinstance(tick, TickIdleCheck):
         # Return early — idle check ticks don't schedule further idle checks
         if _check_idle_state(init):
-            stuck = _detect_stuck_streams(init)
+            stuck = _detect_stuck_streams_tree(init)
             if stuck is not None:
                 stuck_step, stuck_error = stuck
                 state = init.deepcopy()
@@ -249,6 +253,22 @@ def _reduce_tick(
         commands.append(CommandScheduleIdleCheck())
 
     return state, commands
+
+
+@dataclass(frozen=True)
+class _Descent:
+    broker: BrokerState
+    path: tuple[str, ...]
+
+
+def _descend(root_state: BrokerState, path: tuple[str, ...]) -> _Descent | None:
+    broker = root_state
+    for seg in path:
+        child = broker.children.get(seg)
+        if child is None:
+            return None
+        broker = child
+    return _Descent(broker=broker, path=path)
 
 
 def _is_eligible(attempt: EventAttempt) -> bool:
@@ -303,6 +323,7 @@ def _decide_retry_delay(
 def _drain_eligible_queue(
     step_id: StepId,
     state: InternalStepWorkerState,
+    path: tuple[str, ...],
     now_seconds: float,
 ) -> list[WorkflowCommand]:
     """Dispatch eligible queued attempts while worker capacity remains.
@@ -320,7 +341,9 @@ def _drain_eligible_queue(
         if index is None:
             break
         attempt = state.queue.pop(index)
-        commands.extend(_add_or_enqueue_event(attempt, step_id, state, now_seconds))
+        commands.extend(
+            _add_or_enqueue_event(attempt, step_id, state, path, now_seconds)
+        )
     return commands
 
 
@@ -337,8 +360,17 @@ def rewind_in_progress(
     """
     state = state.deepcopy()
     commands: list[WorkflowCommand] = []
-    for step_name, step_state in sorted(state.workers.items(), key=lambda x: x[0]):
-        step_id = StepId.root(step_name)
+    _rewind_broker(state, (), commands, now_seconds)
+    return state, commands
+
+
+def _rewind_broker(
+    state: BrokerState,
+    path: tuple[str, ...],
+    commands: list[WorkflowCommand],
+    now_seconds: float,
+) -> None:
+    for step_id, step_state in sorted(state.workers.items(), key=lambda x: str(x[0])):
         for in_progress in step_state.in_progress:
             step_state.queue.insert(
                 0,
@@ -356,11 +388,12 @@ def rewind_in_progress(
                 ),
             )
         step_state.in_progress = []
-        commands.extend(_drain_eligible_queue(step_id, step_state, now_seconds))
+        commands.extend(_drain_eligible_queue(step_id, step_state, path, now_seconds))
         for attempt in step_state.queue:
             if attempt.not_before is not None:
                 commands.append(CommandScheduleWakeup(at_time=attempt.not_before))
-    return state, commands
+    for key, child in sorted(state.children.items()):
+        _rewind_broker(child, (*path, key), commands, now_seconds)
 
 
 def _check_idle_state(state: BrokerState) -> bool:
@@ -378,11 +411,30 @@ def _check_idle_state(state: BrokerState) -> bool:
     if not state.is_running:
         return False
 
+    return not _broker_busy(state)
+
+
+def _broker_busy(state: BrokerState) -> bool:
     for worker_state in state.workers.values():
         if worker_state.queue or worker_state.in_progress:
-            return False
+            return True
+    return any(_broker_busy(child) for child in state.children.values())
 
-    return True
+
+def _detect_stuck_streams_tree(
+    state: BrokerState,
+) -> tuple[str, WorkflowRuntimeError] | None:
+    def walk(broker: BrokerState, path: tuple[str, ...]):
+        stuck = _detect_stuck_streams(broker, path)
+        if stuck is not None:
+            return stuck
+        for key, child in broker.children.items():
+            found = walk(child, (*path, key))
+            if found is not None:
+                return found
+        return None
+
+    return walk(state, ())
 
 
 def _collect_buffer_diverged(live: list[Event], snapshot: list[Event]) -> bool:
@@ -395,12 +447,14 @@ def _queue_catch_error_event(
     *,
     event: Event,
     step_id: StepId,
+    path: tuple[str, ...],
     recovery_counts: dict[str, int],
 ) -> CommandQueueEvent:
     """Build a catch_error dispatch in the failed work item's stream scope."""
     return CommandQueueEvent(
         event=event,
         step_id=step_id,
+        origin_namespace=path,
         recovery_counts=recovery_counts,
         scope_path=this_execution.scope_path,
     )
@@ -522,6 +576,7 @@ def _apply_step_result(
     *,
     tick: TickStepResult,
     state: BrokerState,
+    path: tuple[str, ...],
     worker_state: InternalStepWorkerState,
     this_execution: InProgressState,
     scope: _FanOutScope,
@@ -558,6 +613,7 @@ def _apply_step_result(
             acc.commands.append(
                 CommandQueueEvent(
                     event=result.result,
+                    origin_namespace=path,
                     recovery_counts=dict(this_execution.recovery_counts),
                     scope_path=scope.emit_stack,
                 )
@@ -574,6 +630,7 @@ def _apply_step_result(
             result,
             tick=tick,
             state=state,
+            path=path,
             worker_state=worker_state,
             this_execution=this_execution,
             acc=acc,
@@ -581,7 +638,7 @@ def _apply_step_result(
         )
     elif isinstance(result, AddCollectedEvent):
         # The current state of collected events.
-        collected_events = state.workers[step_name].collected_events.setdefault(
+        collected_events = state.workers[step_id].collected_events.setdefault(
             result.event_id, []
         )
         # the events snapshot that was sent with the step function execution that yielded this result
@@ -596,7 +653,7 @@ def _apply_step_result(
                 this_execution.shared_state,
                 collected_events={
                     x: list(y)
-                    for x, y in state.workers[step_name].collected_events.items()
+                    for x, y in state.workers[step_id].collected_events.items()
                 },
             )
             this_execution.shared_state = updated_state
@@ -606,6 +663,7 @@ def _apply_step_result(
                     event=result.event,
                     bound_events=this_execution.bound_events,
                     id=this_execution.worker_id,
+                    invocation_namespace=path,
                 )
             )
         else:
@@ -613,7 +671,7 @@ def _apply_step_result(
     elif isinstance(result, DeleteCollectedEvent):
         if did_complete_step:  # allow retries to grab the events
             # indicates that a run has successfully collected its events, and they can be deleted from the collected events state
-            state.workers[step_name].collected_events.pop(result.event_id, None)
+            state.workers[step_id].collected_events.pop(result.event_id, None)
     elif isinstance(result, AddWaiter):
         # indicates that a run has added a waiter to the collected waiters state
         existing = next(
@@ -650,13 +708,14 @@ def _apply_step_result(
                         step_id=step_id,
                         waiter_id=result.waiter_id,
                         timeout=result.timeout,
+                        invocation_namespace=path,
                     )
                 )
     elif isinstance(result, DeleteWaiter):
         if did_complete_step:  # allow retries to grab the waiter events
             # indicates that a run has obtained the waiting event, and it can be deleted from the collected waiters state
             to_remove = result.waiter_id
-            waiters = state.workers[step_name].collected_waiters
+            waiters = state.workers[step_id].collected_waiters
             item = next(filter(lambda w: w.waiter_id == to_remove, waiters), None)
             if item is not None:
                 waiters.remove(item)
@@ -669,6 +728,7 @@ def _schedule_retry_or_route_failure(
     *,
     tick: TickStepResult,
     state: BrokerState,
+    path: tuple[str, ...],
     worker_state: InternalStepWorkerState,
     this_execution: InProgressState,
     acc: _StepResultAcc,
@@ -736,7 +796,7 @@ def _schedule_retry_or_route_failure(
     total_attempts = this_execution.attempts + 1
     elapsed = result.failed_at - first_attempt_at
 
-    handler_name = state.config.handler_for_step.get(step_name)
+    handler_name = state.config.handler_for_step.get(step_id)
     handler = (
         state.config.catch_error_handlers.get(handler_name)
         if handler_name is not None
@@ -769,7 +829,8 @@ def _schedule_retry_or_route_failure(
             _queue_catch_error_event(
                 this_execution,
                 event=step_failed_event,
-                step_id=StepId.root(handler.step_name),
+                step_id=StepId((), handler.step_name),
+                path=path,
                 recovery_counts={
                     **this_execution.recovery_counts,
                     handler.step_name: new_count,
@@ -796,6 +857,7 @@ def _schedule_retry_or_route_failure(
 def _resolve_work_item_in_stream(
     tick: TickStepResult,
     state: BrokerState,
+    path: tuple[str, ...],
     scope: _FanOutScope,
     acc: _StepResultAcc,
     now_seconds: float,
@@ -806,7 +868,7 @@ def _resolve_work_item_in_stream(
     is driven only by source exhaustion plus ``open_work_items == 0``.
     Classification happens once, before any counter mutation.
     """
-    step_name = _root_step_key(tick.step_id)
+    step_id = tick.step_id
     commands: list[WorkflowCommand] = []
     emitted_non_stop = [
         x.result
@@ -828,12 +890,12 @@ def _resolve_work_item_in_stream(
         disposition is WorkDisposition.FANNED_OUT
         and scope.fan_out_stream_id is not None
     ):
-        bindings = state.config.bindings_for_source(step_name)
+        bindings = state.config.bindings_for_source(step_id)
         accepting_binding_ids = tuple(binding.id for binding in bindings)
-        seed = sum(_count_accepting_steps(state, type(m)) for m in emitted_non_stop)
+        seed = sum(_count_accepting_steps(state, m) for m in emitted_non_stop)
         state.streams[scope.fan_out_stream_id] = CollectionStreamInstance(
             stream_id=scope.fan_out_stream_id,
-            source_step=step_name,
+            source_step=step_id,
             scope_path=scope.trigger_stack,
             accepting_binding_ids=accepting_binding_ids,
             open_work_items=seed,
@@ -841,28 +903,34 @@ def _resolve_work_item_in_stream(
         # The parent work item now waits for each child collection release.
         commands.extend(
             _adjust_open_work_items(
-                state, enclosing, len(accepting_binding_ids) - 1, now_seconds
+                state,
+                enclosing,
+                len(accepting_binding_ids) - 1,
+                path,
+                now_seconds,
             )
         )
         if seed == 0:
             commands.extend(
-                _close_collection_stream(state, scope.fan_out_stream_id, now_seconds)
+                _close_collection_stream(
+                    state, scope.fan_out_stream_id, path, now_seconds
+                )
             )
     elif disposition is WorkDisposition.COMPLETED:
         # Same-level resolution (1:1 step, or a collect step firing its
         # summary). Remove this work item and add its same-level successors: one
         # work item per accepting step per emitted event. A step that returns
         # None adds zero successors and simply leaves the set.
-        successors = sum(
-            _count_accepting_steps(state, type(ev)) for ev in emitted_non_stop
-        )
+        successors = sum(_count_accepting_steps(state, ev) for ev in emitted_non_stop)
         commands.extend(
-            _adjust_open_work_items(state, enclosing, successors - 1, now_seconds)
+            _adjust_open_work_items(state, enclosing, successors - 1, path, now_seconds)
         )
     elif disposition is WorkDisposition.ABSORBED:
         # Consumed once per work item, no matter how many slot buffers the
         # invocation touched.
-        commands.extend(_adjust_open_work_items(state, enclosing, -1, now_seconds))
+        commands.extend(
+            _adjust_open_work_items(state, enclosing, -1, path, now_seconds)
+        )
     # STILL_LIVE re-delivers and resolves later; RUN_ENDING needs no accounting.
     return commands
 
@@ -882,9 +950,14 @@ def _process_step_result_tick(
     dispatch any newly-eligible queued work).
     """
     state = init.deepcopy()
+    descent = _descend(state, tick.invocation_namespace)
+    if descent is None:
+        return state, []
+    broker = descent.broker
+    path = descent.path
     step_id = tick.step_id
     step_name = _root_step_key(step_id)
-    worker_state = state.workers[step_name]
+    worker_state = broker.workers[step_id]
     this_execution = _find_in_progress(worker_state, tick.worker_id)
 
     rerun = _rerun_for_stale_collect_buffer(tick, worker_state, this_execution)
@@ -894,7 +967,7 @@ def _process_step_result_tick(
     fanned_out = any(
         isinstance(x, StepWorkerResult) and x.fanned_out for x in tick.result
     )
-    scope = _fan_out_scope(state, step_name, this_execution, fanned_out=fanned_out)
+    scope = _fan_out_scope(broker, step_name, this_execution, fanned_out=fanned_out)
 
     did_complete_step = any(isinstance(x, StepWorkerResult) for x in tick.result)
     acc = _StepResultAcc(commands=[])
@@ -902,7 +975,8 @@ def _process_step_result_tick(
         _apply_step_result(
             result,
             tick=tick,
-            state=state,
+            state=broker,
+            path=path,
             worker_state=worker_state,
             this_execution=this_execution,
             scope=scope,
@@ -912,7 +986,7 @@ def _process_step_result_tick(
         )
 
     acc.commands.extend(
-        _resolve_work_item_in_stream(tick, state, scope, acc, now_seconds)
+        _resolve_work_item_in_stream(tick, broker, path, scope, acc, now_seconds)
     )
 
     is_completed = any(indicates_exit(c) for c in acc.commands)
@@ -922,7 +996,7 @@ def _process_step_result_tick(
             CommandPublishEvent(
                 StepStateChanged(
                     step_state=StepState.NOT_RUNNING,
-                    name=step_name,
+                    name=_static_step_name(path, step_id),
                     input_event_name=str(type(tick.event)),
                     output_event_name=acc.output_event_name,
                     worker_id=str(tick.worker_id),
@@ -933,7 +1007,9 @@ def _process_step_result_tick(
             worker_state.in_progress.remove(this_execution)
     # enqueue next events if there are any
     if not is_completed:
-        acc.commands.extend(_drain_eligible_queue(step_id, worker_state, now_seconds))
+        acc.commands.extend(
+            _drain_eligible_queue(step_id, worker_state, path, now_seconds)
+        )
 
     return state, acc.commands
 
@@ -1003,6 +1079,7 @@ def _add_or_enqueue_event(
     event: EventAttempt,
     step_id: StepId,
     state: InternalStepWorkerState,
+    path: tuple[str, ...],
     now_seconds: float,
 ) -> list[WorkflowCommand]:
     """
@@ -1010,7 +1087,7 @@ def _add_or_enqueue_event(
     Note! This mutates the state, assuming that its already been deepcopied in an outer scope.
     """
     commands: list[WorkflowCommand] = []
-    step_name = _root_step_key(step_id)
+    step_name = _static_step_name(path, step_id)
     # Determine if there is available capacity based on in_progress workers.
     # Delayed attempts (not_before set) are never dispatched here; they wait
     # in the queue without consuming a worker slot until a wakeup flips them.
@@ -1053,6 +1130,7 @@ def _add_or_enqueue_event(
                 step_id=step_id,
                 event=event.event,
                 id=id,
+                invocation_namespace=path,
                 bound_events=event.bound_events,
             )
         )
@@ -1094,7 +1172,10 @@ class _RouteResult:
 
 
 def _redeliver_collection_payload(
-    tick: TickAddEvent, state: BrokerState, now_seconds: float
+    tick: TickAddEvent,
+    state: BrokerState,
+    path: tuple[str, ...],
+    now_seconds: float,
 ) -> list[WorkflowCommand] | None:
     """Re-deliver a payload-carrying tick straight to its collect target.
 
@@ -1127,15 +1208,19 @@ def _redeliver_collection_payload(
             collection_release_payload=payload,
             work_item_id=tick.work_item_id,
         ),
-        StepId.root(binding.target_step),
+        binding.target_step,
         state.workers[binding.target_step],
+        path,
         now_seconds,
     )
 
 
 def _resolve_waiters(
-    tick: TickAddEvent, state: BrokerState, now_seconds: float
-) -> tuple[list[WorkflowCommand], set[str]]:
+    tick: TickAddEvent,
+    state: BrokerState,
+    path: tuple[str, ...],
+    now_seconds: float,
+) -> tuple[list[WorkflowCommand], set[StepId]]:
     """Resolve any waiters the event satisfies, resuming their work items.
 
     Returns the emitted commands plus the set of steps woken via waiter
@@ -1143,10 +1228,9 @@ def _resolve_waiters(
     the same delivery as a normally-accepted event.
     """
     commands: list[WorkflowCommand] = []
-    waiter_resolved_steps: set[str] = set()
-    for step_name, step_config in state.config.steps.items():
-        step_id = StepId.root(step_name)
-        wait_conditions = state.workers[step_name].collected_waiters
+    waiter_resolved_steps: set[StepId] = set()
+    for step_id, step_config in state.config.steps.items():
+        wait_conditions = state.workers[step_id].collected_waiters
         for wait_condition in wait_conditions:
             is_match = event_matches(
                 tick.event,
@@ -1158,7 +1242,7 @@ def _resolve_waiters(
                 for k, v in wait_condition.requirements.items()
             )
             if is_match:
-                waiter_resolved_steps.add(step_name)
+                waiter_resolved_steps.add(step_id)
                 wait_condition.resolved_event = tick.event
                 # Resume re-delivers the suspended work item whole from the
                 # waiter record: original trigger, stream scope, collect batch.
@@ -1172,7 +1256,8 @@ def _resolve_waiters(
                             work_item_id=wait_condition.work_item_id,
                         ),
                         step_id,
-                        state.workers[step_name],
+                        state.workers[step_id],
+                        path,
                         now_seconds,
                     )
                 )
@@ -1182,7 +1267,8 @@ def _resolve_waiters(
 def _route_member_to_collect_step(
     tick: TickAddEvent,
     state: BrokerState,
-    step_name: str,
+    step_id: StepId,
+    path: tuple[str, ...],
     worker_state: InternalStepWorkerState,
     now_seconds: float,
 ) -> tuple[list[WorkflowCommand], bool]:
@@ -1193,6 +1279,7 @@ def _route_member_to_collect_step(
     (a targeted send to a collect step, which the runtime cannot honor).
     """
     commands: list[WorkflowCommand] = []
+    step_name = _static_step_name(path, step_id)
     if not tick.scope_path:
         # Scope-less events (ctx.send_event, external sends) can
         # never join a collect batch — members reach a collect step
@@ -1214,9 +1301,7 @@ def _route_member_to_collect_step(
                     event=WorkflowFailedEvent(step_name=step_name, exception=error)
                 )
             )
-            commands.append(
-                CommandFailWorkflow(step_id=StepId.root(step_name), exception=error)
-            )
+            commands.append(CommandFailWorkflow(step_id=step_id, exception=error))
             return commands, True
         # An untargeted send may be legitimate traffic for other
         # steps that merely overlaps an open stream — warn.
@@ -1229,7 +1314,7 @@ def _route_member_to_collect_step(
         )
         return commands, False
     stream_id = tick.scope_path[-1]
-    binding = state.config.binding_for_target(stream_id, step_name, state.streams)
+    binding = state.config.binding_for_target(stream_id, step_id, state.streams)
     if binding is None:
         # Dropped member: its nearest stream has no binding to this
         # collect step. Balance the stream accounting for the dead
@@ -1242,7 +1327,9 @@ def _route_member_to_collect_step(
             step_name,
             stream_id,
         )
-        commands.extend(_adjust_open_work_items(state, stream_id, -1, now_seconds))
+        commands.extend(
+            _adjust_open_work_items(state, stream_id, -1, path, now_seconds)
+        )
         return commands, False
     release_state = _release_state_for(state, stream_id, binding)
     if not release_state.released:
@@ -1256,17 +1343,19 @@ def _route_member_to_collect_step(
                     worker_state,
                     release,
                     tuple(tick.scope_path[:-1]),
+                    path,
                     now_seconds,
                 )
             )
-    commands.extend(_adjust_open_work_items(state, stream_id, -1, now_seconds))
+    commands.extend(_adjust_open_work_items(state, stream_id, -1, path, now_seconds))
     return commands, False
 
 
 def _route_to_accepting_steps(
     tick: TickAddEvent,
     state: BrokerState,
-    waiter_resolved_steps: set[str],
+    path: tuple[str, ...],
+    waiter_resolved_steps: set[StepId],
     now_seconds: float,
 ) -> _RouteResult:
     """Route the event to every step that accepts (and is targeted by) it.
@@ -1275,15 +1364,14 @@ def _route_to_accepting_steps(
     accounting is balanced for the delivery the waiter swallowed.
     """
     result = _RouteResult(commands=[])
-    for step_name, step_config in state.config.steps.items():
-        step_id = StepId.root(step_name)
+    for step_id, step_config in state.config.steps.items():
         is_accepted = step_accepts_event(
             tick.event,
             step_config.accepted_events,
             allow_subclasses=step_config.accept_event_subclasses,
         )
-        is_targeted = tick.step_id is None or _root_step_key(tick.step_id) == step_name
-        if step_name in waiter_resolved_steps:
+        is_targeted = tick.step_id is None or tick.step_id == step_id
+        if step_id in waiter_resolved_steps:
             if is_accepted and is_targeted and tick.scope_path:
                 # The waiter swallowed a delivery this step would otherwise
                 # have received. The delivery was birth-counted as a work item
@@ -1293,16 +1381,18 @@ def _route_to_accepting_steps(
                 # swallowed member never joins the batch; the waiter consumed
                 # it).
                 result.commands.extend(
-                    _adjust_open_work_items(state, tick.scope_path[-1], -1, now_seconds)
+                    _adjust_open_work_items(
+                        state, tick.scope_path[-1], -1, path, now_seconds
+                    )
                 )
             continue
         if not (is_accepted and is_targeted):
             continue
         result.handled = True
-        worker_state = state.workers[step_name]
+        worker_state = state.workers[step_id]
         if worker_state.config.collection_param is not None:
             member_commands, failed = _route_member_to_collect_step(
-                tick, state, step_name, worker_state, now_seconds
+                tick, state, step_id, path, worker_state, now_seconds
             )
             result.commands.extend(member_commands)
             if failed:
@@ -1320,7 +1410,7 @@ def _route_to_accepting_steps(
                 if tick.scope_path:
                     result.commands.extend(
                         _adjust_open_work_items(
-                            state, tick.scope_path[-1], -1, now_seconds
+                            state, tick.scope_path[-1], -1, path, now_seconds
                         )
                     )
                 continue
@@ -1338,7 +1428,8 @@ def _route_to_accepting_steps(
                     work_item_id=tick.work_item_id,
                 ),
                 step_id,
-                state.workers[step_name],
+                state.workers[step_id],
+                path,
                 now_seconds,
             )
         )
@@ -1377,6 +1468,11 @@ def _process_add_event_tick(
     an UnhandledEvent.
     """
     state = init.deepcopy()
+    descent = _descend(state, tick.origin_namespace)
+    if descent is None:
+        return state, _unhandled_event_commands(tick, state)
+    broker = descent.broker
+    path = descent.path
     if tick.work_item_id is None:
         # A collect re-delivery derives its id from the payload's stable
         # stream+binding key so it matches the invocation fired at release time
@@ -1385,26 +1481,28 @@ def _process_add_event_tick(
         work_item_id = (
             tick.collection_release_payload.work_item_id()
             if tick.collection_release_payload is not None
-            else _next_work_item_id(state)
+            else _next_work_item_id(broker)
         )
         tick = tick.model_copy(update={"work_item_id": work_item_id})
     if isinstance(tick.event, StartEvent):
-        state.is_running = True
+        broker.is_running = True
 
-    payload_commands = _redeliver_collection_payload(tick, state, now_seconds)
+    payload_commands = _redeliver_collection_payload(tick, broker, path, now_seconds)
     if payload_commands is not None:
         return state, payload_commands
 
-    commands, waiter_resolved_steps = _resolve_waiters(tick, state, now_seconds)
+    commands, waiter_resolved_steps = _resolve_waiters(tick, broker, path, now_seconds)
 
-    routed = _route_to_accepting_steps(tick, state, waiter_resolved_steps, now_seconds)
+    routed = _route_to_accepting_steps(
+        tick, broker, path, waiter_resolved_steps, now_seconds
+    )
     commands.extend(routed.commands)
     if routed.failed:
         return state, commands
 
     handled = bool(waiter_resolved_steps) or routed.handled
     if not handled:
-        commands.extend(_unhandled_event_commands(tick, state))
+        commands.extend(_unhandled_event_commands(tick, broker))
     return state, commands
 
 
@@ -1463,8 +1561,8 @@ def _process_timeout_tick(
     state.is_running = False
     _clear_collection_state(state)
     active_steps = [
-        step_name
-        for step_name, worker_state in init.workers.items()
+        str(step_id)
+        for step_id, worker_state in init.workers.items()
         if len(worker_state.in_progress) > 0
     ]
     steps_info = (
@@ -1499,12 +1597,18 @@ def _process_wakeup_tick(
     """
     state = init.deepcopy()
     commands: list[WorkflowCommand] = []
-    for step_name, worker_state in sorted(state.workers.items(), key=lambda x: x[0]):
-        step_id = StepId.root(step_name)
+    descent = _descend(state, ())
+    if descent is None:
+        return state, commands
+    for step_id, worker_state in sorted(
+        descent.broker.workers.items(), key=lambda x: str(x[0])
+    ):
         for attempt in worker_state.queue:
             if attempt.not_before is not None and attempt.not_before <= tick.due:
                 attempt.not_before = None
-        commands.extend(_drain_eligible_queue(step_id, worker_state, now_seconds))
+        commands.extend(
+            _drain_eligible_queue(step_id, worker_state, descent.path, now_seconds)
+        )
     return state, commands
 
 
@@ -1513,11 +1617,14 @@ def _process_waiter_timeout_tick(
 ) -> tuple[BrokerState, list[WorkflowCommand]]:
     state = init.deepcopy()
     commands: list[WorkflowCommand] = []
-    step_id = tick.step_id
-    step_name = _root_step_key(step_id)
-    if step_name not in state.workers:
+    descent = _descend(state, tick.invocation_namespace)
+    if descent is None:
         return state, commands
-    worker_state = state.workers[step_name]
+    broker = descent.broker
+    step_id = tick.step_id
+    if step_id not in broker.workers:
+        return state, commands
+    worker_state = broker.workers[step_id]
     waiter = next(
         (w for w in worker_state.collected_waiters if w.waiter_id == tick.waiter_id),
         None,
@@ -1537,6 +1644,7 @@ def _process_waiter_timeout_tick(
         ),
         step_id,
         worker_state,
+        descent.path,
         now_seconds,
     )
     commands.extend(subcommands)

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
@@ -69,7 +69,6 @@ if TYPE_CHECKING:
 from workflows.runtime.control_loop.reduce import (
     _decide_retry_delay,
     _reduce_tick,
-    _root_step_key,
     rewind_in_progress,
 )
 
@@ -134,12 +133,23 @@ class _ControlLoopRunner:
         self._wakeup_sequence = 0
         # Pull task sequence counter for deterministic journaling
         self._pull_sequence = 0
-        # Map from worker task to (step_id, worker_id) key
-        self._task_keys: dict[asyncio.Task[TickStepResult], tuple[StepId, int]] = {}
+        # Map from worker task to (step_id, invocation_namespace, worker_id) key
+        self._task_keys: dict[
+            asyncio.Task[TickStepResult], tuple[StepId, tuple[str, ...], int]
+        ] = {}
         # Whether a TickIdleCheck is currently in tick_buffer
         self._idle_check_pending = False
         # Pending worker coroutines not yet started (started by adapter in wait_for_next_task)
         self._pending_workers: list[PendingStart] = []
+
+    def _broker_for_namespace(self, namespace: tuple[str, ...]) -> BrokerState | None:
+        broker = self.state
+        for seg in namespace:
+            child = broker.children.get(seg)
+            if child is None:
+                return None
+            broker = child
+        return broker
 
     def schedule_tick(self, tick: WorkflowTick, at_time: float) -> None:
         """Schedule a tick to be processed at a specific time."""
@@ -176,12 +186,17 @@ class _ControlLoopRunner:
 
         async def _run_worker() -> TickStepResult:
             worker: InProgressState | None = None
-            step_name = _root_step_key(command.step_id)
+            step_name = str(command.step_id)
             try:
+                broker = self._broker_for_namespace(command.invocation_namespace)
+                if broker is None:
+                    raise WorkflowRuntimeError(
+                        f"Broker {command.invocation_namespace} not found. This should not happen."
+                    )
                 worker = next(
                     (
                         w
-                        for w in self.state.workers[step_name].in_progress
+                        for w in broker.workers[command.step_id].in_progress
                         if w.worker_id == command.id
                     ),
                     None,
@@ -211,8 +226,14 @@ class _ControlLoopRunner:
                 return TickStepResult(
                     step_id=command.step_id,
                     worker_id=command.id,
+                    invocation_namespace=command.invocation_namespace,
                     event=command.event,
-                    result=self._stamp_retry_decisions(command.step_id, worker, result),
+                    result=self._stamp_retry_decisions(
+                        command.step_id,
+                        command.invocation_namespace,
+                        worker,
+                        result,
+                    ),
                 )
             except Exception as e:
                 if _is_shutdown_error(e):
@@ -227,19 +248,29 @@ class _ControlLoopRunner:
                 return TickStepResult(
                     step_id=command.step_id,
                     worker_id=command.id,
+                    invocation_namespace=command.invocation_namespace,
                     event=command.event,
                     result=self._stamp_retry_decisions(
-                        command.step_id, worker, [failed]
+                        command.step_id,
+                        command.invocation_namespace,
+                        worker,
+                        [failed],
                     ),
                 )
 
         self._pending_workers.append(
-            PendingWorker(command.step_id, command.id, _run_worker())
+            PendingWorker(
+                command.step_id,
+                command.id,
+                _run_worker(),
+                invocation_namespace=command.invocation_namespace,
+            )
         )
 
     def _stamp_retry_decisions(
         self,
         step_id: StepId,
+        invocation_namespace: tuple[str, ...],
         worker: InProgressState | None,
         results: list[StepFunctionResult],
     ) -> list[StepFunctionResult]:
@@ -253,8 +284,11 @@ class _ControlLoopRunner:
         """
         if worker is None:
             return results
-        step_name = _root_step_key(step_id)
-        policy = self.state.workers[step_name].config.retry_policy
+        step_name = str(step_id)
+        broker = self._broker_for_namespace(invocation_namespace)
+        if broker is None:
+            return results
+        policy = broker.workers[step_id].config.retry_policy
         out: list[StepFunctionResult] = []
         for result in results:
             if isinstance(result, StepWorkerFailed) and result.retry_decision is None:
@@ -282,6 +316,7 @@ class _ControlLoopRunner:
                 TickAddEvent(
                     event=command.event,
                     step_id=command.step_id,
+                    origin_namespace=command.origin_namespace,
                     recovery_counts=dict(command.recovery_counts),
                     scope_path=command.scope_path,
                 )
@@ -311,7 +346,11 @@ class _ControlLoopRunner:
         elif isinstance(command, CommandScheduleWaiterTimeout):
             now = await self.adapter.get_now()
             self.schedule_tick(
-                TickWaiterTimeout(step_id=command.step_id, waiter_id=command.waiter_id),
+                TickWaiterTimeout(
+                    step_id=command.step_id,
+                    waiter_id=command.waiter_id,
+                    invocation_namespace=command.invocation_namespace,
+                ),
                 at_time=now + command.timeout,
             )
             return None
@@ -439,7 +478,12 @@ class _ControlLoopRunner:
 
                 # Build running list from existing tasks
                 running: list[WorkerTask | PullTask] = [
-                    WorkerTask(key[0], key[1], task)
+                    WorkerTask(
+                        key[0],
+                        key[2],
+                        task,
+                        invocation_namespace=key[1],
+                    )
                     for task in self.worker_tasks
                     for key in [self._task_keys.get(task)]
                     if key is not None
@@ -464,7 +508,11 @@ class _ControlLoopRunner:
                         pull_task = nt.task
                     elif isinstance(nt, WorkerTask):
                         self.worker_tasks.add(nt.task)
-                        self._task_keys[nt.task] = (nt.step_id, nt.worker_id)
+                        self._task_keys[nt.task] = (
+                            nt.step_id,
+                            nt.invocation_namespace,
+                            nt.worker_id,
+                        )
 
                 completed_task = result.completed
 

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/streams.py
@@ -8,6 +8,7 @@ import logging
 from enum import Enum
 
 from workflows._event_matching import (
+    step_accepts_event,
     step_accepts_type,
 )
 from workflows.collect import Collect, Take
@@ -35,7 +36,6 @@ from workflows.runtime.types.results import (
     StepWorkerFailed,
     StepWorkerResult,
 )
-from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
     TickStepResult,
 )
@@ -45,10 +45,12 @@ logger = logging.getLogger("workflows.runtime.control_loop")
 
 def _detect_stuck_streams(
     state: BrokerState,
+    path: tuple[str, ...] = (),
 ) -> tuple[str, WorkflowRuntimeError] | None:
-    """Detect a provably-stuck run while the state is quiescent.
+    """Detect a provably-stuck broker while its state is quiescent.
 
-    Two conditions, returned as ``(step_name, error)``:
+    Operates on one broker; the reducer walks the whole tree and path-qualifies
+    the diagnostic step name. Two conditions, returned as ``(step_name, error)``:
 
     - An unreleased release-state whose stream no longer exists. The close
       path fires releases inline within the same reduce, so this should be
@@ -60,6 +62,7 @@ def _detect_stuck_streams(
       never reach zero open work items: the run would hang to timeout (or
       forever).
     """
+    prefix = "/".join(path) + "/" if path else ""
     orphaned = next(
         (
             release
@@ -70,7 +73,9 @@ def _detect_stuck_streams(
     )
     if orphaned is not None:
         binding = state.config.collection_bindings.get(orphaned.binding_id)
-        step_name = binding.target_step if binding is not None else "<unknown>"
+        step_name = (
+            prefix + str(binding.target_step) if binding is not None else "<unknown>"
+        )
         return step_name, WorkflowRuntimeError(
             f"Workflow is idle with a pending collect release for step "
             f"{step_name!r} (binding {orphaned.binding_id!r}) whose stream "
@@ -91,11 +96,11 @@ def _detect_stuck_streams(
         return None
     first_leaked = next(iter(state.streams.values()))
     details = "; ".join(
-        f"stream {stream.stream_id!r} opened by step {stream.source_step!r} "
+        f"stream {stream.stream_id!r} opened by step {str(stream.source_step)!r} "
         f"with {stream.open_work_items} open work item(s)"
         for stream in state.streams.values()
     )
-    return first_leaked.source_step, WorkflowRuntimeError(
+    return prefix + str(first_leaked.source_step), WorkflowRuntimeError(
         "Workflow is idle but collection streams are still open, so the run "
         f"can never complete: {details}. No queued, running, or resumable "
         "scoped work remains that can close the stream. This indicates "
@@ -119,30 +124,44 @@ def _clear_collection_state(state: BrokerState) -> None:
     state.collection_release_states.clear()
 
 
-def _count_accepting_steps(state: BrokerState, event_type: type) -> int:
-    """Number of steps that accept ``event_type`` — the work-item fan-out factor.
+def _count_accepting_steps(state: BrokerState, event: Event | type[Event]) -> int:
+    """Work-item fan-out factor for an emitted ``event`` within one broker.
 
-    An event routed at a stream level becomes one work item per accepting step
-    (1:1 *and* collect steps count). This is the per-emission birth count for the
-    open_work_items set: a single emitted event accepted by N steps is N work
-    items. Must mirror the routing predicate in ``_process_add_event_tick``
-    exactly (including subclass-aware acceptance) — a birth count that differs
-    from the delivery count drifts the stream counter.
+    Broker-local birth count for the open_work_items set: one per accepting
+    local step. It must mirror the delivery predicate exactly.
     """
     return sum(
         1
         for cfg in state.config.steps.values()
-        if step_accepts_type(
-            event_type,
-            cfg.accepted_events,
-            allow_subclasses=cfg.accept_event_subclasses,
+        if (
+            step_accepts_type(
+                event,
+                cfg.accepted_events,
+                allow_subclasses=cfg.accept_event_subclasses,
+            )
+            if isinstance(event, type)
+            else step_accepts_event(
+                event,
+                cfg.accepted_events,
+                allow_subclasses=cfg.accept_event_subclasses,
+            )
         )
     )
 
 
 def _adjust_open_work_items(
-    state: BrokerState, stream_id: str | None, delta: int, now_seconds: float
+    state: BrokerState,
+    stream_id: str | None,
+    delta: int,
+    path: tuple[str, ...] | float,
+    now_seconds: float | None = None,
 ) -> list[WorkflowCommand]:
+    if now_seconds is None:
+        if isinstance(path, tuple):
+            raise TypeError("now_seconds is required when path is provided")
+        now_seconds = float(path)
+        path = ()
+    assert isinstance(path, tuple)
     if stream_id is None:
         return []
     stream = state.streams.get(stream_id)
@@ -166,14 +185,23 @@ def _adjust_open_work_items(
             stream.source_step,
         )
     if stream.open_work_items <= 0:
-        return _close_collection_stream(state, stream_id, now_seconds)
+        return _close_collection_stream(state, stream_id, path, now_seconds)
     return []
 
 
 def _close_collection_stream(
-    state: BrokerState, stream_id: str, now_seconds: float
+    state: BrokerState,
+    stream_id: str,
+    path: tuple[str, ...] | float,
+    now_seconds: float | None = None,
 ) -> list[WorkflowCommand]:
     """Close a zero-count stream and release any buffered collection batches."""
+    if now_seconds is None:
+        if isinstance(path, tuple):
+            raise TypeError("now_seconds is required when path is provided")
+        now_seconds = float(path)
+        path = ()
+    assert isinstance(path, tuple)
     stream = state.streams.pop(stream_id, None)
     if stream is None:
         return []
@@ -200,6 +228,7 @@ def _close_collection_stream(
                 worker_state,
                 release,
                 tuple(stream.scope_path),
+                path,
                 now_seconds,
             )
         )
@@ -332,6 +361,7 @@ def _fire_collection_release(
     worker_state: InternalStepWorkerState,
     events: list[Event],
     output_stack: tuple[str, ...],
+    path: tuple[str, ...],
     now_seconds: float,
 ) -> list[WorkflowCommand]:
     # Inline import breaks the reduce<->streams cycle: _add_or_enqueue_event is
@@ -352,7 +382,8 @@ def _fire_collection_release(
             collection_release_payload=payload,
             work_item_id=payload.work_item_id(),
         ),
-        StepId.root(binding.target_step),
+        binding.target_step,
         worker_state,
+        path,
         now_seconds,
     )

--- a/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
@@ -27,6 +27,7 @@ class CommandRunWorker:
     step_id: StepId
     event: Event
     id: int
+    invocation_namespace: tuple[str, ...] = ()
     bound_events: dict[str, Event] | None = None
 
 
@@ -34,6 +35,7 @@ class CommandRunWorker:
 class CommandQueueEvent:
     event: Event
     step_id: StepId | None = None
+    origin_namespace: tuple[str, ...] = ()
     recovery_counts: dict[str, int] = field(default_factory=dict)
     scope_path: tuple[str, ...] = field(default_factory=tuple)
 
@@ -57,6 +59,7 @@ class CommandFailWorkflow:
 @dataclass(frozen=True)
 class CommandPublishEvent:
     event: Event
+    origin_namespace: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -64,6 +67,7 @@ class CommandScheduleWaiterTimeout:
     step_id: StepId
     waiter_id: str
     timeout: float
+    invocation_namespace: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import dataclasses
 import importlib
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Mapping, TypeVar
 
 from workflows._event_matching import step_accepts_type
 from workflows._stream_levels import event_types, stream_level_types_by_producer
@@ -38,6 +38,17 @@ if TYPE_CHECKING:
     from workflows.context.serializers import BaseSerializer
 
 
+T = TypeVar("T")
+
+
+def _normalize_step_id(value: Any) -> StepId:
+    return value if isinstance(value, StepId) else StepId.from_str(value)
+
+
+def _normalize_step_id_keys(mapping: Mapping[Any, T]) -> dict[StepId, T]:
+    return {_normalize_step_id(step_id): value for step_id, value in mapping.items()}
+
+
 @dataclass(frozen=True)
 class CollectionBinding:
     """
@@ -49,8 +60,8 @@ class CollectionBinding:
     """
 
     id: str
-    source_step: str
-    target_step: str
+    source_step: StepId | str
+    target_step: StepId
     item_types: tuple[type[Event], ...]
     policy: Collect
 
@@ -66,7 +77,7 @@ class CollectionStreamInstance:
     """
 
     stream_id: str
-    source_step: str
+    source_step: StepId | str
     scope_path: tuple[str, ...]
     open_work_items: int = 0
     accepting_binding_ids: tuple[str, ...] = ()
@@ -112,13 +123,26 @@ class BrokerState:
 
     is_running: bool
     config: BrokerConfig
-    workers: dict[str, InternalStepWorkerState]
+    workers: dict[Any, InternalStepWorkerState]
     stream_seq: int = 0
     work_item_seq: int = 0
     streams: dict[str, CollectionStreamInstance] = field(default_factory=dict)
     collection_release_states: dict[str, CollectionReleaseState] = field(
         default_factory=dict
     )
+    children: dict[str, BrokerState] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self._normalize_worker_keys()
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        if "children" not in state:
+            self.children = {}
+        self._normalize_worker_keys()
+
+    def _normalize_worker_keys(self) -> None:
+        self.workers = _normalize_step_id_keys(self.workers)
 
     def deepcopy(self) -> BrokerState:
         """
@@ -128,8 +152,8 @@ class BrokerState:
             is_running=self.is_running,
             config=self.config,  # immutable
             workers={
-                name: worker_state._deepcopy()
-                for name, worker_state in self.workers.items()
+                step_id: worker_state._deepcopy()
+                for step_id, worker_state in self.workers.items()
             },
             stream_seq=self.stream_seq,
             work_item_seq=self.work_item_seq,
@@ -138,37 +162,31 @@ class BrokerState:
                 key: state._copy()
                 for key, state in self.collection_release_states.items()
             },
+            children={key: child.deepcopy() for key, child in self.children.items()},
         )
 
     @staticmethod
     def from_workflow(workflow: Workflow) -> BrokerState:
+        config = _config_from_instance(workflow)
+        state = BrokerState.from_config(config)
+        state.is_running = False
+        return state
+
+    @staticmethod
+    def from_config(config: BrokerConfig) -> BrokerState:
         return BrokerState(
-            is_running=False,
-            config=BrokerConfig(
-                steps={
-                    name: InternalStepConfig(
-                        accepted_events=step_func._step_config.accepted_events,
-                        retry_policy=step_func._step_config.retry_policy,
-                        num_workers=step_func._step_config.num_workers,
-                        accept_event_subclasses=step_func._step_config.accept_event_subclasses,
-                    )
-                    for name, step_func in workflow._get_steps().items()
-                },
-                timeout=workflow._timeout,
-                catch_error_handlers=dict(workflow._catch_error_handlers),
-                handler_for_step=dict(workflow._handler_for_step),
-                collection_bindings=_compute_collection_bindings(workflow),
-            ),
+            is_running=True,
+            config=config,
             workers={
-                name: InternalStepWorkerState(
+                step_id: InternalStepWorkerState(
                     queue=[],
-                    config=step_func._step_config,
+                    config=step_config,
                     in_progress=[],
                     collected_events={},
                     static_collect_events=[],
                     collected_waiters=[],
                 )
-                for name, step_func in workflow._get_steps().items()
+                for step_id, step_config in config.steps.items()
             },
         )
 
@@ -177,149 +195,12 @@ class BrokerState:
         Rehydrates non-serializable state by re-running commands
         """
         commands: list[WorkflowTick] = []
-        for step_name, worker_state in sorted(self.workers.items(), key=lambda x: x[0]):
-            for waiter in sorted(
-                worker_state.collected_waiters, key=lambda x: x.waiter_id
-            ):
-                if waiter.has_requirements and not waiter.requirements:
-                    # Re-ping the step with its whole work record so the
-                    # re-registered waiter keeps its stream scope and any
-                    # collect batch.
-                    commands.append(
-                        TickAddEvent(
-                            event=waiter.event,
-                            step_id=StepId.root(step_name),
-                            bound_events=waiter.bound_events,
-                            scope_path=waiter.scope_path,
-                            collection_release_payload=waiter.collection_release_payload,
-                            work_item_id=waiter.work_item_id,
-                        )
-                    )
+        _rehydrate_broker(self, (), commands)
         return commands
 
     def to_serialized(self, serializer: BaseSerializer) -> SerializedContext:
         """Serialize the broker state to a SerializedContext."""
-
-        workers_dict = {}
-        for step_name, worker_state in self.workers.items():
-            # Serialize queue with retry and stream scope info
-            queue = [
-                SerializedEventAttempt(
-                    event=serializer.serialize(attempt.event),
-                    bound_events={
-                        name: serializer.serialize(event)
-                        for name, event in attempt.bound_events.items()
-                    }
-                    if attempt.bound_events is not None
-                    else None,
-                    attempts=attempt.attempts or 0,
-                    first_attempt_at=attempt.first_attempt_at,
-                    last_exception=attempt.last_exception,
-                    last_failed_at=attempt.last_failed_at,
-                    recovery_counts=dict(attempt.recovery_counts),
-                    not_before=attempt.not_before,
-                    scope_path=list(attempt.scope_path),
-                    collection_release_payload=_serialize_release_payload(
-                        attempt.collection_release_payload, serializer
-                    ),
-                    work_item_id=attempt.work_item_id,
-                )
-                for attempt in worker_state.queue
-            ]
-            # Serialize in-progress attempts so they can be re-queued on resume.
-            in_progress = [
-                SerializedEventAttempt(
-                    event=serializer.serialize(ip.event),
-                    bound_events={
-                        name: serializer.serialize(event)
-                        for name, event in ip.bound_events.items()
-                    }
-                    if ip.bound_events is not None
-                    else None,
-                    attempts=ip.attempts or 0,
-                    first_attempt_at=ip.first_attempt_at,
-                    last_exception=ip.last_exception,
-                    last_failed_at=ip.last_failed_at,
-                    recovery_counts=dict(ip.recovery_counts),
-                    scope_path=list(ip.scope_path),
-                    collection_release_payload=_serialize_release_payload(
-                        ip.shared_state.collection_release_payload, serializer
-                    ),
-                    work_item_id=ip.work_item_id,
-                )
-                for ip in worker_state.in_progress
-            ]
-
-            # Serialize collected events
-            collected_events = {
-                buffer_id: [serializer.serialize(ev) for ev in events]
-                for buffer_id, events in worker_state.collected_events.items()
-            }
-
-            # Serialize waiters
-            waiters = [
-                SerializedWaiter(
-                    waiter_id=waiter.waiter_id,
-                    event=serializer.serialize(waiter.event),
-                    bound_events={
-                        name: serializer.serialize(event)
-                        for name, event in waiter.bound_events.items()
-                    }
-                    if waiter.bound_events is not None
-                    else None,
-                    waiting_for_event=f"{waiter.waiting_for_event.__module__}.{waiter.waiting_for_event.__name__}",
-                    has_requirements=bool(len(waiter.requirements))
-                    or waiter.has_requirements,
-                    resolved_event=serializer.serialize(waiter.resolved_event)
-                    if waiter.resolved_event
-                    else None,
-                    scope_path=list(waiter.scope_path),
-                    collection_release_payload=_serialize_release_payload(
-                        waiter.collection_release_payload, serializer
-                    ),
-                    work_item_id=waiter.work_item_id,
-                )
-                for waiter in worker_state.collected_waiters
-            ]
-
-            workers_dict[step_name] = SerializedStepWorkerState(
-                queue=queue,
-                in_progress=in_progress,
-                collected_events=collected_events,
-                static_collect_events=[
-                    serializer.serialize(ev)
-                    for ev in worker_state.static_collect_events
-                ],
-                collected_waiters=waiters,
-            )
-
-        return SerializedContext(
-            version=CURRENT_SERIALIZED_VERSION,
-            state={},  # State is filled separately by the state store
-            is_running=self.is_running,
-            workers=workers_dict,
-            stream_seq=self.stream_seq,
-            work_item_seq=self.work_item_seq,
-            streams={
-                sid: SerializedCollectionStreamInstance(
-                    stream_id=stream.stream_id,
-                    source_step=stream.source_step,
-                    scope_path=list(stream.scope_path),
-                    open_work_items=stream.open_work_items,
-                    accepting_binding_ids=list(stream.accepting_binding_ids),
-                )
-                for sid, stream in self.streams.items()
-            },
-            collection_release_states={
-                key: SerializedCollectionReleaseState(
-                    binding_id=release.binding_id,
-                    stream_id=release.stream_id,
-                    buffer=[serializer.serialize(ev) for ev in release.buffer],
-                    released=release.released,
-                )
-                for key, release in self.collection_release_states.items()
-            },
-        )
+        return _broker_to_serialized(self, serializer)
 
     @staticmethod
     def from_serialized(
@@ -330,97 +211,283 @@ class BrokerState:
         """Deserialize a SerializedContext into a BrokerState."""
 
         serializer = serializer or JsonSerializer()
-
-        # Start with a base state from the workflow
         base_state = BrokerState.from_workflow(workflow)
-        # Unfortunately, important to preserve this state, since the workflow needs to know this to decide
-        # whether to create a start_event from kwargs (it only constructs and passes a start event if not already running)
-        base_state.is_running = serialized.is_running
-        base_state.stream_seq = serialized.stream_seq
-        base_state.work_item_seq = serialized.work_item_seq
-        base_state.streams = {
-            sid: CollectionStreamInstance(
-                stream_id=stream.stream_id,
-                source_step=stream.source_step,
-                scope_path=tuple(stream.scope_path),
-                open_work_items=stream.open_work_items,
-                accepting_binding_ids=tuple(stream.accepting_binding_ids),
-            )
-            for sid, stream in serialized.streams.items()
-        }
-        base_state.collection_release_states = {
-            key: CollectionReleaseState(
-                binding_id=release.binding_id,
-                stream_id=release.stream_id,
-                buffer=[serializer.deserialize(ev) for ev in release.buffer],
-                released=release.released,
-            )
-            for key, release in serialized.collection_release_states.items()
-        }
+        _load_broker_from_serialized(base_state, serialized, serializer)
+        return base_state
 
-        # Restore worker state (queues, collected events, waiters)
-        # We do this regardless of is_running state so workflows can resume from where they left off
-        for step_name, worker_data in serialized.workers.items():
-            if step_name not in base_state.workers:
-                continue
 
-            worker = base_state.workers[step_name]
+def _config_from_instance(workflow: Workflow) -> BrokerConfig:
+    steps_by_name = workflow._get_steps()
+    steps: dict[StepId, InternalStepConfig] = {
+        StepId((), name): _internal_step_config(func._step_config)
+        for name, func in steps_by_name.items()
+    }
+    catch_error_handlers: dict[StepId, CatchErrorHandler] = {
+        StepId((), name): handler
+        for name, handler in workflow._catch_error_handlers.items()
+    }
+    handler_for_step: dict[StepId, StepId] = {
+        StepId((), step_name): StepId((), handler_name)
+        for step_name, handler_name in workflow._handler_for_step.items()
+    }
+    return BrokerConfig(
+        steps=steps,
+        timeout=workflow._timeout,
+        catch_error_handlers=catch_error_handlers,
+        handler_for_step=handler_for_step,
+        collection_bindings=_compute_collection_bindings(
+            {name: func._step_config for name, func in steps_by_name.items()}
+        ),
+    )
 
-            # Restore queue with retry and stream scope info.
-            # in_progress events are moved to the queue on deserialization;
-            # they will be restarted when the workflow runs.
-            worker.queue = [
-                _deserialize_event_attempt(attempt, serializer)
-                for attempt in [*worker_data.queue, *worker_data.in_progress]
-            ]
 
-            # Restore collected events
-            worker.collected_events = {
-                buffer_id: [serializer.deserialize(ev) for ev in events]
-                for buffer_id, events in worker_data.collected_events.items()
-            }
-            worker.static_collect_events = [
-                serializer.deserialize(ev) for ev in worker_data.static_collect_events
-            ]
+def _internal_step_config(step_config: StepConfig) -> InternalStepConfig:
+    return InternalStepConfig(
+        accepted_events=step_config.accepted_events,
+        retry_policy=step_config.retry_policy,
+        num_workers=step_config.num_workers,
+        accept_event_subclasses=step_config.accept_event_subclasses,
+        collection_param=step_config.collection_param,
+        collect_params=step_config.collect_params,
+        collection_policy=step_config.collection_policy,
+    )
 
-            # Restore waiters
-            worker.collected_waiters = []
-            for waiter_data in worker_data.collected_waiters:
-                waiter_payload = _deserialize_release_payload(
-                    waiter_data.collection_release_payload, serializer
-                )
-                worker.collected_waiters.append(
-                    StepWorkerWaiter(
-                        waiter_id=waiter_data.waiter_id,
-                        bound_events={
-                            name: serializer.deserialize(event)
-                            for name, event in waiter_data.bound_events.items()
-                        }
-                        if waiter_data.bound_events is not None
-                        else None,
-                        # For a suspended collect invocation the payload is the
-                        # authoritative record; the trigger event is derived
-                        # from it so the two cannot diverge on resume.
-                        event=waiter_payload.as_event()
-                        if waiter_payload is not None
-                        else serializer.deserialize(waiter_data.event),
-                        waiting_for_event=_import_event_type(
-                            waiter_data.waiting_for_event
-                        ),
-                        requirements={},
-                        has_requirements=waiter_data.has_requirements,
-                        resolved_event=serializer.deserialize(
-                            waiter_data.resolved_event
-                        )
-                        if waiter_data.resolved_event
-                        else None,
-                        scope_path=tuple(waiter_data.scope_path),
-                        collection_release_payload=waiter_payload,
-                        work_item_id=waiter_data.work_item_id,
+
+def _rehydrate_broker(
+    state: BrokerState, path: tuple[str, ...], commands: list[WorkflowTick]
+) -> None:
+    for step_id, worker_state in sorted(state.workers.items(), key=lambda x: str(x[0])):
+        for waiter in sorted(worker_state.collected_waiters, key=lambda x: x.waiter_id):
+            if waiter.has_requirements and not waiter.requirements:
+                # Re-ping the step with its whole work record so the
+                # re-registered waiter keeps its stream scope and any
+                # collect batch.
+                commands.append(
+                    TickAddEvent(
+                        event=waiter.event,
+                        step_id=step_id,
+                        bound_events=waiter.bound_events,
+                        scope_path=waiter.scope_path,
+                        origin_namespace=path,
+                        collection_release_payload=waiter.collection_release_payload,
+                        work_item_id=waiter.work_item_id,
                     )
                 )
+    for key, child in sorted(state.children.items()):
+        _rehydrate_broker(child, (*path, key), commands)
 
-        return base_state
+
+def _broker_to_serialized(
+    state: BrokerState, serializer: BaseSerializer
+) -> SerializedContext:
+    workers_dict = {}
+    for step_id, worker_state in state.workers.items():
+        step_name = str(step_id)
+        # Serialize queue with retry and stream scope info
+        queue = [
+            SerializedEventAttempt(
+                event=serializer.serialize(attempt.event),
+                bound_events={
+                    name: serializer.serialize(event)
+                    for name, event in attempt.bound_events.items()
+                }
+                if attempt.bound_events is not None
+                else None,
+                attempts=attempt.attempts or 0,
+                first_attempt_at=attempt.first_attempt_at,
+                last_exception=attempt.last_exception,
+                last_failed_at=attempt.last_failed_at,
+                recovery_counts=dict(attempt.recovery_counts),
+                not_before=attempt.not_before,
+                scope_path=list(attempt.scope_path),
+                collection_release_payload=_serialize_release_payload(
+                    attempt.collection_release_payload, serializer
+                ),
+                work_item_id=attempt.work_item_id,
+            )
+            for attempt in worker_state.queue
+        ]
+        # Serialize in-progress attempts so they can be re-queued on resume.
+        in_progress = [
+            SerializedEventAttempt(
+                event=serializer.serialize(ip.event),
+                bound_events={
+                    name: serializer.serialize(event)
+                    for name, event in ip.bound_events.items()
+                }
+                if ip.bound_events is not None
+                else None,
+                attempts=ip.attempts or 0,
+                first_attempt_at=ip.first_attempt_at,
+                last_exception=ip.last_exception,
+                last_failed_at=ip.last_failed_at,
+                recovery_counts=dict(ip.recovery_counts),
+                scope_path=list(ip.scope_path),
+                collection_release_payload=_serialize_release_payload(
+                    ip.shared_state.collection_release_payload, serializer
+                ),
+                work_item_id=ip.work_item_id,
+            )
+            for ip in worker_state.in_progress
+        ]
+
+        # Serialize collected events
+        collected_events = {
+            buffer_id: [serializer.serialize(ev) for ev in events]
+            for buffer_id, events in worker_state.collected_events.items()
+        }
+
+        # Serialize waiters
+        waiters = [
+            SerializedWaiter(
+                waiter_id=waiter.waiter_id,
+                event=serializer.serialize(waiter.event),
+                bound_events={
+                    name: serializer.serialize(event)
+                    for name, event in waiter.bound_events.items()
+                }
+                if waiter.bound_events is not None
+                else None,
+                waiting_for_event=f"{waiter.waiting_for_event.__module__}.{waiter.waiting_for_event.__name__}",
+                has_requirements=bool(len(waiter.requirements))
+                or waiter.has_requirements,
+                resolved_event=serializer.serialize(waiter.resolved_event)
+                if waiter.resolved_event
+                else None,
+                scope_path=list(waiter.scope_path),
+                collection_release_payload=_serialize_release_payload(
+                    waiter.collection_release_payload, serializer
+                ),
+                work_item_id=waiter.work_item_id,
+            )
+            for waiter in worker_state.collected_waiters
+        ]
+
+        workers_dict[step_name] = SerializedStepWorkerState(
+            queue=queue,
+            in_progress=in_progress,
+            collected_events=collected_events,
+            static_collect_events=[
+                serializer.serialize(ev) for ev in worker_state.static_collect_events
+            ],
+            collected_waiters=waiters,
+        )
+
+    return SerializedContext(
+        version=CURRENT_SERIALIZED_VERSION,
+        state={},  # State is filled separately by the state store
+        is_running=state.is_running,
+        workers=workers_dict,
+        stream_seq=state.stream_seq,
+        work_item_seq=state.work_item_seq,
+        streams={
+            sid: SerializedCollectionStreamInstance(
+                stream_id=stream.stream_id,
+                source_step=str(stream.source_step),
+                scope_path=list(stream.scope_path),
+                open_work_items=stream.open_work_items,
+                accepting_binding_ids=list(stream.accepting_binding_ids),
+            )
+            for sid, stream in state.streams.items()
+        },
+        collection_release_states={
+            key: SerializedCollectionReleaseState(
+                binding_id=release.binding_id,
+                stream_id=release.stream_id,
+                buffer=[serializer.serialize(ev) for ev in release.buffer],
+                released=release.released,
+            )
+            for key, release in state.collection_release_states.items()
+        },
+    )
+
+
+def _load_broker_from_serialized(
+    base_state: BrokerState, serialized: SerializedContext, serializer: BaseSerializer
+) -> None:
+    # Unfortunately, important to preserve this state, since the workflow needs to know this to decide
+    # whether to create a start_event from kwargs (it only constructs and passes a start event if not already running)
+    base_state.is_running = serialized.is_running
+    base_state.stream_seq = serialized.stream_seq
+    base_state.work_item_seq = serialized.work_item_seq
+    base_state.streams = {
+        sid: CollectionStreamInstance(
+            stream_id=stream.stream_id,
+            source_step=StepId.from_str(stream.source_step),
+            scope_path=tuple(stream.scope_path),
+            open_work_items=stream.open_work_items,
+            accepting_binding_ids=tuple(stream.accepting_binding_ids),
+        )
+        for sid, stream in serialized.streams.items()
+    }
+    base_state.collection_release_states = {
+        key: CollectionReleaseState(
+            binding_id=release.binding_id,
+            stream_id=release.stream_id,
+            buffer=[serializer.deserialize(ev) for ev in release.buffer],
+            released=release.released,
+        )
+        for key, release in serialized.collection_release_states.items()
+    }
+
+    # Restore worker state (queues, collected events, waiters)
+    # We do this regardless of is_running state so workflows can resume from where they left off
+    for step_key, worker_data in serialized.workers.items():
+        step_id = StepId.from_str(step_key)
+        if step_id not in base_state.workers:
+            continue
+
+        worker = base_state.workers[step_id]
+
+        # Restore queue with retry and stream scope info.
+        # in_progress events are moved to the queue on deserialization;
+        # they will be restarted when the workflow runs.
+        worker.queue = [
+            _deserialize_event_attempt(attempt, serializer)
+            for attempt in [*worker_data.queue, *worker_data.in_progress]
+        ]
+
+        # Restore collected events
+        worker.collected_events = {
+            buffer_id: [serializer.deserialize(ev) for ev in events]
+            for buffer_id, events in worker_data.collected_events.items()
+        }
+        worker.static_collect_events = [
+            serializer.deserialize(ev) for ev in worker_data.static_collect_events
+        ]
+
+        # Restore waiters
+        worker.collected_waiters = []
+        for waiter_data in worker_data.collected_waiters:
+            waiter_payload = _deserialize_release_payload(
+                waiter_data.collection_release_payload, serializer
+            )
+            worker.collected_waiters.append(
+                StepWorkerWaiter(
+                    waiter_id=waiter_data.waiter_id,
+                    bound_events={
+                        name: serializer.deserialize(event)
+                        for name, event in waiter_data.bound_events.items()
+                    }
+                    if waiter_data.bound_events is not None
+                    else None,
+                    # For a suspended collect invocation the payload is the
+                    # authoritative record; the trigger event is derived
+                    # from it so the two cannot diverge on resume.
+                    event=waiter_payload.as_event()
+                    if waiter_payload is not None
+                    else serializer.deserialize(waiter_data.event),
+                    waiting_for_event=_import_event_type(waiter_data.waiting_for_event),
+                    requirements={},
+                    has_requirements=waiter_data.has_requirements,
+                    resolved_event=serializer.deserialize(waiter_data.resolved_event)
+                    if waiter_data.resolved_event
+                    else None,
+                    scope_path=tuple(waiter_data.scope_path),
+                    collection_release_payload=waiter_payload,
+                    work_item_id=waiter_data.work_item_id,
+                )
+            )
 
 
 def _deserialize_event_attempt(
@@ -470,8 +537,8 @@ def _import_event_type(qualified_name: str) -> type[Event]:
 
 
 def _binding_id(
-    source_step: str,
-    target_step: str,
+    source_step: StepId,
+    target_step: StepId,
     item_types: tuple[type[Event], ...],
     policy: Collect,
 ) -> str:
@@ -482,7 +549,9 @@ def _binding_id(
     return f"{source_step}->{target_step}:{type_names}:{card_repr}:nearest"
 
 
-def _compute_collection_bindings(workflow: Workflow) -> dict[str, CollectionBinding]:
+def _compute_collection_bindings(
+    steps: dict[str, StepConfig],
+) -> dict[str, CollectionBinding]:
     """
     Compute static list[E] stream bindings from the workflow graph.
 
@@ -491,7 +560,6 @@ def _compute_collection_bindings(workflow: Workflow) -> dict[str, CollectionBind
     :mod:`workflows._stream_levels` for the level traversal, shared with static
     validation).
     """
-    steps = {name: fn._step_config for name, fn in workflow._get_steps().items()}
     collects: dict[str, tuple[Any, ...]] = {
         name: cfg.collection_param[1]
         for name, cfg in steps.items()
@@ -499,21 +567,23 @@ def _compute_collection_bindings(workflow: Workflow) -> dict[str, CollectionBind
     }
 
     bindings: dict[str, CollectionBinding] = {}
-    for source_step, level_types in stream_level_types_by_producer(steps).items():
-        for target_step, collect_types in collects.items():
+    for source_name, level_types in stream_level_types_by_producer(steps).items():
+        for target_name, collect_types in collects.items():
             item_types = tuple(event_types(collect_types))
             if not any(
                 step_accepts_type(
                     produced,
                     item_types,
-                    allow_subclasses=steps[target_step].accept_event_subclasses,
+                    allow_subclasses=steps[target_name].accept_event_subclasses,
                 )
                 for produced in level_types
             ):
                 continue
-            policy = steps[target_step].collection_policy
+            policy = steps[target_name].collection_policy
             if policy is None:
                 continue
+            source_step = StepId((), source_name)
+            target_step = StepId((), target_name)
             binding = CollectionBinding(
                 id=_binding_id(source_step, target_step, item_types, policy),
                 source_step=source_step,
@@ -540,13 +610,38 @@ class BrokerConfig:
         collection_bindings: Static list[E] stream bindings keyed by binding id
     """
 
-    steps: dict[str, InternalStepConfig]
+    steps: dict[Any, InternalStepConfig]
     timeout: float | None
-    catch_error_handlers: dict[str, CatchErrorHandler] = field(default_factory=dict)
-    handler_for_step: dict[str, str] = field(default_factory=dict)
+    catch_error_handlers: dict[Any, CatchErrorHandler] = field(default_factory=dict)
+    handler_for_step: dict[Any, StepId] = field(default_factory=dict)
     collection_bindings: dict[str, CollectionBinding] = field(default_factory=dict)
 
-    def bindings_for_source(self, source_step: str) -> tuple[CollectionBinding, ...]:
+    def __post_init__(self) -> None:
+        self._normalize_step_id_maps()
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._normalize_step_id_maps()
+
+    def _normalize_step_id_maps(self) -> None:
+        object.__setattr__(self, "steps", _normalize_step_id_keys(self.steps))
+        object.__setattr__(
+            self,
+            "catch_error_handlers",
+            _normalize_step_id_keys(self.catch_error_handlers),
+        )
+        object.__setattr__(
+            self,
+            "handler_for_step",
+            {
+                _normalize_step_id(step_id): _normalize_step_id(handler_id)
+                for step_id, handler_id in self.handler_for_step.items()
+            },
+        )
+
+    def bindings_for_source(
+        self, source_step: StepId | str
+    ) -> tuple[CollectionBinding, ...]:
         return tuple(
             binding
             for binding in self.collection_bindings.values()
@@ -556,7 +651,7 @@ class BrokerConfig:
     def binding_for_target(
         self,
         stream_id: str,
-        target_step: str,
+        target_step: StepId,
         streams: dict[str, CollectionStreamInstance],
     ) -> CollectionBinding | None:
         stream = streams.get(stream_id)
@@ -584,6 +679,9 @@ class InternalStepConfig:
     retry_policy: RetryPolicy | None
     num_workers: int
     accept_event_subclasses: bool = False
+    collection_param: tuple[str, tuple[Any, ...]] | None = None
+    collect_params: list[tuple[str, Any]] | None = None
+    collection_policy: Collect | None = None
 
 
 @dataclass()
@@ -618,6 +716,21 @@ class EventAttempt:
     collection_release_payload: CollectionReleasePayload | None = None
     work_item_id: str | None = None
 
+    def _copy(self) -> EventAttempt:
+        return EventAttempt(
+            event=self.event,
+            bound_events=dict(self.bound_events) if self.bound_events else None,
+            attempts=self.attempts,
+            first_attempt_at=self.first_attempt_at,
+            last_exception=self.last_exception,
+            last_failed_at=self.last_failed_at,
+            recovery_counts=dict(self.recovery_counts),
+            not_before=self.not_before,
+            scope_path=self.scope_path,
+            collection_release_payload=self.collection_release_payload,
+            work_item_id=self.work_item_id,
+        )
+
 
 @dataclass()
 class InternalStepWorkerState:
@@ -636,7 +749,7 @@ class InternalStepWorkerState:
     """
 
     queue: list[EventAttempt]
-    config: StepConfig
+    config: InternalStepConfig
     in_progress: list[InProgressState]
     collected_events: dict[str, list[Event]]
     collected_waiters: list[StepWorkerWaiter]
@@ -644,7 +757,7 @@ class InternalStepWorkerState:
 
     def _deepcopy(self) -> InternalStepWorkerState:
         return InternalStepWorkerState(
-            queue=[dataclasses.replace(x) for x in self.queue],
+            queue=[x._copy() for x in self.queue],
             config=self.config,
             in_progress=[x._deepcopy() for x in self.in_progress],
             collected_events={k: list(v) for k, v in self.collected_events.items()},

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -60,7 +60,7 @@ class CollectionBinding:
     """
 
     id: str
-    source_step: StepId | str
+    source_step: StepId
     target_step: StepId
     item_types: tuple[type[Event], ...]
     policy: Collect
@@ -77,7 +77,7 @@ class CollectionStreamInstance:
     """
 
     stream_id: str
-    source_step: StepId | str
+    source_step: StepId
     scope_path: tuple[str, ...]
     open_work_items: int = 0
     accepting_binding_ids: tuple[str, ...] = ()
@@ -639,9 +639,7 @@ class BrokerConfig:
             },
         )
 
-    def bindings_for_source(
-        self, source_step: StepId | str
-    ) -> tuple[CollectionBinding, ...]:
+    def bindings_for_source(self, source_step: StepId) -> tuple[CollectionBinding, ...]:
         return tuple(
             binding
             for binding in self.collection_bindings.values()

--- a/packages/llama-index-workflows/src/workflows/runtime/types/named_task.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/named_task.py
@@ -23,10 +23,14 @@ class WorkerTask:
     step_id: StepId
     worker_id: int
     task: Task[Any]
+    invocation_namespace: tuple[str, ...] = ()
 
     @property
     def key(self) -> str:
-        return f"{self.step_id}:{self.worker_id}"
+        if self.invocation_namespace == ():
+            return f"{self.step_id}:{self.worker_id}"
+        invocation = "/".join(self.invocation_namespace)
+        return f"{self.step_id}:{invocation}:{self.worker_id}"
 
 
 @dataclass
@@ -94,14 +98,23 @@ class PendingWorker:
     step_id: StepId
     worker_id: int
     coro: Coroutine[Any, Any, Any]
+    invocation_namespace: tuple[str, ...] = ()
 
     @property
     def key(self) -> str:
-        return f"{self.step_id}:{self.worker_id}"
+        if self.invocation_namespace == ():
+            return f"{self.step_id}:{self.worker_id}"
+        invocation = "/".join(self.invocation_namespace)
+        return f"{self.step_id}:{invocation}:{self.worker_id}"
 
     def start(self, task: Task[Any]) -> WorkerTask:
         """Convert to a started WorkerTask."""
-        return WorkerTask(self.step_id, self.worker_id, task)
+        return WorkerTask(
+            self.step_id,
+            self.worker_id,
+            task,
+            invocation_namespace=self.invocation_namespace,
+        )
 
 
 @dataclass

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -17,13 +17,24 @@ from __future__ import annotations
 
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, TypeAdapter
+from pydantic import (
+    AliasChoices,
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    TypeAdapter,
+)
 from workflows.events import SerializableEvent, SerializableOptionalException
 from workflows.runtime.types.results import (
     SerializableCollectionReleasePayload,
     StepFunctionResult,
 )
 from workflows.runtime.types.step_id import StepId
+
+# Pre-StepId journals serialized this field as ``step_name``; accept both so
+# persisted ticks still deserialize. New ticks serialize under ``step_id``.
+_STEP_ID_ALIAS = AliasChoices("step_id", "step_name")
 
 
 class TickStepResult(BaseModel):
@@ -33,8 +44,9 @@ class TickStepResult(BaseModel):
         frozen=True, arbitrary_types_allowed=True, populate_by_name=True
     )
     type: Literal["step_result"] = "step_result"
-    step_id: StepId = Field(validation_alias="step_name")
+    step_id: StepId = Field(validation_alias=_STEP_ID_ALIAS)
     worker_id: int
+    invocation_namespace: tuple[str, ...] = Field(default=(), exclude=True)
     event: SerializableEvent
     result: list[Annotated[StepFunctionResult, Discriminator("type")]]
 
@@ -47,8 +59,9 @@ class TickAddEvent(BaseModel):
     )
     type: Literal["add_event"] = "add_event"
     event: SerializableEvent
-    step_id: StepId | None = Field(default=None, validation_alias="step_name")
+    step_id: StepId | None = Field(default=None, validation_alias=_STEP_ID_ALIAS)
     bound_events: dict[str, SerializableEvent] | None = None
+    origin_namespace: tuple[str, ...] = Field(default=(), exclude=True)
     attempts: int | None = None
     first_attempt_at: float | None = None
     last_exception: SerializableOptionalException = None
@@ -98,8 +111,9 @@ class TickWaiterTimeout(BaseModel):
 
     model_config = ConfigDict(frozen=True, populate_by_name=True)
     type: Literal["waiter_timeout"] = "waiter_timeout"
-    step_id: StepId = Field(validation_alias="step_name")
+    step_id: StepId = Field(validation_alias=_STEP_ID_ALIAS)
     waiter_id: str
+    invocation_namespace: tuple[str, ...] = Field(default=(), exclude=True)
 
 
 class TickIdleCheck(BaseModel):

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop_transformations.py
@@ -14,7 +14,6 @@ from collections.abc import AsyncIterator
 from typing import cast
 
 import pytest
-from workflows.decorators import StepConfig
 from workflows.errors import WorkflowTimeoutError
 from workflows.events import (
     Event,
@@ -92,6 +91,8 @@ from workflows.runtime.types.ticks import (
 )
 
 pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+TEST_STEP_ID = StepId.root("test_step")
+OTHER_STEP_ID = StepId.root("other_step")
 
 
 class MyTestEvent(Event):
@@ -105,20 +106,16 @@ class OtherEvent(Event):
 @pytest.fixture
 def base_state() -> BrokerState:
     """Create a minimal BrokerState for testing."""
-    step_config = StepConfig(
+    step_config = InternalStepConfig(
         accepted_events=[MyTestEvent, StartEvent],
-        event_name="ev",
-        return_types=[StopEvent, OtherEvent, type(None)],
-        context_parameter="ctx",
         retry_policy=None,
         num_workers=1,
-        resources=[],
     )
     return BrokerState(
         is_running=True,
         config=BrokerConfig(
             steps={
-                "test_step": InternalStepConfig(
+                TEST_STEP_ID: InternalStepConfig(
                     accepted_events=[MyTestEvent, StartEvent],
                     retry_policy=None,
                     num_workers=1,
@@ -127,7 +124,7 @@ def base_state() -> BrokerState:
             timeout=None,
         ),
         workers={
-            "test_step": InternalStepWorkerState(
+            TEST_STEP_ID: InternalStepWorkerState(
                 queue=[],
                 config=step_config,
                 in_progress=[],
@@ -146,7 +143,7 @@ def add_worker(
     snapshot_collected: dict[str, list[Event]] | None = None,
 ) -> None:
     """Helper to add an in-progress worker to state."""
-    state.workers["test_step"].in_progress.append(
+    state.workers[TEST_STEP_ID].in_progress.append(
         InProgressState(
             event=event,
             worker_id=worker_id,
@@ -213,7 +210,7 @@ def test_add_event_matches_waiter_does_not_emit_unhandled(
     base_state: BrokerState,
 ) -> None:
     """Events that satisfy a waiter should not emit UnhandledEvent."""
-    base_state.workers["test_step"].collected_waiters.append(
+    base_state.workers[TEST_STEP_ID].collected_waiters.append(
         StepWorkerWaiter(
             waiter_id="waiter-1",
             event=StartEvent(),
@@ -268,12 +265,12 @@ def test_step_worker_results(
             assert isinstance(commands[i], expected_type)
 
     # Worker should be removed from in_progress
-    assert len(new_state.workers["test_step"].in_progress) == 0
+    assert len(new_state.workers[TEST_STEP_ID].in_progress) == 0
 
 
 def test_step_worker_failed_with_retry(base_state: BrokerState) -> None:
     """Test that failures with retry policy re-queue a retry in state."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=1.0
     )
     event = MyTestEvent(value=42)
@@ -289,7 +286,7 @@ def test_step_worker_failed_with_retry(base_state: BrokerState) -> None:
     new_state, commands = _process_step_result_tick(tick, base_state, now_seconds=110.0)
 
     # The retry lives in the worker queue with its eligibility time
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP_ID].queue
     assert len(queue) == 1
     assert queue[0].attempts == 1
     assert queue[0].not_before == 111.0
@@ -335,14 +332,14 @@ def test_collected_events(base_state: BrokerState) -> None:
         result=[AddCollectedEvent(event_id="buf1", event=OtherEvent(data="e1"))],
     )
     new_state, _ = _process_step_result_tick(tick, base_state, now_seconds=110.0)
-    assert "buf1" in new_state.workers["test_step"].collected_events
+    assert "buf1" in new_state.workers[TEST_STEP_ID].collected_events
 
     # Delete event from the matching legacy collect_events() snapshot.
     add_worker(
         new_state,
         event,
         snapshot_collected={
-            "buf1": list(new_state.workers["test_step"].collected_events["buf1"])
+            "buf1": list(new_state.workers[TEST_STEP_ID].collected_events["buf1"])
         },
     )
     tick = TickStepResult(
@@ -355,7 +352,7 @@ def test_collected_events(base_state: BrokerState) -> None:
         ],
     )
     new_state, _ = _process_step_result_tick(tick, new_state, now_seconds=110.0)
-    assert "buf1" not in new_state.workers["test_step"].collected_events
+    assert "buf1" not in new_state.workers[TEST_STEP_ID].collected_events
 
 
 def test_stale_collect_events_firing_reruns_without_deleting_buffer(
@@ -364,7 +361,7 @@ def test_stale_collect_events_firing_reruns_without_deleting_buffer(
     event = MyTestEvent(value=42)
     live = OtherEvent(data="live")
     stale = OtherEvent(data="stale")
-    base_state.workers["test_step"].collected_events["buf1"] = [live]
+    base_state.workers[TEST_STEP_ID].collected_events["buf1"] = [live]
     add_worker(base_state, event, snapshot_collected={"buf1": [stale]})
 
     tick = TickStepResult(
@@ -379,7 +376,7 @@ def test_stale_collect_events_firing_reruns_without_deleting_buffer(
 
     new_state, commands = _process_step_result_tick(tick, base_state, now_seconds=110.0)
 
-    assert new_state.workers["test_step"].collected_events["buf1"] == [live]
+    assert new_state.workers[TEST_STEP_ID].collected_events["buf1"] == [live]
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
     assert run_cmds[0].event is event
@@ -408,7 +405,7 @@ def test_waiters(base_state: BrokerState) -> None:
         ],
     )
     new_state, _ = _process_step_result_tick(tick, base_state, now_seconds=110.0)
-    assert len(new_state.workers["test_step"].collected_waiters) == 1
+    assert len(new_state.workers[TEST_STEP_ID].collected_waiters) == 1
 
     # Delete waiter
     add_worker(new_state, event)
@@ -422,7 +419,7 @@ def test_waiters(base_state: BrokerState) -> None:
         ],
     )
     new_state, _ = _process_step_result_tick(tick, new_state, now_seconds=110.0)
-    assert len(new_state.workers["test_step"].collected_waiters) == 0
+    assert len(new_state.workers[TEST_STEP_ID].collected_waiters) == 0
 
 
 def test_start_event_sets_running(base_state: BrokerState) -> None:
@@ -462,19 +459,15 @@ def test_per_step_explicit_routing_accepts_only_matching_types(
 def test_explicit_routing_requires_acceptance(base_state: BrokerState) -> None:
     """Explicit step routing should still require accepted event types."""
     # Add a second step that does NOT accept MyTestEvent
-    other_step_cfg = StepConfig(
+    other_step_cfg = InternalStepConfig(
         accepted_events=[StartEvent],
-        event_name="ev",
-        return_types=[StopEvent, OtherEvent, type(None)],
-        context_parameter="ctx",
         retry_policy=None,
         num_workers=1,
-        resources=[],
     )
-    base_state.config.steps["other_step"] = InternalStepConfig(
+    base_state.config.steps[OTHER_STEP_ID] = InternalStepConfig(
         accepted_events=[StartEvent], retry_policy=None, num_workers=1
     )
-    base_state.workers["other_step"] = InternalStepWorkerState(
+    base_state.workers[OTHER_STEP_ID] = InternalStepWorkerState(
         queue=[],
         config=other_step_cfg,
         in_progress=[],
@@ -510,13 +503,13 @@ def test_waiter_resolution(base_state: BrokerState) -> None:
         has_requirements=True,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP_ID].collected_waiters.append(waiter)
 
     tick = TickAddEvent(event=OtherEvent(data="expected"))
     new_state, commands = _process_add_event_tick(tick, base_state, now_seconds=100.0)
 
     assert (
-        new_state.workers["test_step"].collected_waiters[0].resolved_event is not None
+        new_state.workers[TEST_STEP_ID].collected_waiters[0].resolved_event is not None
     )
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert any(c.event == original_event for c in run_cmds)
@@ -613,11 +606,12 @@ def test_add_when_capacity_available(base_state: BrokerState) -> None:
     commands = _add_or_enqueue_event(
         EventAttempt(event=event),
         StepId.root("test_step"),
-        base_state.workers["test_step"],
+        base_state.workers[TEST_STEP_ID],
+        (),
         now_seconds=100.0,
     )
 
-    assert len(base_state.workers["test_step"].in_progress) == 1
+    assert len(base_state.workers[TEST_STEP_ID].in_progress) == 1
     assert any(isinstance(c, CommandRunWorker) for c in commands)
     assert any(
         isinstance(c, CommandPublishEvent)
@@ -637,11 +631,12 @@ def test_enqueue_when_no_capacity(base_state: BrokerState) -> None:
     commands = _add_or_enqueue_event(
         EventAttempt(event=event),
         StepId.root("test_step"),
-        base_state.workers["test_step"],
+        base_state.workers[TEST_STEP_ID],
+        (),
         now_seconds=100.0,
     )
 
-    assert len(base_state.workers["test_step"].queue) == 1
+    assert len(base_state.workers[TEST_STEP_ID].queue) == 1
     # PREPARING should be published when we enqueue
     assert isinstance(commands[0], CommandPublishEvent)
     assert isinstance(commands[0].event, StepStateChanged)
@@ -650,8 +645,8 @@ def test_enqueue_when_no_capacity(base_state: BrokerState) -> None:
 
 def test_rewind_restarts_workers(base_state: BrokerState) -> None:
     """Test that in_progress workers are restarted."""
-    base_state.workers["test_step"].config.num_workers = 2
-    base_state.config.steps["test_step"].num_workers = 2
+    base_state.workers[TEST_STEP_ID].config.num_workers = 2
+    base_state.config.steps[TEST_STEP_ID].num_workers = 2
 
     add_worker(base_state, MyTestEvent(value=1), worker_id=0)
     add_worker(base_state, MyTestEvent(value=2), worker_id=1)
@@ -661,7 +656,7 @@ def test_rewind_restarts_workers(base_state: BrokerState) -> None:
     # Both should be restarted
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 2
-    assert len(new_state.workers["test_step"].in_progress) == 2
+    assert len(new_state.workers[TEST_STEP_ID].in_progress) == 2
 
 
 def test_add_event_tick_preserves_retry_metadata(base_state: BrokerState) -> None:
@@ -683,7 +678,7 @@ def test_add_event_tick_preserves_retry_metadata(base_state: BrokerState) -> Non
     assert len(run_cmds) == 1
 
     # Verify retry metadata was preserved in the InProgressState
-    in_progress = new_state.workers["test_step"].in_progress
+    in_progress = new_state.workers[TEST_STEP_ID].in_progress
     assert len(in_progress) == 1
     assert in_progress[0].attempts == attempts
     assert in_progress[0].first_attempt_at == first_attempt_time
@@ -699,7 +694,7 @@ def test_add_event_tick_uses_now_when_no_retry_metadata(
 
     new_state, _ = _process_add_event_tick(tick, base_state, now_seconds=now)
 
-    in_progress = new_state.workers["test_step"].in_progress
+    in_progress = new_state.workers[TEST_STEP_ID].in_progress
     assert len(in_progress) == 1
     assert in_progress[0].attempts == 0
     assert in_progress[0].first_attempt_at == now
@@ -708,7 +703,7 @@ def test_add_event_tick_uses_now_when_no_retry_metadata(
 def test_step_worker_failed_retry_preserves_delay(base_state: BrokerState) -> None:
     """Test that the re-queued retry carries the delay as an absolute not_before."""
     retry_delay = 5.0
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=retry_delay
     )
     event = MyTestEvent(value=42)
@@ -723,28 +718,28 @@ def test_step_worker_failed_retry_preserves_delay(base_state: BrokerState) -> No
 
     new_state, commands = _process_step_result_tick(tick, base_state, now_seconds=110.0)
 
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP_ID].queue
     assert len(queue) == 1
     assert queue[0].not_before == 110.0 + retry_delay
     assert queue[0].attempts == 1
     assert queue[0].first_attempt_at == 100.0  # from add_worker fixture
     # The retry must not be dispatched within this reduction
     assert not any(isinstance(c, CommandRunWorker) for c in commands)
-    assert len(new_state.workers["test_step"].in_progress) == 0
+    assert len(new_state.workers[TEST_STEP_ID].in_progress) == 0
 
 
 def test_step_worker_failed_retry_preserves_first_attempt_at(
     base_state: BrokerState,
 ) -> None:
     """Test that first_attempt_at stays constant across retries."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=5, delay=1.0
     )
     event = MyTestEvent(value=42)
 
     original_first_attempt_at = 50.0
     # Simulate a worker that's already been retried twice
-    base_state.workers["test_step"].in_progress.append(
+    base_state.workers[TEST_STEP_ID].in_progress.append(
         InProgressState(
             event=event,
             worker_id=0,
@@ -767,7 +762,7 @@ def test_step_worker_failed_retry_preserves_first_attempt_at(
 
     new_state, _ = _process_step_result_tick(tick, base_state, now_seconds=200.0)
 
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP_ID].queue
     assert len(queue) == 1
     assert queue[0].attempts == 3  # incremented from 2
     assert queue[0].first_attempt_at == original_first_attempt_at  # preserved!
@@ -784,7 +779,7 @@ def test_step_worker_failed_exponential_jitter_deterministic(
         maximum_attempts=5,
         jitter=True,
     )
-    base_state.workers["test_step"].config.retry_policy = policy
+    base_state.workers[TEST_STEP_ID].config.retry_policy = policy
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
 
@@ -819,8 +814,8 @@ def test_step_worker_failed_exponential_jitter_deterministic(
         tick, base_state, now_seconds=110.0, run_id=run_id
     )
 
-    first_not_before = state_first.workers["test_step"].queue[0].not_before
-    second_not_before = state_second.workers["test_step"].queue[0].not_before
+    first_not_before = state_first.workers[TEST_STEP_ID].queue[0].not_before
+    second_not_before = state_second.workers[TEST_STEP_ID].queue[0].not_before
     assert first_not_before is not None
     assert first_not_before == second_not_before == 110.0 + expected_delay
 
@@ -832,7 +827,7 @@ def test_step_worker_failed_exponential_jitter_deterministic(
 
 def test_wakeup_dispatches_eligible_attempt(base_state: BrokerState) -> None:
     """TickWakeup dispatches attempts whose not_before is covered by its due."""
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=110.0)
     )
 
@@ -841,14 +836,14 @@ def test_wakeup_dispatches_eligible_attempt(base_state: BrokerState) -> None:
         TickWakeup(due=105.0), base_state, 105.0
     )
     assert not any(isinstance(c, CommandRunWorker) for c in commands_before)
-    assert len(state_before.workers["test_step"].queue) == 1
+    assert len(state_before.workers[TEST_STEP_ID].queue) == 1
 
     # Wakeup due at eligibility: dispatched
     state_after, commands_after = _reduce_tick(TickWakeup(due=110.0), base_state, 110.0)
     run_cmds = [c for c in commands_after if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert len(state_after.workers["test_step"].queue) == 0
-    assert state_after.workers["test_step"].in_progress[0].attempts == 1
+    assert len(state_after.workers[TEST_STEP_ID].queue) == 0
+    assert state_after.workers[TEST_STEP_ID].in_progress[0].attempts == 1
 
 
 def test_wakeup_eligibility_is_due_driven_not_clock_driven(
@@ -860,7 +855,7 @@ def test_wakeup_eligibility_is_due_driven_not_clock_driven(
     wakeup identically to the live run, even though the replay-time clock is
     far past every not_before.
     """
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=110.0)
     )
 
@@ -868,7 +863,7 @@ def test_wakeup_eligibility_is_due_driven_not_clock_driven(
     # still NOT dispatch — the live run didn't dispatch on it either.
     state, commands = _reduce_tick(TickWakeup(due=105.0), base_state, 99_999.0)
     assert not any(isinstance(c, CommandRunWorker) for c in commands)
-    queue = state.workers["test_step"].queue
+    queue = state.workers[TEST_STEP_ID].queue
     assert len(queue) == 1
     assert queue[0].not_before == 110.0
 
@@ -877,7 +872,7 @@ def test_ineligible_attempt_does_not_block_eligible_behind_it(
     base_state: BrokerState,
 ) -> None:
     """An ineligible attempt at the queue head must not starve eligible work."""
-    worker_state = base_state.workers["test_step"]
+    worker_state = base_state.workers[TEST_STEP_ID]
     worker_state.queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=999.0)
     )
@@ -890,14 +885,14 @@ def test_ineligible_attempt_does_not_block_eligible_behind_it(
     assert isinstance(run_cmds[0].event, MyTestEvent)
     assert run_cmds[0].event.value == 2
     # Delayed attempt remains queued, not consuming the worker slot
-    remaining = state.workers["test_step"].queue
+    remaining = state.workers[TEST_STEP_ID].queue
     assert len(remaining) == 1
     assert remaining[0].not_before == 999.0
 
 
 def test_retry_with_zero_delay_dispatches_immediately(base_state: BrokerState) -> None:
     """A zero-delay retry is re-dispatched within the same reduction."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=0
     )
     event = MyTestEvent(value=42)
@@ -915,13 +910,13 @@ def test_retry_with_zero_delay_dispatches_immediately(base_state: BrokerState) -
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
     assert not any(isinstance(c, CommandScheduleWakeup) for c in commands)
-    assert len(new_state.workers["test_step"].queue) == 0
-    assert new_state.workers["test_step"].in_progress[0].attempts == 1
+    assert len(new_state.workers[TEST_STEP_ID].queue) == 0
+    assert new_state.workers[TEST_STEP_ID].in_progress[0].attempts == 1
 
 
 def test_rewind_rearms_wakeup_for_delayed_attempt(base_state: BrokerState) -> None:
     """Resume re-arms a wakeup for queued future-not_before attempts."""
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=2, not_before=150.0)
     )
 
@@ -929,7 +924,7 @@ def test_rewind_rearms_wakeup_for_delayed_attempt(base_state: BrokerState) -> No
 
     # Not dispatched, stays queued with retry info intact
     assert not any(isinstance(c, CommandRunWorker) for c in commands)
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP_ID].queue
     assert len(queue) == 1
     assert queue[0].attempts == 2
     # Poke re-armed at the eligibility time
@@ -945,7 +940,7 @@ def test_rewind_rearms_wakeup_even_when_past_due(base_state: BrokerState) -> Non
     The runner fires a past-due wakeup immediately, so delivery is prompt —
     but it arrives as a journaled tick, keeping replay deterministic.
     """
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=2, not_before=110.0)
     )
 
@@ -955,7 +950,7 @@ def test_rewind_rearms_wakeup_even_when_past_due(base_state: BrokerState) -> Non
     wakeups = [c for c in commands if isinstance(c, CommandScheduleWakeup)]
     assert len(wakeups) == 1
     assert wakeups[0].at_time == 110.0
-    queue = new_state.workers["test_step"].queue
+    queue = new_state.workers[TEST_STEP_ID].queue
     assert len(queue) == 1
     assert queue[0].attempts == 2
 
@@ -963,8 +958,8 @@ def test_rewind_rearms_wakeup_even_when_past_due(base_state: BrokerState) -> Non
     final_state, wake_commands = _reduce_tick(TickWakeup(due=110.0), new_state, 120.0)
     run_cmds = [c for c in wake_commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert len(final_state.workers["test_step"].queue) == 0
-    assert final_state.workers["test_step"].in_progress[0].attempts == 2
+    assert len(final_state.workers[TEST_STEP_ID].queue) == 0
+    assert final_state.workers[TEST_STEP_ID].in_progress[0].attempts == 2
 
 
 def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
@@ -978,7 +973,7 @@ def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
     the TickAddEvent must consume that queued attempt instead of dispatching
     a duplicate that would re-run the step after a resume.
     """
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=1.0
     )
     event = MyTestEvent(value=42)
@@ -990,7 +985,7 @@ def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
         result=[StepWorkerFailed(exception=ValueError("test"), failed_at=110.0)],
     )
     state, _ = _process_step_result_tick(fail_tick, base_state, now_seconds=110.0)
-    assert state.workers["test_step"].queue[0].not_before == 111.0
+    assert state.workers[TEST_STEP_ID].queue[0].not_before == 111.0
 
     # Old-format journal re-delivers the retry after the delay elapsed
     add_tick = TickAddEvent(
@@ -1004,16 +999,16 @@ def test_old_journal_retry_add_event_supersedes_queued_delayed_attempt(
 
     run_cmds = [c for c in commands if isinstance(c, CommandRunWorker)]
     assert len(run_cmds) == 1
-    assert final_state.workers["test_step"].queue == []
-    assert len(final_state.workers["test_step"].in_progress) == 1
-    assert final_state.workers["test_step"].in_progress[0].attempts == 1
+    assert final_state.workers[TEST_STEP_ID].queue == []
+    assert len(final_state.workers[TEST_STEP_ID].in_progress) == 1
+    assert final_state.workers[TEST_STEP_ID].in_progress[0].attempts == 1
 
 
 def test_plain_add_event_does_not_consume_queued_delayed_attempt(
     base_state: BrokerState,
 ) -> None:
     """A normal event (no retry metadata) leaves a queued delayed retry alone."""
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=999.0)
     )
 
@@ -1025,7 +1020,7 @@ def test_plain_add_event_does_not_consume_queued_delayed_attempt(
     assert len(run_cmds) == 1
     assert isinstance(run_cmds[0].event, MyTestEvent)
     assert run_cmds[0].event.value == 2
-    remaining = state.workers["test_step"].queue
+    remaining = state.workers[TEST_STEP_ID].queue
     assert len(remaining) == 1
     assert remaining[0].not_before == 999.0
 
@@ -1041,7 +1036,7 @@ def test_replay_recomputes_jittered_not_before_with_run_id(
     step-result tick crashed with "Worker not found in in_progress".
     """
     run_id = "test-run-id"
-    base_state.workers["test_step"].config.retry_policy = retry_policy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = retry_policy(
         wait=wait_exponential_jitter(initial=0.5, exp_base=2.0, max=60.0, jitter=10.0),
         stop=stop_after_attempt(5),
     )
@@ -1063,15 +1058,15 @@ def test_replay_recomputes_jittered_not_before_with_run_id(
     # so the journaled wakeup flips the attempt during replay
     replayed = rebuild_state_from_ticks(base_state, [fail_tick], run_id=run_id)
     assert (
-        replayed.workers["test_step"].queue[0].not_before
-        == live_state.workers["test_step"].queue[0].not_before
+        replayed.workers[TEST_STEP_ID].queue[0].not_before
+        == live_state.workers[TEST_STEP_ID].queue[0].not_before
         == live_wakeup.at_time
     )
     flipped, flip_commands = _reduce_tick(
         TickWakeup(due=live_wakeup.at_time), replayed, 99_999.0
     )
     assert any(isinstance(c, CommandRunWorker) for c in flip_commands)
-    assert flipped.workers["test_step"].queue == []
+    assert flipped.workers[TEST_STEP_ID].queue == []
 
 
 class _MustNotBeInvokedPolicy:
@@ -1098,7 +1093,7 @@ def test_journaled_retry_decision_is_used_without_invoking_policy(
     The live runner stamps the decision into StepWorkerFailed before the tick
     is journaled; reduction (live and replay alike) consumes it as data.
     """
-    base_state.workers["test_step"].config.retry_policy = _MustNotBeInvokedPolicy()
+    base_state.workers[TEST_STEP_ID].config.retry_policy = _MustNotBeInvokedPolicy()
     event = MyTestEvent(value=42)
     add_worker(base_state, event)
     fail_tick: TickStepResult = TickStepResult(
@@ -1116,7 +1111,7 @@ def test_journaled_retry_decision_is_used_without_invoking_policy(
 
     state, commands = _process_step_result_tick(fail_tick, base_state, 110.0)
 
-    assert state.workers["test_step"].queue[0].not_before == 111.0
+    assert state.workers[TEST_STEP_ID].queue[0].not_before == 111.0
     wakeups = [c for c in commands if isinstance(c, CommandScheduleWakeup)]
     assert len(wakeups) == 1
     assert wakeups[0].at_time == 111.0
@@ -1126,7 +1121,7 @@ def test_journaled_stop_decision_fails_workflow_even_if_policy_would_retry(
     base_state: BrokerState,
 ) -> None:
     """RetryDecision(delay=None) means stop, regardless of current policy."""
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=10, delay=1.0
     )
     event = MyTestEvent(value=42)
@@ -1146,7 +1141,7 @@ def test_journaled_stop_decision_fails_workflow_even_if_policy_would_retry(
 
     state, commands = _process_step_result_tick(fail_tick, base_state, 110.0)
 
-    assert state.workers["test_step"].queue == []
+    assert state.workers[TEST_STEP_ID].queue == []
     assert any(isinstance(c, CommandFailWorkflow) for c in commands)
 
 
@@ -1176,18 +1171,18 @@ def test_replay_with_changed_policy_honors_journaled_decision(
     )
 
     # The policy was reconfigured between the live run and this replay
-    base_state.workers["test_step"].config.retry_policy = retry_policy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = retry_policy(
         wait=wait_fixed(50.0), stop=stop_after_attempt(5)
     )
     add_worker(base_state, event)
 
     replayed = rebuild_state_from_ticks(base_state, [fail_tick], run_id="test-run-id")
-    assert replayed.workers["test_step"].queue[0].not_before == 111.0
+    assert replayed.workers[TEST_STEP_ID].queue[0].not_before == 111.0
 
     flipped, commands = _reduce_tick(TickWakeup(due=111.0), replayed, 99_999.0)
     assert any(isinstance(c, CommandRunWorker) for c in commands)
-    assert flipped.workers["test_step"].queue == []
-    assert flipped.workers["test_step"].in_progress[0].attempts == 1
+    assert flipped.workers[TEST_STEP_ID].queue == []
+    assert flipped.workers[TEST_STEP_ID].in_progress[0].attempts == 1
 
 
 def test_journaled_first_attempt_at_survives_rebuilt_state(
@@ -1200,7 +1195,7 @@ def test_journaled_first_attempt_at_survives_rebuilt_state(
     rebuild clock, so elapsed-based retry budgets (stop_after_delay)
     silently restarted on every snapshot/resume.
     """
-    base_state.workers["test_step"].config.retry_policy = ConstantDelayRetryPolicy(
+    base_state.workers[TEST_STEP_ID].config.retry_policy = ConstantDelayRetryPolicy(
         maximum_attempts=3, delay=1.0
     )
     event = MyTestEvent(value=42)
@@ -1223,7 +1218,7 @@ def test_journaled_first_attempt_at_survives_rebuilt_state(
 
     state, _ = _process_step_result_tick(fail_tick, base_state, 110.0)
 
-    assert state.workers["test_step"].queue[0].first_attempt_at == 100.0
+    assert state.workers[TEST_STEP_ID].queue[0].first_attempt_at == 100.0
 
 
 def test_journaled_first_attempt_at_used_for_elapsed_on_failure(
@@ -1272,7 +1267,7 @@ def test_check_idle_state_not_running(base_state: BrokerState) -> None:
 
 def test_check_idle_state_has_queued_events(base_state: BrokerState) -> None:
     """A workflow with queued events is not idle."""
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=1))
     )
     assert _check_idle_state(base_state) is False
@@ -1285,7 +1280,7 @@ def test_check_idle_state_delayed_retry_is_pending_work(
 
     This is what defers idle release (e.g. DBOS) during a retry-delay window.
     """
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=1), attempts=1, not_before=10_000.0)
     )
     assert _check_idle_state(base_state) is False
@@ -1312,7 +1307,7 @@ def test_check_idle_state_is_idle_with_waiter(base_state: BrokerState) -> None:
         has_requirements=False,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP_ID].collected_waiters.append(waiter)
     assert _check_idle_state(base_state) is True
 
 
@@ -1349,19 +1344,15 @@ def test_check_idle_state_multi_step_not_idle_if_one_has_work(
 ) -> None:
     """With multiple steps, not idle if any step has work."""
     # Add a second step
-    other_step_cfg = StepConfig(
+    other_step_cfg = InternalStepConfig(
         accepted_events=[OtherEvent],
-        event_name="ev",
-        return_types=[StopEvent, type(None)],
-        context_parameter="ctx",
         retry_policy=None,
         num_workers=1,
-        resources=[],
     )
-    base_state.config.steps["other_step"] = InternalStepConfig(
+    base_state.config.steps[OTHER_STEP_ID] = InternalStepConfig(
         accepted_events=[OtherEvent], retry_policy=None, num_workers=1
     )
-    base_state.workers["other_step"] = InternalStepWorkerState(
+    base_state.workers[OTHER_STEP_ID] = InternalStepWorkerState(
         queue=[],
         config=other_step_cfg,
         in_progress=[],
@@ -1378,13 +1369,13 @@ def test_check_idle_state_multi_step_not_idle_if_one_has_work(
         has_requirements=False,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP_ID].collected_waiters.append(waiter)
 
     # Without work in other_step, workflow is idle
     assert _check_idle_state(base_state) is True
 
     # Add in_progress work to other_step - now not idle
-    base_state.workers["other_step"].in_progress.append(
+    base_state.workers[OTHER_STEP_ID].in_progress.append(
         InProgressState(
             event=OtherEvent(data="test"),
             worker_id=0,
@@ -1400,8 +1391,8 @@ def test_check_idle_state_multi_step_not_idle_if_one_has_work(
     assert _check_idle_state(base_state) is False
 
     # Or with queued work
-    base_state.workers["other_step"].in_progress = []
-    base_state.workers["other_step"].queue.append(
+    base_state.workers[OTHER_STEP_ID].in_progress = []
+    base_state.workers[OTHER_STEP_ID].queue.append(
         EventAttempt(event=OtherEvent(data="queued"))
     )
     assert _check_idle_state(base_state) is False
@@ -1413,7 +1404,7 @@ def test_no_idle_event_when_work_remains(base_state: BrokerState) -> None:
     add_worker(base_state, event)
 
     # Queue another event so work remains after processing
-    base_state.workers["test_step"].queue.append(
+    base_state.workers[TEST_STEP_ID].queue.append(
         EventAttempt(event=MyTestEvent(value=99))
     )
 
@@ -1448,7 +1439,7 @@ def test_no_idle_event_when_workflow_completes(base_state: BrokerState) -> None:
         has_requirements=False,
         resolved_event=None,
     )
-    base_state.workers["test_step"].collected_waiters.append(waiter)
+    base_state.workers[TEST_STEP_ID].collected_waiters.append(waiter)
 
     # Complete the workflow with StopEvent
     tick: TickStepResult = TickStepResult(
@@ -1500,7 +1491,7 @@ def test_rebuild_state_from_ticks_clears_in_progress(base_state: BrokerState) ->
         collected_events={},
         collected_waiters=[],
     )
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP_ID].in_progress = [
         InProgressState(
             event=event1,
             worker_id=1,  # Original worker ID from checkpoint
@@ -1546,7 +1537,7 @@ def test_rebuild_state_from_ticks_clears_in_progress(base_state: BrokerState) ->
 
     # Verify the workflow completed
     assert final_state.is_running is False
-    assert len(final_state.workers["test_step"].in_progress) == 0
+    assert len(final_state.workers[TEST_STEP_ID].in_progress) == 0
 
 
 def test_rebuild_state_from_ticks_preserves_queue_order(
@@ -1569,7 +1560,7 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
         collected_events={},
         collected_waiters=[],
     )
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP_ID].in_progress = [
         InProgressState(
             event=event1,
             worker_id=0,
@@ -1579,7 +1570,7 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
         ),
     ]
     # Also has queued event
-    base_state.workers["test_step"].queue = [
+    base_state.workers[TEST_STEP_ID].queue = [
         EventAttempt(event=event2, attempts=0, first_attempt_at=None)
     ]
 
@@ -1588,13 +1579,13 @@ def test_rebuild_state_from_ticks_preserves_queue_order(
 
     # rewind_in_progress re-starts workers, so event1 should be back in in_progress
     # with worker_id=0 (reassigned) and retry info preserved
-    assert len(result.workers["test_step"].in_progress) == 1
-    assert result.workers["test_step"].in_progress[0].event == event1
-    assert result.workers["test_step"].in_progress[0].worker_id == 0
-    assert result.workers["test_step"].in_progress[0].attempts == 2
+    assert len(result.workers[TEST_STEP_ID].in_progress) == 1
+    assert result.workers[TEST_STEP_ID].in_progress[0].event == event1
+    assert result.workers[TEST_STEP_ID].in_progress[0].worker_id == 0
+    assert result.workers[TEST_STEP_ID].in_progress[0].attempts == 2
     # Queue should have event2 (since num_workers=1, only 1 can be in_progress)
-    assert len(result.workers["test_step"].queue) == 1
-    assert result.workers["test_step"].queue[0].event == event2
+    assert len(result.workers[TEST_STEP_ID].queue) == 1
+    assert result.workers[TEST_STEP_ID].queue[0].event == event2
 
 
 async def _aiter(ticks: list[WorkflowTick]) -> AsyncIterator[WorkflowTick]:
@@ -1628,7 +1619,7 @@ async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) ->
         step_name="test_step", collected_events={}, collected_waiters=[]
     )
     event1 = MyTestEvent(value=1)
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP_ID].in_progress = [
         InProgressState(
             event=event1,
             worker_id=0,
@@ -1641,9 +1632,9 @@ async def test_rebuild_state_from_ticks_stream_empty(base_state: BrokerState) ->
     streamed = await rebuild_state_from_ticks_stream(base_state, _aiter([]))
 
     # rewind_in_progress re-assigns worker_id=0 starting fresh; in_progress preserved.
-    assert len(streamed.workers["test_step"].in_progress) == 1
-    assert streamed.workers["test_step"].in_progress[0].worker_id == 0
-    assert streamed.workers["test_step"].in_progress[0].event == event1
+    assert len(streamed.workers[TEST_STEP_ID].in_progress) == 1
+    assert streamed.workers[TEST_STEP_ID].in_progress[0].worker_id == 0
+    assert streamed.workers[TEST_STEP_ID].in_progress[0].event == event1
 
 
 async def test_rebuild_state_from_ticks_stream_single_tick(
@@ -1694,7 +1685,7 @@ async def test_rebuild_state_from_ticks_stream_clears_in_progress(
     shared_state = StepWorkerState(
         step_name="test_step", collected_events={}, collected_waiters=[]
     )
-    base_state.workers["test_step"].in_progress = [
+    base_state.workers[TEST_STEP_ID].in_progress = [
         InProgressState(
             event=event1,
             worker_id=1,
@@ -1730,7 +1721,7 @@ async def test_rebuild_state_from_ticks_stream_clears_in_progress(
     final_state = await rebuild_state_from_ticks_stream(base_state, _aiter(ticks))
 
     assert final_state.is_running is False
-    assert len(final_state.workers["test_step"].in_progress) == 0
+    assert len(final_state.workers[TEST_STEP_ID].in_progress) == 0
 
 
 async def test_replay_ticks_stream_surfaces_stop_event(base_state: BrokerState) -> None:

--- a/packages/llama-index-workflows/tests/runtime/test_state.py
+++ b/packages/llama-index-workflows/tests/runtime/test_state.py
@@ -16,6 +16,7 @@ from workflows.runtime.types.internal_state import (
     InProgressState,
 )
 from workflows.runtime.types.results import StepWorkerState
+from workflows.runtime.types.step_id import StepId
 from workflows.workflow import Workflow
 
 
@@ -154,7 +155,8 @@ def test_in_progress_retry_state_survives_serialization() -> None:
     """In-flight work is requeued with its retry state on resume."""
     workflow = _RetryStateWorkflow()
     state = BrokerState.from_workflow(workflow)
-    state.workers["start"].in_progress.append(
+    step_id = StepId.root("start")
+    state.workers[step_id].in_progress.append(
         InProgressState(
             event=StartEvent(),
             worker_id=0,
@@ -174,7 +176,7 @@ def test_in_progress_retry_state_survives_serialization() -> None:
     serializer = JsonSerializer()
     serialized = state.to_serialized(serializer)
     restored = BrokerState.from_serialized(serialized, workflow, serializer)
-    attempt = restored.workers["start"].queue[0]
+    attempt = restored.workers[step_id].queue[0]
 
     assert serialized.version == CURRENT_SERIALIZED_VERSION
     assert attempt.attempts == 2
@@ -188,7 +190,8 @@ def test_queued_not_before_survives_serialization() -> None:
     """The v2 change preserves the delayed-retry field added to queued attempts."""
     workflow = _RetryStateWorkflow()
     state = BrokerState.from_workflow(workflow)
-    state.workers["start"].queue.append(
+    step_id = StepId.root("start")
+    state.workers[step_id].queue.append(
         EventAttempt(
             event=StartEvent(),
             attempts=1,
@@ -202,7 +205,7 @@ def test_queued_not_before_survives_serialization() -> None:
     restored = BrokerState.from_serialized(serialized, workflow, serializer)
 
     assert serialized.workers["start"].queue[0].not_before == 150.0
-    assert restored.workers["start"].queue[0].not_before == 150.0
+    assert restored.workers[step_id].queue[0].not_before == 150.0
 
 
 def test_deserialize_broken_state_raises_validation_error(workflow: Workflow) -> None:

--- a/packages/llama-index-workflows/tests/test_catch_error.py
+++ b/packages/llama-index-workflows/tests/test_catch_error.py
@@ -36,6 +36,7 @@ from workflows.retry_policy import (
     wait_fixed,
 )
 from workflows.runtime.types.internal_state import BrokerState, EventAttempt
+from workflows.runtime.types.step_id import StepId
 
 
 def _retry(attempts: int) -> Any:
@@ -118,7 +119,7 @@ def test_last_exception_serialization_roundtrip() -> None:
 
     wf = Flow()
     state = BrokerState.from_workflow(wf)
-    state.workers["a"].queue.append(
+    state.workers[StepId.root("a")].queue.append(
         EventAttempt(
             event=StartEvent(),
             attempts=1,
@@ -129,7 +130,7 @@ def test_last_exception_serialization_roundtrip() -> None:
     )
     serialized = state.to_serialized(JsonSerializer())
     restored = BrokerState.from_serialized(serialized, wf, JsonSerializer())
-    restored_attempt = restored.workers["a"].queue[0]
+    restored_attempt = restored.workers[StepId.root("a")].queue[0]
     assert isinstance(restored_attempt.last_exception, ValueError)
     assert str(restored_attempt.last_exception) == "boom"
     assert restored_attempt.last_failed_at == 123.456
@@ -517,7 +518,7 @@ def test_recovery_counts_serialization_roundtrip() -> None:
     wf = Flow()
     wf._validate()
     state = BrokerState.from_workflow(wf)
-    state.workers["a"].queue.append(
+    state.workers[StepId.root("a")].queue.append(
         EventAttempt(
             event=StartEvent(),
             attempts=1,
@@ -527,5 +528,5 @@ def test_recovery_counts_serialization_roundtrip() -> None:
     )
     serialized = state.to_serialized(JsonSerializer())
     restored = BrokerState.from_serialized(serialized, wf, JsonSerializer())
-    restored_attempt = restored.workers["a"].queue[0]
+    restored_attempt = restored.workers[StepId.root("a")].queue[0]
     assert restored_attempt.recovery_counts == {"handler": 1}

--- a/packages/llama-index-workflows/tests/test_collection_stream_liveness_model.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_liveness_model.py
@@ -69,10 +69,11 @@ def _state() -> BrokerState:
 def _open_stream(state: BrokerState, open_work_items: int) -> CollectionStreamInstance:
     stream = CollectionStreamInstance(
         stream_id="stream-test",
-        source_step="fan_out",
+        source_step=StepId.root("fan_out"),
         scope_path=(),
         accepting_binding_ids=tuple(
-            binding.id for binding in state.config.bindings_for_source("fan_out")
+            binding.id
+            for binding in state.config.bindings_for_source(StepId.root("fan_out"))
         ),
         open_work_items=open_work_items,
     )
@@ -83,8 +84,8 @@ def _open_stream(state: BrokerState, open_work_items: int) -> CollectionStreamIn
 def test_count_accepting_steps_is_work_item_fan_out_factor() -> None:
     state = _state()
     # Task is accepted by exactly one step (work); Done by two collects.
-    assert _count_accepting_steps(state, Task) == 1
-    assert _count_accepting_steps(state, Done) == 2
+    assert _count_accepting_steps(state, Task(n=0)) == 1
+    assert _count_accepting_steps(state, Done(n=0)) == 2
 
 
 def _release_targets(commands: list[WorkflowCommand]) -> list[str]:
@@ -96,13 +97,13 @@ def test_close_fires_exactly_when_live_empties() -> None:
     state = _state()
     _open_stream(state, open_work_items=1)
     # A positive/neutral delta never closes.
-    assert _adjust_open_work_items(state, "stream-test", +2, 0.0) == []
+    assert _adjust_open_work_items(state, "stream-test", +2, (), 0.0) == []
     assert state.streams["stream-test"].open_work_items == 3
-    assert _adjust_open_work_items(state, "stream-test", -2, 0.0) == []
+    assert _adjust_open_work_items(state, "stream-test", -2, (), 0.0) == []
     assert state.streams["stream-test"].open_work_items == 1
     # Reaching zero closes exactly once: the record is removed and both
     # bindings' releases fire inline as collect invocations.
-    commands = _adjust_open_work_items(state, "stream-test", -1, 0.0)
+    commands = _adjust_open_work_items(state, "stream-test", -1, (), 0.0)
     assert _release_targets(commands) == ["collect_a", "collect_b"]
     assert "stream-test" not in state.streams
     assert state.collection_release_states == {}
@@ -117,7 +118,7 @@ def test_full_two_collect_stream_drains_to_close() -> None:
     """
     state = _state()
     members = [Task(n=i) for i in range(3)]
-    seed = sum(_count_accepting_steps(state, type(m)) for m in members)
+    seed = sum(_count_accepting_steps(state, m) for m in members)
     _open_stream(state, open_work_items=seed)
     assert seed == 3
 
@@ -125,7 +126,11 @@ def test_full_two_collect_stream_drains_to_close() -> None:
     for _ in range(3):
         assert (
             _adjust_open_work_items(
-                state, "stream-test", _count_accepting_steps(state, Done) - 1, 0.0
+                state,
+                "stream-test",
+                _count_accepting_steps(state, Done(n=0)) - 1,
+                (),
+                0.0,
             )
             == []
         )
@@ -135,16 +140,16 @@ def test_full_two_collect_stream_drains_to_close() -> None:
     # closes, firing both bindings' releases inline.
     closed: list[WorkflowCommand] = []
     for _ in range(6):
-        closed.extend(_adjust_open_work_items(state, "stream-test", -1, 0.0))
+        closed.extend(_adjust_open_work_items(state, "stream-test", -1, (), 0.0))
     assert _release_targets(closed) == ["collect_a", "collect_b"]
     assert "stream-test" not in state.streams
 
 
 def test_apply_delta_is_noop_for_missing_or_none_stream() -> None:
     state = _state()
-    assert _adjust_open_work_items(state, None, -1, 0.0) == []
-    assert _adjust_open_work_items(state, "nonexistent", -1, 0.0) == []
-    assert _close_collection_stream(state, "nonexistent", 0.0) == []
+    assert _adjust_open_work_items(state, None, -1, (), 0.0) == []
+    assert _adjust_open_work_items(state, "nonexistent", -1, (), 0.0) == []
+    assert _close_collection_stream(state, "nonexistent", (), 0.0) == []
 
 
 def test_failed_work_without_redelivery_is_not_classified_live() -> None:
@@ -170,8 +175,8 @@ def test_unreleased_release_buffer_serializes_and_fires_on_close() -> None:
     stream = _open_stream(state, open_work_items=1)
     binding = next(
         b
-        for b in state.config.bindings_for_source("fan_out")
-        if b.target_step == "collect_a"
+        for b in state.config.bindings_for_source(StepId.root("fan_out"))
+        if b.target_step == StepId.root("collect_a")
     )
     key = f"{stream.stream_id}:{binding.id}"
     state.collection_release_states[key] = CollectionReleaseState(
@@ -187,10 +192,10 @@ def test_unreleased_release_buffer_serializes_and_fires_on_close() -> None:
     restored_buffer = restored.collection_release_states[key].buffer
     assert [event.n for event in restored_buffer] == [7]
 
-    commands = _close_collection_stream(restored, stream.stream_id, 0.0)
+    commands = _close_collection_stream(restored, stream.stream_id, (), 0.0)
     assert _release_targets(commands) == ["collect_a", "collect_b"]
     payload = (
-        restored.workers["collect_a"]
+        restored.workers[StepId.root("collect_a")]
         .in_progress[0]
         .shared_state.collection_release_payload
     )

--- a/packages/llama-index-workflows/tests/test_collection_stream_loudness.py
+++ b/packages/llama-index-workflows/tests/test_collection_stream_loudness.py
@@ -151,7 +151,7 @@ def _leaked_stream_state() -> BrokerState:
     state.is_running = True
     state.streams["stream-x"] = CollectionStreamInstance(
         stream_id="stream-x",
-        source_step="fan_out",
+        source_step=StepId.root("fan_out"),
         scope_path=("stream-x",),
         open_work_items=1,
     )
@@ -212,7 +212,7 @@ def _waiter(scope_path: tuple[str, ...]) -> StepWorkerWaiter:
 
 def test_idle_check_with_in_stream_waiter_publishes_idle_not_failure() -> None:
     state = _leaked_stream_state()
-    state.workers["work"].collected_waiters.append(_waiter(("stream-x",)))
+    state.workers[StepId.root("work")].collected_waiters.append(_waiter(("stream-x",)))
     _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
 
     assert not any(isinstance(c, CommandFailWorkflow) for c in commands), commands
@@ -233,7 +233,7 @@ def test_idle_check_with_out_of_stream_waiter_still_fails_run() -> None:
     attempt counters — this is not an exhausted step attempt.
     """
     state = _leaked_stream_state()
-    state.workers["work"].collected_waiters.append(_waiter(()))
+    state.workers[StepId.root("work")].collected_waiters.append(_waiter(()))
     _, commands = _reduce_tick(TickIdleCheck(), state, 0.0)
 
     failures = [c for c in commands if isinstance(c, CommandFailWorkflow)]

--- a/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
+++ b/packages/llama-index-workflows/tests/test_heterogeneous_fan_in.py
@@ -12,6 +12,7 @@ from workflows.decorators import step as free_step
 from workflows.errors import WorkflowValidationError
 from workflows.events import Event, StartEvent, StepFailedEvent, StopEvent
 from workflows.runtime.types.internal_state import BrokerState, EventAttempt
+from workflows.runtime.types.step_id import StepId
 
 
 class Header(Event):
@@ -376,7 +377,7 @@ def test_collect_mode_state_serializes_static_buffers() -> None:
     workflow = SerializeWorkflow()
     serializer = JsonSerializer()
     state = BrokerState.from_workflow(workflow)
-    worker = state.workers["assemble"]
+    worker = state.workers[StepId.root("assemble")]
     worker.static_collect_events.append(Header(value="pending"))
     worker.queue.append(
         EventAttempt(
@@ -393,7 +394,7 @@ def test_collect_mode_state_serializes_static_buffers() -> None:
         workflow,
         serializer,
     )
-    restored_worker = restored.workers["assemble"]
+    restored_worker = restored.workers[StepId.root("assemble")]
 
     assert restored_worker.static_collect_events == [Header(value="pending")]
     assert restored_worker.queue[0].bound_events == {


### PR DESCRIPTION
The control loop assumes exactly one broker per run: `BrokerState` is a flat singleton, worker maps key on bare step-name strings, and the reducer, runner, and stream accounting all address steps globally. Nothing in that shape can host more than one broker per run.

This restructures the internals so the same machinery operates on a *tree* of brokers — of exactly one node. There is no way to create a second node yet, and no behavior or serialization change:

- Worker and step maps key on `StepId` (namespace + name) instead of bare strings; the root namespace is the empty tuple, and serialization still projects root ids to the same bare strings as before.
- Traversal helpers (`_broker_for_namespace`, recursive rewind/rehydrate/idle walks) address brokers by namespace path; every caller passes root.
- Stream accounting threads the owning namespace path through the collection-stream helpers.
- Ticks and commands gain namespace fields defaulting to root, marked `exclude=True` so the journal wire format is unchanged.
- Worker task keys are namespaced with a bare-root projection, so task names match today's exactly.

**The review story is byte-identity.** A childless run's snapshot and tick journal produced on this branch are byte-identical to ones produced on `main` (verified by capturing both from the same deterministic script and `cmp`), and the golden fixtures from #723 pass unchanged. Existing test files are untouched except for internals-poking tests (`test_control_loop_transformations`, state/stream-model tests) whose setup constructs `BrokerState` by hand — those switch string keys to `StepId.root(...)` and thread the new namespace parameters; no behavioral assertion changed.

Stacked on #723.