### PR TITLE
Add handler completion polling to WorkflowClient

### DIFF
--- a/.changeset/wait-for-workflow-handler.md
+++ b/.changeset/wait-for-workflow-handler.md
@@ -1,0 +1,5 @@
+---
+"llama-agents-client": patch
+---
+
+Add a polling helper for waiting on workflow handler completion

--- a/.changeset/wait-for-workflow-handler.md
+++ b/.changeset/wait-for-workflow-handler.md
@@ -2,4 +2,4 @@
 "llama-agents-client": patch
 ---
 
-Add a polling helper for waiting on workflow handler completion
+Add a polling helper with configurable backoff for workflow handler completion

--- a/packages/llama-agents-client/src/llama_agents/client/client.py
+++ b/packages/llama-agents-client/src/llama_agents/client/client.py
@@ -26,6 +26,7 @@ from .protocol import (
     SendEventResponse,
     Status,
     WorkflowsListResponse,
+    is_status_completed,
 )
 from .protocol.serializable_events import (
     EventEnvelope,
@@ -508,6 +509,50 @@ class WorkflowClient:
             _raise_for_status_with_body(response)
 
             return HandlerData.model_validate(response.json())
+
+    async def wait_for_handler(
+        self,
+        handler_id: str,
+        *,
+        timeout: float | None = None,
+        poll_interval: float = 0.5,
+    ) -> HandlerData:
+        """Wait until a workflow handler reaches a terminal status.
+
+        Args:
+            handler_id: ID of the handler to poll.
+            timeout: Maximum number of seconds to wait. ``None`` waits
+                indefinitely.
+            poll_interval: Number of seconds between status requests.
+
+        Raises:
+            TimeoutError: If the handler is still running after ``timeout``.
+            ValueError: If ``timeout`` or ``poll_interval`` is negative.
+            httpx.HTTPStatusError: If a status request fails.
+        """
+        if timeout is not None and timeout < 0:
+            raise ValueError("timeout must be non-negative or None")
+        if poll_interval < 0:
+            raise ValueError("poll_interval must be non-negative")
+
+        loop = asyncio.get_running_loop()
+        deadline = None if timeout is None else loop.time() + timeout
+
+        while True:
+            handler = await self.get_handler(handler_id)
+            if is_status_completed(handler.status):
+                return handler
+
+            if deadline is None:
+                await asyncio.sleep(poll_interval)
+                continue
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise TimeoutError(
+                    f"Handler {handler_id!r} did not complete within {timeout} seconds"
+                )
+            await asyncio.sleep(min(poll_interval, remaining))
 
     async def cancel_handler(
         self, handler_id: str, purge: bool = False

--- a/packages/llama-agents-client/src/llama_agents/client/client.py
+++ b/packages/llama-agents-client/src/llama_agents/client/client.py
@@ -55,6 +55,20 @@ def _raise_for_status_with_body(response: httpx.Response) -> None:
         raise
 
 
+def _next_poll_interval(
+    current_interval: float,
+    backoff: Literal["constant", "linear", "exponential"],
+    max_interval: float,
+) -> float:
+    if backoff == "constant":
+        return current_interval
+    if backoff == "linear":
+        return min(current_interval + 1.0, max_interval)
+    if backoff == "exponential":
+        return min(current_interval * 2.0, max_interval)
+    raise ValueError(f"invalid backoff strategy: {backoff}")
+
+
 @dataclass(frozen=True)
 class _QueuedEvent:
     sequence: int | Literal["now"]
@@ -516,6 +530,8 @@ class WorkflowClient:
         *,
         timeout: float | None = None,
         poll_interval: float = 0.5,
+        max_poll_interval: float = 5.0,
+        backoff: Literal["constant", "linear", "exponential"] = "linear",
     ) -> HandlerData:
         """Wait until a workflow handler reaches a terminal status.
 
@@ -523,7 +539,10 @@ class WorkflowClient:
             handler_id: ID of the handler to poll.
             timeout: Maximum number of seconds to wait. ``None`` waits
                 indefinitely.
-            poll_interval: Number of seconds between status requests.
+            poll_interval: Initial number of seconds between status requests.
+            max_poll_interval: Maximum number of seconds between requests.
+            backoff: Strategy for increasing the polling interval after each
+                non-terminal response.
 
         Raises:
             TimeoutError: If the handler is still running after ``timeout``.
@@ -534,9 +553,18 @@ class WorkflowClient:
             raise ValueError("timeout must be non-negative or None")
         if poll_interval < 0:
             raise ValueError("poll_interval must be non-negative")
+        if max_poll_interval < 0:
+            raise ValueError("max_poll_interval must be non-negative")
+        if max_poll_interval < poll_interval:
+            raise ValueError(
+                "max_poll_interval must be greater than or equal to poll_interval"
+            )
+        if backoff not in ("constant", "linear", "exponential"):
+            raise ValueError(f"invalid backoff strategy: {backoff}")
 
         loop = asyncio.get_running_loop()
         deadline = None if timeout is None else loop.time() + timeout
+        current_interval = poll_interval
 
         while True:
             handler = await self.get_handler(handler_id)
@@ -544,15 +572,19 @@ class WorkflowClient:
                 return handler
 
             if deadline is None:
-                await asyncio.sleep(poll_interval)
-                continue
+                sleep_interval = current_interval
+            else:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    raise TimeoutError(
+                        f"Handler {handler_id!r} did not complete within {timeout} seconds"
+                    )
+                sleep_interval = min(current_interval, remaining)
 
-            remaining = deadline - loop.time()
-            if remaining <= 0:
-                raise TimeoutError(
-                    f"Handler {handler_id!r} did not complete within {timeout} seconds"
-                )
-            await asyncio.sleep(min(poll_interval, remaining))
+            await asyncio.sleep(sleep_interval)
+            current_interval = _next_poll_interval(
+                current_interval, backoff, max_poll_interval
+            )
 
     async def cancel_handler(
         self, handler_id: str, purge: bool = False

--- a/packages/llama-agents-client/tests/client/test_client.py
+++ b/packages/llama-agents-client/tests/client/test_client.py
@@ -1,6 +1,7 @@
 # ty: ignore[invalid-argument-type, not-iterable]
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Callable
 from unittest.mock import AsyncMock
@@ -107,6 +108,129 @@ async def test_get_handler(client: WorkflowClient) -> None:
     assert handler_data.started_at is not None
     assert handler_data.updated_at is not None
     assert handler_data.completed_at is not None
+
+
+def _handler_payload(status: str) -> dict[str, Any]:
+    is_terminal = status != "running"
+    return {
+        "handler_id": "handler-1",
+        "workflow_name": "greeting",
+        "run_id": "run-1",
+        "error": "workflow failed" if status == "failed" else None,
+        "result": None,
+        "status": status,
+        "started_at": "2026-08-18T00:00:00+00:00",
+        "updated_at": "2026-08-18T00:00:01+00:00",
+        "completed_at": "2026-08-18T00:00:01+00:00" if is_terminal else None,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
+async def test_wait_for_handler_returns_terminal_status(status: str) -> None:
+    requests = 0
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(200, json=_handler_payload(status))
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        handler = await wf_client.wait_for_handler("handler-1")
+
+    assert handler.status == status
+    assert requests == 1
+
+
+@pytest.mark.asyncio
+async def test_wait_for_handler_observes_completion() -> None:
+    statuses = iter(["running", "completed"])
+    requests = 0
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(200, json=_handler_payload(next(statuses)))
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        handler = await wf_client.wait_for_handler(
+            "handler-1", timeout=1, poll_interval=0
+        )
+
+    assert handler.status == "completed"
+    assert requests == 2
+
+
+@pytest.mark.asyncio
+async def test_wait_for_handler_zero_timeout_fetches_once() -> None:
+    requests = 0
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(200, json=_handler_payload("running"))
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        with pytest.raises(TimeoutError, match="handler-1.*0"):
+            await wf_client.wait_for_handler("handler-1", timeout=0)
+
+    assert requests == 1
+
+
+@pytest.mark.asyncio
+async def test_wait_for_handler_caps_sleep_at_timeout() -> None:
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_handler_payload("running"))
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        loop = asyncio.get_running_loop()
+        started = loop.time()
+        with pytest.raises(TimeoutError):
+            await wf_client.wait_for_handler("handler-1", timeout=0.02, poll_interval=1)
+        elapsed = loop.time() - started
+
+    assert elapsed < 0.2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"timeout": -1}, "timeout must be non-negative or None"),
+        ({"poll_interval": -1}, "poll_interval must be non-negative"),
+    ],
+)
+async def test_wait_for_handler_validates_before_request(
+    kwargs: dict[str, float], message: str
+) -> None:
+    requests = 0
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        nonlocal requests
+        requests += 1
+        return httpx.Response(200, json=_handler_payload("completed"))
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        with pytest.raises(ValueError, match=message):
+            await wf_client.wait_for_handler("handler-1", **kwargs)
+
+    assert requests == 0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_handler_unknown_handler_raises() -> None:
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"detail": "Handler not found"})
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        with pytest.raises(httpx.HTTPStatusError, match="404 Not Found"):
+            await wf_client.wait_for_handler("missing")
 
 
 @pytest.mark.asyncio

--- a/packages/llama-agents-client/tests/client/test_client.py
+++ b/packages/llama-agents-client/tests/client/test_client.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
-from typing import Any, AsyncIterator, Callable
-from unittest.mock import AsyncMock
+from typing import Any, AsyncIterator, Callable, Literal
+from unittest.mock import AsyncMock, call
 
 import httpx
 import pytest
@@ -164,6 +164,62 @@ async def test_wait_for_handler_observes_completion() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("backoff", "expected_sleeps"),
+    [
+        ("constant", [call(0.5), call(0.5), call(0.5)]),
+        ("linear", [call(0.5), call(1.5), call(2.5)]),
+        ("exponential", [call(0.5), call(1.0), call(2.0)]),
+    ],
+)
+async def test_wait_for_handler_applies_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+    backoff: Literal["constant", "linear", "exponential"],
+    expected_sleeps: list[Any],
+) -> None:
+    statuses = iter(["running", "running", "running", "completed"])
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_handler_payload(next(statuses)))
+
+    sleep = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        await wf_client.wait_for_handler("handler-1", backoff=backoff)
+
+    assert sleep.await_args_list == expected_sleeps
+
+
+@pytest.mark.asyncio
+async def test_wait_for_handler_default_backoff_caps_interval(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    statuses = iter(["running"] * 7 + ["completed"])
+
+    def respond(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_handler_payload(next(statuses)))
+
+    sleep = AsyncMock()
+    monkeypatch.setattr(asyncio, "sleep", sleep)
+
+    async with _mock_client(respond) as http_client:
+        wf_client = WorkflowClient(httpx_client=http_client)
+        await wf_client.wait_for_handler("handler-1")
+
+    assert sleep.await_args_list == [
+        call(0.5),
+        call(1.5),
+        call(2.5),
+        call(3.5),
+        call(4.5),
+        call(5.0),
+        call(5.0),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_wait_for_handler_zero_timeout_fetches_once() -> None:
     requests = 0
 
@@ -202,10 +258,16 @@ async def test_wait_for_handler_caps_sleep_at_timeout() -> None:
     [
         ({"timeout": -1}, "timeout must be non-negative or None"),
         ({"poll_interval": -1}, "poll_interval must be non-negative"),
+        ({"max_poll_interval": -1}, "max_poll_interval must be non-negative"),
+        (
+            {"poll_interval": 2, "max_poll_interval": 1},
+            "max_poll_interval must be greater than or equal to poll_interval",
+        ),
+        ({"backoff": "invalid"}, "invalid backoff strategy"),
     ],
 )
 async def test_wait_for_handler_validates_before_request(
-    kwargs: dict[str, float], message: str
+    kwargs: dict[str, Any], message: str
 ) -> None:
     requests = 0
 


### PR DESCRIPTION
## Summary

- add `WorkflowClient.wait_for_handler()` for polling asynchronous workflow runs until they reach a terminal state
- support bounded waits with monotonic timeout accounting and configurable polling intervals
- preserve failed and cancelled terminal results while propagating HTTP errors unchanged
- cover completion transitions, terminal states, timeout boundaries, invalid options, and missing handlers
- add a patch changeset for `llama-agents-client`

## Validation

- `uv run pytest packages/llama-agents-client/tests -n0` (62 passed)
- `uv run ruff format --check packages/llama-agents-client/src/llama_agents/client packages/llama-agents-client/tests`
- `uv run ruff check packages/llama-agents-client/src/llama_agents/client packages/llama-agents-client/tests`
- `uv run ty check packages/llama-agents-client/src/llama_agents/client packages/llama-agents-client/tests`
- `git diff --check origin/main...HEAD`

## Known gaps

The full-repository pre-commit run could not complete locally because the workspace environment does not include optional AgentCore and llamactl dependencies. The checks scoped to the affected client package pass.
