### PR TITLE
Measure workflow timeout as accumulated alive time

### DIFF
--- a/.changeset/alive-timeout-budget.md
+++ b/.changeset/alive-timeout-budget.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": minor
+---
+
+Workflow timeouts now measure accumulated alive time across resumes instead of resetting on each resume; long-suspended runs that repeatedly resume can now time out where they previously would not.

--- a/packages/llama-index-workflows/src/workflows/context/context_types.py
+++ b/packages/llama-index-workflows/src/workflows/context/context_types.py
@@ -215,6 +215,14 @@ class SerializedContext(BaseModel):
     collection_release_states: dict[str, SerializedCollectionReleaseState] = Field(
         default_factory=dict
     )
+    # Elapsed known-alive time (seconds) this broker has consumed against its
+    # timeout budget. Persisted so a resumed run keeps its spent budget instead
+    # of resetting; downtime between sessions never accrues (see the reducer's
+    # session-start marker handling). ``last_alive_stamp`` is the accrual
+    # reference point; it is reset by the session marker on resume, so its
+    # persisted value is informational.
+    elapsed_alive: float = Field(default=0.0)
+    last_alive_stamp: float | None = Field(default=None)
 
     @staticmethod
     def from_v0(v0: SerializedContextV0) -> "SerializedContext":

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -83,11 +83,13 @@ from workflows.runtime.types.results import (
 )
 from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
+    STAMPED_TICK_TYPES,
     TickAddEvent,
     TickCancelRun,
     TickIdleCheck,
     TickIdleRelease,
     TickPublishEvent,
+    TickSessionStart,
     TickStepResult,
     TickTimeout,
     TickWaiterTimeout,
@@ -201,12 +203,64 @@ async def rebuild_state_from_ticks_stream(
     return (await replay_ticks_stream(state, ticks, run_id=run_id)).state
 
 
+def _effective_now(tick: WorkflowTick, now_seconds: float) -> float:
+    """Prefer a journaled tick timestamp over the reducer's clock.
+
+    Fixes the replay clock: a tick stamped before ``on_tick`` carries the live
+    run's time, so replaying it makes the same time-based decisions. Old ticks
+    (no stamp) fall back to ``now_seconds``.
+    """
+    stamped = _tick_stamp(tick)
+    return stamped if stamped is not None else now_seconds
+
+
+def _tick_stamp(tick: WorkflowTick) -> float | None:
+    """The tick's journaled wall-clock stamp, or None for unstamped ticks.
+
+    Only stamped ticks accrue alive time. Old markerless journals carry no
+    stamps, so they replay with an empty budget and never fire a spurious
+    timeout under the legacy fallback.
+    """
+    return tick.stamped_at if isinstance(tick, STAMPED_TICK_TYPES) else None
+
+
+def _accrue_alive(broker: BrokerState, stamp: float) -> None:
+    """Accrue one broker's known-alive time up to ``stamp``.
+
+    ``elapsed_alive`` gains the gap since the last reference (the process was
+    alive across it); the reference then advances. The session-start marker moves
+    the reference without accruing, so inter-session downtime never counts.
+    """
+    if broker.last_alive_stamp is not None:
+        delta = stamp - broker.last_alive_stamp
+        if delta > 0:
+            broker.elapsed_alive += delta
+    broker.last_alive_stamp = stamp
+
+
+def _reset_alive_stamps(state: BrokerState, stamp: float | None) -> None:
+    """Session-start reset: advance every broker's accrual reference, no accrual.
+
+    Forgives the inter-session downtime (the gap between the previous session's
+    last tick and this resume) uniformly across the whole broker tree, on both
+    the snapshot-resume and full-journal-replay paths.
+    """
+
+    def walk(broker: BrokerState) -> None:
+        broker.last_alive_stamp = stamp
+        for child in broker.children.values():
+            walk(child)
+
+    walk(state)
+
+
 def _reduce_tick(
     tick: WorkflowTick,
     init: BrokerState,
     now_seconds: float,
     run_id: str | None = None,
 ) -> tuple[BrokerState, list[WorkflowCommand]]:
+    now_seconds = _effective_now(tick, now_seconds)
     if isinstance(tick, TickStepResult):
         state, commands = _process_step_result_tick(tick, init, now_seconds, run_id)
     elif isinstance(tick, TickAddEvent):
@@ -220,6 +274,13 @@ def _reduce_tick(
         state, commands = _process_publish_event_tick(tick, init)
     elif isinstance(tick, TickTimeout):
         state, commands = _process_timeout_tick(tick, init)
+    elif isinstance(tick, TickSessionStart):
+        # Session boundary: advance every broker's accrual reference to this
+        # stamp WITHOUT accruing, so the downtime since the previous session is
+        # forgiven. Never schedules further work.
+        state = init.deepcopy()
+        _reset_alive_stamps(state, _tick_stamp(tick))
+        return state, []
     elif isinstance(tick, TickWaiterTimeout):
         state, commands = _process_waiter_timeout_tick(tick, init, now_seconds)
     elif isinstance(tick, TickIdleCheck):
@@ -259,6 +320,13 @@ def _reduce_tick(
 class _Descent:
     broker: BrokerState
     path: tuple[str, ...]
+
+
+def _accrue_descent(descent: _Descent, stamp: float | None) -> None:
+    """Accrue alive time on the addressed broker."""
+    if stamp is None:
+        return
+    _accrue_alive(descent.broker, stamp)
 
 
 def _descend(root_state: BrokerState, path: tuple[str, ...]) -> _Descent | None:
@@ -953,6 +1021,7 @@ def _process_step_result_tick(
     descent = _descend(state, tick.invocation_namespace)
     if descent is None:
         return state, []
+    _accrue_descent(descent, _tick_stamp(tick))
     broker = descent.broker
     path = descent.path
     step_id = tick.step_id
@@ -1471,6 +1540,7 @@ def _process_add_event_tick(
     descent = _descend(state, tick.origin_namespace)
     if descent is None:
         return state, _unhandled_event_commands(tick, state)
+    _accrue_descent(descent, _tick_stamp(tick))
     broker = descent.broker
     path = descent.path
     if tick.work_item_id is None:

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -1643,10 +1643,11 @@ def _process_timeout_tick(
         _accrue_alive(state, stamp)
         if state.elapsed_alive + 1e-9 < tick.timeout:
             remaining = tick.timeout - state.elapsed_alive
+            base = max(stamp, state.last_alive_stamp or stamp)
             return state, [
                 CommandScheduleTimeout(
                     timeout=tick.timeout,
-                    at_time=stamp + remaining,
+                    at_time=base + remaining,
                 )
             ]
     state.is_running = False

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/reduce.py
@@ -58,6 +58,7 @@ from workflows.runtime.types.commands import (
     CommandQueueEvent,
     CommandRunWorker,
     CommandScheduleIdleCheck,
+    CommandScheduleTimeout,
     CommandScheduleWaiterTimeout,
     CommandScheduleWakeup,
     WorkflowCommand,
@@ -235,7 +236,12 @@ def _accrue_alive(broker: BrokerState, stamp: float) -> None:
         delta = stamp - broker.last_alive_stamp
         if delta > 0:
             broker.elapsed_alive += delta
-    broker.last_alive_stamp = stamp
+    # An out-of-order tick must not move the anchor backwards and inflate a later gap.
+    broker.last_alive_stamp = (
+        stamp
+        if broker.last_alive_stamp is None
+        else max(broker.last_alive_stamp, stamp)
+    )
 
 
 def _reset_alive_stamps(state: BrokerState, stamp: float | None) -> None:
@@ -320,23 +326,27 @@ def _reduce_tick(
 class _Descent:
     broker: BrokerState
     path: tuple[str, ...]
+    chain: tuple[BrokerState, ...]
 
 
 def _accrue_descent(descent: _Descent, stamp: float | None) -> None:
-    """Accrue alive time on the addressed broker."""
+    """Accrue alive time on every broker from the root to the addressed broker."""
     if stamp is None:
         return
-    _accrue_alive(descent.broker, stamp)
+    for broker in descent.chain:
+        _accrue_alive(broker, stamp)
 
 
 def _descend(root_state: BrokerState, path: tuple[str, ...]) -> _Descent | None:
     broker = root_state
+    chain = [broker]
     for seg in path:
         child = broker.children.get(seg)
         if child is None:
             return None
         broker = child
-    return _Descent(broker=broker, path=path)
+        chain.append(broker)
+    return _Descent(broker=broker, path=path, chain=tuple(chain))
 
 
 def _is_eligible(attempt: EventAttempt) -> bool:
@@ -1628,6 +1638,17 @@ def _process_timeout_tick(
     tick: TickTimeout, init: BrokerState
 ) -> tuple[BrokerState, list[WorkflowCommand]]:
     state = init.deepcopy()
+    stamp = _tick_stamp(tick)
+    if stamp is not None:
+        _accrue_alive(state, stamp)
+        if state.elapsed_alive + 1e-9 < tick.timeout:
+            remaining = tick.timeout - state.elapsed_alive
+            return state, [
+                CommandScheduleTimeout(
+                    timeout=tick.timeout,
+                    at_time=stamp + remaining,
+                )
+            ]
     state.is_running = False
     _clear_collection_state(state)
     active_steps = [
@@ -1670,6 +1691,7 @@ def _process_wakeup_tick(
     descent = _descend(state, ())
     if descent is None:
         return state, commands
+    _accrue_descent(descent, _tick_stamp(tick))
     for step_id, worker_state in sorted(
         descent.broker.workers.items(), key=lambda x: str(x[0])
     ):
@@ -1690,6 +1712,7 @@ def _process_waiter_timeout_tick(
     descent = _descend(state, tick.invocation_namespace)
     if descent is None:
         return state, commands
+    _accrue_descent(descent, _tick_stamp(tick))
     broker = descent.broker
     step_id = tick.step_id
     if step_id not in broker.workers:

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
@@ -52,8 +52,10 @@ from workflows.runtime.types.results import (
 )
 from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
+    STAMPED_TICK_TYPES,
     TickAddEvent,
     TickIdleCheck,
+    TickSessionStart,
     TickStepResult,
     TickTimeout,
     TickWaiterTimeout,
@@ -73,6 +75,19 @@ from workflows.runtime.control_loop.reduce import (
 )
 
 logger = logging.getLogger("workflows.runtime.control_loop")
+
+
+def _stamp_tick(tick: WorkflowTick, now: float) -> WorkflowTick:
+    """Stamp a tick's journaled timestamp with the live-run clock, if it has one.
+
+    Ticks that carry a ``stamped_at`` field record ``now`` before journaling so a
+    later replay makes the same time-based decisions as the live run instead of
+    reading the replay clock. Ticks without the field (cancel, publish, etc.) and
+    already-stamped ticks pass through unchanged.
+    """
+    if isinstance(tick, STAMPED_TICK_TYPES) and tick.stamped_at is None:
+        return tick.model_copy(update={"stamped_at": now})
+    return tick
 
 
 def _is_shutdown_error(e: BaseException) -> bool:
@@ -407,18 +422,26 @@ class _ControlLoopRunner:
             The final StopEvent from the workflow
         """
 
+        start = await self.adapter.get_now()
+        # Journal a session-start marker at every run()/resume. It marks the
+        # alive-session boundary so downtime never accrues. It leads the journal
+        # so replay sees the boundary before any work of this session.
+        self.tick_buffer.insert(0, TickSessionStart(stamped_at=start))
+
         # Queue initial event
         if start_event is not None:
             self.tick_buffer.append(TickAddEvent(event=start_event))
 
-        start = await self.adapter.get_now()
-        # Schedule workflow timeout if configured
+        # Schedule the root timeout on its remaining alive-time budget. Across a
+        # resume the root keeps the alive time it already spent (elapsed_alive),
+        # instead of the old fresh-budget-per-resume reset; downtime is forgiven
+        # by the session-start marker. A fresh run has elapsed_alive == 0, so
+        # this is the full timeout.
         if start_with_timeout and self.workflow._timeout is not None:
-            # Get initial time
-            timeout_time = start + self.workflow._timeout
+            remaining = max(0.0, self.workflow._timeout - self.state.elapsed_alive)
             self.schedule_tick(
                 TickTimeout(timeout=self.workflow._timeout),
-                at_time=timeout_time,
+                at_time=start + remaining,
             )
 
         # Resume any in-progress work
@@ -575,6 +598,9 @@ class _ControlLoopRunner:
         """Process a single tick and return StopEvent if workflow completes."""
         try:
             start = await self.adapter.get_now()
+            # Stamp the live-run time before journaling so replay reads the same
+            # clock the live run used.
+            tick = _stamp_tick(tick, start)
             self.state, commands = _reduce_tick(
                 tick, self.state, start, run_id=self.adapter.run_id
             )

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
@@ -23,6 +23,7 @@ from workflows.runtime.types.commands import (
     CommandQueueEvent,
     CommandRunWorker,
     CommandScheduleIdleCheck,
+    CommandScheduleTimeout,
     CommandScheduleWaiterTimeout,
     CommandScheduleWakeup,
     WorkflowCommand,
@@ -369,6 +370,11 @@ class _ControlLoopRunner:
                 at_time=now + command.timeout,
             )
             return None
+        elif isinstance(command, CommandScheduleTimeout):
+            self.schedule_tick(
+                TickTimeout(timeout=command.timeout), at_time=command.at_time
+            )
+            return None
         elif isinstance(command, CommandScheduleWakeup):
             self.schedule_tick(TickWakeup(due=command.at_time), at_time=command.at_time)
             return None
@@ -439,10 +445,11 @@ class _ControlLoopRunner:
         # this is the full timeout.
         if start_with_timeout and self.workflow._timeout is not None:
             remaining = max(0.0, self.workflow._timeout - self.state.elapsed_alive)
-            self.schedule_tick(
-                TickTimeout(timeout=self.workflow._timeout),
-                at_time=start + remaining,
-            )
+            timeout_tick = TickTimeout(timeout=self.workflow._timeout)
+            if remaining <= 0:
+                self.tick_buffer.insert(1, timeout_tick)
+            else:
+                self.schedule_tick(timeout_tick, at_time=start + remaining)
 
         # Resume any in-progress work
         self.state, commands = rewind_in_progress(self.state, start)

--- a/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/control_loop/runner.py
@@ -472,6 +472,12 @@ class _ControlLoopRunner:
                 # Get current time
                 now = await self.adapter.get_now()
 
+                # A completed worker or pull task must not starve scheduled work.
+                # Append due ticks after anything already buffered so the buffer's
+                # existing processing order remains stable.
+                for due_tick in self.pop_due_ticks(now):
+                    self.tick_buffer.append(due_tick)
+
                 # optimization, only reload "now" if any work was done
                 was_buffered = bool(self.tick_buffer)
                 # Drain and process buffered ticks first (from rehydration, queue_tick, etc.)

--- a/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/commands.py
@@ -83,6 +83,14 @@ class CommandScheduleWakeup:
 
 
 @dataclass(frozen=True)
+class CommandScheduleTimeout:
+    """Schedule the root workflow timeout at an absolute adapter time."""
+
+    timeout: float
+    at_time: float
+
+
+@dataclass(frozen=True)
 class CommandScheduleIdleCheck:
     """Schedule a deferred idle check via TickIdleCheck.
 
@@ -103,6 +111,7 @@ WorkflowCommand = (
     | CommandFailWorkflow
     | CommandPublishEvent
     | CommandScheduleIdleCheck
+    | CommandScheduleTimeout
     | CommandScheduleWaiterTimeout
     | CommandScheduleWakeup
 )

--- a/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/internal_state.py
@@ -119,6 +119,10 @@ class BrokerState:
         stream_seq: Monotonic counter used to mint deterministic collection stream ids
         streams: Open collection streams keyed by stream id
         collection_release_states: Per-binding release buffers keyed by stream and binding
+        elapsed_alive: Known-alive seconds this broker has spent against its
+            timeout budget.
+        last_alive_stamp: Accrual reference point (the last stamp seen), reset by
+            session-start markers without accruing downtime.
     """
 
     is_running: bool
@@ -131,6 +135,8 @@ class BrokerState:
         default_factory=dict
     )
     children: dict[str, BrokerState] = field(default_factory=dict)
+    elapsed_alive: float = 0.0
+    last_alive_stamp: float | None = None
 
     def __post_init__(self) -> None:
         self._normalize_worker_keys()
@@ -139,6 +145,10 @@ class BrokerState:
         self.__dict__.update(state)
         if "children" not in state:
             self.children = {}
+        if "elapsed_alive" not in state:
+            self.elapsed_alive = 0.0
+        if "last_alive_stamp" not in state:
+            self.last_alive_stamp = None
         self._normalize_worker_keys()
 
     def _normalize_worker_keys(self) -> None:
@@ -163,6 +173,8 @@ class BrokerState:
                 for key, state in self.collection_release_states.items()
             },
             children={key: child.deepcopy() for key, child in self.children.items()},
+            elapsed_alive=self.elapsed_alive,
+            last_alive_stamp=self.last_alive_stamp,
         )
 
     @staticmethod
@@ -399,6 +411,8 @@ def _broker_to_serialized(
             )
             for key, release in state.collection_release_states.items()
         },
+        elapsed_alive=state.elapsed_alive,
+        last_alive_stamp=state.last_alive_stamp,
     )
 
 
@@ -410,6 +424,8 @@ def _load_broker_from_serialized(
     base_state.is_running = serialized.is_running
     base_state.stream_seq = serialized.stream_seq
     base_state.work_item_seq = serialized.work_item_seq
+    base_state.elapsed_alive = serialized.elapsed_alive
+    base_state.last_alive_stamp = serialized.last_alive_stamp
     base_state.streams = {
         sid: CollectionStreamInstance(
             stream_id=stream.stream_id,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -49,6 +49,10 @@ class TickStepResult(BaseModel):
     invocation_namespace: tuple[str, ...] = Field(default=(), exclude=True)
     event: SerializableEvent
     result: list[Annotated[StepFunctionResult, Discriminator("type")]]
+    # Wall-clock stamp recorded before ``on_tick`` journaling, so replay reads
+    # the same time the live run used instead of the replay clock. Additive:
+    # old journals default to None and fall back to the reducer's ``now``.
+    stamped_at: float | None = None
 
 
 class TickAddEvent(BaseModel):
@@ -74,6 +78,8 @@ class TickAddEvent(BaseModel):
     collection_release_payload: SerializableCollectionReleasePayload = None
     # Stable identity for this work item when re-delivering suspended work.
     work_item_id: str | None = None
+    # See TickStepResult.stamped_at.
+    stamped_at: float | None = None
 
 
 class TickCancelRun(BaseModel):
@@ -116,6 +122,21 @@ class TickWaiterTimeout(BaseModel):
     invocation_namespace: tuple[str, ...] = Field(default=(), exclude=True)
 
 
+class TickSessionStart(BaseModel):
+    """Session-start marker journaled at each ``run()`` start and resume.
+
+    Drives the elapsed-alive timeout budget: it marks the boundary between alive
+    sessions, resetting every broker's ``last_alive_stamp`` without accruing, so
+    the inter-session gap (downtime) never enters any broker's budget — on the
+    snapshot-resume path and the full-journal-replay path identically. Additive
+    to the journal; old journals simply lack it.
+    """
+
+    model_config = ConfigDict(frozen=True)
+    type: Literal["session_start"] = "session_start"
+    stamped_at: float | None = None
+
+
 class TickIdleCheck(BaseModel):
     """Scheduled after state appears idle, to re-check after async sends run.
 
@@ -146,6 +167,13 @@ class TickWakeup(BaseModel):
     due: float
 
 
+# Ticks that carry a journaled wall-clock stamp. See TickStepResult.stamped_at.
+STAMPED_TICK_TYPES = (
+    TickStepResult,
+    TickAddEvent,
+    TickSessionStart,
+)
+
 WorkflowTick = Annotated[
     TickStepResult
     | TickAddEvent
@@ -153,6 +181,7 @@ WorkflowTick = Annotated[
     | TickPublishEvent
     | TickTimeout
     | TickWaiterTimeout
+    | TickSessionStart
     | TickIdleCheck
     | TickIdleRelease
     | TickWakeup,

--- a/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
+++ b/packages/llama-index-workflows/src/workflows/runtime/types/ticks.py
@@ -110,6 +110,7 @@ class TickTimeout(BaseModel):
     model_config = ConfigDict(frozen=True)
     type: Literal["timeout"] = "timeout"
     timeout: float
+    stamped_at: float | None = None
 
 
 class TickWaiterTimeout(BaseModel):
@@ -120,6 +121,7 @@ class TickWaiterTimeout(BaseModel):
     step_id: StepId = Field(validation_alias=_STEP_ID_ALIAS)
     waiter_id: str
     invocation_namespace: tuple[str, ...] = Field(default=(), exclude=True)
+    stamped_at: float | None = None
 
 
 class TickSessionStart(BaseModel):
@@ -165,13 +167,17 @@ class TickWakeup(BaseModel):
     model_config = ConfigDict(frozen=True)
     type: Literal["wakeup"] = "wakeup"
     due: float
+    stamped_at: float | None = None
 
 
 # Ticks that carry a journaled wall-clock stamp. See TickStepResult.stamped_at.
 STAMPED_TICK_TYPES = (
     TickStepResult,
     TickAddEvent,
+    TickTimeout,
+    TickWaiterTimeout,
     TickSessionStart,
+    TickWakeup,
 )
 
 WorkflowTick = Annotated[

--- a/packages/llama-index-workflows/tests/context/test_context.py
+++ b/packages/llama-index-workflows/tests/context/test_context.py
@@ -226,15 +226,25 @@ async def test_send_event_step_is_none() -> None:
         handler.ctx.send_event(ev)
         external_face = handler.ctx._face
         assert isinstance(external_face, ExternalContext)
+        ext = external_face  # narrowed for use inside the closure below
 
-        # Wait for event to appear in tick log (up to 1 second)
+        # Wait for event to appear in tick log (up to 1 second). stamped_at is
+        # the journaled live-run clock; normalize it away for the comparison.
         expected_tick = TickAddEvent(event=ev, step_id=None)
+
+        def _add_events() -> list[TickAddEvent]:
+            return [
+                t.model_copy(update={"stamped_at": None})
+                for t in ext._tick_log
+                if isinstance(t, TickAddEvent)
+            ]
+
         for _ in range(100):
-            if expected_tick in external_face._tick_log:
+            if expected_tick in _add_events():
                 break
             await asyncio.sleep(0.01)
 
-        assert expected_tick in external_face._tick_log
+        assert expected_tick in _add_events()
 
         # Let workflow complete
         result = await handler

--- a/packages/llama-index-workflows/tests/fixtures/golden_serialization/README.md
+++ b/packages/llama-index-workflows/tests/fixtures/golden_serialization/README.md
@@ -11,6 +11,10 @@ and replay unchanged at the behavioral level:
 - `journal.json` — `{"result": 12, "ticks": [...]}`: a full tick journal for a
   fan-out + `collect_events` run. Replaying the ticks from a canonical
   `BrokerState.from_workflow` must reach `StopEvent(result=12)`.
+- `current_journal.json` — the same completed workflow journal in the current
+  format, including a `session_start` marker and non-null stamps on stamped
+  ticks. It pins additions to the current journal shape without changing the
+  legacy compatibility fixture.
 
 Regenerate only when intentionally updating the pinned main serialization
 formats; see `tests/test_golden_serialization_fixtures.py` for the workflow

--- a/packages/llama-index-workflows/tests/fixtures/golden_serialization/current_journal.json
+++ b/packages/llama-index-workflows/tests/fixtures/golden_serialization/current_journal.json
@@ -1,0 +1,592 @@
+{
+  "result": 12,
+  "ticks": [
+    {
+      "type": "session_start",
+      "stamped_at": 1000.0
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {},
+        "qualified_name": "workflows.events.StartEvent"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001
+    },
+    {
+      "type": "step_result",
+      "step_id": "start",
+      "worker_id": 0,
+      "event": {
+        "__is_pydantic": true,
+        "value": {},
+        "qualified_name": "workflows.events.StartEvent"
+      },
+      "result": [
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 0
+            },
+            "qualified_name": "__main__.Item"
+          },
+          "fanned_out": true
+        },
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 1
+            },
+            "qualified_name": "__main__.Item"
+          },
+          "fanned_out": true
+        },
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 2
+            },
+            "qualified_name": "__main__.Item"
+          },
+          "fanned_out": true
+        },
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 3
+            },
+            "qualified_name": "__main__.Item"
+          },
+          "fanned_out": true
+        }
+      ],
+      "stamped_at": 1001.01
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 0
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.02
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 1
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.03
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 2
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.04
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 3
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.05
+    },
+    {
+      "type": "idle_check"
+    },
+    {
+      "type": "step_result",
+      "step_id": "work",
+      "worker_id": 0,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 0
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "result": [
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 0
+            },
+            "qualified_name": "__main__.Partial"
+          },
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.07
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 0
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.08
+    },
+    {
+      "type": "step_result",
+      "step_id": "work",
+      "worker_id": 3,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 3
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "result": [
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 6
+            },
+            "qualified_name": "__main__.Partial"
+          },
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.09
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 6
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.1
+    },
+    {
+      "type": "step_result",
+      "step_id": "collect",
+      "worker_id": 0,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 0
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "result": [
+        {
+          "type": "add_collected",
+          "event_id": "default",
+          "event": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 0
+            },
+            "qualified_name": "__main__.Partial"
+          }
+        },
+        {
+          "type": "result",
+          "result": null,
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.11
+    },
+    {
+      "type": "step_result",
+      "step_id": "collect",
+      "worker_id": 1,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 6
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "result": [
+        {
+          "type": "add_collected",
+          "event_id": "default",
+          "event": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 6
+            },
+            "qualified_name": "__main__.Partial"
+          }
+        },
+        {
+          "type": "result",
+          "result": null,
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.12
+    },
+    {
+      "type": "step_result",
+      "step_id": "work",
+      "worker_id": 2,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 2
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "result": [
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 4
+            },
+            "qualified_name": "__main__.Partial"
+          },
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.13
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 4
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.14
+    },
+    {
+      "type": "step_result",
+      "step_id": "collect",
+      "worker_id": 1,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 6
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "result": [
+        {
+          "type": "add_collected",
+          "event_id": "default",
+          "event": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 6
+            },
+            "qualified_name": "__main__.Partial"
+          }
+        },
+        {
+          "type": "result",
+          "result": null,
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.15
+    },
+    {
+      "type": "step_result",
+      "step_id": "collect",
+      "worker_id": 0,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 4
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "result": [
+        {
+          "type": "add_collected",
+          "event_id": "default",
+          "event": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 4
+            },
+            "qualified_name": "__main__.Partial"
+          }
+        },
+        {
+          "type": "result",
+          "result": null,
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.16
+    },
+    {
+      "type": "step_result",
+      "step_id": "work",
+      "worker_id": 1,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 1
+        },
+        "qualified_name": "__main__.Item"
+      },
+      "result": [
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 2
+            },
+            "qualified_name": "__main__.Partial"
+          },
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.17
+    },
+    {
+      "type": "add_event",
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 2
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "step_id": null,
+      "bound_events": null,
+      "attempts": null,
+      "first_attempt_at": null,
+      "last_exception": null,
+      "last_failed_at": null,
+      "recovery_counts": {},
+      "scope_path": [
+        "stream-b9acd2b2e403993b"
+      ],
+      "collection_release_payload": null,
+      "work_item_id": null,
+      "stamped_at": 1001.18
+    },
+    {
+      "type": "step_result",
+      "step_id": "collect",
+      "worker_id": 0,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 4
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "result": [
+        {
+          "type": "add_collected",
+          "event_id": "default",
+          "event": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 4
+            },
+            "qualified_name": "__main__.Partial"
+          }
+        },
+        {
+          "type": "result",
+          "result": null,
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.19
+    },
+    {
+      "type": "step_result",
+      "step_id": "collect",
+      "worker_id": 1,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 2
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "result": [
+        {
+          "type": "add_collected",
+          "event_id": "default",
+          "event": {
+            "__is_pydantic": true,
+            "value": {
+              "n": 2
+            },
+            "qualified_name": "__main__.Partial"
+          }
+        },
+        {
+          "type": "result",
+          "result": null,
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.2
+    },
+    {
+      "type": "step_result",
+      "step_id": "collect",
+      "worker_id": 1,
+      "event": {
+        "__is_pydantic": true,
+        "value": {
+          "n": 2
+        },
+        "qualified_name": "__main__.Partial"
+      },
+      "result": [
+        {
+          "type": "delete_collected",
+          "event_id": "default"
+        },
+        {
+          "type": "result",
+          "result": {
+            "__is_pydantic": true,
+            "value": {
+              "result": 12
+            },
+            "qualified_name": "workflows.events.StopEvent"
+          },
+          "fanned_out": false
+        }
+      ],
+      "stamped_at": 1001.21
+    }
+  ]
+}

--- a/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
+++ b/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+from workflows import Workflow, step
+from workflows.context.serializers import JsonSerializer
+from workflows.events import StartEvent, StopEvent
+from workflows.runtime.control_loop.reduce import _reduce_tick
+from workflows.runtime.types.internal_state import BrokerState
+from workflows.runtime.types.ticks import TickAddEvent, TickSessionStart
+
+
+class _AliveBudgetWorkflow(Workflow):
+    @step
+    async def start(self, ev: StartEvent) -> StopEvent:
+        return StopEvent(result="ok")
+
+
+def test_stamped_ticks_accrue_alive_budget_and_round_trip() -> None:
+    workflow = _AliveBudgetWorkflow()
+    state = BrokerState.from_workflow(workflow)
+
+    state, _ = _reduce_tick(TickSessionStart(stamped_at=10.0), state, 999.0)
+    state, _ = _reduce_tick(
+        TickAddEvent(event=StartEvent(), stamped_at=12.5), state, 999.0
+    )
+
+    assert state.elapsed_alive == 2.5
+    assert state.last_alive_stamp == 12.5
+
+    serializer = JsonSerializer()
+    serialized = state.to_serialized(serializer)
+    restored = BrokerState.from_serialized(serialized, workflow, serializer)
+
+    assert serialized.elapsed_alive == 2.5
+    assert serialized.last_alive_stamp == 12.5
+    assert restored.elapsed_alive == 2.5
+    assert restored.last_alive_stamp == 12.5
+
+
+def test_session_start_forgives_downtime_without_accruing() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state.elapsed_alive = 1.0
+    state.last_alive_stamp = 10.0
+
+    state, _ = _reduce_tick(TickSessionStart(stamped_at=100.0), state, 100.0)
+
+    assert state.elapsed_alive == 1.0
+    assert state.last_alive_stamp == 100.0
+
+    state, _ = _reduce_tick(
+        TickAddEvent(event=StartEvent(), stamped_at=101.0), state, 101.0
+    )
+
+    assert state.elapsed_alive == 2.0
+    assert state.last_alive_stamp == 101.0
+
+
+def test_legacy_unstamped_ticks_do_not_accrue_alive_budget() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+
+    state, _ = _reduce_tick(TickAddEvent(event=StartEvent()), state, 50.0)
+
+    assert state.elapsed_alive == 0.0
+    assert state.last_alive_stamp is None

--- a/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
+++ b/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
@@ -112,6 +112,21 @@ def test_timeout_tick_rearms_when_budget_is_not_spent() -> None:
     assert schedules == [CommandScheduleTimeout(timeout=5.0, at_time=15.0)]
 
 
+def test_stale_timeout_tick_rearms_from_monotonic_anchor() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state.elapsed_alive = 4.0
+    state.last_alive_stamp = 100.0
+
+    _, commands = _reduce_tick(
+        TickTimeout(timeout=10.0, stamped_at=90.0), state, 999.0
+    )
+
+    schedules = [
+        command for command in commands if isinstance(command, CommandScheduleTimeout)
+    ]
+    assert schedules == [CommandScheduleTimeout(timeout=10.0, at_time=106.0)]
+
+
 def test_legacy_unstamped_timeout_tick_halts_unconditionally() -> None:
     state = BrokerState.from_workflow(_AliveBudgetWorkflow())
 

--- a/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
+++ b/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
@@ -118,9 +118,7 @@ def test_stale_timeout_tick_rearms_from_monotonic_anchor() -> None:
     state.elapsed_alive = 4.0
     state.last_alive_stamp = 100.0
 
-    _, commands = _reduce_tick(
-        TickTimeout(timeout=10.0, stamped_at=90.0), state, 999.0
-    )
+    _, commands = _reduce_tick(TickTimeout(timeout=10.0, stamped_at=90.0), state, 999.0)
 
     schedules = [
         command for command in commands if isinstance(command, CommandScheduleTimeout)

--- a/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
+++ b/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
@@ -3,12 +3,29 @@
 
 from __future__ import annotations
 
+from typing import cast
+
+import pytest
 from workflows import Workflow, step
+from workflows.context import Context
 from workflows.context.serializers import JsonSerializer
+from workflows.errors import WorkflowTimeoutError
 from workflows.events import StartEvent, StopEvent
 from workflows.runtime.control_loop.reduce import _reduce_tick
+from workflows.runtime.control_loop.runner import _ControlLoopRunner
+from workflows.runtime.types.commands import CommandHalt, CommandScheduleTimeout
 from workflows.runtime.types.internal_state import BrokerState
-from workflows.runtime.types.ticks import TickAddEvent, TickSessionStart
+from workflows.runtime.types.step_function import as_step_worker_functions
+from workflows.runtime.types.step_id import StepId
+from workflows.runtime.types.ticks import (
+    TickAddEvent,
+    TickSessionStart,
+    TickTimeout,
+    TickWaiterTimeout,
+    TickWakeup,
+)
+
+from .conftest import MockRunAdapter
 
 
 class _AliveBudgetWorkflow(Workflow):
@@ -64,3 +81,120 @@ def test_legacy_unstamped_ticks_do_not_accrue_alive_budget() -> None:
 
     assert state.elapsed_alive == 0.0
     assert state.last_alive_stamp is None
+
+
+def test_timeout_tick_accrues_at_fire_and_halts_when_budget_is_spent() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state, _ = _reduce_tick(TickSessionStart(stamped_at=10.0), state, 999.0)
+
+    state, commands = _reduce_tick(
+        TickTimeout(timeout=5.0, stamped_at=15.0), state, 999.0
+    )
+
+    assert state.elapsed_alive == 5.0
+    assert state.last_alive_stamp == 15.0
+    assert any(isinstance(command, CommandHalt) for command in commands)
+
+
+def test_timeout_tick_rearms_when_budget_is_not_spent() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state, _ = _reduce_tick(TickSessionStart(stamped_at=10.0), state, 999.0)
+
+    state, commands = _reduce_tick(
+        TickTimeout(timeout=5.0, stamped_at=13.0), state, 999.0
+    )
+
+    assert state.elapsed_alive == 3.0
+    assert not any(isinstance(command, CommandHalt) for command in commands)
+    schedules = [
+        command for command in commands if isinstance(command, CommandScheduleTimeout)
+    ]
+    assert schedules == [CommandScheduleTimeout(timeout=5.0, at_time=15.0)]
+
+
+def test_legacy_unstamped_timeout_tick_halts_unconditionally() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+
+    _, commands = _reduce_tick(TickTimeout(timeout=5.0), state, 1.0)
+
+    assert any(isinstance(command, CommandHalt) for command in commands)
+
+
+@pytest.mark.asyncio
+async def test_resume_with_exhausted_budget_halts_before_running_step() -> None:
+    calls: list[str] = []
+
+    class CountingWorkflow(Workflow):
+        @step
+        async def start(self, ev: StartEvent) -> StopEvent:
+            calls.append("start")
+            return StopEvent(result="ok")
+
+    workflow = CountingWorkflow(timeout=5.0)
+    state = BrokerState.from_workflow(workflow)
+    state.elapsed_alive = 5.0
+    adapter = MockRunAdapter(run_id="test")
+    runner = _ControlLoopRunner(
+        workflow,
+        adapter,
+        cast(Context, object()),
+        as_step_worker_functions(workflow),
+        state,
+    )
+
+    with pytest.raises(WorkflowTimeoutError):
+        await runner.run(start_event=StartEvent())
+
+    assert calls == []
+    assert not any(isinstance(tick, TickAddEvent) for tick in adapter.replay())
+
+
+def test_clock_regression_does_not_move_accrual_anchor_backwards() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state, _ = _reduce_tick(TickSessionStart(stamped_at=100.0), state, 999.0)
+    state, _ = _reduce_tick(
+        TickAddEvent(event=StartEvent(), stamped_at=90.0), state, 999.0
+    )
+    state, _ = _reduce_tick(
+        TickAddEvent(event=StartEvent(), stamped_at=101.0), state, 999.0
+    )
+
+    assert state.elapsed_alive == 1.0
+    assert state.last_alive_stamp == 101.0
+
+
+def test_namespaced_tick_accrues_root_to_leaf_descent_chain() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state.children["nested"] = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state, _ = _reduce_tick(TickSessionStart(stamped_at=10.0), state, 999.0)
+
+    state, _ = _reduce_tick(
+        TickAddEvent(
+            event=StartEvent(),
+            origin_namespace=("nested",),
+            stamped_at=12.0,
+        ),
+        state,
+        999.0,
+    )
+
+    assert state.elapsed_alive == 2.0
+    assert state.children["nested"].elapsed_alive == 2.0
+
+
+def test_wakeup_and_waiter_timeout_ticks_accrue_alive_budget() -> None:
+    state = BrokerState.from_workflow(_AliveBudgetWorkflow())
+    state, _ = _reduce_tick(TickSessionStart(stamped_at=10.0), state, 999.0)
+    state, _ = _reduce_tick(TickWakeup(due=11.0, stamped_at=11.0), state, 999.0)
+    state, _ = _reduce_tick(
+        TickWaiterTimeout(
+            step_id=StepId.root("start"),
+            waiter_id="missing",
+            stamped_at=12.0,
+        ),
+        state,
+        999.0,
+    )
+
+    assert state.elapsed_alive == 2.0
+    assert state.last_alive_stamp == 12.0

--- a/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
+++ b/packages/llama-index-workflows/tests/runtime/test_alive_timeout.py
@@ -15,6 +15,7 @@ from workflows.runtime.control_loop.reduce import _reduce_tick
 from workflows.runtime.control_loop.runner import _ControlLoopRunner
 from workflows.runtime.types.commands import CommandHalt, CommandScheduleTimeout
 from workflows.runtime.types.internal_state import BrokerState
+from workflows.runtime.types.results import StepWorkerWaiter
 from workflows.runtime.types.step_function import as_step_worker_functions
 from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
@@ -148,6 +149,17 @@ async def test_resume_with_exhausted_budget_halts_before_running_step() -> None:
     workflow = CountingWorkflow(timeout=5.0)
     state = BrokerState.from_workflow(workflow)
     state.elapsed_alive = 5.0
+    state.workers[StepId.root("start")].collected_waiters.append(
+        StepWorkerWaiter(
+            waiter_id="rehydrated-waiter",
+            event=StartEvent(),
+            waiting_for_event=StopEvent,
+            requirements={},
+            has_requirements=True,
+            resolved_event=None,
+        )
+    )
+    assert any(isinstance(tick, TickAddEvent) for tick in state.rehydrate_with_ticks())
     adapter = MockRunAdapter(run_id="test")
     runner = _ControlLoopRunner(
         workflow,
@@ -158,7 +170,7 @@ async def test_resume_with_exhausted_budget_halts_before_running_step() -> None:
     )
 
     with pytest.raises(WorkflowTimeoutError):
-        await runner.run(start_event=StartEvent())
+        await runner.run()
 
     assert calls == []
     assert not any(isinstance(tick, TickAddEvent) for tick in adapter.replay())

--- a/packages/llama-index-workflows/tests/runtime/test_control_loop.py
+++ b/packages/llama-index-workflows/tests/runtime/test_control_loop.py
@@ -44,7 +44,12 @@ from workflows.retry_policy import (
 )
 from workflows.runtime.control_loop.runner import _ControlLoopRunner, control_loop
 from workflows.runtime.types.internal_state import BrokerState
-from workflows.runtime.types.plugin import RunContext, run_context
+from workflows.runtime.types.named_task import NamedTask, PendingStart
+from workflows.runtime.types.plugin import (
+    RunContext,
+    WaitForNextTaskResult,
+    run_context,
+)
 from workflows.runtime.types.step_function import as_step_worker_function
 from workflows.runtime.types.step_id import StepId
 from workflows.runtime.types.ticks import (
@@ -218,6 +223,45 @@ async def wait_for_stop_event(
                 return None
     except Exception:
         return None
+
+
+@pytest.mark.asyncio
+async def test_scheduled_timeout_is_not_starved_by_completed_workers() -> None:
+    class LoopEvent(Event):
+        pass
+
+    class BusyWorkflow(Workflow):
+        @step
+        async def loop(self, ev: StartEvent | LoopEvent) -> LoopEvent | StopEvent:
+            return LoopEvent()
+
+    class TimeAdvancingAdapter(MockRunAdapter):
+        completed_tasks = 0
+
+        async def wait_for_next_task(
+            self,
+            running: list[NamedTask],
+            pending: list[PendingStart],
+            timeout: float | None = None,
+        ) -> WaitForNextTaskResult:
+            result = await super().wait_for_next_task(running, pending, timeout)
+            if result.completed is not None:
+                self.completed_tasks += 1
+                self.advance_time(1.0)
+            return result
+
+    adapter = TimeAdvancingAdapter(run_id="test")
+    with pytest.raises(WorkflowTimeoutError):
+        await asyncio.wait_for(
+            run_control_loop(
+                workflow=BusyWorkflow(timeout=3.0),
+                start_event=StartEvent(),
+                test_runtime=adapter,
+            ),
+            timeout=1.0,
+        )
+
+    assert adapter.completed_tasks >= 3
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
+++ b/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
@@ -33,6 +33,7 @@ from workflows.runtime.types.ticks import (
     TickAddEvent,
     TickCancelRun,
     TickPublishEvent,
+    TickSessionStart,
     TickStepResult,
     TickTimeout,
     TickWaiterTimeout,
@@ -166,6 +167,10 @@ def test_event_type_roundtrip() -> None:
             id="cancel_run",
         ),
         pytest.param(
+            TickSessionStart(stamped_at=1234567890.0),
+            id="session_start",
+        ),
+        pytest.param(
             TickTimeout(timeout=30.5),
             id="timeout",
         ),
@@ -178,6 +183,7 @@ def test_event_type_roundtrip() -> None:
                 step_id=StepId.root("process"),
                 worker_id=42,
                 event=MyEvent(value="trigger"),
+                stamped_at=1234567890.0,
                 result=[StepWorkerResult(result=StopEvent(result="done"))],
             ),
             id="step_result_with_event",
@@ -327,6 +333,7 @@ def test_workflow_tick_discriminated_union_roundtrip() -> None:
         TickAddEvent(event=StartEvent(), step_id=StepId.root("s")),
         TickPublishEvent(event=MyEvent(value="x")),
         TickCancelRun(),
+        TickSessionStart(stamped_at=123.0),
         TickTimeout(timeout=10.0),
         TickStepResult(
             step_id=StepId.root("s"),

--- a/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
+++ b/packages/llama-index-workflows/tests/runtime/test_tick_serialization.py
@@ -155,6 +155,7 @@ def test_event_type_roundtrip() -> None:
                 step_id=StepId.root("my_step"),
                 attempts=3,
                 first_attempt_at=1234567890.0,
+                stamped_at=1234567891.0,
             ),
             id="add_event",
         ),
@@ -171,12 +172,20 @@ def test_event_type_roundtrip() -> None:
             id="session_start",
         ),
         pytest.param(
-            TickTimeout(timeout=30.5),
+            TickTimeout(timeout=30.5, stamped_at=1234567892.0),
             id="timeout",
         ),
         pytest.param(
-            TickWakeup(due=12345.5),
+            TickWakeup(due=12345.5, stamped_at=1234567893.0),
             id="wakeup",
+        ),
+        pytest.param(
+            TickWaiterTimeout(
+                step_id=StepId.root("waiter"),
+                waiter_id="w-1",
+                stamped_at=1234567894.0,
+            ),
+            id="waiter_timeout",
         ),
         pytest.param(
             TickStepResult(

--- a/packages/llama-index-workflows/tests/test_golden_serialization_fixtures.py
+++ b/packages/llama-index-workflows/tests/test_golden_serialization_fixtures.py
@@ -100,6 +100,10 @@ def test_golden_journal_replays_from_canonical_state() -> None:
 
     assert result is not None
     assert result.result == journal["result"]
+    # Legacy fallback: the pre-child journal has no stamps or session markers, so
+    # the elapsed-alive budget never accrues and no spurious timeout can fire.
+    assert state.elapsed_alive == 0.0
+    assert state.last_alive_stamp is None
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/test_golden_serialization_fixtures.py
+++ b/packages/llama-index-workflows/tests/test_golden_serialization_fixtures.py
@@ -24,7 +24,11 @@ from workflows.events import Event, HumanResponseEvent, StartEvent, StopEvent
 from workflows.runtime.control_loop.reduce import _reduce_tick, rewind_in_progress
 from workflows.runtime.types.commands import CommandCompleteRun
 from workflows.runtime.types.internal_state import BrokerState
-from workflows.runtime.types.ticks import WorkflowTickAdapter
+from workflows.runtime.types.ticks import (
+    STAMPED_TICK_TYPES,
+    TickSessionStart,
+    WorkflowTickAdapter,
+)
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "golden_serialization"
 
@@ -104,6 +108,30 @@ def test_golden_journal_replays_from_canonical_state() -> None:
     # the elapsed-alive budget never accrues and no spurious timeout can fire.
     assert state.elapsed_alive == 0.0
     assert state.last_alive_stamp is None
+
+
+def test_current_golden_journal_replays_with_stamped_ticks() -> None:
+    journal = _load("current_journal.json")
+    ticks = [WorkflowTickAdapter.validate_python(t) for t in journal["ticks"]]
+
+    assert isinstance(ticks[0], TickSessionStart)
+    stamped_ticks = [tick for tick in ticks if isinstance(tick, STAMPED_TICK_TYPES)]
+    assert stamped_ticks
+    assert all(tick.stamped_at is not None for tick in stamped_ticks)
+
+    state = BrokerState.from_workflow(GoldenJournalWorkflow())
+    state, _ = rewind_in_progress(state, time.time())
+    result: Any = None
+    for tick in ticks:
+        state, commands = _reduce_tick(tick, state, time.time())
+        for command in commands:
+            if isinstance(command, CommandCompleteRun):
+                result = command.result
+
+    assert result is not None
+    assert result.result == journal["result"]
+    assert state.elapsed_alive > 0.0
+    assert state.last_alive_stamp is not None
 
 
 @pytest.mark.asyncio

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -141,7 +141,14 @@ async def test_workflow_step_send_event_to_None() -> None:
 
     assert isinstance(result.ctx._face, ExternalContext)
     replay = result.ctx._face._tick_log
-    assert TickAddEvent(event=OneTestEvent()) in replay
+    # stamped_at is the journaled live-run clock; normalize it away to compare
+    # the semantic tick contents.
+    add_events = [
+        t.model_copy(update={"stamped_at": None})
+        for t in replay
+        if isinstance(t, TickAddEvent)
+    ]
+    assert TickAddEvent(event=OneTestEvent()) in add_events
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
A workflow's timeout clock restarts from zero on every resume. The runner schedules `TickTimeout` a full `timeout` seconds out each time a run starts or resumes, so a run that repeatedly suspends and resumes never times out, no matter how much execution time it has accumulated. Charging the wall-clock gap instead isn't right either, since a run suspended across a week of downtime shouldn't have that week counted against it.

The timeout now measures accumulated alive time. Ticks are stamped with the live run's clock before they are journaled, so a replay reads the same time the live run read. The reducer accrues the gap between stamps into each broker's `elapsed_alive`, and a `session_start` marker journaled at every `run()` and resume advances the accrual anchor without accruing, so time between sessions never enters the budget. The ticks that accrue are:

- step results
- add-event
- wakeups
- waiter timeouts
- the timeout tick itself, at fire time

Resume schedules the timeout from the remaining budget (`timeout - elapsed_alive`). If the budget is already spent at resume, the run times out before any rehydrated work executes. The accrued budget is authoritative at fire time. The reducer accrues up to the timeout tick's stamp, times out the run if the budget is spent, and re-arms for the remainder if the scheduler fired early relative to the accrued time.

A due timeout can also no longer be starved. The runner drains due scheduled ticks on every loop iteration, so a continuous stream of completing tasks can't keep a fired timeout sitting behind the buffer.

On compatibility: old journals carry no stamps and no session marker, so they replay with an empty budget and never fire a spurious timeout. New journals lead with a `session_start` tick, so a build that predates it can't read them. Time spent inside a step that crashed before delivering its result is refunded on resume, so the budget undercounts rather than overcharges, which is deliberate. A golden fixture pins the current journal shape and the legacy fixtures are untouched.

The behavior change is a minor bump in the changeset: a run that previously dodged its timeout by resuming now times out once its accumulated alive time spends the budget.

Stacked on #725.
