### PR TITLE
Enforce workflow concurrency through DBOS worker queues

### DIFF
--- a/.changeset/calm-queues-wait.md
+++ b/.changeset/calm-queues-wait.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-dbos": minor
+---
+
+Route workflow runs through stable DBOS queues and enforce per-worker concurrency limits.

--- a/.changeset/calm-queues-wait.md
+++ b/.changeset/calm-queues-wait.md
@@ -2,4 +2,4 @@
 "llama-agents-dbos": minor
 ---
 
-Route workflow runs through stable DBOS queues and enforce per-worker concurrency limits.
+Enforce `num_concurrent_runs` on `DBOSRuntime` as per-worker DBOS queue concurrency. Workflows without a limit keep starting directly.

--- a/.changeset/valid-workflows-run.md
+++ b/.changeset/valid-workflows-run.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Reject invalid workflow concurrency limits during construction.

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -8,6 +8,53 @@ Workflows can run steps at the same time. When several steps are independent and
 
 The usual pattern is fan-out and fan-in. You split the work into pieces, run them at the same time, then join the results back together. You write this directly in the step signatures. Return a `list` from a step and it fans out, with one event per element. Take a `list` parameter and it fans in, firing once on the whole batch. The `@step` decorator reads those types. The validator and the [visualization](/python/llamaagents/workflows/drawing) then connect each producer step to the steps that consume its events, with no extra work from you. When you need to emit events that do not follow from the signature, you can send them yourself with `ctx.send_event`. The [dynamic API](#the-dynamic-api) at the end of this page covers that.
 
+## Limit simultaneous workflow runs
+
+Whole-run concurrency and step concurrency are separate. Set
+`num_concurrent_runs` on a workflow to limit how many calls to `run()` may be
+active at once:
+
+```python
+workflow = ParallelFlow(num_concurrent_runs=4)
+```
+
+The value must be a positive integer or `None`. The default is `None`, which
+allows unlimited runs. With the default runtime, the limit applies to one
+workflow instance in one Python process. Additional calls wait until an active
+run finishes.
+
+With `DBOSRuntime`, every run goes through a stable DBOS queue and
+`num_concurrent_runs` sets that queue's concurrency for each worker. For
+example, `num_concurrent_runs=4` with three live workers allows roughly 12
+active runs across the deployment. `None` leaves each worker unlimited.
+
+Changing between a positive limit and `None` keeps the same queue, so queued
+work is not stranded. Set an explicit, stable `workflow_name` if a workflow's
+Python module or class may be renamed. The name identifies its DBOS queue and
+durable registrations:
+
+```python
+from llama_agents.dbos import DBOSRuntime
+
+runtime = DBOSRuntime()
+workflow = ParallelFlow(
+    runtime=runtime,
+    workflow_name="document-processing.v1",
+    num_concurrent_runs=4,
+)
+```
+
+During the first rollout from direct DBOS starts to queued starts, runs started
+by the old code may finish alongside the newly limited runs. The deployment can
+therefore exceed the new limit temporarily. Let the old workers and their
+active runs drain before treating the limit as strict. See
+[DBOS-backed workflows](/python/llamaagents/workflows/dbos) for durable naming,
+scaling, and deployment guidance.
+
+Use `@step(num_workers=...)` for concurrency inside each run. It controls how
+many copies of that step can process events at once and does not limit the
+number of workflow runs.
+
 ## Fan-out: return a list
 
 Return a `list` from a step and each element fires as its own event. Here five `Task`s run concurrently under `work`:

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -50,8 +50,7 @@ class Fetcher(Workflow):
 
 Every run shares the one semaphore, so at most three `fetch` steps are in the
 API call at any moment, whichever runs they belong to. The semaphore lives in
-one Python process. Under a multi-replica DBOS deployment each replica has its
-own, so the effective cap is the value times the number of replicas.
+one Python process. If you deploy multiple processes, each has its own.
 
 ## Fan-out: return a list
 

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -28,6 +28,31 @@ Use `@step(num_workers=...)` for concurrency inside each run. It controls how
 many copies of that step can process events at once and does not limit the
 number of workflow runs.
 
+## Limit active steps across runs
+
+To limit how many copies of a step run at once across all runs, for example to
+cap concurrent calls to an external API, share an `asyncio.Semaphore` between
+them. Steps are plain async functions, so this needs no library support:
+
+```python
+import asyncio
+
+API_SLOTS = asyncio.Semaphore(3)
+
+
+class Fetcher(Workflow):
+    @step
+    async def fetch(self, ev: FetchRequest) -> FetchResult:
+        async with API_SLOTS:
+            data = await call_external_api(ev.url)
+        return FetchResult(data=data)
+```
+
+Every run shares the one semaphore, so at most three `fetch` steps are in the
+API call at any moment, whichever runs they belong to. The semaphore lives in
+one Python process. Under a multi-replica DBOS deployment each replica has its
+own, so the effective cap is the value times the number of replicas.
+
 ## Fan-out: return a list
 
 Return a `list` from a step and each element fires as its own event. Here five `Task`s run concurrently under `work`:

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -19,17 +19,10 @@ workflow = ParallelFlow(num_concurrent_runs=4)
 ```
 
 The value must be a positive integer or `None`. The default is `None`, which
-allows unlimited runs. With the default runtime, the limit applies to one
-workflow instance in one Python process. Additional calls wait until an active
-run finishes.
-
-With `DBOSRuntime`, the limit applies to each worker. `num_concurrent_runs=4`
-with three live workers allows roughly 12 active runs across the deployment.
-Runs beyond the limit wait in a DBOS queue and start within about a second of
-a slot opening. Leaving the value unset keeps runs starting directly, with no
-queue in the path. See
-[DBOS-backed workflows](/python/llamaagents/workflows/dbos) for durable naming,
-scaling, and deployment guidance.
+allows unlimited runs. The limit restricts concurrency within a process:
+additional calls wait until an active run finishes.
+[DBOS-backed workflows](/python/llamaagents/workflows/dbos#run-concurrency-limits)
+also support it, applied per worker.
 
 Use `@step(num_workers=...)` for concurrency inside each run. It controls how
 many copies of that step can process events at once and does not limit the

--- a/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
+++ b/docs/src/content/docs/llamaagents/workflows/concurrent_execution.md
@@ -23,31 +23,11 @@ allows unlimited runs. With the default runtime, the limit applies to one
 workflow instance in one Python process. Additional calls wait until an active
 run finishes.
 
-With `DBOSRuntime`, every run goes through a stable DBOS queue and
-`num_concurrent_runs` sets that queue's concurrency for each worker. For
-example, `num_concurrent_runs=4` with three live workers allows roughly 12
-active runs across the deployment. `None` leaves each worker unlimited.
-
-Changing between a positive limit and `None` keeps the same queue, so queued
-work is not stranded. Set an explicit, stable `workflow_name` if a workflow's
-Python module or class may be renamed. The name identifies its DBOS queue and
-durable registrations:
-
-```python
-from llama_agents.dbos import DBOSRuntime
-
-runtime = DBOSRuntime()
-workflow = ParallelFlow(
-    runtime=runtime,
-    workflow_name="document-processing.v1",
-    num_concurrent_runs=4,
-)
-```
-
-During the first rollout from direct DBOS starts to queued starts, runs started
-by the old code may finish alongside the newly limited runs. The deployment can
-therefore exceed the new limit temporarily. Let the old workers and their
-active runs drain before treating the limit as strict. See
+With `DBOSRuntime`, the limit applies to each worker. `num_concurrent_runs=4`
+with three live workers allows roughly 12 active runs across the deployment.
+Runs beyond the limit wait in a DBOS queue and start within about a second of
+a slot opening. Leaving the value unset keeps runs starting directly, with no
+queue in the path. See
 [DBOS-backed workflows](/python/llamaagents/workflows/dbos) for durable naming,
 scaling, and deployment guidance.
 

--- a/docs/src/content/docs/llamaagents/workflows/dbos.md
+++ b/docs/src/content/docs/llamaagents/workflows/dbos.md
@@ -231,6 +231,22 @@ For production multi-replica deployments, [DBOS Conductor](https://docs.dbos.dev
 
 Understanding the DBOS execution model helps you write workflows that behave correctly across restarts and replicas.
 
+### Workflow identity
+
+A workflow's name is its durable identity. Journal entries, step registrations, and the admission queue are all keyed by it, so everything DBOS has recorded for a workflow is filed under that name. The default is the module-qualified class name (e.g. `my_app.CounterWorkflow`), which means moving or renaming the class silently changes the identity. For anything long-lived, set the name explicitly and treat it as permanent:
+
+```python
+wf = CounterWorkflow(runtime=runtime, workflow_name="counter-v1")
+```
+
+A worker only looks for recorded work under the names it registers. After a rename, in-flight and queued runs filed under the old name are invisible to the new deployment — keep workers registering the old name running until that work finishes.
+
+When using a server, the name passed to `add_workflow` is the HTTP route name, independent of the workflow's durable name:
+
+```python
+server.add_workflow("counter", CounterWorkflow(runtime=runtime, workflow_name="counter-v1"))
+```
+
 ### Replica ownership
 
 Each replica is identified by its `executor_id` and **owns** every workflow it starts. A workflow and all of its steps run in the same process — there is no distribution of individual steps across replicas. This means your steps can safely rely on local state like in-memory caches, local files, or process-level singletons. The trade-off is that a single workflow's workload cannot be spread across multiple replicas.
@@ -251,19 +267,7 @@ Replica IDs and replica counts must be stable. If you scale down and remove a re
 
 Since resumption is based on journal replay, changing a workflow's code while historical runs are still in progress can cause non-determinism — for example, a step that now accepts a different set of events than when the run was originally started. To avoid this:
 - **Drain in-flight workflows** before deploying code changes, or
-- **Register the updated workflow under a new name** so that old runs continue against the original code and new runs use the updated version
-
-A workflow's name defaults to its module-qualified class name (e.g. `my_app.CounterWorkflow`). You can set it explicitly with the `workflow_name` parameter:
-
-```python
-wf = CounterWorkflow(runtime=runtime, workflow_name="counter-v2")
-```
-
-When using a server, the name passed to `add_workflow` is the HTTP route name, independent of the workflow's internal name:
-
-```python
-server.add_workflow("counter-v2", CounterWorkflow(runtime=runtime, workflow_name="counter-v2"))
-```
+- **Register the updated workflow under a new name** (e.g. `workflow_name="counter-v2"`) so that old runs continue against the original code and new runs use the updated version. This is a deliberate identity change — see [Workflow identity](#workflow-identity) for what the name keys.
 
 ### Run concurrency limits
 
@@ -278,6 +282,22 @@ queue in the path.
 ```python
 wf = CounterWorkflow(runtime=runtime, num_concurrent_runs=4)
 ```
+
+The queue is keyed by the workflow's durable name (see
+[Workflow identity](#workflow-identity)), so runs waiting under an old name
+are invisible after a rename. Changing or removing the limit itself is safe:
+waiting runs stay on the same queue and keep admitting. A new limit does not
+count runs that started before it, so a replica can briefly exceed it while
+those finish.
+
+A waiting run cannot be cancelled until it starts, because cancellation is a
+message delivered to the running workflow. The request is saved, and the run
+stops itself as soon as it is admitted.
+
+DBOS normally watches every queue automatically. An application that instead
+passes an explicit list to `DBOS.listen_queues` must add this runtime's
+queues to it (`runtime.workflow_queues`), collected after registering
+workflows and before launch.
 
 ### Event streaming behavior
 

--- a/docs/src/content/docs/llamaagents/workflows/dbos.md
+++ b/docs/src/content/docs/llamaagents/workflows/dbos.md
@@ -265,6 +265,20 @@ When using a server, the name passed to `add_workflow` is the HTTP route name, i
 server.add_workflow("counter-v2", CounterWorkflow(runtime=runtime, workflow_name="counter-v2"))
 ```
 
+### Run concurrency limits
+
+`Workflow(num_concurrent_runs=N)` limits active runs of that workflow to N per
+replica, so deployment capacity is roughly N times the number of replicas.
+Runs beyond the limit wait in a DBOS queue and start within about a second of
+a slot opening. The queue is shared across replicas: a waiting run has no
+affinity to the replica that submitted it, and any replica with a free slot
+can pick it up. Leaving the value unset keeps runs starting directly, with no
+queue in the path.
+
+```python
+wf = CounterWorkflow(runtime=runtime, num_concurrent_runs=4)
+```
+
 ### Event streaming behavior
 
 When using `handler.stream_events()` in-process (outside of a server), DBOS streams are replayed from the beginning on each call. This means you will receive all events the workflow has ever emitted, not just new ones.

--- a/packages/llama-agents-dbos/ARCHITECTURE.md
+++ b/packages/llama-agents-dbos/ARCHITECTURE.md
@@ -18,8 +18,9 @@ The `executor_id` model means horizontal scaling works by adding replicas that e
 
 ## Workflow Admission Queues
 
-`DBOSRuntime` owns one stable DBOS queue for each workflow name at registration.
-A later WorkflowServer route alias keeps that queue and its DBOS registration.
+`DBOSRuntime` owns one stable DBOS queue for each workflow name captured when
+the workflow first enters the runtime. WorkflowServer route aliases keep that
+queue and its DBOS registration.
 Every run is enqueued, including workflows with no configured limit. A workflow's
 `num_concurrent_runs` value becomes the queue's `worker_concurrency`:
 
@@ -36,14 +37,26 @@ the new limit until runs started by the previous revision finish.
 DBOS associates queued runs with an application version. A deployment that
 changes that version must keep old-version workers available until their queue
 has drained. A new application version does not take ownership of those runs.
+The default durable name includes the workflow's Python module and class name.
+Applications that may rename either should set an explicit `workflow_name` and
+treat it as a durable identifier. Changing it also changes DBOS's control-loop
+and step registration names, so a queue alias alone cannot migrate old work.
 
-The runtime registers queues before `DBOS.launch()` and checks restricted
-`DBOS.listen_queues` configurations. Admission normally takes about the
-configured `polling_interval_sec`, but DBOS can back off longer while queues
-are idle. Queue objects stay owned by the live runtime. A later runtime can
-reuse their reserved names only after the owner destroys DBOS. Calling
-`runtime.destroy(destroy_dbos=False)` keeps that ownership because the
-application still owns the DBOS lifecycle.
+The runtime declares queues through DBOS's public `Queue` API before
+`DBOS.launch()`. Matching declarations reuse the same process-global queue.
+Conflicting declarations from live runtimes fail, while a later runtime can
+change the local limit after the owner destroys DBOS. Calling
+`runtime.destroy(destroy_dbos=False)` keeps that declaration active because
+the application still owns the DBOS lifecycle. The adapter does not inspect or
+mutate DBOS's private queue registry.
+
+Applications that restrict `DBOS.listen_queues` must include
+`runtime.workflow_queues`; DBOS does not expose that listener selection for
+validation. The default listener discovers late queue declarations, but an
+explicit listener list does not. Applications using one must register all
+workflows and collect their queues before launch. Admission normally takes
+about the configured `polling_interval_sec`, but DBOS can back off longer while
+queues are idle.
 
 Cancellation uses `TickCancelRun` instead of DBOS hard cancellation. An
 `ENQUEUED` run therefore waits for admission before it processes cancellation,

--- a/packages/llama-agents-dbos/ARCHITECTURE.md
+++ b/packages/llama-agents-dbos/ARCHITECTURE.md
@@ -18,50 +18,29 @@ The `executor_id` model means horizontal scaling works by adding replicas that e
 
 ## Workflow Admission Queues
 
-`DBOSRuntime` owns one stable DBOS queue for each workflow name captured when
-the workflow first enters the runtime. WorkflowServer route aliases keep that
-queue and its DBOS registration.
-Every run is enqueued, including workflows with no configured limit. A workflow's
-`num_concurrent_runs` value becomes the queue's `worker_concurrency`:
+`DBOSRuntime.register()` declares one DBOS queue per workflow, named
+`_llamaindex_workflow_queue:<workflow_name>`, with `worker_concurrency` taken
+from the workflow's `num_concurrent_runs`. Workflows with a limit submit runs
+through the queue. Workflows without one start directly and never touch it.
+The queue is declared either way, so removing a limit still leaves a listener
+for rows that were `ENQUEUED` under the old one.
 
-- `None` is the default and does not impose an admission limit.
-- A positive integer limits active runs on each DBOS worker.
+Queue declarations live in a process-level map because DBOS's own registry
+survives `DBOS.destroy()` and rejects redeclaring a name. Recreating the
+runtime reuses the existing queue object and updates its `worker_concurrency`
+in place, which DBOS's poller reads live on every tick.
 
-The queue name does not depend on the limit. Turning a limit on, changing it,
-or returning to unlimited operation does not strand queued work. During a
-rolling deployment, workers in the same DBOS application version can briefly
-enforce different limits. Total capacity is the sum of the limits on all live
-workers. The first rollout from direct starts to queues can temporarily exceed
-the new limit until runs started by the previous revision finish.
+DBOS stamps every run with an application version and only dequeues or
+recovers runs whose version matches. Under this adapter the version is stable
+across changes to workflow step code, because every workflow registers the
+same control-loop wrapper. It shifts when a workflow is added or removed, or
+when the `dbos` or `llama-agents-dbos` package changes. After such a
+deployment, keep old workers running until their in-flight and enqueued runs
+drain.
 
-DBOS associates queued runs with an application version. A deployment that
-changes that version must keep old-version workers available until their queue
-has drained. A new application version does not take ownership of those runs.
-The default durable name includes the workflow's Python module and class name.
-Applications that may rename either should set an explicit `workflow_name` and
-treat it as a durable identifier. Changing it also changes DBOS's control-loop
-and step registration names, so a queue alias alone cannot migrate old work.
-
-The runtime declares queues through DBOS's public `Queue` API before
-`DBOS.launch()`. Matching declarations reuse the same process-global queue.
-Conflicting declarations from live runtimes fail, while a later runtime can
-change the local limit after the owner destroys DBOS. Calling
-`runtime.destroy(destroy_dbos=False)` keeps that declaration active because
-the application still owns the DBOS lifecycle. The adapter does not inspect or
-mutate DBOS's private queue registry.
-
-Applications that restrict `DBOS.listen_queues` must include
-`runtime.workflow_queues`; DBOS does not expose that listener selection for
-validation. The default listener discovers late queue declarations, but an
-explicit listener list does not. Applications using one must register all
-workflows and collect their queues before launch. Admission normally takes
-about the configured `polling_interval_sec`, but DBOS can back off longer while
-queues are idle.
-
-Cancellation uses `TickCancelRun` instead of DBOS hard cancellation. An
-`ENQUEUED` run therefore waits for admission before it processes cancellation,
-publishes `WorkflowCancelledEvent`, and lets server persistence record the
-terminal event.
+Cancellation uses `TickCancelRun` instead of DBOS hard cancellation, so an
+`ENQUEUED` run processes the cancellation after admission and publishes
+`WorkflowCancelledEvent` on its way out.
 
 ## Process Layout
 

--- a/packages/llama-agents-dbos/ARCHITECTURE.md
+++ b/packages/llama-agents-dbos/ARCHITECTURE.md
@@ -25,22 +25,26 @@ through the queue. Workflows without one start directly and never touch it.
 The queue is declared either way, so removing a limit still leaves a listener
 for rows that were `ENQUEUED` under the old one.
 
-Queue declarations live in a process-level map because DBOS's own registry
-survives `DBOS.destroy()` and rejects redeclaring a name. Recreating the
-runtime reuses the existing queue object and updates its `worker_concurrency`
-in place, which DBOS's poller reads live on every tick.
+DBOS remembers every queue ever declared in the process, even after
+`DBOS.destroy()`, and declaring the same name twice raises. So the adapter
+keeps its own module-level dict of queue objects. A recreated runtime reuses
+the existing object and just changes `worker_concurrency` on it, which DBOS
+reads fresh on every poll.
 
-DBOS stamps every run with an application version and only dequeues or
-recovers runs whose version matches. Under this adapter the version is stable
-across changes to workflow step code, because every workflow registers the
-same control-loop wrapper. It shifts when a workflow is added or removed, or
-when the `dbos` or `llama-agents-dbos` package changes. After such a
-deployment, keep old workers running until their in-flight and enqueued runs
-drain.
+DBOS tags every run with an application version, a fingerprint of the
+registered workflow functions, and a worker only picks up runs whose
+fingerprint matches its own. This protects a run from being resumed by code
+that changed under it. Under this adapter every workflow registers the same
+control-loop wrapper, so the fingerprint does not change when users edit
+their step code. It does change when a workflow is added or removed, or when
+the `dbos` or `llama-agents-dbos` package changes. After such a deployment,
+runs tagged with the old fingerprint can only be finished by workers running
+the old code, so keep those workers up until that work drains.
 
-Cancellation uses `TickCancelRun` instead of DBOS hard cancellation, so an
-`ENQUEUED` run processes the cancellation after admission and publishes
-`WorkflowCancelledEvent` on its way out.
+Cancellation uses `TickCancelRun` instead of DBOS hard cancellation. A run
+still waiting in the queue cannot process it yet; the request is saved, and
+the run publishes `WorkflowCancelledEvent` and stops as soon as it is
+admitted.
 
 ## Process Layout
 

--- a/packages/llama-agents-dbos/ARCHITECTURE.md
+++ b/packages/llama-agents-dbos/ARCHITECTURE.md
@@ -16,6 +16,40 @@ Each DBOS replica is configured with a unique `executor_id` (e.g. `"replica-8001
 
 The `executor_id` model means horizontal scaling works by adding replicas that each own a slice of the workload, not by distributing individual workflow steps across nodes.
 
+## Workflow Admission Queues
+
+`DBOSRuntime` owns one stable DBOS queue for each workflow name at registration.
+A later WorkflowServer route alias keeps that queue and its DBOS registration.
+Every run is enqueued, including workflows with no configured limit. A workflow's
+`num_concurrent_runs` value becomes the queue's `worker_concurrency`:
+
+- `None` is the default and does not impose an admission limit.
+- A positive integer limits active runs on each DBOS worker.
+
+The queue name does not depend on the limit. Turning a limit on, changing it,
+or returning to unlimited operation does not strand queued work. During a
+rolling deployment, workers in the same DBOS application version can briefly
+enforce different limits. Total capacity is the sum of the limits on all live
+workers. The first rollout from direct starts to queues can temporarily exceed
+the new limit until runs started by the previous revision finish.
+
+DBOS associates queued runs with an application version. A deployment that
+changes that version must keep old-version workers available until their queue
+has drained. A new application version does not take ownership of those runs.
+
+The runtime registers queues before `DBOS.launch()` and checks restricted
+`DBOS.listen_queues` configurations. Admission normally takes about the
+configured `polling_interval_sec`, but DBOS can back off longer while queues
+are idle. Queue objects stay owned by the live runtime. A later runtime can
+reuse their reserved names only after the owner destroys DBOS. Calling
+`runtime.destroy(destroy_dbos=False)` keeps that ownership because the
+application still owns the DBOS lifecycle.
+
+Cancellation uses `TickCancelRun` instead of DBOS hard cancellation. An
+`ENQUEUED` run therefore waits for admission before it processes cancellation,
+publishes `WorkflowCancelledEvent`, and lets server persistence record the
+terminal event.
+
 ## Process Layout
 
 ```

--- a/packages/llama-agents-dbos/README.md
+++ b/packages/llama-agents-dbos/README.md
@@ -45,13 +45,30 @@ asyncio.run(main())
 ## Workflow concurrency
 
 The runtime submits every workflow run through a stable DBOS queue named
-`_llamaindex_workflow_queue:<workflow_name>`. The name is fixed when DBOS
-registers the workflow. A later WorkflowServer route alias does not replace the
-queue or strand existing work. The default remains unlimited:
+`_llamaindex_workflow_queue:<workflow_name>`. The runtime fixes that durable
+name when the workflow first enters the runtime. WorkflowServer route aliases
+do not replace the queue or the DBOS workflow registration. The default remains
+unlimited:
 
 ```python
 workflow = MyWorkflow(runtime=runtime, num_concurrent_runs=None)
 ```
+
+The default workflow name includes the Python module and class name. Set an
+explicit `workflow_name` when that code may be renamed and existing DBOS work
+must survive the deployment:
+
+```python
+workflow = MyWorkflow(
+    runtime=runtime,
+    workflow_name="orders.v1",
+    num_concurrent_runs=8,
+)
+```
+
+Treat this name as a durable identifier. Changing it also changes DBOS's
+control-loop and step registrations, so workers using the old name must drain
+their work before they are removed.
 
 Set `num_concurrent_runs` to a positive integer to limit active runs of that
 workflow on each DBOS worker. Changing the value back to `None` removes the
@@ -73,8 +90,11 @@ the cancellation request, but the run must be admitted before it can publish a
 `WorkflowCancelledEvent` and finish.
 
 If the application calls `DBOS.listen_queues`, it must include every queue in
-`runtime.workflow_queues`. The runtime raises an error before launch or late
-workflow registration when a required queue is missing.
+`runtime.workflow_queues`. DBOS does not expose its listener selection, so the
+runtime cannot validate a restricted listener configuration. DBOS's default
+listener discovers queues registered after launch, but an explicit listener
+list does not. Applications using a restricted list must register workflows
+and collect `runtime.workflow_queues` before launch.
 
 ## Features
 

--- a/packages/llama-agents-dbos/README.md
+++ b/packages/llama-agents-dbos/README.md
@@ -56,7 +56,9 @@ with no queue in the path. Limited workflows submit through a DBOS queue named
 `_llamaindex_workflow_queue:<workflow_name>`, and runs beyond the limit wait as
 `ENQUEUED`. Admission takes about the configured
 `DBOSRuntime(polling_interval_sec=...)`, one second by default. Capacity across
-a deployment is the limit times the number of workers.
+a deployment is the limit times the number of workers. The queue is shared, so
+an enqueued run has no affinity to the replica that submitted it. Any worker
+with a free slot can pick it up.
 
 The runtime declares the queue for every workflow, limited or not, so turning a
 limit on or off never strands queued work. A new limit does not count runs that

--- a/packages/llama-agents-dbos/README.md
+++ b/packages/llama-agents-dbos/README.md
@@ -42,8 +42,43 @@ async def main():
 asyncio.run(main())
 ```
 
+## Workflow concurrency
+
+The runtime submits every workflow run through a stable DBOS queue named
+`_llamaindex_workflow_queue:<workflow_name>`. The name is fixed when DBOS
+registers the workflow. A later WorkflowServer route alias does not replace the
+queue or strand existing work. The default remains unlimited:
+
+```python
+workflow = MyWorkflow(runtime=runtime, num_concurrent_runs=None)
+```
+
+Set `num_concurrent_runs` to a positive integer to limit active runs of that
+workflow on each DBOS worker. Changing the value back to `None` removes the
+limit without changing queues, so existing work remains available. Queue
+admission normally takes about the configured
+`DBOSRuntime(polling_interval_sec=...)`, but DBOS can back off longer while a
+queue is idle.
+
+Concurrency changes within the same DBOS application version are safe during a
+rolling deployment. Workers can briefly use different limits while both
+revisions are running, so total capacity is the sum of their per-worker limits.
+The first deployment that moves existing direct-start runs onto queues can also
+temporarily exceed the new limit while those earlier runs finish. If a
+deployment changes the DBOS application version, keep workers for the old
+version running until its queued and active workflows have drained.
+
+Graceful cancellation remains event based. Cancelling an `ENQUEUED` run stores
+the cancellation request, but the run must be admitted before it can publish a
+`WorkflowCancelledEvent` and finish.
+
+If the application calls `DBOS.listen_queues`, it must include every queue in
+`runtime.workflow_queues`. The runtime raises an error before launch or late
+workflow registration when a required queue is missing.
+
 ## Features
 
 - Durable workflow execution backed by DBOS
 - Automatic step recording and replay
 - Distributed workers and recovery support
+- Per-worker workflow concurrency with an unlimited default

--- a/packages/llama-agents-dbos/README.md
+++ b/packages/llama-agents-dbos/README.md
@@ -55,7 +55,7 @@ The default is `None`, which is unlimited. Unlimited workflows start directly,
 with no queue in the path. Limited workflows submit through a DBOS queue named
 `_llamaindex_workflow_queue:<workflow_name>`, and runs beyond the limit wait as
 `ENQUEUED`. Admission takes about the configured
-`DBOSRuntime(polling_interval_sec=...)`, one second by default. Capacity across
+`DBOSRuntime(queue_polling_interval_sec=...)`, one second by default. Capacity across
 a deployment is the limit times the number of workers. The queue is shared, so
 an enqueued run has no affinity to the replica that submitted it. Any worker
 with a free slot can pick it up.

--- a/packages/llama-agents-dbos/README.md
+++ b/packages/llama-agents-dbos/README.md
@@ -64,17 +64,20 @@ The runtime declares the queue for every workflow, limited or not, so turning a
 limit on or off never strands queued work. A new limit does not count runs that
 started before it, so a worker can briefly exceed the limit while those finish.
 
-The queue name comes from `workflow_name`, which defaults to the Python module
-and class name. Treat it as a durable identifier. Renaming it also renames the
-DBOS registrations, so workers using the old name must drain their work before
-they are removed.
+Waiting runs are rows in the database, filed under the workflow's name
+(`workflow_name`, defaulting to the Python module and class name). A worker
+only looks for waiting work under the names it knows, so if you rename a
+workflow, rows filed under the old name are invisible to the new deployment.
+Keep old workers running until they finish that work.
 
-Cancelling an `ENQUEUED` run takes effect after admission, because cancellation
-is delivered as an event to the running control loop.
+A run that is still waiting in the queue cannot be cancelled yet, because
+cancellation is a message delivered to the running workflow. The request is
+saved, and the run stops itself as soon as it starts.
 
-Applications that restrict `DBOS.listen_queues` must include every queue in
-`runtime.workflow_queues`, collected after registering workflows and before
-launch.
+DBOS normally watches every queue automatically. An application that instead
+passes an explicit list to `DBOS.listen_queues` must add this runtime's
+queues to it (`runtime.workflow_queues`), or waiting runs are never picked
+up. Build the list after registering workflows and before launch.
 
 ## Features
 

--- a/packages/llama-agents-dbos/README.md
+++ b/packages/llama-agents-dbos/README.md
@@ -44,57 +44,35 @@ asyncio.run(main())
 
 ## Workflow concurrency
 
-The runtime submits every workflow run through a stable DBOS queue named
-`_llamaindex_workflow_queue:<workflow_name>`. The runtime fixes that durable
-name when the workflow first enters the runtime. WorkflowServer route aliases
-do not replace the queue or the DBOS workflow registration. The default remains
-unlimited:
+Set `num_concurrent_runs` to limit how many runs of a workflow may be active
+at once on each DBOS worker:
 
 ```python
-workflow = MyWorkflow(runtime=runtime, num_concurrent_runs=None)
+workflow = MyWorkflow(runtime=runtime, num_concurrent_runs=8)
 ```
 
-The default workflow name includes the Python module and class name. Set an
-explicit `workflow_name` when that code may be renamed and existing DBOS work
-must survive the deployment:
+The default is `None`, which is unlimited. Unlimited workflows start directly,
+with no queue in the path. Limited workflows submit through a DBOS queue named
+`_llamaindex_workflow_queue:<workflow_name>`, and runs beyond the limit wait as
+`ENQUEUED`. Admission takes about the configured
+`DBOSRuntime(polling_interval_sec=...)`, one second by default. Capacity across
+a deployment is the limit times the number of workers.
 
-```python
-workflow = MyWorkflow(
-    runtime=runtime,
-    workflow_name="orders.v1",
-    num_concurrent_runs=8,
-)
-```
+The runtime declares the queue for every workflow, limited or not, so turning a
+limit on or off never strands queued work. A new limit does not count runs that
+started before it, so a worker can briefly exceed the limit while those finish.
 
-Treat this name as a durable identifier. Changing it also changes DBOS's
-control-loop and step registrations, so workers using the old name must drain
-their work before they are removed.
+The queue name comes from `workflow_name`, which defaults to the Python module
+and class name. Treat it as a durable identifier. Renaming it also renames the
+DBOS registrations, so workers using the old name must drain their work before
+they are removed.
 
-Set `num_concurrent_runs` to a positive integer to limit active runs of that
-workflow on each DBOS worker. Changing the value back to `None` removes the
-limit without changing queues, so existing work remains available. Queue
-admission normally takes about the configured
-`DBOSRuntime(polling_interval_sec=...)`, but DBOS can back off longer while a
-queue is idle.
+Cancelling an `ENQUEUED` run takes effect after admission, because cancellation
+is delivered as an event to the running control loop.
 
-Concurrency changes within the same DBOS application version are safe during a
-rolling deployment. Workers can briefly use different limits while both
-revisions are running, so total capacity is the sum of their per-worker limits.
-The first deployment that moves existing direct-start runs onto queues can also
-temporarily exceed the new limit while those earlier runs finish. If a
-deployment changes the DBOS application version, keep workers for the old
-version running until its queued and active workflows have drained.
-
-Graceful cancellation remains event based. Cancelling an `ENQUEUED` run stores
-the cancellation request, but the run must be admitted before it can publish a
-`WorkflowCancelledEvent` and finish.
-
-If the application calls `DBOS.listen_queues`, it must include every queue in
-`runtime.workflow_queues`. DBOS does not expose its listener selection, so the
-runtime cannot validate a restricted listener configuration. DBOS's default
-listener discovers queues registered after launch, but an explicit listener
-list does not. Applications using a restricted list must register workflows
-and collect `runtime.workflow_queues` before launch.
+Applications that restrict `DBOS.listen_queues` must include every queue in
+`runtime.workflow_queues`, collected after registering workflows and before
+launch.
 
 ## Features
 

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -15,7 +15,9 @@ import sqlite3
 import threading
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, AsyncGenerator, TypedDict, cast
+from weakref import ReferenceType, WeakKeyDictionary, ref
 
 import asyncpg
 from llama_agents.client.protocol.serializable_events import (
@@ -88,10 +90,10 @@ from workflows.runtime.types.step_function import (
 from workflows.runtime.types.ticks import WorkflowTick
 from workflows.workflow import Workflow
 
-from dbos import DBOS, SetWorkflowID, WorkflowHandleAsync
+from dbos import DBOS, Queue, SetWorkflowID, WorkflowHandleAsync
 from dbos._context import get_local_dbos_context
-from dbos._dbos import _get_dbos_instance
-from dbos._error import DBOSNonExistentWorkflowError
+from dbos._dbos import _get_dbos_instance, _get_or_create_dbos_registry
+from dbos._error import DBOSException, DBOSNonExistentWorkflowError
 
 from .executor_lease import ExecutorLeaseManager
 from .idle_release import DBOSIdleReleaseDecorator
@@ -111,6 +113,18 @@ from .journal.task_journal import TaskJournal
 STATE_TABLE_NAME = "workflow_state"
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _QueueOwnership:
+    owner_ref: ReferenceType[DBOSRuntime] | None
+    dbos_id: int | None
+    reusable: bool = False
+
+
+_RUNTIME_QUEUE_OWNERSHIP: WeakKeyDictionary[Queue, _QueueOwnership] = (
+    WeakKeyDictionary()
+)
 
 
 class DBOSWorkflowStore(AbstractWorkflowStore):
@@ -338,6 +352,7 @@ class DBOSRuntime(Runtime):
         self._tracked_workflows: list[Workflow] = []
         self._tracked_workflow_ids: set[int] = set()  # Track by id for dedup
         self._registered: dict[int, RegisteredWorkflow] = {}  # keyed by id(workflow)
+        self._workflow_queue_by_workflow_id: dict[int, tuple[str, Queue]] = {}
 
         self._dbos_launched = False
         # Signaled once DBOS is launched and config (engine, schema, etc.) is
@@ -369,15 +384,195 @@ class DBOSRuntime(Runtime):
         If launch() was already called, registers the workflow immediately.
         This allows late registration for testing scenarios.
         """
+        workflow_id = id(workflow)
+        duplicate = next(
+            (
+                tracked
+                for tracked in self._tracked_workflows
+                if id(tracked) != workflow_id
+                and tracked.workflow_name == workflow.workflow_name
+            ),
+            None,
+        )
+        if duplicate is not None:
+            self._validate_shared_workflow(duplicate, workflow)
+
+        self._queue_for_workflow(workflow)
+        if self._dbos_launched:
+            try:
+                self._ensure_queue_is_listened_to(workflow)
+            except RuntimeError:
+                self._release_workflow_queue(workflow_id, remove_reservation=True)
+                raise
+        if workflow_id not in self._tracked_workflow_ids:
+            self._tracked_workflows.append(workflow)
+            self._tracked_workflow_ids.add(workflow_id)
         if self._dbos_launched:
             # Already launched - register immediately
             registered = self.register(workflow)
-            self._registered[id(workflow)] = registered
+            self._registered[workflow_id] = registered
+
+    def untrack_workflow(self, workflow: Workflow) -> None:
+        """Stop tracking a workflow that has not been launched."""
+        workflow_id = id(workflow)
+        if self._dbos_launched and workflow_id in self._registered:
+            # WorkflowServer wraps an already-launched DBOSRuntime in runtime
+            # decorators. Keep DBOS registration while the workflow changes
+            # its outer runtime reference.
+            return
+        self._tracked_workflows = [
+            tracked for tracked in self._tracked_workflows if id(tracked) != workflow_id
+        ]
+        self._tracked_workflow_ids.discard(workflow_id)
+        self._registered.pop(workflow_id, None)
+        self._release_workflow_queue(workflow_id, remove_reservation=True)
+
+    @property
+    def workflow_queues(self) -> tuple[Queue, ...]:
+        """Queues used to submit workflow runs, in workflow tracking order."""
+        queues = dict.fromkeys(
+            self._queue_for_workflow(workflow) for workflow in self._tracked_workflows
+        )
+        return tuple(queues)
+
+    def _queue_for_workflow(self, workflow: Workflow) -> Queue:
+        """Return the runtime-owned queue for the workflow's current name."""
+        workflow_id = id(workflow)
+        workflow_name = workflow.workflow_name
+        existing_entry = self._workflow_queue_by_workflow_id.get(workflow_id)
+        if existing_entry is not None:
+            existing_name, existing_queue = existing_entry
+            if existing_name == workflow_name or self._dbos_launched:
+                ownership = _RUNTIME_QUEUE_OWNERSHIP[existing_queue]
+                if ownership.dbos_id is None:
+                    try:
+                        ownership.dbos_id = id(_get_dbos_instance())
+                    except DBOSException:
+                        pass
+                return existing_queue
+
+        duplicate = next(
+            (
+                tracked
+                for tracked in self._tracked_workflows
+                if id(tracked) != workflow_id and tracked.workflow_name == workflow_name
+            ),
+            None,
+        )
+        if duplicate is not None:
+            self._validate_shared_workflow(duplicate, workflow)
+            shared_queue = self._queue_for_workflow(duplicate)
+            self._workflow_queue_by_workflow_id[workflow_id] = (
+                workflow_name,
+                shared_queue,
+            )
+            return shared_queue
+
+        queue_name = f"_llamaindex_workflow_queue:{workflow_name}"
+        queue = self._reserve_queue(queue_name, workflow._num_concurrent_runs)
+
+        # Reserve and validate the destination before releasing the old name.
+        self._workflow_queue_by_workflow_id[workflow_id] = (workflow_name, queue)
+        if existing_entry is not None and existing_entry[1] is not queue:
+            self._remove_queue_reservation_if_exclusive(existing_entry[1])
+        return queue
+
+    def _validate_shared_workflow(
+        self, existing: Workflow, candidate: Workflow
+    ) -> None:
+        if type(existing) is not type(candidate):
+            raise RuntimeError(
+                f"DBOSRuntime cannot share workflow name "
+                f"{candidate.workflow_name!r} across different workflow classes"
+            )
+        if existing._num_concurrent_runs != candidate._num_concurrent_runs:
+            raise RuntimeError(
+                f"DBOSRuntime workflow {candidate.workflow_name!r} has conflicting "
+                "num_concurrent_runs declarations"
+            )
+
+    def _reserve_queue(self, queue_name: str, worker_concurrency: int | None) -> Queue:
+        registry = _get_or_create_dbos_registry()
+        queue = registry.queue_info_map.get(queue_name)
+        if queue is None:
+            queue = Queue(
+                queue_name,
+                worker_concurrency=worker_concurrency,
+                polling_interval_sec=self.config.get("polling_interval_sec", 1.0),
+            )
+            ownership = _QueueOwnership(owner_ref=ref(self), dbos_id=None)
+            _RUNTIME_QUEUE_OWNERSHIP[queue] = ownership
         else:
-            wf_id = id(workflow)
-            if wf_id not in self._tracked_workflow_ids:
-                self._tracked_workflows.append(workflow)
-                self._tracked_workflow_ids.add(wf_id)
+            ownership = _RUNTIME_QUEUE_OWNERSHIP.get(queue)
+            if ownership is None:
+                raise RuntimeError(
+                    f"Queue name {queue_name!r} is already owned by the application"
+                )
+            owner = ownership.owner_ref() if ownership.owner_ref is not None else None
+            try:
+                current_dbos = _get_dbos_instance()
+            except DBOSException:
+                current_dbos = None
+            can_reuse = ownership.reusable or (
+                ownership.dbos_id is not None
+                and ownership.dbos_id
+                != (id(current_dbos) if current_dbos is not None else None)
+            )
+            if owner is not self and not can_reuse:
+                raise RuntimeError(
+                    f"Queue name {queue_name!r} is already owned by another live "
+                    "DBOS runtime or by the application"
+                )
+        ownership = _RUNTIME_QUEUE_OWNERSHIP[queue]
+        owner = ownership.owner_ref() if ownership.owner_ref is not None else None
+        if owner is not self:
+            queue.concurrency = None
+            queue.worker_concurrency = worker_concurrency
+            queue.polling_interval_sec = self.config.get("polling_interval_sec", 1.0)
+
+        ownership.owner_ref = ref(self)
+        ownership.reusable = False
+        try:
+            ownership.dbos_id = id(_get_dbos_instance())
+        except DBOSException:
+            ownership.dbos_id = None
+        return queue
+
+    def _release_workflow_queue(
+        self, workflow_id: int, *, remove_reservation: bool
+    ) -> None:
+        entry = self._workflow_queue_by_workflow_id.pop(workflow_id, None)
+        if entry is not None and remove_reservation:
+            self._remove_queue_reservation_if_exclusive(entry[1])
+
+    def _remove_queue_reservation_if_exclusive(self, queue: Queue) -> None:
+        if any(
+            tracked_queue is queue
+            for _, tracked_queue in self._workflow_queue_by_workflow_id.values()
+        ):
+            return
+        ownership = _RUNTIME_QUEUE_OWNERSHIP.get(queue)
+        if (
+            ownership is not None
+            and ownership.owner_ref is not None
+            and ownership.owner_ref() is not self
+        ):
+            return
+        registry = _get_or_create_dbos_registry()
+        if registry.queue_info_map.get(queue.name) is queue:
+            del registry.queue_info_map[queue.name]
+        _RUNTIME_QUEUE_OWNERSHIP.pop(queue, None)
+
+    def _ensure_queue_is_listened_to(self, workflow: Workflow) -> None:
+        listening_queues = _get_dbos_instance()._listening_queues
+        if listening_queues is None:
+            return
+        queue = self._queue_for_workflow(workflow)
+        if all(candidate.name != queue.name for candidate in listening_queues):
+            raise RuntimeError(
+                f"DBOS.listen_queues does not include the workflow queue for "
+                f"{workflow.workflow_name!r}: {queue.name!r}"
+            )
 
     def get_registered(self, workflow: Workflow) -> RegisteredWorkflow | None:
         """Get the registered workflow if available."""
@@ -398,6 +593,7 @@ class DBOSRuntime(Runtime):
 
         # Use workflow's name directly
         name = workflow.workflow_name
+        self._queue_for_workflow(workflow)
 
         # Create DBOS-wrapped control loop with stable name
         wf_kwargs: dict[str, Any] = {"name": f"{name}.control_loop"}
@@ -595,35 +791,36 @@ class DBOSRuntime(Runtime):
         active_serializer = serializer or JsonSerializer()
 
         async def _run_workflow() -> WorkflowHandleAsync[Any]:
-            with SetWorkflowID(run_id):
-                # Write initial state to DB before starting workflow (non-blocking to caller)
-                if serialized_state:
-                    workflow_store = self.create_workflow_store()
-                    await workflow_store.start()
-                    store = workflow_store.create_state_store(
-                        run_id,
-                        infer_state_type(workflow),
-                        serialized_state,
-                        active_serializer,
-                    )
-                    # Materialize the seed before the workflow starts so the
-                    # first step observes the restored state.
-                    if isinstance(store, StateStoreFacade):
-                        await store.ensure_seeded()
+            # Write initial state to DB before starting workflow (non-blocking to caller)
+            if serialized_state:
+                workflow_store = self.create_workflow_store()
+                await workflow_store.start()
+                store = workflow_store.create_state_store(
+                    run_id,
+                    infer_state_type(workflow),
+                    serialized_state,
+                    active_serializer,
+                )
+                # Materialize the seed before the workflow starts so the
+                # first step observes the restored state.
+                if isinstance(store, StateStoreFacade):
+                    await store.ensure_seeded()
 
-                try:
-                    return await DBOS.start_workflow_async(
+            try:
+                with SetWorkflowID(run_id):
+                    queue = self._queue_for_workflow(workflow)
+                    return await queue.enqueue_async(
                         registered.workflow_run_fn,
                         init_state,
                         start_event,
                         get_dispatcher().capture_propagation_context(),
                     )
-                except Exception as e:
-                    logger.error(
-                        f"Failed to submit work to DBOS for {run_id} with start event: {start_event} and init state: {init_state}. Error: {e}",
-                        exc_info=True,
-                    )
-                    raise e
+            except Exception as e:
+                logger.error(
+                    f"Failed to submit work to DBOS for {run_id} with start event: {start_event} and init state: {init_state}. Error: {e}",
+                    exc_info=True,
+                )
+                raise e
 
         # Create startup task and pass to adapter so it can await workflow readiness
         startup_task = asyncio.create_task(_run_workflow())
@@ -854,6 +1051,8 @@ class DBOSRuntime(Runtime):
 
         # Register each pending workflow with DBOS
         for workflow in self._tracked_workflows:
+            self._queue_for_workflow(workflow)
+            self._ensure_queue_is_listened_to(workflow)
             # Register with DBOS (this applies decorators)
             registered = self.register(workflow)
             self._registered[id(workflow)] = registered
@@ -964,8 +1163,9 @@ class DBOSRuntime(Runtime):
                 Set to False when DBOS lifecycle is managed externally
                 (e.g., shared across multiple runtimes in tests).
         """
-        if not self._dbos_launched:
-            return  # Already destroyed or never launched
+        owned_queues = {
+            queue for _, queue in self._workflow_queue_by_workflow_id.values()
+        }
 
         # Cancel lease watcher first to avoid re-entrant destroy
         if self._lease_watch_task is not None:
@@ -1018,6 +1218,17 @@ class DBOSRuntime(Runtime):
             await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
         if destroy_dbos:
             DBOS.destroy()
+            for queue in owned_queues:
+                ownership = _RUNTIME_QUEUE_OWNERSHIP.get(queue)
+                if (
+                    ownership is not None
+                    and ownership.owner_ref is not None
+                    and ownership.owner_ref() is self
+                ):
+                    ownership.owner_ref = None
+                    ownership.dbos_id = None
+                    ownership.reusable = True
+            self._workflow_queue_by_workflow_id.clear()
 
 
 _IO_STREAM_PUBLISHED_EVENTS_NAME = "published_events"

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -249,6 +249,7 @@ class DBOSRuntimeConfig(TypedDict, total=False):
     """
 
     polling_interval_sec: float
+    queue_polling_interval_sec: float
     run_migrations_on_launch: bool
     schema: str | None
     state_table_name: str
@@ -324,6 +325,9 @@ class DBOSRuntime(Runtime):
         Args:
             **kwargs: Configuration options. See DBOSRuntimeConfig for details.
                 polling_interval_sec: Interval for polling workflow results. Default 1.0.
+                queue_polling_interval_sec: Interval for polling workflow
+                    admission queues. Bounds how long a run limited by
+                    ``num_concurrent_runs`` waits for a free slot. Default 1.0.
                 run_migrations_on_launch: Auto-run migrations on launch(). Default True.
                 schema: Database schema name. Default: auto-detected at launch
                     ("dbos" for PostgreSQL, None for SQLite). Pass None explicitly
@@ -441,7 +445,7 @@ class DBOSRuntime(Runtime):
         queue = _declare_workflow_queue(
             f"_llamaindex_workflow_queue:{name}",
             workflow._num_concurrent_runs,
-            self.config.get("polling_interval_sec", 1.0),
+            self.config.get("queue_polling_interval_sec", 1.0),
         )
 
         # Create DBOS-wrapped control loop with stable name

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -15,9 +15,8 @@ import sqlite3
 import threading
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
-from dataclasses import dataclass
 from typing import Any, AsyncGenerator, TypedDict, cast
-from weakref import ReferenceType, WeakKeyDictionary, ref
+from weakref import WeakKeyDictionary
 
 import asyncpg
 from llama_agents.client.protocol.serializable_events import (
@@ -92,8 +91,8 @@ from workflows.workflow import Workflow
 
 from dbos import DBOS, Queue, SetWorkflowID, WorkflowHandleAsync
 from dbos._context import get_local_dbos_context
-from dbos._dbos import _get_dbos_instance, _get_or_create_dbos_registry
-from dbos._error import DBOSException, DBOSNonExistentWorkflowError
+from dbos._dbos import _get_dbos_instance
+from dbos._error import DBOSNonExistentWorkflowError
 
 from .executor_lease import ExecutorLeaseManager
 from .idle_release import DBOSIdleReleaseDecorator
@@ -115,16 +114,66 @@ STATE_TABLE_NAME = "workflow_state"
 logger = logging.getLogger(__name__)
 
 
-@dataclass
-class _QueueOwnership:
-    owner_ref: ReferenceType[DBOSRuntime] | None
-    dbos_id: int | None
-    reusable: bool = False
+class _WorkflowQueueDeclarations:
+    """Coordinate LlamaIndex queue declarations in DBOS's global process scope."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._queues: dict[str, Queue] = {}
+        self._configs: dict[str, tuple[int | None, float]] = {}
+        self._owners: dict[str, set[object]] = {}
+
+    def declare(
+        self,
+        *,
+        owner: object,
+        name: str,
+        worker_concurrency: int | None,
+        polling_interval_sec: float,
+    ) -> Queue:
+        config = (worker_concurrency, polling_interval_sec)
+        with self._lock:
+            queue = self._queues.get(name)
+            if queue is None:
+                try:
+                    queue = Queue(
+                        name,
+                        worker_concurrency=worker_concurrency,
+                        polling_interval_sec=polling_interval_sec,
+                    )
+                except Exception as exc:
+                    raise RuntimeError(
+                        f"DBOS rejected workflow queue {name!r}: {exc}"
+                    ) from exc
+                self._queues[name] = queue
+                self._configs[name] = config
+                self._owners[name] = {owner}
+                return queue
+
+            owners = self._owners[name]
+            existing_config = self._configs[name]
+            other_owners = owners - {owner}
+            if existing_config != config and other_owners:
+                raise RuntimeError(
+                    f"DBOS workflow queue {name!r} is already declared with "
+                    f"worker_concurrency={existing_config[0]!r} and "
+                    f"polling_interval_sec={existing_config[1]!r}"
+                )
+            if existing_config != config:
+                queue.worker_concurrency = worker_concurrency
+                queue.polling_interval_sec = polling_interval_sec
+                self._configs[name] = config
+            owners.add(owner)
+            return queue
+
+    def release(self, *, owner: object, name: str) -> None:
+        with self._lock:
+            owners = self._owners.get(name)
+            if owners is not None:
+                owners.discard(owner)
 
 
-_RUNTIME_QUEUE_OWNERSHIP: WeakKeyDictionary[Queue, _QueueOwnership] = (
-    WeakKeyDictionary()
-)
+_WORKFLOW_QUEUE_DECLARATIONS = _WorkflowQueueDeclarations()
 
 
 class DBOSWorkflowStore(AbstractWorkflowStore):
@@ -352,7 +401,11 @@ class DBOSRuntime(Runtime):
         self._tracked_workflows: list[Workflow] = []
         self._tracked_workflow_ids: set[int] = set()  # Track by id for dedup
         self._registered: dict[int, RegisteredWorkflow] = {}  # keyed by id(workflow)
+        self._registration_name_by_workflow: WeakKeyDictionary[Workflow, str] = (
+            WeakKeyDictionary()
+        )
         self._workflow_queue_by_workflow_id: dict[int, tuple[str, Queue]] = {}
+        self._queue_owner = object()
 
         self._dbos_launched = False
         # Signaled once DBOS is launched and config (engine, schema, etc.) is
@@ -385,25 +438,22 @@ class DBOSRuntime(Runtime):
         This allows late registration for testing scenarios.
         """
         workflow_id = id(workflow)
+        registration_name = self._registration_name_by_workflow.setdefault(
+            workflow,
+            workflow.workflow_name,
+        )
         duplicate = next(
             (
                 tracked
                 for tracked in self._tracked_workflows
                 if id(tracked) != workflow_id
-                and tracked.workflow_name == workflow.workflow_name
+                and self._registration_name_by_workflow[tracked] == registration_name
             ),
             None,
         )
         if duplicate is not None:
             self._validate_shared_workflow(duplicate, workflow)
 
-        self._queue_for_workflow(workflow)
-        if self._dbos_launched:
-            try:
-                self._ensure_queue_is_listened_to(workflow)
-            except RuntimeError:
-                self._release_workflow_queue(workflow_id, remove_reservation=True)
-                raise
         if workflow_id not in self._tracked_workflow_ids:
             self._tracked_workflows.append(workflow)
             self._tracked_workflow_ids.add(workflow_id)
@@ -436,107 +486,60 @@ class DBOSRuntime(Runtime):
         return tuple(queues)
 
     def _queue_for_workflow(self, workflow: Workflow) -> Queue:
-        """Return the runtime-owned queue for the workflow's current name."""
+        """Return the queue for the workflow's stable DBOS registration name."""
         workflow_id = id(workflow)
-        workflow_name = workflow.workflow_name
+        workflow_name = self._registration_name_by_workflow.setdefault(
+            workflow,
+            workflow.workflow_name,
+        )
         existing_entry = self._workflow_queue_by_workflow_id.get(workflow_id)
         if existing_entry is not None:
-            existing_name, existing_queue = existing_entry
-            if existing_name == workflow_name or self._dbos_launched:
-                ownership = _RUNTIME_QUEUE_OWNERSHIP[existing_queue]
-                if ownership.dbos_id is None:
-                    try:
-                        ownership.dbos_id = id(_get_dbos_instance())
-                    except DBOSException:
-                        pass
-                return existing_queue
+            return existing_entry[1]
 
         duplicate = next(
             (
                 tracked
                 for tracked in self._tracked_workflows
-                if id(tracked) != workflow_id and tracked.workflow_name == workflow_name
+                if id(tracked) != workflow_id
+                and self._registration_name_by_workflow[tracked] == workflow_name
             ),
             None,
         )
         if duplicate is not None:
             self._validate_shared_workflow(duplicate, workflow)
-            shared_queue = self._queue_for_workflow(duplicate)
-            self._workflow_queue_by_workflow_id[workflow_id] = (
-                workflow_name,
-                shared_queue,
-            )
-            return shared_queue
+            duplicate_entry = self._workflow_queue_by_workflow_id.get(id(duplicate))
+            if duplicate_entry is not None:
+                self._workflow_queue_by_workflow_id[workflow_id] = (
+                    workflow_name,
+                    duplicate_entry[1],
+                )
+                return duplicate_entry[1]
 
         queue_name = f"_llamaindex_workflow_queue:{workflow_name}"
-        queue = self._reserve_queue(queue_name, workflow._num_concurrent_runs)
+        queue = _WORKFLOW_QUEUE_DECLARATIONS.declare(
+            owner=self._queue_owner,
+            name=queue_name,
+            worker_concurrency=workflow._num_concurrent_runs,
+            polling_interval_sec=self.config.get("polling_interval_sec", 1.0),
+        )
 
-        # Reserve and validate the destination before releasing the old name.
         self._workflow_queue_by_workflow_id[workflow_id] = (workflow_name, queue)
-        if existing_entry is not None and existing_entry[1] is not queue:
-            self._remove_queue_reservation_if_exclusive(existing_entry[1])
         return queue
 
     def _validate_shared_workflow(
         self, existing: Workflow, candidate: Workflow
     ) -> None:
+        candidate_name = self._registration_name_by_workflow[candidate]
         if type(existing) is not type(candidate):
             raise RuntimeError(
                 f"DBOSRuntime cannot share workflow name "
-                f"{candidate.workflow_name!r} across different workflow classes"
+                f"{candidate_name!r} across different workflow classes"
             )
         if existing._num_concurrent_runs != candidate._num_concurrent_runs:
             raise RuntimeError(
-                f"DBOSRuntime workflow {candidate.workflow_name!r} has conflicting "
+                f"DBOSRuntime workflow {candidate_name!r} has conflicting "
                 "num_concurrent_runs declarations"
             )
-
-    def _reserve_queue(self, queue_name: str, worker_concurrency: int | None) -> Queue:
-        registry = _get_or_create_dbos_registry()
-        queue = registry.queue_info_map.get(queue_name)
-        if queue is None:
-            queue = Queue(
-                queue_name,
-                worker_concurrency=worker_concurrency,
-                polling_interval_sec=self.config.get("polling_interval_sec", 1.0),
-            )
-            ownership = _QueueOwnership(owner_ref=ref(self), dbos_id=None)
-            _RUNTIME_QUEUE_OWNERSHIP[queue] = ownership
-        else:
-            ownership = _RUNTIME_QUEUE_OWNERSHIP.get(queue)
-            if ownership is None:
-                raise RuntimeError(
-                    f"Queue name {queue_name!r} is already owned by the application"
-                )
-            owner = ownership.owner_ref() if ownership.owner_ref is not None else None
-            try:
-                current_dbos = _get_dbos_instance()
-            except DBOSException:
-                current_dbos = None
-            can_reuse = ownership.reusable or (
-                ownership.dbos_id is not None
-                and ownership.dbos_id
-                != (id(current_dbos) if current_dbos is not None else None)
-            )
-            if owner is not self and not can_reuse:
-                raise RuntimeError(
-                    f"Queue name {queue_name!r} is already owned by another live "
-                    "DBOS runtime or by the application"
-                )
-        ownership = _RUNTIME_QUEUE_OWNERSHIP[queue]
-        owner = ownership.owner_ref() if ownership.owner_ref is not None else None
-        if owner is not self:
-            queue.concurrency = None
-            queue.worker_concurrency = worker_concurrency
-            queue.polling_interval_sec = self.config.get("polling_interval_sec", 1.0)
-
-        ownership.owner_ref = ref(self)
-        ownership.reusable = False
-        try:
-            ownership.dbos_id = id(_get_dbos_instance())
-        except DBOSException:
-            ownership.dbos_id = None
-        return queue
 
     def _release_workflow_queue(
         self, workflow_id: int, *, remove_reservation: bool
@@ -551,28 +554,10 @@ class DBOSRuntime(Runtime):
             for _, tracked_queue in self._workflow_queue_by_workflow_id.values()
         ):
             return
-        ownership = _RUNTIME_QUEUE_OWNERSHIP.get(queue)
-        if (
-            ownership is not None
-            and ownership.owner_ref is not None
-            and ownership.owner_ref() is not self
-        ):
-            return
-        registry = _get_or_create_dbos_registry()
-        if registry.queue_info_map.get(queue.name) is queue:
-            del registry.queue_info_map[queue.name]
-        _RUNTIME_QUEUE_OWNERSHIP.pop(queue, None)
-
-    def _ensure_queue_is_listened_to(self, workflow: Workflow) -> None:
-        listening_queues = _get_dbos_instance()._listening_queues
-        if listening_queues is None:
-            return
-        queue = self._queue_for_workflow(workflow)
-        if all(candidate.name != queue.name for candidate in listening_queues):
-            raise RuntimeError(
-                f"DBOS.listen_queues does not include the workflow queue for "
-                f"{workflow.workflow_name!r}: {queue.name!r}"
-            )
+        _WORKFLOW_QUEUE_DECLARATIONS.release(
+            owner=self._queue_owner,
+            name=queue.name,
+        )
 
     def get_registered(self, workflow: Workflow) -> RegisteredWorkflow | None:
         """Get the registered workflow if available."""
@@ -583,7 +568,7 @@ class DBOSRuntime(Runtime):
         Wrap workflow with DBOS decorators.
 
         Called at launch() time for each tracked workflow.
-        Uses workflow.workflow_name for stable DBOS registration names.
+        Uses the name captured when the workflow first entered this runtime.
         Idempotent: returns existing registration if already registered.
         """
         # Return existing registration if already registered
@@ -591,8 +576,11 @@ class DBOSRuntime(Runtime):
         if existing is not None:
             return existing
 
-        # Use workflow's name directly
-        name = workflow.workflow_name
+        # DBOS names are fixed when the workflow first enters this runtime.
+        name = self._registration_name_by_workflow.setdefault(
+            workflow,
+            workflow.workflow_name,
+        )
         self._queue_for_workflow(workflow)
 
         # Create DBOS-wrapped control loop with stable name
@@ -1052,7 +1040,6 @@ class DBOSRuntime(Runtime):
         # Register each pending workflow with DBOS
         for workflow in self._tracked_workflows:
             self._queue_for_workflow(workflow)
-            self._ensure_queue_is_listened_to(workflow)
             # Register with DBOS (this applies decorators)
             registered = self.register(workflow)
             self._registered[id(workflow)] = registered
@@ -1183,6 +1170,7 @@ class DBOSRuntime(Runtime):
         self._tracked_workflows.clear()
         self._tracked_workflow_ids.clear()
         self._registered.clear()
+        self._registration_name_by_workflow.clear()
         self._dbos_launched = False
         self._launch_ready = threading.Event()
         self._sql_engine = None
@@ -1219,15 +1207,10 @@ class DBOSRuntime(Runtime):
         if destroy_dbos:
             DBOS.destroy()
             for queue in owned_queues:
-                ownership = _RUNTIME_QUEUE_OWNERSHIP.get(queue)
-                if (
-                    ownership is not None
-                    and ownership.owner_ref is not None
-                    and ownership.owner_ref() is self
-                ):
-                    ownership.owner_ref = None
-                    ownership.dbos_id = None
-                    ownership.reusable = True
+                _WORKFLOW_QUEUE_DECLARATIONS.release(
+                    owner=self._queue_owner,
+                    name=queue.name,
+                )
             self._workflow_queue_by_workflow_id.clear()
 
 

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -249,7 +249,7 @@ class DBOSRuntimeConfig(TypedDict, total=False):
     """
 
     polling_interval_sec: float
-    queue_polling_interval_sec: float
+    queue_polling_interval_sec: float | None
     run_migrations_on_launch: bool
     schema: str | None
     state_table_name: str
@@ -327,7 +327,8 @@ class DBOSRuntime(Runtime):
                 polling_interval_sec: Interval for polling workflow results. Default 1.0.
                 queue_polling_interval_sec: Interval for polling workflow
                     admission queues. Bounds how long a run limited by
-                    ``num_concurrent_runs`` waits for a free slot. Default 1.0.
+                    ``num_concurrent_runs`` waits for a free slot. Defaults to
+                    ``polling_interval_sec``.
                 run_migrations_on_launch: Auto-run migrations on launch(). Default True.
                 schema: Database schema name. Default: auto-detected at launch
                     ("dbos" for PostgreSQL, None for SQLite). Pass None explicitly
@@ -442,10 +443,13 @@ class DBOSRuntime(Runtime):
 
         # Use workflow's name directly
         name = workflow.workflow_name
+        queue_polling_interval = self.config.get("queue_polling_interval_sec")
+        if queue_polling_interval is None:
+            queue_polling_interval = self.config.get("polling_interval_sec", 1.0)
         queue = _declare_workflow_queue(
             f"_llamaindex_workflow_queue:{name}",
             workflow._num_concurrent_runs,
-            self.config.get("queue_polling_interval_sec", 1.0),
+            queue_polling_interval,
         )
 
         # Create DBOS-wrapped control loop with stable name

--- a/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
+++ b/packages/llama-agents-dbos/src/llama_agents/dbos/runtime.py
@@ -15,8 +15,8 @@ import sqlite3
 import threading
 import time
 from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, AsyncGenerator, TypedDict, cast
-from weakref import WeakKeyDictionary
 
 import asyncpg
 from llama_agents.client.protocol.serializable_events import (
@@ -74,12 +74,14 @@ from workflows.runtime.types.named_task import (
 from workflows.runtime.types.plugin import (
     ExternalRunAdapter,
     InternalRunAdapter,
-    RegisteredWorkflow,
     Runtime,
     WaitForNextTaskResult,
     WaitResult,
     WaitResultTick,
     WaitResultTimeout,
+)
+from workflows.runtime.types.plugin import (
+    RegisteredWorkflow as BaseRegisteredWorkflow,
 )
 from workflows.runtime.types.step_function import (
     StepWorkerFunction,
@@ -114,66 +116,33 @@ STATE_TABLE_NAME = "workflow_state"
 logger = logging.getLogger(__name__)
 
 
-class _WorkflowQueueDeclarations:
-    """Coordinate LlamaIndex queue declarations in DBOS's global process scope."""
-
-    def __init__(self) -> None:
-        self._lock = threading.RLock()
-        self._queues: dict[str, Queue] = {}
-        self._configs: dict[str, tuple[int | None, float]] = {}
-        self._owners: dict[str, set[object]] = {}
-
-    def declare(
-        self,
-        *,
-        owner: object,
-        name: str,
-        worker_concurrency: int | None,
-        polling_interval_sec: float,
-    ) -> Queue:
-        config = (worker_concurrency, polling_interval_sec)
-        with self._lock:
-            queue = self._queues.get(name)
-            if queue is None:
-                try:
-                    queue = Queue(
-                        name,
-                        worker_concurrency=worker_concurrency,
-                        polling_interval_sec=polling_interval_sec,
-                    )
-                except Exception as exc:
-                    raise RuntimeError(
-                        f"DBOS rejected workflow queue {name!r}: {exc}"
-                    ) from exc
-                self._queues[name] = queue
-                self._configs[name] = config
-                self._owners[name] = {owner}
-                return queue
-
-            owners = self._owners[name]
-            existing_config = self._configs[name]
-            other_owners = owners - {owner}
-            if existing_config != config and other_owners:
-                raise RuntimeError(
-                    f"DBOS workflow queue {name!r} is already declared with "
-                    f"worker_concurrency={existing_config[0]!r} and "
-                    f"polling_interval_sec={existing_config[1]!r}"
-                )
-            if existing_config != config:
-                queue.worker_concurrency = worker_concurrency
-                queue.polling_interval_sec = polling_interval_sec
-                self._configs[name] = config
-            owners.add(owner)
-            return queue
-
-    def release(self, *, owner: object, name: str) -> None:
-        with self._lock:
-            owners = self._owners.get(name)
-            if owners is not None:
-                owners.discard(owner)
+@dataclass
+class RegisteredWorkflow(BaseRegisteredWorkflow):
+    queue: Queue
 
 
-_WORKFLOW_QUEUE_DECLARATIONS = _WorkflowQueueDeclarations()
+_workflow_queues: dict[str, Queue] = {}
+_workflow_queues_lock = threading.Lock()
+
+
+def _declare_workflow_queue(
+    name: str,
+    worker_concurrency: int | None,
+    polling_interval_sec: float,
+) -> Queue:
+    with _workflow_queues_lock:
+        queue = _workflow_queues.get(name)
+        if queue is None:
+            queue = Queue(
+                name,
+                worker_concurrency=worker_concurrency,
+                polling_interval_sec=polling_interval_sec,
+            )
+            _workflow_queues[name] = queue
+        else:
+            queue.worker_concurrency = worker_concurrency
+            queue.polling_interval_sec = polling_interval_sec
+        return queue
 
 
 class DBOSWorkflowStore(AbstractWorkflowStore):
@@ -401,11 +370,6 @@ class DBOSRuntime(Runtime):
         self._tracked_workflows: list[Workflow] = []
         self._tracked_workflow_ids: set[int] = set()  # Track by id for dedup
         self._registered: dict[int, RegisteredWorkflow] = {}  # keyed by id(workflow)
-        self._registration_name_by_workflow: WeakKeyDictionary[Workflow, str] = (
-            WeakKeyDictionary()
-        )
-        self._workflow_queue_by_workflow_id: dict[int, tuple[str, Queue]] = {}
-        self._queue_owner = object()
 
         self._dbos_launched = False
         # Signaled once DBOS is launched and config (engine, schema, etc.) is
@@ -437,127 +401,23 @@ class DBOSRuntime(Runtime):
         If launch() was already called, registers the workflow immediately.
         This allows late registration for testing scenarios.
         """
-        workflow_id = id(workflow)
-        registration_name = self._registration_name_by_workflow.setdefault(
-            workflow,
-            workflow.workflow_name,
-        )
-        duplicate = next(
-            (
-                tracked
-                for tracked in self._tracked_workflows
-                if id(tracked) != workflow_id
-                and self._registration_name_by_workflow[tracked] == registration_name
-            ),
-            None,
-        )
-        if duplicate is not None:
-            self._validate_shared_workflow(duplicate, workflow)
-
-        if workflow_id not in self._tracked_workflow_ids:
-            self._tracked_workflows.append(workflow)
-            self._tracked_workflow_ids.add(workflow_id)
         if self._dbos_launched:
             # Already launched - register immediately
             registered = self.register(workflow)
-            self._registered[workflow_id] = registered
-
-    def untrack_workflow(self, workflow: Workflow) -> None:
-        """Stop tracking a workflow that has not been launched."""
-        workflow_id = id(workflow)
-        if self._dbos_launched and workflow_id in self._registered:
-            # WorkflowServer wraps an already-launched DBOSRuntime in runtime
-            # decorators. Keep DBOS registration while the workflow changes
-            # its outer runtime reference.
-            return
-        self._tracked_workflows = [
-            tracked for tracked in self._tracked_workflows if id(tracked) != workflow_id
-        ]
-        self._tracked_workflow_ids.discard(workflow_id)
-        self._registered.pop(workflow_id, None)
-        self._release_workflow_queue(workflow_id, remove_reservation=True)
+            self._registered[id(workflow)] = registered
+        else:
+            wf_id = id(workflow)
+            if wf_id not in self._tracked_workflow_ids:
+                self._tracked_workflows.append(workflow)
+                self._tracked_workflow_ids.add(wf_id)
 
     @property
     def workflow_queues(self) -> tuple[Queue, ...]:
-        """Queues used to submit workflow runs, in workflow tracking order."""
+        """Queues declared by this runtime, in registration order."""
         queues = dict.fromkeys(
-            self._queue_for_workflow(workflow) for workflow in self._tracked_workflows
+            registered.queue for registered in self._registered.values()
         )
         return tuple(queues)
-
-    def _queue_for_workflow(self, workflow: Workflow) -> Queue:
-        """Return the queue for the workflow's stable DBOS registration name."""
-        workflow_id = id(workflow)
-        workflow_name = self._registration_name_by_workflow.setdefault(
-            workflow,
-            workflow.workflow_name,
-        )
-        existing_entry = self._workflow_queue_by_workflow_id.get(workflow_id)
-        if existing_entry is not None:
-            return existing_entry[1]
-
-        duplicate = next(
-            (
-                tracked
-                for tracked in self._tracked_workflows
-                if id(tracked) != workflow_id
-                and self._registration_name_by_workflow[tracked] == workflow_name
-            ),
-            None,
-        )
-        if duplicate is not None:
-            self._validate_shared_workflow(duplicate, workflow)
-            duplicate_entry = self._workflow_queue_by_workflow_id.get(id(duplicate))
-            if duplicate_entry is not None:
-                self._workflow_queue_by_workflow_id[workflow_id] = (
-                    workflow_name,
-                    duplicate_entry[1],
-                )
-                return duplicate_entry[1]
-
-        queue_name = f"_llamaindex_workflow_queue:{workflow_name}"
-        queue = _WORKFLOW_QUEUE_DECLARATIONS.declare(
-            owner=self._queue_owner,
-            name=queue_name,
-            worker_concurrency=workflow._num_concurrent_runs,
-            polling_interval_sec=self.config.get("polling_interval_sec", 1.0),
-        )
-
-        self._workflow_queue_by_workflow_id[workflow_id] = (workflow_name, queue)
-        return queue
-
-    def _validate_shared_workflow(
-        self, existing: Workflow, candidate: Workflow
-    ) -> None:
-        candidate_name = self._registration_name_by_workflow[candidate]
-        if type(existing) is not type(candidate):
-            raise RuntimeError(
-                f"DBOSRuntime cannot share workflow name "
-                f"{candidate_name!r} across different workflow classes"
-            )
-        if existing._num_concurrent_runs != candidate._num_concurrent_runs:
-            raise RuntimeError(
-                f"DBOSRuntime workflow {candidate_name!r} has conflicting "
-                "num_concurrent_runs declarations"
-            )
-
-    def _release_workflow_queue(
-        self, workflow_id: int, *, remove_reservation: bool
-    ) -> None:
-        entry = self._workflow_queue_by_workflow_id.pop(workflow_id, None)
-        if entry is not None and remove_reservation:
-            self._remove_queue_reservation_if_exclusive(entry[1])
-
-    def _remove_queue_reservation_if_exclusive(self, queue: Queue) -> None:
-        if any(
-            tracked_queue is queue
-            for _, tracked_queue in self._workflow_queue_by_workflow_id.values()
-        ):
-            return
-        _WORKFLOW_QUEUE_DECLARATIONS.release(
-            owner=self._queue_owner,
-            name=queue.name,
-        )
 
     def get_registered(self, workflow: Workflow) -> RegisteredWorkflow | None:
         """Get the registered workflow if available."""
@@ -568,7 +428,7 @@ class DBOSRuntime(Runtime):
         Wrap workflow with DBOS decorators.
 
         Called at launch() time for each tracked workflow.
-        Uses the name captured when the workflow first entered this runtime.
+        Uses workflow.workflow_name for stable DBOS registration names.
         Idempotent: returns existing registration if already registered.
         """
         # Return existing registration if already registered
@@ -576,12 +436,13 @@ class DBOSRuntime(Runtime):
         if existing is not None:
             return existing
 
-        # DBOS names are fixed when the workflow first enters this runtime.
-        name = self._registration_name_by_workflow.setdefault(
-            workflow,
-            workflow.workflow_name,
+        # Use workflow's name directly
+        name = workflow.workflow_name
+        queue = _declare_workflow_queue(
+            f"_llamaindex_workflow_queue:{name}",
+            workflow._num_concurrent_runs,
+            self.config.get("polling_interval_sec", 1.0),
         )
-        self._queue_for_workflow(workflow)
 
         # Create DBOS-wrapped control loop with stable name
         wf_kwargs: dict[str, Any] = {"name": f"{name}.control_loop"}
@@ -610,7 +471,10 @@ class DBOSRuntime(Runtime):
         }
 
         registered = RegisteredWorkflow(
-            workflow=workflow, workflow_run_fn=_dbos_control_loop, steps=wrapped_steps
+            workflow=workflow,
+            workflow_run_fn=_dbos_control_loop,
+            steps=wrapped_steps,
+            queue=queue,
         )
         self._registered[id(workflow)] = registered
         return registered
@@ -779,36 +643,42 @@ class DBOSRuntime(Runtime):
         active_serializer = serializer or JsonSerializer()
 
         async def _run_workflow() -> WorkflowHandleAsync[Any]:
-            # Write initial state to DB before starting workflow (non-blocking to caller)
-            if serialized_state:
-                workflow_store = self.create_workflow_store()
-                await workflow_store.start()
-                store = workflow_store.create_state_store(
-                    run_id,
-                    infer_state_type(workflow),
-                    serialized_state,
-                    active_serializer,
-                )
-                # Materialize the seed before the workflow starts so the
-                # first step observes the restored state.
-                if isinstance(store, StateStoreFacade):
-                    await store.ensure_seeded()
+            with SetWorkflowID(run_id):
+                # Write initial state to DB before starting workflow (non-blocking to caller)
+                if serialized_state:
+                    workflow_store = self.create_workflow_store()
+                    await workflow_store.start()
+                    store = workflow_store.create_state_store(
+                        run_id,
+                        infer_state_type(workflow),
+                        serialized_state,
+                        active_serializer,
+                    )
+                    # Materialize the seed before the workflow starts so the
+                    # first step observes the restored state.
+                    if isinstance(store, StateStoreFacade):
+                        await store.ensure_seeded()
 
-            try:
-                with SetWorkflowID(run_id):
-                    queue = self._queue_for_workflow(workflow)
-                    return await queue.enqueue_async(
+                try:
+                    if workflow._num_concurrent_runs is not None:
+                        return await registered.queue.enqueue_async(
+                            registered.workflow_run_fn,
+                            init_state,
+                            start_event,
+                            get_dispatcher().capture_propagation_context(),
+                        )
+                    return await DBOS.start_workflow_async(
                         registered.workflow_run_fn,
                         init_state,
                         start_event,
                         get_dispatcher().capture_propagation_context(),
                     )
-            except Exception as e:
-                logger.error(
-                    f"Failed to submit work to DBOS for {run_id} with start event: {start_event} and init state: {init_state}. Error: {e}",
-                    exc_info=True,
-                )
-                raise e
+                except Exception as e:
+                    logger.error(
+                        f"Failed to submit work to DBOS for {run_id} with start event: {start_event} and init state: {init_state}. Error: {e}",
+                        exc_info=True,
+                    )
+                    raise e
 
         # Create startup task and pass to adapter so it can await workflow readiness
         startup_task = asyncio.create_task(_run_workflow())
@@ -1039,7 +909,6 @@ class DBOSRuntime(Runtime):
 
         # Register each pending workflow with DBOS
         for workflow in self._tracked_workflows:
-            self._queue_for_workflow(workflow)
             # Register with DBOS (this applies decorators)
             registered = self.register(workflow)
             self._registered[id(workflow)] = registered
@@ -1150,9 +1019,8 @@ class DBOSRuntime(Runtime):
                 Set to False when DBOS lifecycle is managed externally
                 (e.g., shared across multiple runtimes in tests).
         """
-        owned_queues = {
-            queue for _, queue in self._workflow_queue_by_workflow_id.values()
-        }
+        if not self._dbos_launched:
+            return  # Already destroyed or never launched
 
         # Cancel lease watcher first to avoid re-entrant destroy
         if self._lease_watch_task is not None:
@@ -1170,7 +1038,6 @@ class DBOSRuntime(Runtime):
         self._tracked_workflows.clear()
         self._tracked_workflow_ids.clear()
         self._registered.clear()
-        self._registration_name_by_workflow.clear()
         self._dbos_launched = False
         self._launch_ready = threading.Event()
         self._sql_engine = None
@@ -1206,12 +1073,6 @@ class DBOSRuntime(Runtime):
             await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
         if destroy_dbos:
             DBOS.destroy()
-            for queue in owned_queues:
-                _WORKFLOW_QUEUE_DECLARATIONS.release(
-                    owner=self._queue_owner,
-                    name=queue.name,
-                )
-            self._workflow_queue_by_workflow_id.clear()
 
 
 _IO_STREAM_PUBLISHED_EVENTS_NAME = "published_events"

--- a/packages/llama-agents-dbos/tests/fixtures/replica_server.py
+++ b/packages/llama-agents-dbos/tests/fixtures/replica_server.py
@@ -43,7 +43,9 @@ async def main() -> None:
         "executor_id": args.executor_id or f"test-replica-{args.port}",
     }
     DBOS(config=config)
-    dbos_runtime = DBOSRuntime(polling_interval_sec=0.01)
+    dbos_runtime = DBOSRuntime(
+        polling_interval_sec=0.01, queue_polling_interval_sec=1.0
+    )
 
     wf = workflow_class(runtime=dbos_runtime)
     await dbos_runtime.launch()

--- a/packages/llama-agents-dbos/tests/fixtures/runner_common.py
+++ b/packages/llama-agents-dbos/tests/fixtures/runner_common.py
@@ -64,4 +64,7 @@ def setup_dbos(db_url: str, app_name: str = "test-workflow") -> DBOSRuntime:
         "notification_listener_polling_interval_sec": 0.01,
     }
     DBOS(config=config)
-    return DBOSRuntime(polling_interval_sec=0.01)
+    # Keep queue polling at its slow default: these workflows are unlimited, and
+    # a 10ms queue poll writes-locks the SQLite file hard enough to starve the
+    # workflow's own journal writes on slow CI runners.
+    return DBOSRuntime(polling_interval_sec=0.01, queue_polling_interval_sec=1.0)

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, patch
 import asyncpg
 import pytest
 from dbos import DBOS, DBOSConfig
+from dbos._context import get_local_dbos_context
 from llama_agents.dbos import DBOSRuntime
 from llama_agents.dbos.journal.crud import SqliteJournalCrud
 from llama_agents.dbos.journal.task_journal import TaskJournal
@@ -341,12 +342,24 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
         return StopEvent(result="done")
 
     runtime = DBOSRuntime(polling_interval_sec=0.01)
+    workflow = SimpleWf(runtime=runtime)
     runtime._dbos_launched = True
-    workflow = SimpleWf()
     workflow_store = RecordingWorkflowStore()
     serialized_state = {"store_type": "sqlite", "run_id": "old-run"}
     serializer = JsonSerializer()
     fake_handle = AsyncMock()
+    enqueue_observations: dict[str, Any] = {}
+
+    async def enqueue_async(*args: Any, **kwargs: Any) -> Any:
+        context = get_local_dbos_context()
+        assert context is not None
+        enqueue_observations["run_id"] = context.id_assigned_for_next_workflow
+        enqueue_observations["state_seeded"] = (
+            workflow_store.state_store.ensure_seeded_called
+        )
+        return fake_handle
+
+    enqueue_mock = AsyncMock(side_effect=enqueue_async)
 
     with (
         patch.object(runtime, "create_workflow_store", return_value=workflow_store),
@@ -357,9 +370,10 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
                 workflow=workflow, workflow_run_fn=workflow_run_fn, steps={}
             ),
         ),
-        patch(
-            "llama_agents.dbos.runtime.DBOS.start_workflow_async",
-            new=AsyncMock(return_value=fake_handle),
+        patch.object(
+            runtime.workflow_queues[0],
+            "enqueue_async",
+            new=enqueue_mock,
         ),
     ):
         adapter = runtime.run_workflow(
@@ -376,6 +390,11 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
     assert workflow_store.create_state_store_calls == [
         ("run-1", DictState, serialized_state, serializer)
     ]
+    enqueue_mock.assert_awaited_once()
+    enqueue_args = enqueue_mock.await_args
+    assert enqueue_args is not None
+    assert enqueue_args.args[0] is workflow_run_fn
+    assert enqueue_observations == {"run_id": "run-1", "state_seeded": True}
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-dbos/tests/test_dbos_runtime.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_runtime.py
@@ -348,18 +348,18 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
     serialized_state = {"store_type": "sqlite", "run_id": "old-run"}
     serializer = JsonSerializer()
     fake_handle = AsyncMock()
-    enqueue_observations: dict[str, Any] = {}
+    start_observations: dict[str, Any] = {}
 
-    async def enqueue_async(*args: Any, **kwargs: Any) -> Any:
+    async def start_workflow_async(*args: Any, **kwargs: Any) -> Any:
         context = get_local_dbos_context()
         assert context is not None
-        enqueue_observations["run_id"] = context.id_assigned_for_next_workflow
-        enqueue_observations["state_seeded"] = (
+        start_observations["run_id"] = context.id_assigned_for_next_workflow
+        start_observations["state_seeded"] = (
             workflow_store.state_store.ensure_seeded_called
         )
         return fake_handle
 
-    enqueue_mock = AsyncMock(side_effect=enqueue_async)
+    start_mock = AsyncMock(side_effect=start_workflow_async)
 
     with (
         patch.object(runtime, "create_workflow_store", return_value=workflow_store),
@@ -370,10 +370,9 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
                 workflow=workflow, workflow_run_fn=workflow_run_fn, steps={}
             ),
         ),
-        patch.object(
-            runtime.workflow_queues[0],
-            "enqueue_async",
-            new=enqueue_mock,
+        patch(
+            "llama_agents.dbos.runtime.DBOS.start_workflow_async",
+            new=start_mock,
         ),
     ):
         adapter = runtime.run_workflow(
@@ -390,11 +389,11 @@ async def test_run_workflow_seeds_state_store_from_durable_handle() -> None:
     assert workflow_store.create_state_store_calls == [
         ("run-1", DictState, serialized_state, serializer)
     ]
-    enqueue_mock.assert_awaited_once()
-    enqueue_args = enqueue_mock.await_args
-    assert enqueue_args is not None
-    assert enqueue_args.args[0] is workflow_run_fn
-    assert enqueue_observations == {"run_id": "run-1", "state_seeded": True}
+    start_mock.assert_awaited_once()
+    start_args = start_mock.await_args
+    assert start_args is not None
+    assert start_args.args[0] is workflow_run_fn
+    assert start_observations == {"run_id": "run-1", "state_seeded": True}
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
@@ -4,16 +4,13 @@
 from __future__ import annotations
 
 import asyncio
-import gc
 import threading
-import weakref
 from pathlib import Path
 from typing import Any
 
 import pytest
-from dbos import DBOS, DBOSConfig, Queue
+from dbos import DBOS, DBOSConfig
 from llama_agents.dbos import DBOSRuntime
-from llama_agents.server import WorkflowServer
 from workflows.decorators import step
 from workflows.errors import WorkflowCancelledByUser
 from workflows.events import StartEvent, StopEvent, WorkflowCancelledEvent
@@ -71,409 +68,207 @@ def _blocking_workflow_type(
     return BlockingWorkflow
 
 
-def test_runtime_creates_stable_unlimited_workflow_queue() -> None:
-    runtime = DBOSRuntime(polling_interval_sec=0.125)
-    workflow = _blocking_workflow_type(
-        _AdmissionGate(), class_name="UnlimitedQueueWorkflow"
-    )(
-        runtime=runtime,
-        workflow_name="tests.dbos.unlimited-queue",
-    )
-
-    assert len(runtime.workflow_queues) == 1
-    queue = runtime.workflow_queues[0]
-    assert queue.name == ("_llamaindex_workflow_queue:tests.dbos.unlimited-queue")
-    assert queue.worker_concurrency is None
-    assert queue.polling_interval_sec == 0.125
-
-    runtime.track_workflow(workflow)
-    assert runtime.workflow_queues == (queue,)
-
-
-def test_runtime_creates_stable_limited_workflow_queue() -> None:
-    runtime = DBOSRuntime(polling_interval_sec=0.25)
-    _blocking_workflow_type(_AdmissionGate(), class_name="LimitedQueueWorkflow")(
-        runtime=runtime,
-        workflow_name="tests.dbos.limited-queue",
-        num_concurrent_runs=3,
-    )
-
-    assert len(runtime.workflow_queues) == 1
-    queue = runtime.workflow_queues[0]
-    assert queue.name == "_llamaindex_workflow_queue:tests.dbos.limited-queue"
-    assert queue.worker_concurrency == 3
-    assert queue.concurrency is None
-    assert queue.polling_interval_sec == 0.25
-
-
-def test_untrack_releases_exclusive_prelaunch_queue() -> None:
-    runtime = DBOSRuntime()
-    workflow = _blocking_workflow_type(
-        _AdmissionGate(), class_name="UntrackedQueueWorkflow"
-    )(
-        runtime=runtime,
-        workflow_name="tests.dbos.untracked-queue",
-    )
-    queue = runtime.workflow_queues[0]
-
-    runtime.untrack_workflow(workflow)
-
-    assert runtime.workflow_queues == ()
-    replacement_runtime = DBOSRuntime()
-    _blocking_workflow_type(
-        _AdmissionGate(), class_name="ReplacementUntrackedQueueWorkflow"
-    )(
-        runtime=replacement_runtime,
-        workflow_name="tests.dbos.untracked-queue",
-        num_concurrent_runs=1,
-    )
-    assert replacement_runtime.workflow_queues == (queue,)
-    assert queue.worker_concurrency == 1
-    asyncio.run(replacement_runtime.destroy())
-
-
-def test_workflow_alias_does_not_change_declared_queue() -> None:
-    runtime = DBOSRuntime()
-    workflow = _blocking_workflow_type(
-        _AdmissionGate(), class_name="RenamedQueueWorkflow"
-    )(
-        runtime=runtime,
-        workflow_name="tests.dbos.rename-original",
-    )
-    original_queue = runtime.workflow_queues[0]
-    workflow._switch_workflow_name("tests.dbos.rename-collision")
-    assert runtime.workflow_queues == (original_queue,)
-    assert original_queue.name == (
-        "_llamaindex_workflow_queue:tests.dbos.rename-original"
-    )
-
-
-def test_server_alias_before_launch_keeps_dbos_queue_name() -> None:
-    runtime = DBOSRuntime()
-    workflow = _blocking_workflow_type(
-        _AdmissionGate(), class_name="PrelaunchServerAliasWorkflow"
-    )(
-        runtime=runtime,
-        workflow_name="tests.dbos.stable-registration-name",
-    )
-    server = WorkflowServer(
-        runtime=runtime.build_server_runtime(),
-        workflow_store=runtime.create_workflow_store(),
-    )
-
-    server.add_workflow("route-alias", workflow)
-
-    assert workflow.workflow_name == "route-alias"
-    assert runtime.workflow_queues[0].name == (
-        "_llamaindex_workflow_queue:tests.dbos.stable-registration-name"
-    )
-
-
-def test_runtime_rejects_queue_declared_by_application() -> None:
-    queue_name = "_llamaindex_workflow_queue:tests.dbos.application-queue"
-    Queue(queue_name)
-    runtime = DBOSRuntime()
-    _blocking_workflow_type(_AdmissionGate(), class_name="ApplicationQueueWorkflow")(
-        runtime=runtime,
-        workflow_name="tests.dbos.application-queue",
-    )
-
-    with pytest.raises(RuntimeError, match="DBOS rejected workflow queue"):
-        runtime.workflow_queues
-
-
-def test_runtime_rejects_duplicate_name_with_conflicting_limits() -> None:
-    runtime = DBOSRuntime()
-    workflow_type = _blocking_workflow_type(
-        _AdmissionGate(), class_name="DuplicateNameWorkflow"
-    )
-    workflow_type(
-        runtime=runtime,
-        workflow_name="tests.dbos.duplicate-name",
-    )
-
-    with pytest.raises(RuntimeError, match="conflicting num_concurrent_runs"):
-        workflow_type(
-            runtime=runtime,
-            workflow_name="tests.dbos.duplicate-name",
-            num_concurrent_runs=2,
-        )
-
-
-def test_equivalent_workflows_share_queue_with_instance_registrations() -> None:
-    runtime = DBOSRuntime()
-    workflow_type = _blocking_workflow_type(
-        _AdmissionGate(), class_name="SharedNameWorkflow"
-    )
-    first = workflow_type(
-        runtime=runtime,
-        workflow_name="tests.dbos.shared-name",
-        num_concurrent_runs=2,
-    )
-    second = workflow_type(
-        runtime=runtime,
-        workflow_name="tests.dbos.shared-name",
-        num_concurrent_runs=2,
-    )
-
-    assert len(runtime.workflow_queues) == 1
-    assert runtime.register(first) is not runtime.register(second)
-
-
-def test_destroy_reuses_queue_across_limit_transitions(tmp_path: Path) -> None:
-    workflow_type = _blocking_workflow_type(
-        _AdmissionGate(), class_name="ReusedQueueWorkflow"
-    )
-    workflow_name = "tests.dbos.reused-queue"
-    config = _dbos_config(
-        tmp_path / "reused-queue.sqlite3",
-        "dbos-reused-queue-test",
-    )
-    DBOS(config=config)
-    first_runtime = DBOSRuntime()
-    workflow_type(runtime=first_runtime, workflow_name=workflow_name)
-    queue = first_runtime.workflow_queues[0]
-    asyncio.run(first_runtime.destroy())
-
-    DBOS(config=config)
-    second_runtime = DBOSRuntime()
-    workflow_type(
-        runtime=second_runtime,
-        workflow_name=workflow_name,
-        num_concurrent_runs=1,
-    )
-    assert second_runtime.workflow_queues == (queue,)
-    assert queue.worker_concurrency == 1
-    asyncio.run(second_runtime.destroy())
-
-    DBOS(config=config)
-    third_runtime = DBOSRuntime()
-    workflow_type(runtime=third_runtime, workflow_name=workflow_name)
-    assert third_runtime.workflow_queues == (queue,)
-    assert queue.worker_concurrency is None
-    asyncio.run(third_runtime.destroy())
-
-
-def test_destroy_without_dbos_retains_queue_ownership() -> None:
-    workflow_type = _blocking_workflow_type(
-        _AdmissionGate(), class_name="ExternallyOwnedQueueWorkflow"
-    )
-    workflow_name = "tests.dbos.externally-owned-queue"
-    owner_runtime = DBOSRuntime()
-    workflow_type(runtime=owner_runtime, workflow_name=workflow_name)
-    owner_runtime.workflow_queues
-
-    asyncio.run(owner_runtime.destroy(destroy_dbos=False))
-
-    other_runtime = DBOSRuntime()
-    workflow_type(
-        runtime=other_runtime,
-        workflow_name=workflow_name,
-        num_concurrent_runs=1,
-    )
-    with pytest.raises(RuntimeError, match="already declared"):
-        other_runtime.workflow_queues
-    asyncio.run(owner_runtime.destroy())
-
-
-def test_destroyed_queue_does_not_retain_runtime() -> None:
-    runtime = DBOSRuntime()
-    workflow_type = _blocking_workflow_type(
-        _AdmissionGate(), class_name="ReleasedOwnerQueueWorkflow"
-    )
-    workflow_type(
-        runtime=runtime,
-        workflow_name="tests.dbos.released-owner-queue",
-    )
-    runtime_ref = weakref.ref(runtime)
-
-    asyncio.run(runtime.destroy())
-    del runtime
-    gc.collect()
-
-    assert runtime_ref() is None
-
-
-def test_launch_accepts_runtime_workflow_queues(tmp_path: Path) -> None:
+async def _run_limited_admission_case(tmp_path: Path) -> None:
     DBOS(
         config=_dbos_config(
-            tmp_path / "accepted-listener.sqlite3",
-            "dbos-accepted-listener-test",
+            tmp_path / "limited-admission.sqlite3",
+            "dbos-limited-admission-test",
         )
     )
     runtime = DBOSRuntime(polling_interval_sec=0.01)
+    gate = _AdmissionGate()
     workflow = _blocking_workflow_type(
-        _AdmissionGate(), class_name="AcceptedListenerWorkflow"
-    )(
-        runtime=runtime,
-        workflow_name="tests.dbos.accepted-listener",
-    )
-    DBOS.listen_queues(list(runtime.workflow_queues))
-
-    try:
-        runtime.launch_sync()
-        assert not workflow._runtime_locked
-    finally:
-        asyncio.run(runtime.destroy())
-
-
-def test_late_registration_joins_default_queue_listener(tmp_path: Path) -> None:
-    DBOS(
-        config=_dbos_config(
-            tmp_path / "late-listener.sqlite3",
-            "dbos-late-listener-test",
-        )
-    )
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
-    first_type = _blocking_workflow_type(
-        _AdmissionGate(), class_name="InitialListenerWorkflow"
-    )
-    first_type(runtime=runtime, workflow_name="tests.dbos.initial-listener")
-    try:
-        runtime.launch_sync()
-        late_type = _blocking_workflow_type(
-            _AdmissionGate(), class_name="LateListenerWorkflow"
-        )
-        late_workflow = late_type(
-            runtime=runtime,
-            workflow_name="tests.dbos.late-listener",
-        )
-        assert runtime.get_registered(late_workflow) is not None
-        assert any(
-            queue.name == "_llamaindex_workflow_queue:tests.dbos.late-listener"
-            for queue in runtime.workflow_queues
-        )
-    finally:
-        asyncio.run(runtime.destroy())
-
-
-async def _run_server_rename_after_launch(tmp_path: Path) -> None:
-    DBOS(
-        config=_dbos_config(
-            tmp_path / "server-rename.sqlite3",
-            "dbos-server-rename-test",
-        )
-    )
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
-    workflow_type = _blocking_workflow_type(
-        _AdmissionGate(), class_name="ServerRenamedWorkflow"
-    )
-    workflow = workflow_type(runtime=runtime)
-    original_queue = runtime.workflow_queues[0]
-
-    try:
-        await runtime.launch()
-        server = WorkflowServer(
-            runtime=runtime.build_server_runtime(),
-            workflow_store=runtime.create_workflow_store(),
-        )
-        server.add_workflow("server-alias", workflow)
-
-        assert workflow.workflow_name == "server-alias"
-        assert runtime.workflow_queues == (original_queue,)
-        assert runtime.get_registered(workflow) is not None
-    finally:
-        await runtime.destroy()
-
-
-def test_server_can_rename_workflow_after_dbos_launch(tmp_path: Path) -> None:
-    asyncio.run(_run_server_rename_after_launch(tmp_path))
-
-
-async def _run_admission_cases(
-    tmp_path: Path,
-) -> None:
-    name = "workflow-admission"
-    DBOS(config=_dbos_config(tmp_path / f"{name}.sqlite3", name))
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
-    limited_gate = _AdmissionGate()
-    unlimited_gate = _AdmissionGate()
-    limited_type = _blocking_workflow_type(
-        limited_gate,
+        gate,
         class_name="LimitedAdmissionWorkflow",
-    )
-    unlimited_type = _blocking_workflow_type(
-        unlimited_gate,
-        class_name="UnlimitedAdmissionWorkflow",
-    )
-    limited_workflow = limited_type(
+    )(
         runtime=runtime,
         workflow_name="tests.dbos.limited-admission",
         num_concurrent_runs=1,
         timeout=10,
     )
-    unlimited_workflow = unlimited_type(
+    handlers: dict[str, Any] = {}
+
+    try:
+        await runtime.launch()
+        handlers = {
+            run_id: workflow.run(run=run_id, run_id=run_id)
+            for run_id in ("limited-first", "limited-second")
+        }
+        admitted = await asyncio.to_thread(gate.wait_for_started, 1)
+        assert admitted
+        assert len(gate.started) == 1
+
+        queued_run = (
+            "limited-second" if gate.started == ["limited-first"] else "limited-first"
+        )
+        status = await DBOS.get_workflow_status_async(queued_run)
+        assert status is not None
+        assert status.status == "ENQUEUED"
+
+        gate.release()
+        results = await asyncio.wait_for(
+            asyncio.gather(*handlers.values()),
+            timeout=10,
+        )
+        assert set(results) == {"limited-first", "limited-second"}
+        assert set(gate.started) == {"limited-first", "limited-second"}
+    finally:
+        gate.release()
+        if handlers:
+            await asyncio.gather(*handlers.values(), return_exceptions=True)
+        await runtime.destroy()
+
+
+def test_limited_workflow_queues_excess_runs(tmp_path: Path) -> None:
+    asyncio.run(_run_limited_admission_case(tmp_path))
+
+
+async def _run_unlimited_admission_case(tmp_path: Path) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "unlimited-admission.sqlite3",
+            "dbos-unlimited-admission-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    gate = _AdmissionGate()
+    workflow = _blocking_workflow_type(
+        gate,
+        class_name="UnlimitedAdmissionWorkflow",
+    )(
         runtime=runtime,
         workflow_name="tests.dbos.unlimited-admission",
         timeout=10,
     )
-    handlers: list[Any] = []
+    handlers: dict[str, Any] = {}
 
     try:
         await runtime.launch()
-        handlers = [
-            limited_workflow.run(run="limited-first", run_id="limited-first"),
-            limited_workflow.run(run="limited-second", run_id="limited-second"),
-            unlimited_workflow.run(
-                run="unlimited-first",
-                run_id="unlimited-first",
-            ),
-            unlimited_workflow.run(
-                run="unlimited-second",
-                run_id="unlimited-second",
-            ),
-        ]
-
-        limited_admitted = await asyncio.to_thread(
-            limited_gate.wait_for_started,
-            1,
-        )
-        unlimited_admitted = await asyncio.to_thread(
-            unlimited_gate.wait_for_started,
-            2,
-        )
-        assert limited_admitted
-        assert unlimited_admitted
-        assert len(limited_gate.started) == 1
-        assert limited_gate.started[0] in {"limited-first", "limited-second"}
-        assert set(unlimited_gate.started) == {
-            "unlimited-first",
-            "unlimited-second",
+        handlers = {
+            run_id: workflow.run(run=run_id, run_id=run_id)
+            for run_id in ("unlimited-first", "unlimited-second")
         }
+        admitted = await asyncio.to_thread(gate.wait_for_started, 2)
+        assert admitted
+        assert set(gate.started) == {"unlimited-first", "unlimited-second"}
 
-        unstarted_run = (
-            "limited-second"
-            if limited_gate.started == ["limited-first"]
-            else "limited-first"
+        statuses = await asyncio.gather(
+            *(DBOS.get_workflow_status_async(run_id) for run_id in handlers)
         )
-        status = await DBOS.get_workflow_status_async(unstarted_run)
-        assert status is not None
-        assert status.status == "ENQUEUED"
+        assert all(status is not None for status in statuses)
+        assert all(status.status != "ENQUEUED" for status in statuses if status)
 
-        limited_gate.release()
-        unlimited_gate.release()
+        gate.release()
         results = await asyncio.wait_for(
-            asyncio.gather(*handlers),
+            asyncio.gather(*handlers.values()),
             timeout=10,
         )
-        assert results == [
-            "limited-first",
-            "limited-second",
-            "unlimited-first",
-            "unlimited-second",
-        ]
+        assert set(results) == {"unlimited-first", "unlimited-second"}
     finally:
-        limited_gate.release()
-        unlimited_gate.release()
+        gate.release()
         if handlers:
-            await asyncio.gather(*handlers, return_exceptions=True)
+            await asyncio.gather(*handlers.values(), return_exceptions=True)
         await runtime.destroy()
 
 
-def test_limited_and_unlimited_worker_admission(
-    tmp_path: Path,
-) -> None:
-    asyncio.run(_run_admission_cases(tmp_path))
+def test_unlimited_workflow_starts_runs_directly(tmp_path: Path) -> None:
+    asyncio.run(_run_unlimited_admission_case(tmp_path))
+
+
+async def _run_queue_declaration_case(tmp_path: Path) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "queue-declaration.sqlite3",
+            "dbos-queue-declaration-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.125)
+    _blocking_workflow_type(
+        _AdmissionGate(),
+        class_name="LimitedQueueWorkflow",
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.limited-queue",
+        num_concurrent_runs=3,
+    )
+    _blocking_workflow_type(
+        _AdmissionGate(),
+        class_name="UnlimitedQueueWorkflow",
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.unlimited-queue",
+    )
+
+    try:
+        await runtime.launch()
+        queues = {queue.name: queue for queue in runtime.workflow_queues}
+        assert list(queues) == [
+            "_llamaindex_workflow_queue:tests.dbos.limited-queue",
+            "_llamaindex_workflow_queue:tests.dbos.unlimited-queue",
+        ]
+        assert (
+            queues[
+                "_llamaindex_workflow_queue:tests.dbos.limited-queue"
+            ].worker_concurrency
+            == 3
+        )
+        assert (
+            queues[
+                "_llamaindex_workflow_queue:tests.dbos.unlimited-queue"
+            ].worker_concurrency
+            is None
+        )
+    finally:
+        await runtime.destroy()
+
+
+def test_runtime_declares_queue_for_every_workflow(tmp_path: Path) -> None:
+    asyncio.run(_run_queue_declaration_case(tmp_path))
+
+
+async def _run_destroy_relaunch_case(tmp_path: Path) -> None:
+    config = _dbos_config(
+        tmp_path / "reused-queue.sqlite3",
+        "dbos-reused-queue-test",
+    )
+    workflow_name = "tests.dbos.reused-queue"
+
+    DBOS(config=config)
+    first_runtime = DBOSRuntime(polling_interval_sec=0.01)
+    _blocking_workflow_type(
+        _AdmissionGate(),
+        class_name="FirstReusedQueueWorkflow",
+    )(
+        runtime=first_runtime,
+        workflow_name=workflow_name,
+        num_concurrent_runs=1,
+    )
+    await first_runtime.launch()
+    queue = first_runtime.workflow_queues[0]
+    await first_runtime.destroy(destroy_dbos=True)
+
+    DBOS(config=config)
+    second_runtime = DBOSRuntime(polling_interval_sec=0.02)
+    _blocking_workflow_type(
+        _AdmissionGate(),
+        class_name="SecondReusedQueueWorkflow",
+    )(
+        runtime=second_runtime,
+        workflow_name=workflow_name,
+        num_concurrent_runs=2,
+    )
+
+    try:
+        await second_runtime.launch()
+        assert second_runtime.workflow_queues == (queue,)
+        assert queue.worker_concurrency == 2
+        assert queue.polling_interval_sec == 0.02
+    finally:
+        await second_runtime.destroy(destroy_dbos=True)
+
+
+def test_destroy_relaunch_reuses_queue_with_updated_limit(tmp_path: Path) -> None:
+    asyncio.run(_run_destroy_relaunch_case(tmp_path))
 
 
 async def _run_queued_cancellation_case(tmp_path: Path) -> None:
@@ -492,8 +287,6 @@ async def _run_queued_cancellation_case(tmp_path: Path) -> None:
             run = ev.get("run")
             assert isinstance(run, str)
             await gate.enter(run)
-            # Keep the admitted run active while the control loop reduces the
-            # cancellation tick that was stored before admission.
             await asyncio.sleep(0.2)
             return StopEvent(result=run)
 

--- a/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
@@ -75,7 +75,7 @@ async def _run_limited_admission_case(tmp_path: Path) -> None:
             "dbos-limited-admission-test",
         )
     )
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    runtime = DBOSRuntime(polling_interval_sec=0.01, queue_polling_interval_sec=0.01)
     gate = _AdmissionGate()
     workflow = _blocking_workflow_type(
         gate,
@@ -130,7 +130,7 @@ async def _run_unlimited_admission_case(tmp_path: Path) -> None:
             "dbos-unlimited-admission-test",
         )
     )
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    runtime = DBOSRuntime(polling_interval_sec=0.01, queue_polling_interval_sec=0.01)
     gate = _AdmissionGate()
     workflow = _blocking_workflow_type(
         gate,
@@ -182,7 +182,7 @@ async def _run_queue_declaration_case(tmp_path: Path) -> None:
             "dbos-queue-declaration-test",
         )
     )
-    runtime = DBOSRuntime(polling_interval_sec=0.125)
+    runtime = DBOSRuntime(queue_polling_interval_sec=0.125)
     _blocking_workflow_type(
         _AdmissionGate(),
         class_name="LimitedQueueWorkflow",
@@ -234,7 +234,9 @@ async def _run_destroy_relaunch_case(tmp_path: Path) -> None:
     workflow_name = "tests.dbos.reused-queue"
 
     DBOS(config=config)
-    first_runtime = DBOSRuntime(polling_interval_sec=0.01)
+    first_runtime = DBOSRuntime(
+        polling_interval_sec=0.01, queue_polling_interval_sec=0.01
+    )
     _blocking_workflow_type(
         _AdmissionGate(),
         class_name="FirstReusedQueueWorkflow",
@@ -248,7 +250,9 @@ async def _run_destroy_relaunch_case(tmp_path: Path) -> None:
     await first_runtime.destroy(destroy_dbos=True)
 
     DBOS(config=config)
-    second_runtime = DBOSRuntime(polling_interval_sec=0.02)
+    second_runtime = DBOSRuntime(
+        polling_interval_sec=0.01, queue_polling_interval_sec=0.02
+    )
     _blocking_workflow_type(
         _AdmissionGate(),
         class_name="SecondReusedQueueWorkflow",
@@ -278,7 +282,7 @@ async def _run_restricted_listener_case(tmp_path: Path) -> None:
             "dbos-restricted-listener-test",
         )
     )
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    runtime = DBOSRuntime(polling_interval_sec=0.01, queue_polling_interval_sec=0.01)
     gate = _AdmissionGate()
     workflow = _blocking_workflow_type(
         gate,
@@ -326,7 +330,7 @@ async def _run_queued_cancellation_case(tmp_path: Path) -> None:
             "dbos-queued-cancellation-test",
         )
     )
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    runtime = DBOSRuntime(polling_interval_sec=0.01, queue_polling_interval_sec=0.01)
     gate = _AdmissionGate()
 
     class QueuedCancellationWorkflow(Workflow):

--- a/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
@@ -271,6 +271,54 @@ def test_destroy_relaunch_reuses_queue_with_updated_limit(tmp_path: Path) -> Non
     asyncio.run(_run_destroy_relaunch_case(tmp_path))
 
 
+async def _run_restricted_listener_case(tmp_path: Path) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "restricted-listener.sqlite3",
+            "dbos-restricted-listener-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    gate = _AdmissionGate()
+    workflow = _blocking_workflow_type(
+        gate,
+        class_name="RestrictedListenerWorkflow",
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.restricted-listener",
+        num_concurrent_runs=1,
+        timeout=10,
+    )
+    runtime.register(workflow)
+    DBOS.listen_queues(list(runtime.workflow_queues))
+    handlers: dict[str, Any] = {}
+
+    try:
+        await runtime.launch()
+        handlers = {
+            run_id: workflow.run(run=run_id, run_id=run_id)
+            for run_id in ("restricted-first", "restricted-second")
+        }
+        admitted = await asyncio.to_thread(gate.wait_for_started, 1)
+        assert admitted
+
+        gate.release()
+        results = await asyncio.wait_for(
+            asyncio.gather(*handlers.values()),
+            timeout=10,
+        )
+        assert set(results) == {"restricted-first", "restricted-second"}
+    finally:
+        gate.release()
+        if handlers:
+            await asyncio.gather(*handlers.values(), return_exceptions=True)
+        await runtime.destroy()
+
+
+def test_restricted_listener_admits_runtime_queues(tmp_path: Path) -> None:
+    asyncio.run(_run_restricted_listener_case(tmp_path))
+
+
 async def _run_queued_cancellation_case(tmp_path: Path) -> None:
     DBOS(
         config=_dbos_config(

--- a/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
@@ -114,15 +114,25 @@ def test_untrack_releases_exclusive_prelaunch_queue() -> None:
         runtime=runtime,
         workflow_name="tests.dbos.untracked-queue",
     )
-    queue_name = runtime.workflow_queues[0].name
+    queue = runtime.workflow_queues[0]
 
     runtime.untrack_workflow(workflow)
 
     assert runtime.workflow_queues == ()
-    Queue(queue_name)
+    replacement_runtime = DBOSRuntime()
+    _blocking_workflow_type(
+        _AdmissionGate(), class_name="ReplacementUntrackedQueueWorkflow"
+    )(
+        runtime=replacement_runtime,
+        workflow_name="tests.dbos.untracked-queue",
+        num_concurrent_runs=1,
+    )
+    assert replacement_runtime.workflow_queues == (queue,)
+    assert queue.worker_concurrency == 1
+    asyncio.run(replacement_runtime.destroy())
 
 
-def test_rename_collision_preserves_original_queue() -> None:
+def test_workflow_alias_does_not_change_declared_queue() -> None:
     runtime = DBOSRuntime()
     workflow = _blocking_workflow_type(
         _AdmissionGate(), class_name="RenamedQueueWorkflow"
@@ -131,14 +141,45 @@ def test_rename_collision_preserves_original_queue() -> None:
         workflow_name="tests.dbos.rename-original",
     )
     original_queue = runtime.workflow_queues[0]
-    Queue("_llamaindex_workflow_queue:tests.dbos.rename-collision")
-
     workflow._switch_workflow_name("tests.dbos.rename-collision")
-    with pytest.raises(RuntimeError, match="owned by the application"):
-        runtime.workflow_queues
-
-    workflow._switch_workflow_name("tests.dbos.rename-original")
     assert runtime.workflow_queues == (original_queue,)
+    assert original_queue.name == (
+        "_llamaindex_workflow_queue:tests.dbos.rename-original"
+    )
+
+
+def test_server_alias_before_launch_keeps_dbos_queue_name() -> None:
+    runtime = DBOSRuntime()
+    workflow = _blocking_workflow_type(
+        _AdmissionGate(), class_name="PrelaunchServerAliasWorkflow"
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.stable-registration-name",
+    )
+    server = WorkflowServer(
+        runtime=runtime.build_server_runtime(),
+        workflow_store=runtime.create_workflow_store(),
+    )
+
+    server.add_workflow("route-alias", workflow)
+
+    assert workflow.workflow_name == "route-alias"
+    assert runtime.workflow_queues[0].name == (
+        "_llamaindex_workflow_queue:tests.dbos.stable-registration-name"
+    )
+
+
+def test_runtime_rejects_queue_declared_by_application() -> None:
+    queue_name = "_llamaindex_workflow_queue:tests.dbos.application-queue"
+    Queue(queue_name)
+    runtime = DBOSRuntime()
+    _blocking_workflow_type(_AdmissionGate(), class_name="ApplicationQueueWorkflow")(
+        runtime=runtime,
+        workflow_name="tests.dbos.application-queue",
+    )
+
+    with pytest.raises(RuntimeError, match="DBOS rejected workflow queue"):
+        runtime.workflow_queues
 
 
 def test_runtime_rejects_duplicate_name_with_conflicting_limits() -> None:
@@ -220,12 +261,18 @@ def test_destroy_without_dbos_retains_queue_ownership() -> None:
     workflow_name = "tests.dbos.externally-owned-queue"
     owner_runtime = DBOSRuntime()
     workflow_type(runtime=owner_runtime, workflow_name=workflow_name)
+    owner_runtime.workflow_queues
 
     asyncio.run(owner_runtime.destroy(destroy_dbos=False))
 
     other_runtime = DBOSRuntime()
-    with pytest.raises(RuntimeError, match="another live DBOS runtime"):
-        workflow_type(runtime=other_runtime, workflow_name=workflow_name)
+    workflow_type(
+        runtime=other_runtime,
+        workflow_name=workflow_name,
+        num_concurrent_runs=1,
+    )
+    with pytest.raises(RuntimeError, match="already declared"):
+        other_runtime.workflow_queues
     asyncio.run(owner_runtime.destroy())
 
 
@@ -245,36 +292,6 @@ def test_destroyed_queue_does_not_retain_runtime() -> None:
     gc.collect()
 
     assert runtime_ref() is None
-
-
-def test_launch_rejects_restricted_listener_missing_workflow_queue(
-    tmp_path: Path,
-) -> None:
-    DBOS(
-        config=_dbos_config(
-            tmp_path / "restricted-listener.sqlite3",
-            "dbos-restricted-listener-test",
-        )
-    )
-    runtime = DBOSRuntime(polling_interval_sec=0.01)
-    workflow = _blocking_workflow_type(
-        _AdmissionGate(), class_name="RestrictedListenerWorkflow"
-    )(
-        runtime=runtime,
-        workflow_name="tests.dbos.restricted-listener",
-    )
-    unrelated_queue = Queue("tests.dbos.unrelated-listener")
-    DBOS.listen_queues([unrelated_queue])
-
-    try:
-        with pytest.raises(
-            RuntimeError,
-            match="tests.dbos.restricted-listener",
-        ):
-            runtime.launch_sync()
-        assert not workflow._runtime_locked
-    finally:
-        asyncio.run(runtime.destroy())
 
 
 def test_launch_accepts_runtime_workflow_queues(tmp_path: Path) -> None:
@@ -300,7 +317,7 @@ def test_launch_accepts_runtime_workflow_queues(tmp_path: Path) -> None:
         asyncio.run(runtime.destroy())
 
 
-def test_late_registration_rejects_missing_restricted_queue(tmp_path: Path) -> None:
+def test_late_registration_joins_default_queue_listener(tmp_path: Path) -> None:
     DBOS(
         config=_dbos_config(
             tmp_path / "late-listener.sqlite3",
@@ -312,17 +329,18 @@ def test_late_registration_rejects_missing_restricted_queue(tmp_path: Path) -> N
         _AdmissionGate(), class_name="InitialListenerWorkflow"
     )
     first_type(runtime=runtime, workflow_name="tests.dbos.initial-listener")
-    DBOS.listen_queues(list(runtime.workflow_queues))
-
     try:
         runtime.launch_sync()
         late_type = _blocking_workflow_type(
             _AdmissionGate(), class_name="LateListenerWorkflow"
         )
-        with pytest.raises(RuntimeError, match="late-listener"):
-            late_type(runtime=runtime, workflow_name="tests.dbos.late-listener")
-        assert all(
-            queue.name != "_llamaindex_workflow_queue:tests.dbos.late-listener"
+        late_workflow = late_type(
+            runtime=runtime,
+            workflow_name="tests.dbos.late-listener",
+        )
+        assert runtime.get_registered(late_workflow) is not None
+        assert any(
+            queue.name == "_llamaindex_workflow_queue:tests.dbos.late-listener"
             for queue in runtime.workflow_queues
         )
     finally:

--- a/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
+++ b/packages/llama-agents-dbos/tests/test_dbos_workflow_concurrency.py
@@ -1,0 +1,521 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import threading
+import weakref
+from pathlib import Path
+from typing import Any
+
+import pytest
+from dbos import DBOS, DBOSConfig, Queue
+from llama_agents.dbos import DBOSRuntime
+from llama_agents.server import WorkflowServer
+from workflows.decorators import step
+from workflows.errors import WorkflowCancelledByUser
+from workflows.events import StartEvent, StopEvent, WorkflowCancelledEvent
+from workflows.workflow import Workflow
+
+
+class _AdmissionGate:
+    def __init__(self) -> None:
+        self._condition = threading.Condition()
+        self._release = threading.Event()
+        self.started: list[str] = []
+
+    async def enter(self, run: str) -> None:
+        with self._condition:
+            self.started.append(run)
+            self._condition.notify_all()
+        await asyncio.to_thread(self._release.wait)
+
+    def wait_for_started(self, count: int, timeout: float = 5.0) -> bool:
+        with self._condition:
+            return self._condition.wait_for(
+                lambda: len(self.started) >= count,
+                timeout=timeout,
+            )
+
+    def release(self) -> None:
+        self._release.set()
+
+
+def _dbos_config(db_path: Path, name: str) -> DBOSConfig:
+    return {
+        "name": name,
+        "system_database_url": (
+            f"sqlite+pysqlite:///{db_path}?check_same_thread=false"
+        ),
+        "run_admin_server": False,
+    }  # type: ignore[return-value]
+
+
+def _blocking_workflow_type(
+    gate: _AdmissionGate,
+    *,
+    class_name: str,
+) -> type[Workflow]:
+    class BlockingWorkflow(Workflow):
+        @step
+        async def block(self, ev: StartEvent) -> StopEvent:
+            run = ev.get("run")
+            assert isinstance(run, str)
+            await gate.enter(run)
+            return StopEvent(result=run)
+
+    BlockingWorkflow.__name__ = class_name
+    BlockingWorkflow.__qualname__ = class_name
+    return BlockingWorkflow
+
+
+def test_runtime_creates_stable_unlimited_workflow_queue() -> None:
+    runtime = DBOSRuntime(polling_interval_sec=0.125)
+    workflow = _blocking_workflow_type(
+        _AdmissionGate(), class_name="UnlimitedQueueWorkflow"
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.unlimited-queue",
+    )
+
+    assert len(runtime.workflow_queues) == 1
+    queue = runtime.workflow_queues[0]
+    assert queue.name == ("_llamaindex_workflow_queue:tests.dbos.unlimited-queue")
+    assert queue.worker_concurrency is None
+    assert queue.polling_interval_sec == 0.125
+
+    runtime.track_workflow(workflow)
+    assert runtime.workflow_queues == (queue,)
+
+
+def test_runtime_creates_stable_limited_workflow_queue() -> None:
+    runtime = DBOSRuntime(polling_interval_sec=0.25)
+    _blocking_workflow_type(_AdmissionGate(), class_name="LimitedQueueWorkflow")(
+        runtime=runtime,
+        workflow_name="tests.dbos.limited-queue",
+        num_concurrent_runs=3,
+    )
+
+    assert len(runtime.workflow_queues) == 1
+    queue = runtime.workflow_queues[0]
+    assert queue.name == "_llamaindex_workflow_queue:tests.dbos.limited-queue"
+    assert queue.worker_concurrency == 3
+    assert queue.concurrency is None
+    assert queue.polling_interval_sec == 0.25
+
+
+def test_untrack_releases_exclusive_prelaunch_queue() -> None:
+    runtime = DBOSRuntime()
+    workflow = _blocking_workflow_type(
+        _AdmissionGate(), class_name="UntrackedQueueWorkflow"
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.untracked-queue",
+    )
+    queue_name = runtime.workflow_queues[0].name
+
+    runtime.untrack_workflow(workflow)
+
+    assert runtime.workflow_queues == ()
+    Queue(queue_name)
+
+
+def test_rename_collision_preserves_original_queue() -> None:
+    runtime = DBOSRuntime()
+    workflow = _blocking_workflow_type(
+        _AdmissionGate(), class_name="RenamedQueueWorkflow"
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.rename-original",
+    )
+    original_queue = runtime.workflow_queues[0]
+    Queue("_llamaindex_workflow_queue:tests.dbos.rename-collision")
+
+    workflow._switch_workflow_name("tests.dbos.rename-collision")
+    with pytest.raises(RuntimeError, match="owned by the application"):
+        runtime.workflow_queues
+
+    workflow._switch_workflow_name("tests.dbos.rename-original")
+    assert runtime.workflow_queues == (original_queue,)
+
+
+def test_runtime_rejects_duplicate_name_with_conflicting_limits() -> None:
+    runtime = DBOSRuntime()
+    workflow_type = _blocking_workflow_type(
+        _AdmissionGate(), class_name="DuplicateNameWorkflow"
+    )
+    workflow_type(
+        runtime=runtime,
+        workflow_name="tests.dbos.duplicate-name",
+    )
+
+    with pytest.raises(RuntimeError, match="conflicting num_concurrent_runs"):
+        workflow_type(
+            runtime=runtime,
+            workflow_name="tests.dbos.duplicate-name",
+            num_concurrent_runs=2,
+        )
+
+
+def test_equivalent_workflows_share_queue_with_instance_registrations() -> None:
+    runtime = DBOSRuntime()
+    workflow_type = _blocking_workflow_type(
+        _AdmissionGate(), class_name="SharedNameWorkflow"
+    )
+    first = workflow_type(
+        runtime=runtime,
+        workflow_name="tests.dbos.shared-name",
+        num_concurrent_runs=2,
+    )
+    second = workflow_type(
+        runtime=runtime,
+        workflow_name="tests.dbos.shared-name",
+        num_concurrent_runs=2,
+    )
+
+    assert len(runtime.workflow_queues) == 1
+    assert runtime.register(first) is not runtime.register(second)
+
+
+def test_destroy_reuses_queue_across_limit_transitions(tmp_path: Path) -> None:
+    workflow_type = _blocking_workflow_type(
+        _AdmissionGate(), class_name="ReusedQueueWorkflow"
+    )
+    workflow_name = "tests.dbos.reused-queue"
+    config = _dbos_config(
+        tmp_path / "reused-queue.sqlite3",
+        "dbos-reused-queue-test",
+    )
+    DBOS(config=config)
+    first_runtime = DBOSRuntime()
+    workflow_type(runtime=first_runtime, workflow_name=workflow_name)
+    queue = first_runtime.workflow_queues[0]
+    asyncio.run(first_runtime.destroy())
+
+    DBOS(config=config)
+    second_runtime = DBOSRuntime()
+    workflow_type(
+        runtime=second_runtime,
+        workflow_name=workflow_name,
+        num_concurrent_runs=1,
+    )
+    assert second_runtime.workflow_queues == (queue,)
+    assert queue.worker_concurrency == 1
+    asyncio.run(second_runtime.destroy())
+
+    DBOS(config=config)
+    third_runtime = DBOSRuntime()
+    workflow_type(runtime=third_runtime, workflow_name=workflow_name)
+    assert third_runtime.workflow_queues == (queue,)
+    assert queue.worker_concurrency is None
+    asyncio.run(third_runtime.destroy())
+
+
+def test_destroy_without_dbos_retains_queue_ownership() -> None:
+    workflow_type = _blocking_workflow_type(
+        _AdmissionGate(), class_name="ExternallyOwnedQueueWorkflow"
+    )
+    workflow_name = "tests.dbos.externally-owned-queue"
+    owner_runtime = DBOSRuntime()
+    workflow_type(runtime=owner_runtime, workflow_name=workflow_name)
+
+    asyncio.run(owner_runtime.destroy(destroy_dbos=False))
+
+    other_runtime = DBOSRuntime()
+    with pytest.raises(RuntimeError, match="another live DBOS runtime"):
+        workflow_type(runtime=other_runtime, workflow_name=workflow_name)
+    asyncio.run(owner_runtime.destroy())
+
+
+def test_destroyed_queue_does_not_retain_runtime() -> None:
+    runtime = DBOSRuntime()
+    workflow_type = _blocking_workflow_type(
+        _AdmissionGate(), class_name="ReleasedOwnerQueueWorkflow"
+    )
+    workflow_type(
+        runtime=runtime,
+        workflow_name="tests.dbos.released-owner-queue",
+    )
+    runtime_ref = weakref.ref(runtime)
+
+    asyncio.run(runtime.destroy())
+    del runtime
+    gc.collect()
+
+    assert runtime_ref() is None
+
+
+def test_launch_rejects_restricted_listener_missing_workflow_queue(
+    tmp_path: Path,
+) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "restricted-listener.sqlite3",
+            "dbos-restricted-listener-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    workflow = _blocking_workflow_type(
+        _AdmissionGate(), class_name="RestrictedListenerWorkflow"
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.restricted-listener",
+    )
+    unrelated_queue = Queue("tests.dbos.unrelated-listener")
+    DBOS.listen_queues([unrelated_queue])
+
+    try:
+        with pytest.raises(
+            RuntimeError,
+            match="tests.dbos.restricted-listener",
+        ):
+            runtime.launch_sync()
+        assert not workflow._runtime_locked
+    finally:
+        asyncio.run(runtime.destroy())
+
+
+def test_launch_accepts_runtime_workflow_queues(tmp_path: Path) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "accepted-listener.sqlite3",
+            "dbos-accepted-listener-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    workflow = _blocking_workflow_type(
+        _AdmissionGate(), class_name="AcceptedListenerWorkflow"
+    )(
+        runtime=runtime,
+        workflow_name="tests.dbos.accepted-listener",
+    )
+    DBOS.listen_queues(list(runtime.workflow_queues))
+
+    try:
+        runtime.launch_sync()
+        assert not workflow._runtime_locked
+    finally:
+        asyncio.run(runtime.destroy())
+
+
+def test_late_registration_rejects_missing_restricted_queue(tmp_path: Path) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "late-listener.sqlite3",
+            "dbos-late-listener-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    first_type = _blocking_workflow_type(
+        _AdmissionGate(), class_name="InitialListenerWorkflow"
+    )
+    first_type(runtime=runtime, workflow_name="tests.dbos.initial-listener")
+    DBOS.listen_queues(list(runtime.workflow_queues))
+
+    try:
+        runtime.launch_sync()
+        late_type = _blocking_workflow_type(
+            _AdmissionGate(), class_name="LateListenerWorkflow"
+        )
+        with pytest.raises(RuntimeError, match="late-listener"):
+            late_type(runtime=runtime, workflow_name="tests.dbos.late-listener")
+        assert all(
+            queue.name != "_llamaindex_workflow_queue:tests.dbos.late-listener"
+            for queue in runtime.workflow_queues
+        )
+    finally:
+        asyncio.run(runtime.destroy())
+
+
+async def _run_server_rename_after_launch(tmp_path: Path) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "server-rename.sqlite3",
+            "dbos-server-rename-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    workflow_type = _blocking_workflow_type(
+        _AdmissionGate(), class_name="ServerRenamedWorkflow"
+    )
+    workflow = workflow_type(runtime=runtime)
+    original_queue = runtime.workflow_queues[0]
+
+    try:
+        await runtime.launch()
+        server = WorkflowServer(
+            runtime=runtime.build_server_runtime(),
+            workflow_store=runtime.create_workflow_store(),
+        )
+        server.add_workflow("server-alias", workflow)
+
+        assert workflow.workflow_name == "server-alias"
+        assert runtime.workflow_queues == (original_queue,)
+        assert runtime.get_registered(workflow) is not None
+    finally:
+        await runtime.destroy()
+
+
+def test_server_can_rename_workflow_after_dbos_launch(tmp_path: Path) -> None:
+    asyncio.run(_run_server_rename_after_launch(tmp_path))
+
+
+async def _run_admission_cases(
+    tmp_path: Path,
+) -> None:
+    name = "workflow-admission"
+    DBOS(config=_dbos_config(tmp_path / f"{name}.sqlite3", name))
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    limited_gate = _AdmissionGate()
+    unlimited_gate = _AdmissionGate()
+    limited_type = _blocking_workflow_type(
+        limited_gate,
+        class_name="LimitedAdmissionWorkflow",
+    )
+    unlimited_type = _blocking_workflow_type(
+        unlimited_gate,
+        class_name="UnlimitedAdmissionWorkflow",
+    )
+    limited_workflow = limited_type(
+        runtime=runtime,
+        workflow_name="tests.dbos.limited-admission",
+        num_concurrent_runs=1,
+        timeout=10,
+    )
+    unlimited_workflow = unlimited_type(
+        runtime=runtime,
+        workflow_name="tests.dbos.unlimited-admission",
+        timeout=10,
+    )
+    handlers: list[Any] = []
+
+    try:
+        await runtime.launch()
+        handlers = [
+            limited_workflow.run(run="limited-first", run_id="limited-first"),
+            limited_workflow.run(run="limited-second", run_id="limited-second"),
+            unlimited_workflow.run(
+                run="unlimited-first",
+                run_id="unlimited-first",
+            ),
+            unlimited_workflow.run(
+                run="unlimited-second",
+                run_id="unlimited-second",
+            ),
+        ]
+
+        limited_admitted = await asyncio.to_thread(
+            limited_gate.wait_for_started,
+            1,
+        )
+        unlimited_admitted = await asyncio.to_thread(
+            unlimited_gate.wait_for_started,
+            2,
+        )
+        assert limited_admitted
+        assert unlimited_admitted
+        assert len(limited_gate.started) == 1
+        assert limited_gate.started[0] in {"limited-first", "limited-second"}
+        assert set(unlimited_gate.started) == {
+            "unlimited-first",
+            "unlimited-second",
+        }
+
+        unstarted_run = (
+            "limited-second"
+            if limited_gate.started == ["limited-first"]
+            else "limited-first"
+        )
+        status = await DBOS.get_workflow_status_async(unstarted_run)
+        assert status is not None
+        assert status.status == "ENQUEUED"
+
+        limited_gate.release()
+        unlimited_gate.release()
+        results = await asyncio.wait_for(
+            asyncio.gather(*handlers),
+            timeout=10,
+        )
+        assert results == [
+            "limited-first",
+            "limited-second",
+            "unlimited-first",
+            "unlimited-second",
+        ]
+    finally:
+        limited_gate.release()
+        unlimited_gate.release()
+        if handlers:
+            await asyncio.gather(*handlers, return_exceptions=True)
+        await runtime.destroy()
+
+
+def test_limited_and_unlimited_worker_admission(
+    tmp_path: Path,
+) -> None:
+    asyncio.run(_run_admission_cases(tmp_path))
+
+
+async def _run_queued_cancellation_case(tmp_path: Path) -> None:
+    DBOS(
+        config=_dbos_config(
+            tmp_path / "queued-cancellation.sqlite3",
+            "dbos-queued-cancellation-test",
+        )
+    )
+    runtime = DBOSRuntime(polling_interval_sec=0.01)
+    gate = _AdmissionGate()
+
+    class QueuedCancellationWorkflow(Workflow):
+        @step
+        async def block(self, ev: StartEvent) -> StopEvent:
+            run = ev.get("run")
+            assert isinstance(run, str)
+            await gate.enter(run)
+            # Keep the admitted run active while the control loop reduces the
+            # cancellation tick that was stored before admission.
+            await asyncio.sleep(0.2)
+            return StopEvent(result=run)
+
+    workflow = QueuedCancellationWorkflow(
+        runtime=runtime,
+        workflow_name="tests.dbos.queued-cancellation",
+        num_concurrent_runs=1,
+        timeout=10,
+    )
+    handlers: dict[str, Any] = {}
+
+    try:
+        await runtime.launch()
+        handlers = {
+            run_id: workflow.run(run=run_id, run_id=run_id)
+            for run_id in ("cancel-first", "cancel-second")
+        }
+        admitted = await asyncio.to_thread(gate.wait_for_started, 1)
+        assert admitted
+        queued_run = (
+            "cancel-second" if gate.started == ["cancel-first"] else "cancel-first"
+        )
+        queued_handler = handlers[queued_run]
+
+        await queued_handler._external_adapter.cancel()
+
+        status = await DBOS.get_workflow_status_async(queued_run)
+        assert status is not None
+        assert status.status == "ENQUEUED"
+        gate.release()
+        await handlers[gate.started[0]]
+        with pytest.raises(WorkflowCancelledByUser):
+            await queued_handler
+        assert isinstance(queued_handler.get_stop_event(), WorkflowCancelledEvent)
+    finally:
+        gate.release()
+        if handlers:
+            await asyncio.gather(*handlers.values(), return_exceptions=True)
+        await runtime.destroy()
+
+
+def test_enqueued_cancellation_waits_for_admission(tmp_path: Path) -> None:
+    asyncio.run(_run_queued_cancellation_case(tmp_path))

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -139,6 +139,14 @@ class Workflow(metaclass=WorkflowMeta):
         )
 
         # Configuration
+        if num_concurrent_runs is not None and (
+            isinstance(num_concurrent_runs, bool)
+            or not isinstance(num_concurrent_runs, int)
+            or num_concurrent_runs <= 0
+        ):
+            raise WorkflowValidationError(
+                "num_concurrent_runs must be an integer greater than 0 or None"
+            )
         self._timeout = timeout
         self._verbose = verbose
         self._disable_validation = disable_validation

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -116,7 +116,11 @@ class Workflow(metaclass=WorkflowMeta):
             verbose (bool): If True, print step activity.
             resource_manager (ResourceManager | None): Custom resource manager
                 for dependency injection.
-            num_concurrent_runs (int | None): Limit on concurrent `run()` calls.
+            num_concurrent_runs (int | None): Maximum number of active runs for
+                this workflow. Must be a positive integer or `None`. The
+                default, `None`, allows unlimited runs. The basic runtime
+                applies the limit to this workflow instance. `DBOSRuntime`
+                applies it to each worker through DBOS queue concurrency.
             runtime (Runtime | None): Optional runtime to use for this workflow.
                 If not provided, uses the current context-scoped runtime or
                 falls back to basic_runtime.

--- a/packages/llama-index-workflows/src/workflows/workflow.py
+++ b/packages/llama-index-workflows/src/workflows/workflow.py
@@ -118,9 +118,9 @@ class Workflow(metaclass=WorkflowMeta):
                 for dependency injection.
             num_concurrent_runs (int | None): Maximum number of active runs for
                 this workflow. Must be a positive integer or `None`. The
-                default, `None`, allows unlimited runs. The basic runtime
-                applies the limit to this workflow instance. `DBOSRuntime`
-                applies it to each worker through DBOS queue concurrency.
+                default, `None`, allows unlimited runs. How the limit is
+                scoped is up to the runtime; the basic runtime applies it to
+                this workflow instance within the process.
             runtime (Runtime | None): Optional runtime to use for this workflow.
                 If not provided, uses the current context-scoped runtime or
                 falls back to basic_runtime.

--- a/packages/llama-index-workflows/tests/test_workflow.py
+++ b/packages/llama-index-workflows/tests/test_workflow.py
@@ -395,6 +395,30 @@ class DummyWorkflowForConcurrentRunsTest(Workflow):
         return self.num_active_runs_history
 
 
+@pytest.mark.parametrize("num_concurrent_runs", [0, -1, True, 1.5, "1"])
+def test_workflow_rejects_invalid_num_concurrent_runs(
+    num_concurrent_runs: Any,
+) -> None:
+    with pytest.raises(
+        WorkflowValidationError,
+        match="num_concurrent_runs must be an integer greater than 0",
+    ):
+        DummyWorkflowForConcurrentRunsTest(
+            num_concurrent_runs=num_concurrent_runs,
+        )
+
+
+@pytest.mark.parametrize("num_concurrent_runs", [None, 1, 8])
+def test_workflow_accepts_valid_num_concurrent_runs(
+    num_concurrent_runs: int | None,
+) -> None:
+    workflow = DummyWorkflowForConcurrentRunsTest(
+        num_concurrent_runs=num_concurrent_runs,
+    )
+
+    assert workflow._num_concurrent_runs == num_concurrent_runs
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     (


### PR DESCRIPTION
`DBOSRuntime` starts every control loop directly, so `Workflow(num_concurrent_runs=...)` only limits runs under the basic runtime. DBOS workers cannot apply the limit.

Now `register()` declares one DBOS queue per workflow, named `_llamaindex_workflow_queue:<workflow_name>`, with `worker_concurrency` set from `num_concurrent_runs`. Workflows with a limit submit through the queue, and runs beyond the limit wait as `ENQUEUED`, admitting within about `polling_interval_sec`. Workflows without a limit keep starting directly, so the default path has no added latency. The constructor rejects zero, negative, boolean, and non-integer limits.

The queue is declared even for unlimited workflows, so removing a limit still leaves a listener for rows that were `ENQUEUED` under the old one. Declarations live in a process-level map because DBOS's registry survives `DBOS.destroy()` and rejects redeclaring a name. Recreating the runtime reuses the queue object and updates its limit in place, which DBOS's poller reads live.

The limit is per worker, so deployment capacity is the limit times the number of live workers. Applications that restrict `DBOS.listen_queues` collect `runtime.workflow_queues` after registering workflows and before launch.