### PR TITLE
fix: use immutable defaults for read-only sequences

### DIFF
--- a/.changeset/quiet-defaults-fix.md
+++ b/.changeset/quiet-defaults-fix.md
@@ -1,0 +1,7 @@
+---
+"llama-agents-appserver": patch
+"llama-agents-client": patch
+"llama-agents-server": patch
+---
+
+fix: replace mutable default arguments with None sentinels

--- a/.changeset/quiet-defaults-fix.md
+++ b/.changeset/quiet-defaults-fix.md
@@ -1,7 +1,0 @@
----
-"llama-agents-appserver": patch
-"llama-agents-client": patch
-"llama-agents-server": patch
----
-
-fix: replace mutable default arguments with immutable tuple defaults

--- a/.changeset/quiet-defaults-fix.md
+++ b/.changeset/quiet-defaults-fix.md
@@ -4,4 +4,4 @@
 "llama-agents-server": patch
 ---
 
-fix: replace mutable default arguments with None sentinels
+fix: replace mutable default arguments with immutable tuple defaults

--- a/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
+++ b/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
@@ -311,9 +311,10 @@ def run_uv(
     source_root: Path,
     path: Path,
     cmd: str,
-    args: list[str] = [],
+    args: list[str] | None = None,
     extra_env: dict[str, str] | None = None,
 ) -> None:
+    args = args or []
     env = os.environ.copy()
     if extra_env:
         env.update(extra_env)

--- a/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
+++ b/packages/llama-agents-appserver/src/llama_agents/appserver/workflow_loader.py
@@ -6,6 +6,7 @@ import os
 import socket
 import subprocess
 import sys
+from collections.abc import Sequence
 from dataclasses import dataclass
 from importlib.metadata import requires as pkg_requires
 from importlib.metadata import version as pkg_version
@@ -311,15 +312,14 @@ def run_uv(
     source_root: Path,
     path: Path,
     cmd: str,
-    args: list[str] | None = None,
+    args: Sequence[str] = (),
     extra_env: dict[str, str] | None = None,
 ) -> None:
-    args = args or []
     env = os.environ.copy()
     if extra_env:
         env.update(extra_env)
     run_process(
-        ["uv", cmd] + args,
+        ["uv", cmd, *args],
         cwd=source_root / path,
         prefix=f"[uv {cmd}]",
         color_code="36",

--- a/packages/llama-agents-client/src/llama_agents/client/protocol/serializable_events.py
+++ b/packages/llama-agents-client/src/llama_agents/client/protocol/serializable_events.py
@@ -27,12 +27,12 @@ class EventEnvelopeWithMetadata(BaseModel):
     type: str
     types: list[str] | None
 
-    def load_event(self, registry: list[type[Event]] = []) -> Event:
+    def load_event(self, registry: list[type[Event]] | None = None) -> Event:
         """
         Attempts to load the event data as a python class based on the envelope metadata.
         Looks up the event from the registry, if provided. Falls back to the qualified_name, attempting to load from the module path.
         """
-        registry_lookup = {e.__name__: e for e in registry}
+        registry_lookup = {e.__name__: e for e in registry or []}
         as_event_envelope = EventEnvelope(
             value=self.value, type=self.type, qualified_name=self.qualified_name
         ).model_dump()

--- a/packages/llama-agents-client/src/llama_agents/client/protocol/serializable_events.py
+++ b/packages/llama-agents-client/src/llama_agents/client/protocol/serializable_events.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import builtins
 import json
+from collections.abc import Sequence
 from typing import Any
 
 from pydantic import BaseModel, ValidationError, model_validator
@@ -27,12 +28,12 @@ class EventEnvelopeWithMetadata(BaseModel):
     type: str
     types: list[str] | None
 
-    def load_event(self, registry: list[type[Event]] | None = None) -> Event:
+    def load_event(self, registry: Sequence[type[Event]] = ()) -> Event:
         """
         Attempts to load the event data as a python class based on the envelope metadata.
         Looks up the event from the registry, if provided. Falls back to the qualified_name, attempting to load from the module path.
         """
-        registry_lookup = {e.__name__: e for e in registry or []}
+        registry_lookup = {e.__name__: e for e in registry}
         as_event_envelope = EventEnvelope(
             value=self.value, type=self.type, qualified_name=self.qualified_name
         ).model_dump()

--- a/packages/llama-agents-server/src/llama_agents/server/server.py
+++ b/packages/llama-agents-server/src/llama_agents/server/server.py
@@ -59,7 +59,7 @@ class WorkflowServer:
         middleware: list[Middleware] | None = None,
         exception_handlers: Mapping[Any, Any] | None = None,
         workflow_store: AbstractWorkflowStore | None = None,
-        persistence_backoff: list[float] = [0.5, 3],
+        persistence_backoff: list[float] | None = None,
         runtime: Runtime | None = None,
         idle_timeout: float = 60.0,
         sse_heartbeat_interval: float | None = 25.0,
@@ -98,6 +98,8 @@ class WorkflowServer:
                 instantiate arbitrary Pydantic objects via ``importlib``, so
                 only enable this on trusted networks.
         """
+        if persistence_backoff is None:
+            persistence_backoff = [0.5, 3]
         if runtime is None:
             self._runtime_core = _DurableWorkflowRuntime(
                 workflow_store=workflow_store,

--- a/packages/llama-agents-server/src/llama_agents/server/server.py
+++ b/packages/llama-agents-server/src/llama_agents/server/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from contextlib import asynccontextmanager
 from typing import Any, AsyncGenerator
 
@@ -59,7 +59,7 @@ class WorkflowServer:
         middleware: list[Middleware] | None = None,
         exception_handlers: Mapping[Any, Any] | None = None,
         workflow_store: AbstractWorkflowStore | None = None,
-        persistence_backoff: list[float] | None = None,
+        persistence_backoff: Sequence[float] = (0.5, 3.0),
         runtime: Runtime | None = None,
         idle_timeout: float = 60.0,
         sse_heartbeat_interval: float | None = 25.0,
@@ -98,8 +98,6 @@ class WorkflowServer:
                 instantiate arbitrary Pydantic objects via ``importlib``, so
                 only enable this on trusted networks.
         """
-        if persistence_backoff is None:
-            persistence_backoff = [0.5, 3]
         if runtime is None:
             self._runtime_core = _DurableWorkflowRuntime(
                 workflow_store=workflow_store,


### PR DESCRIPTION
Three read-only parameters use list literals as defaults, so Python shares mutable objects across calls. Their annotations now accept `Sequence` values and their defaults are immutable tuples:

```python
args: Sequence[str] = ()
registry: Sequence[type[Event]] = ()
persistence_backoff: Sequence[float] = (0.5, 3.0)
```

`run_uv` unpacks `args` into the command list, so callers can pass lists or tuples. `WorkflowServer` still copies the retry delays into runtime-owned lists, and an empty sequence still disables retries.