### PR TITLE
Copy state instead of writing through on an unrebuildable set path

### DIFF
--- a/.changeset/state-set-fallback-isolation.md
+++ b/.changeset/state-set-fallback-isolation.md
@@ -1,0 +1,5 @@
+---
+"llama-index-workflows": patch
+---
+
+Fix ctx.store.set writing through to committed state when the path runs through a container it cannot rebuild. A dataclass, tuple, or plain object on the write path made the write visible to lockless readers before it committed; those paths now copy state first.

--- a/.changeset/state-set-fallback-isolation.md
+++ b/.changeset/state-set-fallback-isolation.md
@@ -1,5 +1,0 @@
----
-"llama-index-workflows": patch
----
-
-Fix ctx.store.set writing through to committed state when the path runs through a container it cannot rebuild. A dataclass, tuple, or plain object on the write path made the write visible to lockless readers before it committed; those paths now copy state first.

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -523,34 +523,14 @@ def _rebuild_child(parent: Any, segment: str) -> Any:
     return child
 
 
-def _copy_state_and_set(state: MODEL_T, path: str, value: Any) -> MODEL_T:
-    """Copy all of state the way ``edit_state`` does, then write into the copy.
-
-    Uses ``copy_state_for_edit`` rather than a plain ``deepcopy`` so the
-    fallback inherits the exclude rule: a live handle hung off a model still
-    gets shared instead of cloned.
-
-    A container that ``copy_state_for_edit`` cannot copy at all is shared, so a
-    write through one is still visible immediately. That is unchanged, and
-    unavoidable — an uncopyable handle is shared with readers whether or not
-    anything writes to it, so there was never isolation there to keep.
-    """
-    copied = copy_state_for_edit(state)
-    set_by_path(copied, path, value)
-    return copied
-
-
 def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
     """Set a path by copying its containers and sharing unrelated values.
 
-    Only containers along ``path`` are rebuilt; everything else is shared by
-    reference, so the cost is the depth of the path rather than the size of
-    state.
-
-    ``_shallow_copy_container`` knows how to rebuild models, dicts and lists.
-    A write path through anything else — a dataclass, a tuple, a plain object —
-    falls back to copying all of state, because writing through to ``state``
-    would mutate the committed value that lockless readers are reading.
+    A container the rebuild cannot handle falls back to copying all of state,
+    because writing through to ``state`` would mutate what readers are reading.
+    The fallback copies through ``copy_state_for_edit`` so it keeps the exclude
+    rule; a value that cannot be copied at all is shared, and a write through
+    one is still visible immediately.
     """
     segments = _split_write_path(path)
     try:
@@ -559,7 +539,9 @@ def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
         for segment in segments[:-1]:
             current = _rebuild_child(current, segment)
     except _CannotRebuild:
-        return _copy_state_and_set(state, path, value)
+        copied = copy_state_for_edit(state)
+        set_by_path(copied, path, value)
+        return copied
 
     assign_path_step(current, segments[-1], value)
     return cast(MODEL_T, root)
@@ -1053,11 +1035,8 @@ class StateStoreFacade(Generic[MODEL_T]):
     async def set(self, path: str, value: Any) -> None:
         """Set a nested value using dot-separated paths.
 
-        Only containers along `path` are copied, so the cost is the depth of
-        the path rather than the size of state. A path through a container
-        that cannot be rebuilt (a dataclass, a tuple, a plain object) copies
-        all of state instead. Durable backends still re-encode the full state
-        row.
+        Only containers along `path` are copied. Durable backends still
+        re-encode the full state row.
         """
         async with self._lock.acquire_write():
             async with self._storage.session() as storage:

--- a/packages/llama-index-workflows/src/workflows/context/state_store.py
+++ b/packages/llama-index-workflows/src/workflows/context/state_store.py
@@ -523,10 +523,34 @@ def _rebuild_child(parent: Any, segment: str) -> Any:
     return child
 
 
+def _copy_state_and_set(state: MODEL_T, path: str, value: Any) -> MODEL_T:
+    """Copy all of state the way ``edit_state`` does, then write into the copy.
+
+    Uses ``copy_state_for_edit`` rather than a plain ``deepcopy`` so the
+    fallback inherits the exclude rule: a live handle hung off a model still
+    gets shared instead of cloned.
+
+    A container that ``copy_state_for_edit`` cannot copy at all is shared, so a
+    write through one is still visible immediately. That is unchanged, and
+    unavoidable — an uncopyable handle is shared with readers whether or not
+    anything writes to it, so there was never isolation there to keep.
+    """
+    copied = copy_state_for_edit(state)
+    set_by_path(copied, path, value)
+    return copied
+
+
 def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
     """Set a path by copying its containers and sharing unrelated values.
 
-    Unsupported containers fall back to the in-place writer for compatibility.
+    Only containers along ``path`` are rebuilt; everything else is shared by
+    reference, so the cost is the depth of the path rather than the size of
+    state.
+
+    ``_shallow_copy_container`` knows how to rebuild models, dicts and lists.
+    A write path through anything else — a dataclass, a tuple, a plain object —
+    falls back to copying all of state, because writing through to ``state``
+    would mutate the committed value that lockless readers are reading.
     """
     segments = _split_write_path(path)
     try:
@@ -535,8 +559,7 @@ def set_by_path_copy(state: MODEL_T, path: str, value: Any) -> MODEL_T:
         for segment in segments[:-1]:
             current = _rebuild_child(current, segment)
     except _CannotRebuild:
-        set_by_path(state, path, value)
-        return state
+        return _copy_state_and_set(state, path, value)
 
     assign_path_step(current, segments[-1], value)
     return cast(MODEL_T, root)
@@ -1030,8 +1053,11 @@ class StateStoreFacade(Generic[MODEL_T]):
     async def set(self, path: str, value: Any) -> None:
         """Set a nested value using dot-separated paths.
 
-        Only containers along `path` are copied. Durable backends still
-        re-encode the full state row.
+        Only containers along `path` are copied, so the cost is the depth of
+        the path rather than the size of state. A path through a container
+        that cannot be rebuilt (a dataclass, a tuple, a plain object) copies
+        all of state instead. Durable backends still re-encode the full state
+        row.
         """
         async with self._lock.acquire_write():
             async with self._storage.session() as storage:

--- a/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 from typing import Any, Callable
 
 import pytest
@@ -105,6 +106,29 @@ class Uncopyable:
 
     def __deepcopy__(self, memo: dict[int, Any]) -> Uncopyable:
         raise TypeError("cannot copy a live handle")
+
+
+@dataclasses.dataclass
+class DataHolder:
+    """Dataclass on the write path: copyable, but not a model/dict/list."""
+
+    x: int = 1
+
+
+class PlainHolder:
+    """Plain object on the write path: copyable, but not a model/dict/list."""
+
+    def __init__(self) -> None:
+        self.x = 1
+
+
+class ExcludingModel(BaseModel):
+    """Model with a live dependency the copy must share, not clone."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    dep: Any = Field(default=None, exclude=True)
+    data: dict[str, Any] = Field(default_factory=dict)
 
 
 class CopyCounter:
@@ -365,26 +389,27 @@ class CountingSetter:
         object.__setattr__(self, name, value)
 
 
-def test_subclass_whose_copy_returns_itself_is_not_rebuilt() -> None:
+def test_subclass_whose_copy_returns_itself_falls_back_to_copying_state() -> None:
     """Being a dict is not enough; the copy has to actually be a copy."""
     node = SelfCopyingDict(leaf=0)
     state = DictState(node=node)
 
     result = set_by_path_copy(state, "node.leaf", 9)
 
-    assert result is state
-    assert node["leaf"] == 9
+    assert result is not state
+    assert node["leaf"] == 0
+    assert result["node"]["leaf"] == 9
 
 
-def test_container_with_a_sharing_copy_is_not_rebuilt() -> None:
-    """Unknown containers use the in-place fallback."""
+def test_container_with_a_sharing_copy_falls_back_to_copying_state() -> None:
+    """Unknown containers cost a full state copy rather than a live write."""
     backing: dict[str, Any] = {"leaf": 0}
     state = DictState(node=SharedBacking(backing))
 
     result = set_by_path_copy(state, "node.leaf", 9)
 
-    assert result is state
-    assert backing["leaf"] == 9
+    assert result is not state
+    assert result["node"].leaf == 9
 
 
 def test_fallback_writes_through_a_live_handle_once() -> None:
@@ -395,6 +420,65 @@ def test_fallback_writes_through_a_live_handle_once() -> None:
 
     result = set_by_path_copy(state, "live.target.slot", 7)
 
-    assert result is state
+    assert result is not state
     assert live.target.slot == 7
     assert writes == [7]
+
+
+@pytest.mark.parametrize(
+    ("build", "path"),
+    [
+        pytest.param(lambda: PlainHolder(), "holder.x", id="plain_object"),
+        pytest.param(lambda: DataHolder(), "holder.x", id="dataclass"),
+    ],
+)
+def test_copyable_container_on_the_path_does_not_leak_the_write(
+    build: Callable[[], Any], path: str
+) -> None:
+    """A container the rebuild cannot handle is still copied, not written through."""
+    holder = build()
+    state = DictState(holder=holder, n=0)
+
+    result = set_by_path_copy(state, path, 99)
+
+    assert holder.x == 1
+    assert state["holder"] is holder
+    assert get_by_path(result, path) == 99
+
+
+def test_tuple_on_the_path_does_not_leak_the_write() -> None:
+    """A tuple is immutable but its contents are not."""
+    inner: dict[str, Any] = {"x": 1}
+    state = DictState(t=(inner,), n=0)
+
+    result = set_by_path_copy(state, "t.0.x", 99)
+
+    assert inner["x"] == 1
+    assert result["t"][0]["x"] == 99
+
+
+@pytest.mark.asyncio
+async def test_reader_is_unaffected_by_a_set_through_an_unsupported_container() -> None:
+    """The read-committed contract holds on the fallback path too."""
+    store: InMemoryStateStore[DictState] = InMemoryStateStore(
+        DictState(holder=DataHolder(), n=0)
+    )
+    snapshot = await store.get_state()
+
+    await store.set("holder.x", 99)
+
+    assert snapshot["holder"].x == 1
+    assert await store.get("holder.x") == 99
+
+
+def test_fallback_shares_excluded_fields_instead_of_copying_them() -> None:
+    """The fallback copies through `copy_state_for_edit`, so the exclude rule holds."""
+    dep = CopyCounter()
+    model = ExcludingModel(dep=dep, data={"k": 1})
+    state = DictState(holder=DataHolder(), model=model)
+
+    result = set_by_path_copy(state, "holder.x", 99)
+
+    assert result["model"].dep is dep
+    assert dep.copies == 0
+    assert result["model"].data is not model.data

--- a/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
+++ b/packages/llama-index-workflows/tests/context/test_state_store_path_set.py
@@ -122,15 +122,6 @@ class PlainHolder:
         self.x = 1
 
 
-class ExcludingModel(BaseModel):
-    """Model with a live dependency the copy must share, not clone."""
-
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    dep: Any = Field(default=None, exclude=True)
-    data: dict[str, Any] = Field(default_factory=dict)
-
-
 class CopyCounter:
     """Value that records every attempt to copy it, and shares itself instead."""
 
@@ -426,59 +417,35 @@ def test_fallback_writes_through_a_live_handle_once() -> None:
 
 
 @pytest.mark.parametrize(
-    ("build", "path"),
+    ("build", "path", "read"),
     [
-        pytest.param(lambda: PlainHolder(), "holder.x", id="plain_object"),
-        pytest.param(lambda: DataHolder(), "holder.x", id="dataclass"),
+        pytest.param(PlainHolder, "node.x", lambda n: n.x, id="plain_object"),
+        pytest.param(DataHolder, "node.x", lambda n: n.x, id="dataclass"),
+        pytest.param(lambda: ({"x": 1},), "node.0.x", lambda n: n[0]["x"], id="tuple"),
     ],
 )
-def test_copyable_container_on_the_path_does_not_leak_the_write(
-    build: Callable[[], Any], path: str
+def test_unrebuildable_container_on_the_path_is_copied_not_written_through(
+    build: Callable[[], Any], path: str, read: Callable[[Any], Any]
 ) -> None:
-    """A container the rebuild cannot handle is still copied, not written through."""
-    holder = build()
-    state = DictState(holder=holder, n=0)
+    """A container the rebuild cannot handle is copied, not written through."""
+    node = build()
+    state = DictState(node=node)
 
     result = set_by_path_copy(state, path, 99)
 
-    assert holder.x == 1
-    assert state["holder"] is holder
+    assert read(node) == 1
     assert get_by_path(result, path) == 99
-
-
-def test_tuple_on_the_path_does_not_leak_the_write() -> None:
-    """A tuple is immutable but its contents are not."""
-    inner: dict[str, Any] = {"x": 1}
-    state = DictState(t=(inner,), n=0)
-
-    result = set_by_path_copy(state, "t.0.x", 99)
-
-    assert inner["x"] == 1
-    assert result["t"][0]["x"] == 99
 
 
 @pytest.mark.asyncio
 async def test_reader_is_unaffected_by_a_set_through_an_unsupported_container() -> None:
     """The read-committed contract holds on the fallback path too."""
     store: InMemoryStateStore[DictState] = InMemoryStateStore(
-        DictState(holder=DataHolder(), n=0)
+        DictState(node=DataHolder())
     )
     snapshot = await store.get_state()
 
-    await store.set("holder.x", 99)
+    await store.set("node.x", 99)
 
-    assert snapshot["holder"].x == 1
-    assert await store.get("holder.x") == 99
-
-
-def test_fallback_shares_excluded_fields_instead_of_copying_them() -> None:
-    """The fallback copies through `copy_state_for_edit`, so the exclude rule holds."""
-    dep = CopyCounter()
-    model = ExcludingModel(dep=dep, data={"k": 1})
-    state = DictState(holder=DataHolder(), model=model)
-
-    result = set_by_path_copy(state, "holder.x", 99)
-
-    assert result["model"].dep is dep
-    assert dep.copies == 0
-    assert result["model"].data is not model.data
+    assert snapshot["node"].x == 1
+    assert await store.get("node.x") == 99


### PR DESCRIPTION
`ctx.store.set` fell back to writing straight into committed state when the write path ran through something it could not rebuild, so a dataclass, tuple, or plain object on the path made the write visible to lockless readers before it committed; the fallback now copies state first.