### PR TITLE
Stop crash-looping app rollouts early

### DIFF
--- a/.changeset/fast-crashloop-remediation.md
+++ b/.changeset/fast-crashloop-remediation.md
@@ -1,0 +1,5 @@
+---
+"llama-agents": patch
+---
+
+Stop crash-looping app rollouts within 30 seconds while preserving the previous healthy revision.

--- a/operator/Tiltfile
+++ b/operator/Tiltfile
@@ -22,10 +22,13 @@ allow_k8s_contexts(K8S_CONTEXTS[target])
 def dev_docker_build(ref, context, dockerfile, build_target, deps):
     if target == 'k3s':
         target_arg = ' --target %s' % build_target if build_target else ''
+        local_deps = []
+        for dep in deps:
+            local_deps.append('%s/%s' % (context, dep[2:] if dep.startswith('./') else dep))
         custom_build(
             ref,
             'docker build -t $EXPECTED_REF -f %s%s %s' % (dockerfile, target_arg, context),
-            deps=deps,
+            deps=local_deps,
             disable_push=True,
         )
     else:

--- a/operator/Tiltfile
+++ b/operator/Tiltfile
@@ -150,6 +150,7 @@ k8s_yaml(
         namespace='llama-agents',
         values=['tilt/helm/values-dev.yaml'],
         set=helm_sets,
+        skip_crds=True,
     ),
 )
 

--- a/operator/Tiltfile
+++ b/operator/Tiltfile
@@ -1,8 +1,8 @@
 # Tiltfile for llama-agents local development
-# Supports kind (default) and docker-desktop targets.
-# Pass target via: tilt up -- --target=docker-desktop
+# Supports kind (default), docker-desktop, and local k3s targets.
+# Pass target via: tilt up -- --target=k3s
 
-config.define_string('target', args=True, usage='Cluster target: kind or docker-desktop')
+config.define_string('target', args=True, usage='Cluster target: kind, docker-desktop, or k3s')
 config.define_string('apps-namespace', args=False, usage='Namespace for LlamaDeployment CRs and app resources. Unset = release namespace.')
 cfg = config.parse()
 target = cfg.get('target', 'kind')
@@ -11,6 +11,7 @@ apps_namespace = cfg.get('apps-namespace', '')
 K8S_CONTEXTS = {
     'kind': 'kind-kind',
     'docker-desktop': 'docker-desktop',
+    'k3s': 'default',
 }
 allow_k8s_contexts(K8S_CONTEXTS[target])
 
@@ -18,13 +19,31 @@ allow_k8s_contexts(K8S_CONTEXTS[target])
 # Docker images
 # ---------------------------------------------------------------------------
 
+def dev_docker_build(ref, context, dockerfile, build_target, deps):
+    if target == 'k3s':
+        target_arg = ' --target %s' % build_target if build_target else ''
+        custom_build(
+            ref,
+            'docker build -t $EXPECTED_REF -f %s%s %s' % (dockerfile, target_arg, context),
+            deps=deps,
+            disable_push=True,
+        )
+    else:
+        docker_build(
+            ref,
+            context=context,
+            dockerfile=dockerfile,
+            target=build_target,
+            only=deps,
+        )
+
 # Control plane (Python) — Tilt auto-injects into the deployment's image: field
-docker_build(
+dev_docker_build(
     'llama-agents-control-plane',
     context='..',
     dockerfile='../docker/Dockerfile',
-    target='controlplane',
-    only=[
+    build_target='controlplane',
+    deps=[
         './packages/',
         './docker/Dockerfile',
         './pyproject.toml',
@@ -34,11 +53,12 @@ docker_build(
 )
 
 # Operator (Go) — Tilt auto-injects into the deployment's image: field
-docker_build(
+dev_docker_build(
     'llama-agents-operator',
     context='..',
     dockerfile='../docker/operator.Dockerfile',
-    only=[
+    build_target='',
+    deps=[
         './operator/',
         './docker/operator.Dockerfile',
     ],
@@ -53,7 +73,7 @@ APPSERVER_IMG = 'llama-agents-appserver:%s' % APPSERVER_TAG
 if target == 'kind':
     _appserver_cmd = 'docker build -t %s -f ../docker/Dockerfile --target appserver .. && kind load docker-image %s --name kind' % (APPSERVER_IMG, APPSERVER_IMG)
 else:
-    # docker-desktop shares the Docker daemon — no load step needed
+    # docker-desktop and Docker-backed k3s share the Docker daemon.
     _appserver_cmd = 'docker build -t %s -f ../docker/Dockerfile --target appserver ..' % APPSERVER_IMG
 
 local_resource(
@@ -96,7 +116,7 @@ if os.path.exists('../.env'):
 # ---------------------------------------------------------------------------
 
 local(
-    'helm upgrade --install llama-agents-crds ../charts/llama-agents-crds -n llama-agents --create-namespace',
+    'helm upgrade --install llama-agents-crds ../charts/llama-agents-crds -n llama-agents --create-namespace --server-side=false',
     quiet=True,
 )
 

--- a/operator/dev.py
+++ b/operator/dev.py
@@ -12,6 +12,7 @@ Local development environment for cloud_llama_deploy.
 Targets:
   kind            — (default) creates a kind cluster
   docker-desktop  — uses Docker Desktop's built-in Kubernetes
+  k3s             — uses the local k3s cluster in the default context
 """
 
 import os
@@ -26,10 +27,11 @@ PROJECT_ROOT = Path(__file__).parent.parent.absolute()
 NAMESPACE = "llama-agents"
 APPS_NAMESPACE = "llama-agents-apps"
 
-TARGETS = ("kind", "docker-desktop")
+TARGETS = ("kind", "docker-desktop", "k3s")
 K8S_CONTEXTS = {
     "kind": "kind-kind",
     "docker-desktop": "docker-desktop",
+    "k3s": "default",
 }
 
 
@@ -137,6 +139,23 @@ def ensure_docker_desktop_cluster() -> None:
     # Switch to the docker-desktop context
     run(["kubectl", "config", "use-context", context])
     install_ingress_controller("docker-desktop")
+
+
+def ensure_k3s_cluster() -> None:
+    context = K8S_CONTEXTS["k3s"]
+    result = run(
+        ["kubectl", "--context", context, "cluster-info"],
+        check=False,
+        capture=True,
+    )
+    if result.returncode != 0:
+        print(
+            f"Kubernetes context '{context}' is not reachable.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    run(["kubectl", "config", "use-context", context])
 
 
 # ---------------------------------------------------------------------------
@@ -263,8 +282,10 @@ def up(ctx: click.Context, target: str | None, apps_namespace: str | None) -> No
 
     if target == "kind":
         ensure_kind_cluster()
-    else:
+    elif target == "docker-desktop":
         ensure_docker_desktop_cluster()
+    else:
+        ensure_k3s_cluster()
 
     # Ensure namespaces exist
     for ns in [NAMESPACE] + ([apps_namespace] if apps_namespace else []):

--- a/operator/internal/controller/lifecycle.go
+++ b/operator/internal/controller/lifecycle.go
@@ -11,11 +11,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	llamadeployv1 "llama-agents-operator/api/v1"
+)
+
+const (
+	activeRolloutPollInterval = 30 * time.Second
+	crashLoopBackOffReason    = "CrashLoopBackOff"
 )
 
 // isFailedPhase returns true for phases where failure remediation may be needed.
@@ -221,16 +227,80 @@ func (r *LlamaDeploymentReconciler) assessDeploymentHealth(ctx context.Context, 
 
 	// Check operator-level rollout timeout for in-progress phases
 	if phase == PhasePending || phase == PhaseRollingOut {
-		toResult := r.checkRolloutTimeout(ctx, ld)
-		if toResult.TimedOut {
-			phase = toResult.Phase
-			message = toResult.Message
-		} else if toResult.RequeueAfter > 0 {
-			requeueAfter = toResult.RequeueAfter
+		if crashPhase, crashMessage, found := r.detectCurrentRolloutCrashLoop(ctx, ld); found {
+			phase = crashPhase
+			message = crashMessage
+		} else {
+			toResult := r.checkRolloutTimeout(ctx, ld)
+			if toResult.TimedOut {
+				phase = toResult.Phase
+				message = toResult.Message
+			} else if toResult.RequeueAfter > 0 {
+				requeueAfter = min(toResult.RequeueAfter, activeRolloutPollInterval)
+			} else {
+				requeueAfter = activeRolloutPollInterval
+			}
 		}
 	}
 
 	return phase, message, requeueAfter, statusDirty, nil
+}
+
+// detectCurrentRolloutCrashLoop checks only the newest ReplicaSet's active pods.
+// Pod and ReplicaSet reads bypass the informer cache, so active rollouts poll.
+func (r *LlamaDeploymentReconciler) detectCurrentRolloutCrashLoop(ctx context.Context, ld *llamadeployv1.LlamaDeployment) (string, string, bool) {
+	if r.DirectClient == nil {
+		return "", "", false
+	}
+
+	logger := log.FromContext(ctx)
+	deployment, newestRS, hasOlderAvailable, err := r.currentRolloutReplicaSet(ctx, ld)
+	if err != nil {
+		logger.Error(err, "Failed to inspect current rollout ReplicaSet")
+		return "", "", false
+	}
+	if newestRS == nil {
+		return "", "", false
+	}
+
+	pods := &corev1.PodList{}
+	if err := r.directClient().List(ctx, pods,
+		client.InNamespace(ld.Namespace),
+		client.MatchingLabels(deployment.Spec.Selector.MatchLabels),
+	); err != nil {
+		logger.Error(err, "Failed to inspect current rollout pods")
+		return "", "", false
+	}
+
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		owner := metav1.GetControllerOf(pod)
+		if !pod.DeletionTimestamp.IsZero() || owner == nil || owner.UID != newestRS.UID {
+			continue
+		}
+		if podHasAppCrashLoop(pod) {
+			if hasOlderAvailable {
+				return PhaseRolloutFailed, "New rollout is crash-looping; previous version remains available", true
+			}
+			return PhaseFailed, "Deployment app is crash-looping; failing pods stopped", true
+		}
+	}
+
+	return "", "", false
+}
+
+func podHasAppCrashLoop(pod *corev1.Pod) bool {
+	for _, status := range pod.Status.InitContainerStatuses {
+		if status.State.Waiting != nil && status.State.Waiting.Reason == crashLoopBackOffReason {
+			return true
+		}
+	}
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name == ContainerNameApp && status.State.Waiting != nil && status.State.Waiting.Reason == crashLoopBackOffReason {
+			return true
+		}
+	}
+	return false
 }
 
 // determineDeploymentPhase analyzes the deployment status and returns the appropriate phase and message
@@ -353,7 +423,7 @@ func (r *LlamaDeploymentReconciler) checkRolloutTimeout(ctx context.Context, lla
 // remediateFailedRollout handles failure remediation: classifies pod failures,
 // records the failed generation, and scales down the appropriate resources.
 // Returns a non-nil result to short-circuit the reconcile (infra failures).
-func (r *LlamaDeploymentReconciler) remediateFailedRollout(ctx context.Context, ld *llamadeployv1.LlamaDeployment, phase string, buildId string) *ctrl.Result {
+func (r *LlamaDeploymentReconciler) remediateFailedRollout(ctx context.Context, ld *llamadeployv1.LlamaDeployment, phase string, buildId string) (*ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	// Classify pod failures before acting — infrastructure issues should not
@@ -367,25 +437,27 @@ func (r *LlamaDeploymentReconciler) remediateFailedRollout(ctx context.Context, 
 				"Pods are being evicted or preempted; not scaling down — check node/resource configuration")
 		}
 		result := ctrl.Result{RequeueAfter: 30 * time.Second}
-		return &result
+		return &result, nil
 	}
-
-	ld.Status.FailedRolloutGeneration = ld.Generation
-	ld.Status.RolloutStartedAt = nil
 
 	if phase == PhaseRolloutFailed {
 		// Rollout failed but old RS has healthy traffic — pause and scale
 		// down the newest RS to stop crash-looping while preserving old pods.
 		if scaleErr := r.scaleDownFailingReplicaSet(ctx, ld); scaleErr != nil {
-			logger.Error(scaleErr, "Failed to scale down failing ReplicaSet")
+			return nil, scaleErr
 		}
 	} else {
 		// Fully failed (no healthy pods) — set replicas=0 via the normal
 		// SSA path. Set phase before reconcileDeployment so
 		// createDeploymentForLlama sees PhaseFailed and produces replicas=0.
+		oldPhase := ld.Status.Phase
+		oldFailedGeneration := ld.Status.FailedRolloutGeneration
 		ld.Status.Phase = PhaseFailed
+		ld.Status.FailedRolloutGeneration = ld.Generation
 		if reconcileErr := r.reconcileDeployment(ctx, ld, buildId); reconcileErr != nil {
-			logger.Error(reconcileErr, "Failed to scale down deployment via replicas")
+			ld.Status.Phase = oldPhase
+			ld.Status.FailedRolloutGeneration = oldFailedGeneration
+			return nil, reconcileErr
 		}
 		if r.Recorder != nil {
 			r.Recorder.Event(ld, corev1.EventTypeWarning, "DeploymentScaledDown",
@@ -393,7 +465,20 @@ func (r *LlamaDeploymentReconciler) remediateFailedRollout(ctx context.Context, 
 		}
 	}
 
-	return nil
+	ld.Status.FailedRolloutGeneration = ld.Generation
+	ld.Status.RolloutStartedAt = nil
+	return nil, nil
+}
+
+func (r *LlamaDeploymentReconciler) remediateAndFinalizeFailure(ctx context.Context, ld *llamadeployv1.LlamaDeployment, phase, message string, requeueAfter time.Duration, buildId string) (ctrl.Result, error) {
+	result, err := r.remediateFailedRollout(ctx, ld, phase, buildId)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if result != nil {
+		return *result, nil
+	}
+	return r.finalizePhase(ctx, ld, phase, message, requeueAfter, true)
 }
 
 // failureType classifies the kind of pod failure.
@@ -471,7 +556,7 @@ func classifyPod(pod *corev1.Pod) failureType {
 		for _, cs := range statuses {
 			if cs.State.Waiting != nil {
 				switch cs.State.Waiting.Reason {
-				case "CrashLoopBackOff", "ImagePullBackOff", "ErrImagePull", "CreateContainerConfigError":
+				case crashLoopBackOffReason, "ImagePullBackOff", "ErrImagePull", "CreateContainerConfigError":
 					return failureApp
 				}
 			}
@@ -494,16 +579,12 @@ func classifyPod(pod *corev1.Pod) failureType {
 func (r *LlamaDeploymentReconciler) scaleDownFailingReplicaSet(ctx context.Context, llamaDeploy *llamadeployv1.LlamaDeployment) error {
 	logger := log.FromContext(ctx)
 
-	// Get the Deployment
-	deployment := &appsv1.Deployment{}
-	if err := r.Get(ctx, client.ObjectKey{
-		Name:      llamaDeploy.Name,
-		Namespace: llamaDeploy.Namespace,
-	}, deployment); err != nil {
-		return fmt.Errorf("failed to get deployment: %w", err)
+	deployment, newestRS, hasOtherHealthyRS, err := r.currentRolloutReplicaSet(ctx, llamaDeploy)
+	if err != nil {
+		return err
 	}
 
-	// Pause the Deployment so the Deployment controller does not fight our RS changes
+	// Pause the Deployment so the Deployment controller does not fight our RS changes.
 	if !deployment.Spec.Paused {
 		patch := client.MergeFrom(deployment.DeepCopy())
 		deployment.Spec.Paused = true
@@ -511,66 +592,6 @@ func (r *LlamaDeploymentReconciler) scaleDownFailingReplicaSet(ctx context.Conte
 			return fmt.Errorf("failed to pause deployment: %w", err)
 		}
 		logger.Info("Paused Deployment for rollout timeout remediation")
-	}
-
-	// Use DirectClient for ReplicaSet operations to avoid starting an informer
-	// that would cache ALL ReplicaSets in the namespace. With hundreds of
-	// Deployments this can consume gigabytes of memory.
-	rsClient := r.directClient()
-
-	// List ReplicaSets with matching labels
-	rsList := &appsv1.ReplicaSetList{}
-	if err := rsClient.List(ctx, rsList,
-		client.InNamespace(llamaDeploy.Namespace),
-		client.MatchingLabels(deployment.Spec.Selector.MatchLabels),
-	); err != nil {
-		return fmt.Errorf("failed to list ReplicaSets: %w", err)
-	}
-
-	// Filter to ReplicaSets owned by this Deployment and find the newest by revision
-	var newestRS *appsv1.ReplicaSet
-	var maxRevision int64 = -1
-	hasOtherHealthyRS := false
-
-	for i := range rsList.Items {
-		rs := &rsList.Items[i]
-
-		// Check ownership
-		owned := false
-		for _, ownerRef := range rs.OwnerReferences {
-			if ownerRef.UID == deployment.UID {
-				owned = true
-				break
-			}
-		}
-		if !owned {
-			continue
-		}
-
-		// Track whether newest once determined
-		revStr := rs.Annotations["deployment.kubernetes.io/revision"]
-		rev, err := strconv.ParseInt(revStr, 10, 64)
-		if err != nil {
-			if newestRS == nil || rs.CreationTimestamp.After(newestRS.CreationTimestamp.Time) {
-				// Track whether previous newest had healthy replicas
-				if newestRS != nil && newestRS.Status.AvailableReplicas > 0 {
-					hasOtherHealthyRS = true
-				}
-				newestRS = rs
-			} else if rs.Status.AvailableReplicas > 0 {
-				hasOtherHealthyRS = true
-			}
-			continue
-		}
-		if rev > maxRevision {
-			if newestRS != nil && newestRS.Status.AvailableReplicas > 0 {
-				hasOtherHealthyRS = true
-			}
-			maxRevision = rev
-			newestRS = rs
-		} else if rs.Status.AvailableReplicas > 0 {
-			hasOtherHealthyRS = true
-		}
 	}
 
 	if newestRS == nil {
@@ -598,7 +619,7 @@ func (r *LlamaDeploymentReconciler) scaleDownFailingReplicaSet(ctx context.Conte
 	}
 
 	newestRS.Spec.Replicas = ptr(int32(0))
-	if err := rsClient.Update(ctx, newestRS); err != nil {
+	if err := r.directClient().Update(ctx, newestRS); err != nil {
 		return fmt.Errorf("failed to scale down ReplicaSet %s: %w", newestRS.Name, err)
 	}
 
@@ -612,6 +633,75 @@ func (r *LlamaDeploymentReconciler) scaleDownFailingReplicaSet(ctx context.Conte
 	}
 
 	return nil
+}
+
+// currentRolloutReplicaSet returns the newest owned ReplicaSet and whether a
+// distinct older ReplicaSet is still available.
+func (r *LlamaDeploymentReconciler) currentRolloutReplicaSet(ctx context.Context, ld *llamadeployv1.LlamaDeployment) (*appsv1.Deployment, *appsv1.ReplicaSet, bool, error) {
+	directClient := r.directClient()
+	deployment := &appsv1.Deployment{}
+	if err := directClient.Get(ctx, client.ObjectKey{Name: ld.Name, Namespace: ld.Namespace}, deployment); err != nil {
+		return nil, nil, false, fmt.Errorf("failed to get deployment: %w", err)
+	}
+
+	replicaSets := &appsv1.ReplicaSetList{}
+	if err := directClient.List(ctx, replicaSets,
+		client.InNamespace(ld.Namespace),
+		client.MatchingLabels(deployment.Spec.Selector.MatchLabels),
+	); err != nil {
+		return nil, nil, false, fmt.Errorf("failed to list ReplicaSets: %w", err)
+	}
+
+	var newest *appsv1.ReplicaSet
+	for i := range replicaSets.Items {
+		candidate := &replicaSets.Items[i]
+		if !hasOwnerUID(candidate.OwnerReferences, deployment.UID) {
+			continue
+		}
+		if newest == nil || replicaSetIsNewer(candidate, newest) {
+			newest = candidate
+		}
+	}
+	if newest == nil {
+		return deployment, nil, false, nil
+	}
+
+	hasOlderAvailable := false
+	for i := range replicaSets.Items {
+		candidate := &replicaSets.Items[i]
+		if candidate.UID != newest.UID && hasOwnerUID(candidate.OwnerReferences, deployment.UID) && candidate.Status.AvailableReplicas > 0 {
+			hasOlderAvailable = true
+			break
+		}
+	}
+
+	return deployment, newest, hasOlderAvailable, nil
+}
+
+func hasOwnerUID(ownerReferences []metav1.OwnerReference, uid types.UID) bool {
+	for _, owner := range ownerReferences {
+		if owner.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+func replicaSetIsNewer(candidate, current *appsv1.ReplicaSet) bool {
+	candidateRevision, candidateOK := replicaSetRevision(candidate)
+	currentRevision, currentOK := replicaSetRevision(current)
+	if candidateOK != currentOK {
+		return candidateOK
+	}
+	if candidateOK && candidateRevision != currentRevision {
+		return candidateRevision > currentRevision
+	}
+	return candidate.CreationTimestamp.After(current.CreationTimestamp.Time)
+}
+
+func replicaSetRevision(replicaSet *appsv1.ReplicaSet) (int64, bool) {
+	revision, err := strconv.ParseInt(replicaSet.Annotations["deployment.kubernetes.io/revision"], 10, 64)
+	return revision, err == nil
 }
 
 // finalizePhase writes the assessed phase to the status subresource and emits

--- a/operator/internal/controller/lifecycle_test.go
+++ b/operator/internal/controller/lifecycle_test.go
@@ -11,6 +11,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	llamadeployv1 "llama-agents-operator/api/v1"
@@ -27,6 +29,225 @@ func testSchemeWithApps() *runtime.Scheme {
 // ---------------------------------------------------------------------------
 // assessDeploymentHealth tests
 // ---------------------------------------------------------------------------
+
+func newPendingRolloutObjects(status appsv1.DeploymentStatus, objects ...client.Object) (*LlamaDeploymentReconciler, *llamadeployv1.LlamaDeployment) {
+	scheme := testSchemeWithApps()
+	replicas := int32(1)
+	startedAt := metav1.NewTime(time.Now().Add(-time.Minute))
+	ld := &llamadeployv1.LlamaDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default"},
+		Spec:       llamadeployv1.LlamaDeploymentSpec{ProjectId: "p", RepoUrl: "r"},
+		Status: llamadeployv1.LlamaDeploymentStatus{
+			Phase:            PhasePending,
+			RolloutStartedAt: &startedAt,
+		},
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default", UID: types.UID("deployment-uid")},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "my-app"}},
+		},
+		Status: status,
+	}
+	allObjects := []client.Object{ld, deployment}
+	allObjects = append(allObjects, objects...)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(allObjects...).
+		WithStatusSubresource(ld).
+		Build()
+	return &LlamaDeploymentReconciler{
+		Client:       fakeClient,
+		DirectClient: fakeClient,
+		Scheme:       scheme,
+	}, ld
+}
+
+func rolloutReplicaSet(name, revision string, uid types.UID, availableReplicas int32) *appsv1.ReplicaSet {
+	replicas := int32(1)
+	return &appsv1.ReplicaSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			UID:         uid,
+			Labels:      map[string]string{"app": "my-app"},
+			Annotations: map[string]string{"deployment.kubernetes.io/revision": revision},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "my-app",
+				UID:        types.UID("deployment-uid"),
+				Controller: ptr(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "my-app"}},
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Replicas:          1,
+			AvailableReplicas: availableReplicas,
+		},
+	}
+}
+
+func crashLoopPod(name string, ownerUID types.UID) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels:    map[string]string{"app": "my-app"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "ReplicaSet",
+				Name:       "owner",
+				UID:        ownerUID,
+				Controller: ptr(true),
+			}},
+		},
+		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "busybox"}}},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "app",
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason: "CrashLoopBackOff",
+				}},
+			}},
+		},
+	}
+}
+
+func pendingDeploymentStatus(availableReplicas, replicas int32) appsv1.DeploymentStatus {
+	return appsv1.DeploymentStatus{
+		AvailableReplicas: availableReplicas,
+		Replicas:          replicas,
+		Conditions: []appsv1.DeploymentCondition{{
+			Type:   appsv1.DeploymentProgressing,
+			Status: corev1.ConditionTrue,
+		}},
+	}
+}
+
+func TestAssessDeploymentHealth_CurrentReplicaSetCrashLoopFailsBeforeTimeout(t *testing.T) {
+	currentRS := rolloutReplicaSet("my-app-current", "2", types.UID("current-rs-uid"), 0)
+	pod := crashLoopPod("my-app-crash", currentRS.UID)
+	r, ld := newPendingRolloutObjects(pendingDeploymentStatus(0, 1), currentRS, pod)
+
+	phase, _, _, _, err := r.assessDeploymentHealth(context.Background(), ld)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if phase != PhaseFailed {
+		t.Errorf("expected phase %q for a crash-looping sole ReplicaSet, got %q", PhaseFailed, phase)
+	}
+}
+
+func TestAssessDeploymentHealth_CurrentReplicaSetCrashLoopPreservesOldReplicaSet(t *testing.T) {
+	oldRS := rolloutReplicaSet("my-app-old", "1", types.UID("old-rs-uid"), 1)
+	currentRS := rolloutReplicaSet("my-app-current", "2", types.UID("current-rs-uid"), 0)
+	pod := crashLoopPod("my-app-crash", currentRS.UID)
+	r, ld := newPendingRolloutObjects(pendingDeploymentStatus(1, 2), oldRS, currentRS, pod)
+
+	phase, _, _, _, err := r.assessDeploymentHealth(context.Background(), ld)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if phase != PhaseRolloutFailed {
+		t.Errorf("expected phase %q when an old ReplicaSet remains available, got %q", PhaseRolloutFailed, phase)
+	}
+}
+
+func TestAssessDeploymentHealth_HealthyPendingRolloutPollsWithinThirtySeconds(t *testing.T) {
+	currentRS := rolloutReplicaSet("my-app-current", "1", types.UID("current-rs-uid"), 0)
+	r, ld := newPendingRolloutObjects(pendingDeploymentStatus(0, 1), currentRS)
+
+	phase, _, requeueAfter, _, err := r.assessDeploymentHealth(context.Background(), ld)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if phase != PhasePending {
+		t.Errorf("expected phase %q, got %q", PhasePending, phase)
+	}
+	if requeueAfter <= 0 || requeueAfter > 30*time.Second {
+		t.Errorf("expected active rollout requeue within 30s, got %v", requeueAfter)
+	}
+}
+
+func TestAssessDeploymentHealth_IgnoresOldReplicaSetCrashLoop(t *testing.T) {
+	oldRS := rolloutReplicaSet("my-app-old", "1", types.UID("old-rs-uid"), 0)
+	currentRS := rolloutReplicaSet("my-app-current", "2", types.UID("current-rs-uid"), 0)
+	oldPod := crashLoopPod("my-app-old-crash", oldRS.UID)
+	r, ld := newPendingRolloutObjects(pendingDeploymentStatus(0, 1), oldRS, currentRS, oldPod)
+
+	phase, _, _, _, err := r.assessDeploymentHealth(context.Background(), ld)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if phase != PhasePending {
+		t.Errorf("expected old ReplicaSet crash loop to be ignored, got phase %q", phase)
+	}
+}
+
+func TestAssessDeploymentHealth_IgnoresTerminatingCrashLoopPod(t *testing.T) {
+	currentRS := rolloutReplicaSet("my-app-current", "1", types.UID("current-rs-uid"), 0)
+	pod := crashLoopPod("my-app-terminating", currentRS.UID)
+	deletionTime := metav1.Now()
+	pod.DeletionTimestamp = &deletionTime
+	pod.Finalizers = []string{"test.llamaindex.ai/keep-terminating"}
+	r, ld := newPendingRolloutObjects(pendingDeploymentStatus(0, 1), currentRS, pod)
+
+	phase, _, _, _, err := r.assessDeploymentHealth(context.Background(), ld)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if phase != PhasePending {
+		t.Errorf("expected terminating crash-loop pod to be ignored, got phase %q", phase)
+	}
+}
+
+func TestAssessDeploymentHealth_SoleCurrentReplicaSetOverridesStaleDeploymentAvailability(t *testing.T) {
+	currentRS := rolloutReplicaSet("my-app-current", "1", types.UID("current-rs-uid"), 0)
+	pod := crashLoopPod("my-app-crash", currentRS.UID)
+	r, ld := newPendingRolloutObjects(pendingDeploymentStatus(1, 1), currentRS, pod)
+
+	phase, _, _, _, err := r.assessDeploymentHealth(context.Background(), ld)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if phase != PhaseFailed {
+		t.Errorf("expected phase %q when the only ReplicaSet is crash-looping, got %q", PhaseFailed, phase)
+	}
+}
+
+func TestRemediateFailedRollout_ScaleDownErrorKeepsGenerationRetryable(t *testing.T) {
+	scheme := testSchemeWithApps()
+	startedAt := metav1.Now()
+	ld := &llamadeployv1.LlamaDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default", Generation: 7},
+		Status: llamadeployv1.LlamaDeploymentStatus{
+			Phase:            PhaseRollingOut,
+			RolloutStartedAt: &startedAt,
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ld).Build()
+	r := &LlamaDeploymentReconciler{Client: fakeClient, DirectClient: fakeClient, Scheme: scheme}
+
+	result, err := r.remediateFailedRollout(context.Background(), ld, PhaseRolloutFailed, "")
+	if err == nil {
+		t.Fatal("expected missing Deployment to make scale-down fail")
+	}
+	if result != nil {
+		t.Errorf("expected no reconcile result on scale-down error, got %+v", result)
+	}
+	if ld.Status.FailedRolloutGeneration != 0 {
+		t.Errorf("expected failed generation to remain retryable, got %d", ld.Status.FailedRolloutGeneration)
+	}
+	if ld.Status.RolloutStartedAt == nil {
+		t.Error("expected rollout start time to remain set for retry")
+	}
+}
 
 func TestAssessDeploymentHealth_RolloutTimeout(t *testing.T) {
 	scheme := testSchemeWithApps()

--- a/operator/internal/controller/llamadeployment_controller_test.go
+++ b/operator/internal/controller/llamadeployment_controller_test.go
@@ -2853,6 +2853,15 @@ var _ = Describe("LlamaDeployment Controller", func() {
 						Name:      testName + "-crash",
 						Namespace: testNamespace,
 						Labels:    map[string]string{"app": testName},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "apps/v1",
+								Kind:       "ReplicaSet",
+								Name:       newRS.Name,
+								UID:        newRS.UID,
+								Controller: ptr(true),
+							},
+						},
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -2875,13 +2884,13 @@ var _ = Describe("LlamaDeployment Controller", func() {
 				}
 				Expect(k8sClient.Status().Update(ctx, pod)).To(Succeed())
 
-				By("Simulating ProgressDeadlineExceeded on the Deployment")
+				By("Keeping the Deployment rollout in progress")
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Name: testName, Namespace: testNamespace}, deployment)).To(Succeed())
 				deployment.Status.ReadyReplicas = 1
 				deployment.Status.AvailableReplicas = 1
 				deployment.Status.Replicas = 2
 				deployment.Status.Conditions = []appsv1.DeploymentCondition{
-					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionFalse, Reason: "ProgressDeadlineExceeded"},
+					{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "ReplicaSetUpdated"},
 				}
 				Expect(k8sClient.Status().Update(ctx, deployment)).To(Succeed())
 

--- a/operator/internal/controller/reconcile.go
+++ b/operator/internal/controller/reconcile.go
@@ -207,6 +207,21 @@ func (r *LlamaDeploymentReconciler) ensureFinalizer(ctx context.Context, ld *lla
 // schema migration to prevent infinite loops.
 func (r *LlamaDeploymentReconciler) handleAlreadyFailed(ctx context.Context, ld *llamadeployv1.LlamaDeployment, needsFullReconcile bool) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
+	if ld.Status.Phase == PhaseFailed {
+		deployment := &appsv1.Deployment{}
+		if err := r.Get(ctx, client.ObjectKeyFromObject(ld), deployment); err != nil {
+			if !errors.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
+		} else if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 {
+			patch := client.MergeFrom(deployment.DeepCopy())
+			deployment.Spec.Replicas = ptr(int32(0))
+			if err := r.Patch(ctx, deployment, patch); err != nil {
+				return ctrl.Result{}, err
+			}
+			logger.Info("Restored failed Deployment to zero replicas")
+		}
+	}
 	if needsFullReconcile {
 		if err := r.updateVersionTracking(ctx, ld); err != nil {
 			logger.Error(err, "Failed to update version tracking for terminal deployment")

--- a/operator/internal/controller/reconcile.go
+++ b/operator/internal/controller/reconcile.go
@@ -346,10 +346,7 @@ func (r *LlamaDeploymentReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 	if isFailedPhase(phase) && ld.Status.FailedRolloutGeneration != ld.Generation {
-		if result := r.remediateFailedRollout(ctx, ld, phase, buildId); result != nil {
-			return *result, nil
-		}
-		statusDirty = true
+		return r.remediateAndFinalizeFailure(ctx, ld, phase, message, requeueAfter, buildId)
 	}
 
 	return r.finalizePhase(ctx, ld, phase, message, requeueAfter, statusDirty)

--- a/operator/internal/controller/reconcile_test.go
+++ b/operator/internal/controller/reconcile_test.go
@@ -7,7 +7,9 @@ import (
 	"fmt"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	llamadeployv1 "llama-agents-operator/api/v1"
@@ -165,6 +167,39 @@ func TestHandleAlreadyFailed_SkipsWhenNoFullReconcile(t *testing.T) {
 	}
 	if result.RequeueAfter != 0 {
 		t.Errorf("expected empty result, got %+v", result)
+	}
+}
+
+func TestHandleAlreadyFailed_RestoresFailedDeploymentToZeroReplicas(t *testing.T) {
+	scheme := testSchemeWithApps()
+	ld := &llamadeployv1.LlamaDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-app", Namespace: "default", Generation: 1},
+		Spec:       llamadeployv1.LlamaDeploymentSpec{ProjectId: "p", RepoUrl: "r"},
+		Status: llamadeployv1.LlamaDeploymentStatus{
+			Phase:                   PhaseFailed,
+			FailedRolloutGeneration: 1,
+		},
+	}
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: ld.Name, Namespace: ld.Namespace},
+		Spec:       appsv1.DeploymentSpec{Replicas: ptr(int32(1))},
+	}
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(ld, deployment).
+		WithStatusSubresource(ld).
+		Build()
+	r := &LlamaDeploymentReconciler{Client: fakeClient, Scheme: scheme}
+	ctx := context.Background()
+
+	if _, err := r.handleAlreadyFailed(ctx, ld, false); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := fakeClient.Get(ctx, types.NamespacedName{Name: ld.Name, Namespace: ld.Namespace}, deployment); err != nil {
+		t.Fatalf("failed to get Deployment: %v", err)
+	}
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 {
+		t.Fatalf("expected replicas=0, got %v", deployment.Spec.Replicas)
 	}
 }
 


### PR DESCRIPTION
Managed app rollouts wait for the full rollout deadline before the operator reacts to `CrashLoopBackOff`, even after Kubernetes has identified a persistent app failure.

The operator now polls active rollouts every 30 seconds and inspects non-terminating pods owned by the newest ReplicaSet. An app or init container in `CrashLoopBackOff` enters the existing remediation path immediately:

- A first revision becomes `Failed`, and terminal reconciles keep its Deployment at zero replicas.
- A failed new revision becomes `RolloutFailed`. The operator pauses the Deployment, scales only the newest ReplicaSet to zero, and leaves the available older revision serving.
- Slow starts, image pulls, terminating pods, and crash loops owned by older ReplicaSets keep the existing rollout policy.

The operator uses uncached Pod and ReplicaSet reads for this polling path, so it does not add namespace-wide informers.

The local operator workflow also supports Docker-backed k3s through the existing dev command and Tiltfile. Tilt builds images into the shared host daemon without pushing to Docker Hub, watches the repository inputs behind those custom builds, and leaves the Helm-managed CRDs in place during `tilt down`.