### PR TITLE
Rebuild only the written path in ctx.store.set

### DIFF
--- a/.changeset/state-set-path-copy.md
+++ b/.changeset/state-set-path-copy.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Writing one path with ctx.store.set no longer copies the rest of the state. Only the containers along the written path are rebuilt, so the cost of a write no longer grows with the size of unrelated values, and those values are shared rather than cloned.

--- a/.changeset/state-set-path-copy.md
+++ b/.changeset/state-set-path-copy.md
@@ -2,4 +2,4 @@
 "llama-index-workflows": patch
 ---
 
-Writing one path with ctx.store.set no longer copies the rest of the state. Only the containers along the written path are rebuilt, so the cost of a write no longer grows with the size of unrelated values, and those values are shared rather than cloned.
+ctx.store.set now rebuilds only the written path instead of copying the whole state, so the cost of a write no longer grows with the size of unrelated values.

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -493,7 +493,18 @@ class _CannotRebuild(Exception):
 
 
 def _shallow_copy_container(obj: Any) -> Any:
-    """Copy one container on a write path, sharing everything it holds."""
+    """Copy one container on a write path, sharing everything it holds.
+
+    Only the types whose shallow copy is known to be independent of the
+    original. A hand-written ``__copy__`` may return the object itself, or a
+    new instance still backed by the same mutable state, and writing through
+    one of those would make the write visible to a lockless reader before the
+    new root is committed. That cannot be detected from the outside, so anything
+    unrecognized is left to the in-place writer instead.
+
+    Raises:
+        _CannotRebuild: If obj is not a container this can safely copy.
+    """
     if isinstance(obj, DictLikeModel):
         copied = obj.model_copy()
         # model_copy rebuilds the private-attr mapping but keeps its values,
@@ -503,16 +514,9 @@ def _shallow_copy_container(obj: Any) -> Any:
         return copied
     if isinstance(obj, BaseModel):
         return obj.model_copy()
-    try:
-        copied = copy(obj)
-    except Exception as exc:
-        raise _CannotRebuild from exc
-    if copied is obj:
-        # Immutables, and live handles that opt out by returning self. Writing
-        # through one would make the write visible to readers before the new
-        # root is committed, so treat it as unrebuildable.
-        raise _CannotRebuild
-    return copied
+    if isinstance(obj, (dict, list, set)):
+        return copy(obj)
+    raise _CannotRebuild
 
 
 def _rebuild_child(parent: Any, segment: str) -> Any:
@@ -548,11 +552,13 @@ def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
 
     Intermediate dicts are created as needed, matching `set_by_path`.
 
-    Some containers cannot be rebuilt: live handles wrapping a lock or a socket,
-    frozen models, read-only properties. Writing one of those used to work,
-    because the old writer only ever assigned the leaf. Rather than fail it now,
-    fall back to writing in place and return the same root — that write loses
-    reader isolation for this one path, and reproduces the old behavior exactly,
+    Some containers cannot be rebuilt: anything that is not a dict, list, set,
+    or pydantic model (see `_shallow_copy_container`), and any container that
+    refuses to be reassigned to its own parent, such as a frozen model or a
+    read-only property. Writing through one of those used to work, because the
+    old writer only ever assigned the leaf. Rather than fail it now, fall back
+    to writing in place and return the same root — that write loses reader
+    isolation for this one path, and reproduces the old behavior exactly,
     including the exception when there was one.
 
     Args:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -488,21 +488,17 @@ def set_by_path(state: Any, path: str, value: Any) -> None:
     assign_path_step(current, segments[-1], value)
 
 
-class _UncopyablePathContainer(Exception):
-    """A container on a write path could not be shallow-copied."""
+class _CannotRebuild(Exception):
+    """A container on the write path cannot be copied or reassigned."""
 
 
 def _shallow_copy_container(obj: Any) -> Any:
-    """Copy one container on a write path, sharing everything it holds.
-
-    Raises:
-        _UncopyablePathContainer: If obj cannot be shallow-copied.
-    """
+    """Copy one container on a write path, sharing everything it holds."""
     if isinstance(obj, DictLikeModel):
         copied = obj.model_copy()
-        # Pydantic's shallow copy rebuilds the private-attr mapping but keeps
-        # its values, so the clone would otherwise write dynamic keys straight
-        # into the committed _data.
+        # model_copy rebuilds the private-attr mapping but keeps its values,
+        # so the clone would otherwise write dynamic keys straight into the
+        # committed _data.
         copied._data = dict(obj._data)
         return copied
     if isinstance(obj, BaseModel):
@@ -510,72 +506,57 @@ def _shallow_copy_container(obj: Any) -> Any:
     try:
         copied = copy(obj)
     except Exception as exc:
-        raise _UncopyablePathContainer from exc
+        raise _CannotRebuild from exc
     if copied is obj:
-        # Immutables and handles that opt out of copying by returning self.
-        # There is nothing to rebuild, so this is a write-through too.
-        raise _UncopyablePathContainer
+        # Immutables, and live handles that opt out by returning self. Writing
+        # through one would make the write visible to readers before the new
+        # root is committed, so treat it as unrebuildable.
+        raise _CannotRebuild
     return copied
 
 
-def _rebuild_path(state: Any, segments: list[str], value: Any) -> Any:
-    """Rebuild the containers along segments, sharing everything else."""
-    # Walk down the existing spine, recording the container to rebuild at each
-    # step. Iterative on purpose: a recursive rebuild would raise RecursionError
-    # well before MAX_DEPTH.
-    spine: list[tuple[Any, str]] = []
-    current: Any = state
-    missing_at: int | None = None
-    for i, segment in enumerate(segments[:-1]):
-        spine.append((current, segment))
-        try:
-            current = traverse_path_step(current, segment)
-        except (KeyError, AttributeError, IndexError, TypeError):
-            missing_at = i
-            break
+def _rebuild_child(parent: Any, segment: str) -> Any:
+    """Replace parent's child at segment with a copy of it, and return the copy.
+
+    Raises:
+        _CannotRebuild: If the child cannot be copied, or the parent refuses the
+            copy (a frozen model, a read-only property).
+    """
+    try:
+        child = traverse_path_step(parent, segment)
+    except (KeyError, AttributeError, IndexError, TypeError):
+        child = {}  # missing intermediate, matching set_by_path
     else:
-        spine.append((current, segments[-1]))
+        child = _shallow_copy_container(child)
 
-    # Copy the whole spine before assigning anything. Copying as we go would
-    # let an uncopyable ancestor abort a rebuild that had already run the
-    # assignments below it, and the in-place fallback would then repeat them.
-    copies = [_shallow_copy_container(container) for container, _ in spine]
-
-    child: Any = value
-    if missing_at is not None:
-        # The walk stopped early: the rest of the path becomes fresh dicts,
-        # matching the intermediates set_by_path creates in place.
-        for segment in reversed(segments[missing_at + 1 :]):
-            child = {segment: child}
-
-    # Bottom-up, so each container is assigned the subtree rebuilt beneath it.
-    # Only copies are mutated: an exception here leaves state untouched.
-    for copied, (_, segment) in zip(reversed(copies), reversed(spine)):
-        assign_path_step(copied, segment, child)
-        child = copied
+    try:
+        assign_path_step(parent, segment, child)
+    except Exception as exc:
+        raise _CannotRebuild from exc
     return child
 
 
 def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
     """Return state with path set to value, copying only the path.
 
-    Copy-on-write counterpart of `set_by_path`: the containers along `path` are
-    shallow-copied and rebuilt bottom-up, so every value off the path stays the
+    Copy-on-write counterpart of `set_by_path`: each container along `path` is
+    replaced by a shallow copy of itself, so every value off the path stays the
     same object. Cost is the summed width of the containers on the path and does
-    not depend on the size of anything stored elsewhere. The input state is not
-    mutated, so a reader holding it keeps seeing the pre-write values.
+    not depend on the size of anything stored elsewhere. The walk only ever
+    mutates copies, so the input state is untouched and a reader holding it
+    keeps seeing the pre-write values.
 
     Intermediate dicts are created as needed, matching `set_by_path`.
 
-    A container on the path that cannot be shallow-copied is the one exception:
-    a live handle wrapping a lock, module, or socket, or one that opts out by
-    returning itself from `__copy__`. Rather than fail a write that used to
-    succeed, write through it in place and return the same root. The whole path
-    is copied before anything is assigned, so the fallback never repeats an
-    assignment the rebuild already made.
+    Some containers cannot be rebuilt: live handles wrapping a lock or a socket,
+    frozen models, read-only properties. Writing one of those used to work,
+    because the old writer only ever assigned the leaf. Rather than fail it now,
+    fall back to writing in place and return the same root — that write loses
+    reader isolation for this one path, and reproduces the old behavior exactly,
+    including the exception when there was one.
 
     Args:
-        state: The root state object (not mutated, outside the fallback above).
+        state: The root state object (mutated only in the fallback above).
         path: Dot-separated path to write.
         value: Value to assign.
 
@@ -587,10 +568,20 @@ def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
     """
     segments = _split_write_path(path)
     try:
-        return cast(MODEL_T, _rebuild_path(state, segments, value))
-    except _UncopyablePathContainer:
+        root = _shallow_copy_container(state)
+        current = root
+        # Iterative on purpose: a recursive rebuild would raise RecursionError
+        # well before MAX_DEPTH.
+        for segment in segments[:-1]:
+            current = _rebuild_child(current, segment)
+    except _CannotRebuild:
         set_by_path(state, path, value)
         return state
+
+    # Outside the try: a leaf that rejects the value rejected it before this
+    # change too, so that error belongs to the caller, not to the fallback.
+    assign_path_step(current, segments[-1], value)
+    return cast(MODEL_T, root)
 
 
 def merge_state(current_state: MODEL_T, incoming: BaseModel) -> MODEL_T:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -444,14 +444,7 @@ def get_by_path(state: Any, path: str, default: Any = Ellipsis) -> Any:
 
 
 def _split_write_path(path: str) -> list[str]:
-    """Validate and split a write path into segments.
-
-    Shared by the in-place and copy-on-write writers so their errors cannot
-    drift apart.
-
-    Raises:
-        ValueError: If the path is empty or exceeds MAX_DEPTH.
-    """
+    """Validate and split a write path."""
     if not path:
         raise ValueError("Path cannot be empty")
 
@@ -493,26 +486,12 @@ class _CannotRebuild(Exception):
 
 
 def _shallow_copy_container(obj: Any) -> Any:
-    """Copy one container on a write path, sharing everything it holds.
-
-    Only pydantic models, dicts, and lists are rebuilt. Rebuilding through a
-    container whose copy still shares its backing state would publish the write
-    to a lockless reader before the new root is committed, and a hand-written
-    copy hook can do exactly that. A hook that hands back the original is caught
-    below; one that hands back a proxy over the same storage is not detectable
-    from the outside, which is why unrecognized types are left to the in-place
-    writer instead.
-
-    Raises:
-        _CannotRebuild: If obj is not a container this can copy.
-    """
+    """Shallow-copy a supported path container."""
     if isinstance(obj, BaseModel):
         copied = obj.model_copy()
     elif isinstance(obj, (dict, list)):
         copied = copy(obj)
     else:
-        # Sets included: assign_path_step cannot write into one, so rebuilding
-        # a set only ever precedes a failure.
         raise _CannotRebuild
 
     if copied is obj:
@@ -526,16 +505,11 @@ def _shallow_copy_container(obj: Any) -> Any:
 
 
 def _rebuild_child(parent: Any, segment: str) -> Any:
-    """Replace parent's child at segment with a copy of it, and return the copy.
-
-    Raises:
-        _CannotRebuild: If the child cannot be copied, or the parent refuses the
-            copy (a frozen model, a read-only property).
-    """
+    """Replace one child with a shallow copy and return it."""
     try:
         child = traverse_path_step(parent, segment)
     except (KeyError, AttributeError, IndexError, TypeError):
-        child = {}  # missing intermediate, matching set_by_path
+        child = {}
     else:
         child = _shallow_copy_container(child)
 
@@ -547,51 +521,20 @@ def _rebuild_child(parent: Any, segment: str) -> Any:
 
 
 def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
-    """Return state with path set to value, copying only the path.
+    """Set a path by copying its containers and sharing unrelated values.
 
-    Copy-on-write counterpart of `set_by_path`: each container along `path` is
-    replaced by a shallow copy of itself, so every value off the path stays the
-    same object. Cost is the summed width of the containers on the path and does
-    not depend on the size of anything stored elsewhere. The walk only ever
-    mutates copies, so the input state is untouched and a reader holding it
-    keeps seeing the pre-write values.
-
-    Intermediate dicts are created as needed, matching `set_by_path`.
-
-    Some containers cannot be rebuilt: anything that is not a dict, list, or
-    pydantic model (see `_shallow_copy_container`), and any container that
-    refuses to be reassigned to its own parent, such as a frozen model or a
-    read-only property. Writing through one of those used to work, because the
-    old writer only ever assigned the leaf. Rather than fail it now, fall back
-    to writing in place and return the same root — that write loses reader
-    isolation for this one path, and reproduces the old behavior exactly,
-    including the exception when there was one.
-
-    Args:
-        state: The root state object (mutated only in the fallback above).
-        path: Dot-separated path to write.
-        value: Value to assign.
-
-    Returns:
-        The state to commit: a new root, or `state` itself in the fallback case.
-
-    Raises:
-        ValueError: If the path is empty or exceeds MAX_DEPTH.
+    Unsupported containers fall back to the in-place writer for compatibility.
     """
     segments = _split_write_path(path)
     try:
         root = _shallow_copy_container(state)
         current = root
-        # Iterative on purpose: a recursive rebuild would raise RecursionError
-        # well before MAX_DEPTH.
         for segment in segments[:-1]:
             current = _rebuild_child(current, segment)
     except _CannotRebuild:
         set_by_path(state, path, value)
         return state
 
-    # Outside the try: a leaf that rejects the value rejected it before this
-    # change too, so that error belongs to the caller, not to the fallback.
     assign_path_step(current, segments[-1], value)
     return cast(MODEL_T, root)
 
@@ -822,10 +765,8 @@ class StateStoreFacade(Generic[MODEL_T]):
     the backend's committed row, in-memory reads see the committed record.
     An in-flight `edit_state` block works on an isolated copy, so reads
     (including reads inside the block) return the pre-edit state until the
-    block commits on exit. `set` rebuilds only the containers along the
-    written path and swaps in the new root, so it is equally invisible
-    until it commits, while values off the path stay shared with the
-    previous state. Nested writers raise.
+    block commits on exit. `set` swaps in a rebuilt path atomically. Nested
+    writers raise.
 
     Workflow stores memoize one facade per run so in-process writers share
     that lock. Writers in other processes or replicas are not serialized;
@@ -1004,13 +945,8 @@ class StateStoreFacade(Generic[MODEL_T]):
     async def set(self, path: str, value: Any) -> None:
         """Set a nested value using dot-separated paths.
 
-        Copy-on-write: only the containers along `path` are rebuilt, so the cost
-        does not scale with the size of values stored elsewhere, and those values
-        stay the same objects instead of being cloned. Readers stay lockless and
-        read-committed — the rebuilt root is swapped in atomically.
-
-        Durable backends still decode and re-encode the whole state row per
-        write; this removes the in-process copy, not the round trip.
+        Only containers along `path` are copied. Durable backends still
+        re-encode the full state row.
         """
         async with self._lock.acquire_write():
             async with self._storage.session() as storage:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -495,28 +495,34 @@ class _CannotRebuild(Exception):
 def _shallow_copy_container(obj: Any) -> Any:
     """Copy one container on a write path, sharing everything it holds.
 
-    Only the types whose shallow copy is known to be independent of the
-    original. A hand-written ``__copy__`` may return the object itself, or a
-    new instance still backed by the same mutable state, and writing through
-    one of those would make the write visible to a lockless reader before the
-    new root is committed. That cannot be detected from the outside, so anything
-    unrecognized is left to the in-place writer instead.
+    Only pydantic models, dicts, and lists are rebuilt. Rebuilding through a
+    container whose copy still shares its backing state would publish the write
+    to a lockless reader before the new root is committed, and a hand-written
+    copy hook can do exactly that. A hook that hands back the original is caught
+    below; one that hands back a proxy over the same storage is not detectable
+    from the outside, which is why unrecognized types are left to the in-place
+    writer rather than copied hopefully.
 
     Raises:
-        _CannotRebuild: If obj is not a container this can safely copy.
+        _CannotRebuild: If obj is not a container this can copy.
     """
-    if isinstance(obj, DictLikeModel):
+    if isinstance(obj, BaseModel):
         copied = obj.model_copy()
+    elif isinstance(obj, (dict, list)):
+        copied = copy(obj)
+    else:
+        # Sets included: assign_path_step cannot write into one, so rebuilding
+        # a set only ever precedes a failure.
+        raise _CannotRebuild
+
+    if copied is obj:
+        raise _CannotRebuild
+    if isinstance(copied, DictLikeModel):
         # model_copy rebuilds the private-attr mapping but keeps its values,
         # so the clone would otherwise write dynamic keys straight into the
         # committed _data.
-        copied._data = dict(obj._data)
-        return copied
-    if isinstance(obj, BaseModel):
-        return obj.model_copy()
-    if isinstance(obj, (dict, list, set)):
-        return copy(obj)
-    raise _CannotRebuild
+        copied._data = dict(copied._data)
+    return copied
 
 
 def _rebuild_child(parent: Any, segment: str) -> Any:
@@ -552,8 +558,8 @@ def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
 
     Intermediate dicts are created as needed, matching `set_by_path`.
 
-    Some containers cannot be rebuilt: anything that is not a dict, list, set,
-    or pydantic model (see `_shallow_copy_container`), and any container that
+    Some containers cannot be rebuilt: anything that is not a dict, list, or
+    pydantic model (see `_shallow_copy_container`), and any container that
     refuses to be reassigned to its own parent, such as a frozen model or a
     read-only property. Writing through one of those used to work, because the
     old writer only ever assigned the leaf. Rather than fail it now, fall back

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -9,7 +9,7 @@ import json
 import uuid
 import warnings
 from contextlib import asynccontextmanager
-from copy import deepcopy
+from copy import copy, deepcopy
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -443,6 +443,24 @@ def get_by_path(state: Any, path: str, default: Any = Ellipsis) -> Any:
     return value
 
 
+def _split_write_path(path: str) -> list[str]:
+    """Validate and split a write path into segments.
+
+    Shared by the in-place and copy-on-write writers so their errors cannot
+    drift apart.
+
+    Raises:
+        ValueError: If the path is empty or exceeds MAX_DEPTH.
+    """
+    if not path:
+        raise ValueError("Path cannot be empty")
+
+    segments = path.split(".")
+    if len(segments) > MAX_DEPTH:
+        raise ValueError(f"Path length exceeds {MAX_DEPTH} segments")
+    return segments
+
+
 def set_by_path(state: Any, path: str, value: Any) -> None:
     """Set a nested value on state using a dot-separated path.
 
@@ -456,12 +474,7 @@ def set_by_path(state: Any, path: str, value: Any) -> None:
     Raises:
         ValueError: If the path is empty or exceeds MAX_DEPTH.
     """
-    if not path:
-        raise ValueError("Path cannot be empty")
-
-    segments = path.split(".")
-    if len(segments) > MAX_DEPTH:
-        raise ValueError(f"Path length exceeds {MAX_DEPTH} segments")
+    segments = _split_write_path(path)
 
     current = state
     for segment in segments[:-1]:
@@ -473,6 +486,111 @@ def set_by_path(state: Any, path: str, value: Any) -> None:
             current = intermediate
 
     assign_path_step(current, segments[-1], value)
+
+
+class _UncopyablePathContainer(Exception):
+    """A container on a write path could not be shallow-copied."""
+
+
+def _shallow_copy_container(obj: Any) -> Any:
+    """Copy one container on a write path, sharing everything it holds.
+
+    Raises:
+        _UncopyablePathContainer: If obj cannot be shallow-copied.
+    """
+    if isinstance(obj, DictLikeModel):
+        copied = obj.model_copy()
+        # Pydantic's shallow copy rebuilds the private-attr mapping but keeps
+        # its values, so the clone would otherwise write dynamic keys straight
+        # into the committed _data.
+        copied._data = dict(obj._data)
+        return copied
+    if isinstance(obj, BaseModel):
+        return obj.model_copy()
+    try:
+        copied = copy(obj)
+    except Exception as exc:
+        raise _UncopyablePathContainer from exc
+    if copied is obj:
+        # Immutables and handles that opt out of copying by returning self.
+        # There is nothing to rebuild, so this is a write-through too.
+        raise _UncopyablePathContainer
+    return copied
+
+
+def _rebuild_path(state: Any, segments: list[str], value: Any) -> Any:
+    """Rebuild the containers along segments, sharing everything else."""
+    # Walk down the existing spine, recording the container to rebuild at each
+    # step. Iterative on purpose: a recursive rebuild would raise RecursionError
+    # well before MAX_DEPTH.
+    spine: list[tuple[Any, str]] = []
+    current: Any = state
+    missing_at: int | None = None
+    for i, segment in enumerate(segments[:-1]):
+        spine.append((current, segment))
+        try:
+            current = traverse_path_step(current, segment)
+        except (KeyError, AttributeError, IndexError, TypeError):
+            missing_at = i
+            break
+    else:
+        spine.append((current, segments[-1]))
+
+    # Copy the whole spine before assigning anything. Copying as we go would
+    # let an uncopyable ancestor abort a rebuild that had already run the
+    # assignments below it, and the in-place fallback would then repeat them.
+    copies = [_shallow_copy_container(container) for container, _ in spine]
+
+    child: Any = value
+    if missing_at is not None:
+        # The walk stopped early: the rest of the path becomes fresh dicts,
+        # matching the intermediates set_by_path creates in place.
+        for segment in reversed(segments[missing_at + 1 :]):
+            child = {segment: child}
+
+    # Bottom-up, so each container is assigned the subtree rebuilt beneath it.
+    # Only copies are mutated: an exception here leaves state untouched.
+    for copied, (_, segment) in zip(reversed(copies), reversed(spine)):
+        assign_path_step(copied, segment, child)
+        child = copied
+    return child
+
+
+def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
+    """Return state with path set to value, copying only the path.
+
+    Copy-on-write counterpart of `set_by_path`: the containers along `path` are
+    shallow-copied and rebuilt bottom-up, so every value off the path stays the
+    same object. Cost is the summed width of the containers on the path and does
+    not depend on the size of anything stored elsewhere. The input state is not
+    mutated, so a reader holding it keeps seeing the pre-write values.
+
+    Intermediate dicts are created as needed, matching `set_by_path`.
+
+    A container on the path that cannot be shallow-copied is the one exception:
+    a live handle wrapping a lock, module, or socket, or one that opts out by
+    returning itself from `__copy__`. Rather than fail a write that used to
+    succeed, write through it in place and return the same root. The whole path
+    is copied before anything is assigned, so the fallback never repeats an
+    assignment the rebuild already made.
+
+    Args:
+        state: The root state object (not mutated, outside the fallback above).
+        path: Dot-separated path to write.
+        value: Value to assign.
+
+    Returns:
+        The state to commit: a new root, or `state` itself in the fallback case.
+
+    Raises:
+        ValueError: If the path is empty or exceeds MAX_DEPTH.
+    """
+    segments = _split_write_path(path)
+    try:
+        return cast(MODEL_T, _rebuild_path(state, segments, value))
+    except _UncopyablePathContainer:
+        set_by_path(state, path, value)
+        return state
 
 
 def merge_state(current_state: MODEL_T, incoming: BaseModel) -> MODEL_T:
@@ -701,7 +819,10 @@ class StateStoreFacade(Generic[MODEL_T]):
     the backend's committed row, in-memory reads see the committed record.
     An in-flight `edit_state` block works on an isolated copy, so reads
     (including reads inside the block) return the pre-edit state until the
-    block commits on exit. Nested writers raise.
+    block commits on exit. `set` rebuilds only the containers along the
+    written path and swaps in the new root, so it is equally invisible
+    until it commits, while values off the path stay shared with the
+    previous state. Nested writers raise.
 
     Workflow stores memoize one facade per run so in-process writers share
     that lock. Writers in other processes or replicas are not serialized;
@@ -878,9 +999,20 @@ class StateStoreFacade(Generic[MODEL_T]):
         return get_by_path(await self._load_state(), path, default)
 
     async def set(self, path: str, value: Any) -> None:
-        """Set a nested value using dot-separated paths."""
-        async with self.edit_state() as state:
-            set_by_path(state, path, value)
+        """Set a nested value using dot-separated paths.
+
+        Copy-on-write: only the containers along `path` are rebuilt, so the cost
+        does not scale with the size of values stored elsewhere, and those values
+        stay the same objects instead of being cloned. Readers stay lockless and
+        read-committed — the rebuilt root is swapped in atomically.
+
+        Durable backends still decode and re-encode the whole state row per
+        write; this removes the in-process copy, not the round trip.
+        """
+        async with self._lock.acquire_write():
+            async with self._storage.session() as storage:
+                state = await self._load_state(storage)
+                await self._save_state(set_by_path_copy(state, path, value), storage)
 
     async def clear(self) -> None:
         """Reset the state to its type defaults.

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -501,7 +501,7 @@ def _shallow_copy_container(obj: Any) -> Any:
     copy hook can do exactly that. A hook that hands back the original is caught
     below; one that hands back a proxy over the same storage is not detectable
     from the outside, which is why unrecognized types are left to the in-place
-    writer rather than copied hopefully.
+    writer instead.
 
     Raises:
         _CannotRebuild: If obj is not a container this can copy.

--- a/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
@@ -1,0 +1,396 @@
+# SPDX-License-Identifier: MIT
+# Copyright (c) 2026 LlamaIndex Inc.
+
+"""Copy-on-write behavior of `StateStore.set` and `set_by_path_copy`.
+
+`set` rebuilds only the containers along the written path. These tests pin the
+two things that buys — values off the path keep their identity and are never
+copied — and the parity with the in-place `set_by_path` it replaced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from copy import deepcopy
+from typing import Any, Callable
+
+import pytest
+from pydantic import BaseModel
+from workflows.context.serializers import JsonSerializer
+from workflows.context.state_store import (
+    MAX_DEPTH,
+    DictState,
+    InMemoryStateStore,
+    StateStoreFacade,
+    get_by_path,
+    set_by_path,
+    set_by_path_copy,
+)
+from workflows.events import DictLikeModel, StopEvent
+
+from .test_state_store_facade import FakeDurableStorage
+
+
+class TypedRoot(BaseModel):
+    a: int = 0
+    b: int = 0
+
+
+class TypedDictLike(DictLikeModel):
+    foo: int = 7
+
+
+class ReadOnlyAttr:
+    """Path container whose attribute cannot be assigned."""
+
+    @property
+    def value(self) -> int:
+        return 1
+
+
+class Uncopyable:
+    """Live handle that refuses to be copied, like a lock or socket wrapper."""
+
+    def __init__(self, target: Any = None) -> None:
+        self.slot = 0
+        self.target = target
+
+    def __copy__(self) -> Uncopyable:
+        raise TypeError("cannot copy a live handle")
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> Uncopyable:
+        raise TypeError("cannot copy a live handle")
+
+
+class CopyCounter:
+    """Value that records every attempt to copy it, and shares itself instead."""
+
+    def __init__(self) -> None:
+        self.copies = 0
+
+    def __copy__(self) -> CopyCounter:
+        self.copies += 1
+        return self
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> CopyCounter:
+        self.copies += 1
+        return self
+
+
+def durable_store() -> StateStoreFacade[DictState]:
+    return StateStoreFacade(FakeDurableStorage(), DictState, JsonSerializer())
+
+
+def make_store(durable: bool) -> Any:
+    return durable_store() if durable else InMemoryStateStore(DictState())
+
+
+def dump(value: Any) -> Any:
+    """Plain-data view of a state graph, for comparing two writers' results."""
+    if isinstance(value, DictLikeModel):
+        return {
+            "fields": {k: dump(getattr(value, k)) for k in type(value).model_fields},
+            "data": {k: dump(v) for k, v in value.items()},
+        }
+    if isinstance(value, BaseModel):
+        return {k: dump(getattr(value, k)) for k in type(value).model_fields}
+    if isinstance(value, dict):
+        return {k: dump(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [dump(v) for v in value]
+    return value
+
+
+# ============================================================================
+# Readers hold committed state across a write
+# ============================================================================
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("durable", [False, True])
+async def test_reader_holding_state_is_unaffected_by_set(durable: bool) -> None:
+    """Values read before a write keep their old contents after it commits."""
+    store = make_store(durable)
+    await store.set("a.b", 1)
+
+    snapshot = await store.get_state()
+    nested = await store.get("a")
+
+    await store.set("a.b", 2)
+
+    assert snapshot["a"]["b"] == 1
+    assert nested["b"] == 1
+    assert await store.get("a.b") == 2
+
+
+@pytest.mark.asyncio
+async def test_nested_set_rebuilds_only_the_spine() -> None:
+    """Containers on the path are new objects; everything else is shared."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+    await store.set("a", {"b": {"c": 0}, "sibling": {"keep": 1}})
+    await store.set("other", {"unrelated": 1})
+
+    before = await store.get_state()
+    old_a, old_b = before["a"], before["a"]["b"]
+    old_sibling, old_other = before["a"]["sibling"], before["other"]
+
+    await store.set("a.b.c", 1)
+    after = await store.get_state()
+
+    assert after["a"] is not old_a
+    assert after["a"]["b"] is not old_b
+    assert after["a"]["sibling"] is old_sibling
+    assert after["other"] is old_other
+    assert old_b["c"] == 0
+    assert after["a"]["b"]["c"] == 1
+
+
+@pytest.mark.asyncio
+async def test_set_does_not_copy_values_off_the_path() -> None:
+    """Repeated writes never copy an unrelated value, however large."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+    sentinel = CopyCounter()
+    await store.set("sentinel", sentinel)
+    await store.set("bulk", {str(i): i for i in range(100_000)})
+    bulk = await store.get("bulk")
+
+    for i in range(200):
+        await store.set("counter", i)
+
+    assert sentinel.copies == 0
+    assert await store.get("sentinel") is sentinel
+    assert await store.get("bulk") is bulk
+    assert await store.get("counter") == 199
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sets_do_not_lose_writes() -> None:
+    """Read-modify-write under the lock keeps every concurrent write."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+    await store.set("root", {})
+
+    async def writer(i: int) -> None:
+        await store.set(f"k{i}", i)
+        await store.set(f"root.n{i}", i)
+
+    await asyncio.gather(*(writer(i) for i in range(50)))
+
+    state = await store.get_state()
+    for i in range(50):
+        assert state[f"k{i}"] == i
+        assert state["root"][f"n{i}"] == i
+
+
+@pytest.mark.asyncio
+async def test_uncopyable_container_on_path_is_written_through() -> None:
+    """A live handle on the path still accepts a write, in place."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+    live = Uncopyable()
+    await store.set("live", live)
+
+    await store.set("live.slot", 7)
+
+    assert await store.get("live") is live
+    assert await store.get("live.slot") == 7
+
+
+# ============================================================================
+# Parity with the in-place writer
+# ============================================================================
+
+PARITY_CASES: list[tuple[str, Callable[[], Any], str, Any]] = [
+    ("missing_intermediates", DictState, "x.y.z", 1),
+    ("method_named_segment", DictState, "items.nested", 1),
+    ("numeric_string_key", DictState, "0", "zero"),
+    ("list_index", lambda: DictState(nums=[1, 2, 3]), "nums.0", 9),
+    ("list_index_out_of_range", lambda: DictState(nums=[1]), "nums.5", 9),
+    ("declared_field", TypedDictLike, "foo", 9),
+    ("property_segment", lambda: DictState(ev=StopEvent(result=42)), "ev.result", 7),
+    ("typed_root_field", TypedRoot, "a", 5),
+    ("typed_root_missing_field", TypedRoot, "nope", 5),
+    ("through_a_scalar", lambda: DictState(n=5), "n.x", 1),
+    ("through_a_tuple", lambda: DictState(t=(1, 2)), "t.0", 9),
+    ("read_only_attribute", lambda: DictState(obj=ReadOnlyAttr()), "obj.value", 5),
+    ("nested_existing", lambda: DictState(a={"b": {"c": 0}}), "a.b.c", 1),
+]
+
+
+@pytest.mark.parametrize(
+    ("build", "path", "value"),
+    [pytest.param(b, p, v, id=name) for name, b, p, v in PARITY_CASES],
+)
+def test_set_by_path_copy_matches_set_by_path(
+    build: Callable[[], Any], path: str, value: Any
+) -> None:
+    """Same result, or the same failure with state left alone."""
+    in_place = build()
+    in_place_error: type[BaseException] | None = None
+    try:
+        set_by_path(in_place, path, value)
+    except Exception as exc:
+        in_place_error = type(exc)
+
+    copied_from = build()
+    untouched = dump(copied_from)
+    copy_error: type[BaseException] | None = None
+    result: Any = None
+    try:
+        result = set_by_path_copy(copied_from, path, value)
+    except Exception as exc:
+        copy_error = type(exc)
+
+    assert copy_error is in_place_error
+    if copy_error is not None:
+        assert dump(copied_from) == untouched
+        return
+    assert dump(result) == dump(in_place)
+    assert dump(copied_from) == untouched
+
+
+def test_declared_field_is_not_shadowed_in_data() -> None:
+    """Declared fields stay fields on the rebuilt copy."""
+    result = set_by_path_copy(TypedDictLike(), "foo", 9)
+    assert result.foo == 9
+    assert "foo" not in result._data
+
+
+def test_set_by_path_copy_shares_values_off_the_path() -> None:
+    """Only the path is rebuilt; sibling values keep their identity."""
+    sibling = {"big": list(range(10))}
+    state = DictState(a={"b": 0}, sibling=sibling)
+
+    result = set_by_path_copy(state, "a.b", 1)
+
+    assert result is not state
+    assert result["sibling"] is sibling
+    assert result["a"] is not state["a"]
+    assert state["a"]["b"] == 0
+
+
+# ============================================================================
+# Path validation
+# ============================================================================
+
+
+def test_empty_path_raises() -> None:
+    with pytest.raises(ValueError):
+        set_by_path_copy(DictState(), "", 1)
+
+
+def test_max_depth_boundary() -> None:
+    """MAX_DEPTH segments write; one more raises, as with the in-place writer."""
+    path = ".".join(f"s{i}" for i in range(MAX_DEPTH))
+    state = set_by_path_copy(DictState(), path, 1)
+    assert get_by_path(state, path) == 1
+
+    with pytest.raises(ValueError):
+        set_by_path_copy(DictState(), f"{path}.over", 1)
+
+
+@pytest.mark.asyncio
+async def test_set_inside_edit_state_raises_for_any_path() -> None:
+    """Path validation must not preempt the nested-writer check."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+
+    with pytest.raises(RuntimeError):
+        async with store.edit_state():
+            await store.set("a", 1)
+
+    with pytest.raises(RuntimeError):
+        async with store.edit_state():
+            await store.set("", 1)
+
+
+# ============================================================================
+# Durable backends
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_durable_set_writes_one_row_and_keeps_siblings() -> None:
+    """Durable writes still re-encode the whole row, once per set."""
+    storage = FakeDurableStorage()
+    store: StateStoreFacade[DictState] = StateStoreFacade(
+        storage, DictState, JsonSerializer()
+    )
+    await store.set("a", 1)
+    await store.set("b", {"c": 2})
+    saves = storage.save_count
+
+    await store.set("b.c", 3)
+
+    assert storage.save_count == saves + 1
+    assert await store.get("a") == 1
+    assert await store.get("b.c") == 3
+
+
+@pytest.mark.asyncio
+async def test_edit_state_still_isolates_the_whole_state() -> None:
+    """The transactional block keeps its copy semantics."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
+    await store.set("nums", [1])
+
+    async with store.edit_state() as state:
+        state["nums"].append(2)
+        assert await store.get("nums") == [1]
+
+    assert await store.get("nums") == [1, 2]
+
+
+def test_deepcopy_of_state_is_unaffected_by_sharing() -> None:
+    """A caller that wants isolation can still deep-copy the state itself."""
+    state = DictState(a={"b": 1})
+    isolated = deepcopy(state)
+    result = set_by_path_copy(state, "a.b", 2)
+
+    assert isolated["a"]["b"] == 1
+    assert result["a"]["b"] == 2
+
+
+class SelfCopy:
+    """Path container that opts out of copying by returning itself."""
+
+    def __init__(self) -> None:
+        self.slot = 0
+
+    def __copy__(self) -> SelfCopy:
+        return self
+
+
+class CountingSetter:
+    """Path container whose attribute assignment has a visible side effect."""
+
+    writes: list[Any]
+    slot: int
+
+    def __init__(self, writes: list[Any]) -> None:
+        object.__setattr__(self, "writes", writes)
+        object.__setattr__(self, "slot", 0)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        self.writes.append(value)
+        object.__setattr__(self, name, value)
+
+
+def test_container_that_copies_to_itself_is_written_through() -> None:
+    """A `__copy__` returning self means "share me", so write in place."""
+    shared = SelfCopy()
+    state = DictState(shared=shared)
+
+    result = set_by_path_copy(state, "shared.slot", 1)
+
+    assert result is state
+    assert shared.slot == 1
+
+
+def test_uncopyable_ancestor_assigns_exactly_once() -> None:
+    """Falling back must not repeat assignments the rebuild already made."""
+    writes: list[Any] = []
+    live = Uncopyable(CountingSetter(writes))
+    state = DictState(live=live)
+
+    result = set_by_path_copy(state, "live.target.slot", 7)
+
+    assert result is state
+    assert live.target.slot == 7
+    assert writes == [7]

--- a/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
@@ -1,12 +1,7 @@
 # SPDX-License-Identifier: MIT
 # Copyright (c) 2026 LlamaIndex Inc.
 
-"""Copy-on-write behavior of `StateStore.set` and `set_by_path_copy`.
-
-`set` rebuilds only the containers along the written path. These tests pin the
-two things that buys — values off the path keep their identity and are never
-copied — and the parity with the in-place `set_by_path` it replaced.
-"""
+"""Copy-on-write path tests for `StateStore.set`."""
 
 from __future__ import annotations
 
@@ -147,11 +142,6 @@ def dump(value: Any) -> Any:
     return value
 
 
-# ============================================================================
-# Readers hold committed state across a write
-# ============================================================================
-
-
 @pytest.mark.asyncio
 @pytest.mark.parametrize("durable", [False, True])
 async def test_reader_holding_state_is_unaffected_by_set(durable: bool) -> None:
@@ -244,10 +234,6 @@ async def test_uncopyable_container_on_path_is_written_through() -> None:
     assert await store.get("live.slot") == 7
 
 
-# ============================================================================
-# Parity with the in-place writer
-# ============================================================================
-
 PARITY_CASES: list[tuple[str, Callable[[], Any], str, Any]] = [
     ("missing_intermediates", DictState, "x.y.z", 1),
     ("method_named_segment", DictState, "items.nested", 1),
@@ -262,8 +248,6 @@ PARITY_CASES: list[tuple[str, Callable[[], Any], str, Any]] = [
     ("through_a_tuple", lambda: DictState(t=(1, 2)), "t.0", 9),
     ("read_only_attribute", lambda: DictState(obj=ReadOnlyAttr()), "obj.value", 5),
     ("nested_existing", lambda: DictState(a={"b": {"c": 0}}), "a.b.c", 1),
-    # Ancestors the rebuild cannot replace. The old writer only ever assigned
-    # the leaf, so these writes must keep working.
     ("frozen_ancestor", lambda: FrozenRoot(inner={"x": 0}), "inner.x", 1),
     ("read_only_ancestor", lambda: ReadOnlyAncestor(data={"k": 0}), "view.k", 1),
     ("self_copying_ancestor", lambda: DictState(s=SelfCopy()), "s.slot", 1),
@@ -300,8 +284,6 @@ def test_set_by_path_copy_matches_set_by_path(
         return
     assert dump(result) == dump(in_place)
     if result is not copied_from:
-        # A real rebuild leaves the input alone. The write-through fallback
-        # returns the input itself, and is allowed to have mutated it.
         assert dump(copied_from) == untouched
 
 
@@ -323,11 +305,6 @@ def test_set_by_path_copy_shares_values_off_the_path() -> None:
     assert result["sibling"] is sibling
     assert result["a"] is not state["a"]
     assert state["a"]["b"] == 0
-
-
-# ============================================================================
-# Path validation
-# ============================================================================
 
 
 def test_empty_path_raises() -> None:
@@ -353,11 +330,6 @@ async def test_invalid_path_inside_edit_state_still_raises_nested_writer() -> No
     with pytest.raises(RuntimeError):
         async with store.edit_state():
             await store.set("", 1)
-
-
-# ============================================================================
-# Durable backends
-# ============================================================================
 
 
 @pytest.mark.asyncio
@@ -405,13 +377,7 @@ def test_subclass_whose_copy_returns_itself_is_not_rebuilt() -> None:
 
 
 def test_container_with_a_sharing_copy_is_not_rebuilt() -> None:
-    """A copy that still shares its backing is not isolation, so don't claim it.
-
-    Rebuilding through one would publish the write to a lockless reader before
-    the new root is committed. Nothing can tell such a copy apart from a real
-    one, so only known container types are rebuilt and this takes the in-place
-    path instead.
-    """
+    """Unknown containers use the in-place fallback."""
     backing: dict[str, Any] = {"leaf": 0}
     state = DictState(node=SharedBacking(backing))
 

--- a/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
@@ -75,6 +75,13 @@ class SelfCopy:
         return self
 
 
+class SelfCopyingDict(dict):  # type: ignore[type-arg]
+    """dict subclass whose copy hook hands back the original."""
+
+    def __copy__(self) -> SelfCopyingDict:
+        return self
+
+
 class SharedBacking:
     """Path container whose copy is a new object over the same backing dict."""
 
@@ -384,6 +391,17 @@ class CountingSetter:
     def __setattr__(self, name: str, value: Any) -> None:
         self.writes.append(value)
         object.__setattr__(self, name, value)
+
+
+def test_subclass_whose_copy_returns_itself_is_not_rebuilt() -> None:
+    """Being a dict is not enough; the copy has to actually be a copy."""
+    node = SelfCopyingDict(leaf=0)
+    state = DictState(node=node)
+
+    result = set_by_path_copy(state, "node.leaf", 9)
+
+    assert result is state
+    assert node["leaf"] == 9
 
 
 def test_container_with_a_sharing_copy_is_not_rebuilt() -> None:

--- a/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
@@ -11,11 +11,10 @@ copied — and the parity with the in-place `set_by_path` it replaced.
 from __future__ import annotations
 
 import asyncio
-from copy import deepcopy
 from typing import Any, Callable
 
 import pytest
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
 from workflows.context.serializers import JsonSerializer
 from workflows.context.state_store import (
     MAX_DEPTH,
@@ -48,6 +47,34 @@ class ReadOnlyAttr:
         return 1
 
 
+class FrozenRoot(BaseModel):
+    """State model that refuses reassignment of its own fields."""
+
+    model_config = ConfigDict(frozen=True)
+
+    inner: dict[str, Any] = Field(default_factory=dict)
+
+
+class ReadOnlyAncestor(BaseModel):
+    """State model reached through a property with no setter."""
+
+    data: dict[str, Any] = Field(default_factory=dict)
+
+    @property
+    def view(self) -> dict[str, Any]:
+        return self.data
+
+
+class SelfCopy:
+    """Path container that opts out of copying by returning itself."""
+
+    def __init__(self) -> None:
+        self.slot = 0
+
+    def __copy__(self) -> SelfCopy:
+        return self
+
+
 class Uncopyable:
     """Live handle that refuses to be copied, like a lock or socket wrapper."""
 
@@ -77,14 +104,6 @@ class CopyCounter:
         return self
 
 
-def durable_store() -> StateStoreFacade[DictState]:
-    return StateStoreFacade(FakeDurableStorage(), DictState, JsonSerializer())
-
-
-def make_store(durable: bool) -> Any:
-    return durable_store() if durable else InMemoryStateStore(DictState())
-
-
 def dump(value: Any) -> Any:
     """Plain-data view of a state graph, for comparing two writers' results."""
     if isinstance(value, DictLikeModel):
@@ -98,6 +117,10 @@ def dump(value: Any) -> Any:
         return {k: dump(v) for k, v in value.items()}
     if isinstance(value, (list, tuple)):
         return [dump(v) for v in value]
+    if hasattr(value, "__dict__"):
+        # Plain objects compare structurally, so a mutation through one is
+        # visible here instead of collapsing into an identity comparison.
+        return {k: dump(v) for k, v in vars(value).items()}
     return value
 
 
@@ -110,7 +133,11 @@ def dump(value: Any) -> Any:
 @pytest.mark.parametrize("durable", [False, True])
 async def test_reader_holding_state_is_unaffected_by_set(durable: bool) -> None:
     """Values read before a write keep their old contents after it commits."""
-    store = make_store(durable)
+    store: Any = (
+        StateStoreFacade(FakeDurableStorage(), DictState, JsonSerializer())
+        if durable
+        else InMemoryStateStore(DictState())
+    )
     await store.set("a.b", 1)
 
     snapshot = await store.get_state()
@@ -212,6 +239,11 @@ PARITY_CASES: list[tuple[str, Callable[[], Any], str, Any]] = [
     ("through_a_tuple", lambda: DictState(t=(1, 2)), "t.0", 9),
     ("read_only_attribute", lambda: DictState(obj=ReadOnlyAttr()), "obj.value", 5),
     ("nested_existing", lambda: DictState(a={"b": {"c": 0}}), "a.b.c", 1),
+    # Ancestors the rebuild cannot replace. The old writer only ever assigned
+    # the leaf, so these writes must keep working.
+    ("frozen_ancestor", lambda: FrozenRoot(inner={"x": 0}), "inner.x", 1),
+    ("read_only_ancestor", lambda: ReadOnlyAncestor(data={"k": 0}), "view.k", 1),
+    ("self_copying_ancestor", lambda: DictState(s=SelfCopy()), "s.slot", 1),
 ]
 
 
@@ -222,7 +254,7 @@ PARITY_CASES: list[tuple[str, Callable[[], Any], str, Any]] = [
 def test_set_by_path_copy_matches_set_by_path(
     build: Callable[[], Any], path: str, value: Any
 ) -> None:
-    """Same result, or the same failure with state left alone."""
+    """Same committed result, or the same failure with state left alone."""
     in_place = build()
     in_place_error: type[BaseException] | None = None
     try:
@@ -244,7 +276,10 @@ def test_set_by_path_copy_matches_set_by_path(
         assert dump(copied_from) == untouched
         return
     assert dump(result) == dump(in_place)
-    assert dump(copied_from) == untouched
+    if result is not copied_from:
+        # A real rebuild leaves the input alone. The write-through fallback
+        # returns the input itself, and is allowed to have mutated it.
+        assert dump(copied_from) == untouched
 
 
 def test_declared_field_is_not_shadowed_in_data() -> None:
@@ -288,13 +323,9 @@ def test_max_depth_boundary() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_inside_edit_state_raises_for_any_path() -> None:
+async def test_invalid_path_inside_edit_state_still_raises_nested_writer() -> None:
     """Path validation must not preempt the nested-writer check."""
     store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
-
-    with pytest.raises(RuntimeError):
-        async with store.edit_state():
-            await store.set("a", 1)
 
     with pytest.raises(RuntimeError):
         async with store.edit_state():
@@ -324,39 +355,6 @@ async def test_durable_set_writes_one_row_and_keeps_siblings() -> None:
     assert await store.get("b.c") == 3
 
 
-@pytest.mark.asyncio
-async def test_edit_state_still_isolates_the_whole_state() -> None:
-    """The transactional block keeps its copy semantics."""
-    store: InMemoryStateStore[DictState] = InMemoryStateStore(DictState())
-    await store.set("nums", [1])
-
-    async with store.edit_state() as state:
-        state["nums"].append(2)
-        assert await store.get("nums") == [1]
-
-    assert await store.get("nums") == [1, 2]
-
-
-def test_deepcopy_of_state_is_unaffected_by_sharing() -> None:
-    """A caller that wants isolation can still deep-copy the state itself."""
-    state = DictState(a={"b": 1})
-    isolated = deepcopy(state)
-    result = set_by_path_copy(state, "a.b", 2)
-
-    assert isolated["a"]["b"] == 1
-    assert result["a"]["b"] == 2
-
-
-class SelfCopy:
-    """Path container that opts out of copying by returning itself."""
-
-    def __init__(self) -> None:
-        self.slot = 0
-
-    def __copy__(self) -> SelfCopy:
-        return self
-
-
 class CountingSetter:
     """Path container whose attribute assignment has a visible side effect."""
 
@@ -372,19 +370,8 @@ class CountingSetter:
         object.__setattr__(self, name, value)
 
 
-def test_container_that_copies_to_itself_is_written_through() -> None:
-    """A `__copy__` returning self means "share me", so write in place."""
-    shared = SelfCopy()
-    state = DictState(shared=shared)
-
-    result = set_by_path_copy(state, "shared.slot", 1)
-
-    assert result is state
-    assert shared.slot == 1
-
-
-def test_uncopyable_ancestor_assigns_exactly_once() -> None:
-    """Falling back must not repeat assignments the rebuild already made."""
+def test_fallback_writes_through_a_live_handle_once() -> None:
+    """Falling back must not repeat an assignment the rebuild already made."""
     writes: list[Any] = []
     live = Uncopyable(CountingSetter(writes))
     state = DictState(live=live)

--- a/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
@@ -75,6 +75,22 @@ class SelfCopy:
         return self
 
 
+class SharedBacking:
+    """Path container whose copy is a new object over the same backing dict."""
+
+    def __init__(self, backing: dict[str, Any]) -> None:
+        object.__setattr__(self, "backing", backing)
+
+    def __copy__(self) -> SharedBacking:
+        return type(self)(self.backing)
+
+    def __getattr__(self, name: str) -> Any:
+        return self.backing[name]
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        self.backing[name] = value
+
+
 class Uncopyable:
     """Live handle that refuses to be copied, like a lock or socket wrapper."""
 
@@ -368,6 +384,23 @@ class CountingSetter:
     def __setattr__(self, name: str, value: Any) -> None:
         self.writes.append(value)
         object.__setattr__(self, name, value)
+
+
+def test_container_with_a_sharing_copy_is_not_rebuilt() -> None:
+    """A copy that still shares its backing is not isolation, so don't claim it.
+
+    Rebuilding through one would publish the write to a lockless reader before
+    the new root is committed. Nothing can tell such a copy apart from a real
+    one, so only known container types are rebuilt and this takes the in-place
+    path instead.
+    """
+    backing: dict[str, Any] = {"leaf": 0}
+    state = DictState(node=SharedBacking(backing))
+
+    result = set_by_path_copy(state, "node.leaf", 9)
+
+    assert result is state
+    assert backing["leaf"] == 9
 
 
 def test_fallback_writes_through_a_live_handle_once() -> None:


### PR DESCRIPTION
`ctx.store.set` uses `edit_state` for lock correctness under concurrency, however by default `edit_state` creates a deep copy, which can be expensive. This optimizes that path to create targeted shallow copies to retain immutable updates while avoiding copying untouched trees